### PR TITLE
[inductor] Optimize full slice_scatter chains

### DIFF
--- a/test/inductor/test_slice_scatter_chunking.py
+++ b/test/inductor/test_slice_scatter_chunking.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import gc
+import operator
 from unittest import mock, skipIf
 
 import torch
@@ -44,7 +45,7 @@ class TestSliceScatterChunking(TestCase):
         return gm
 
     @parametrize("factory", ("empty", "empty_strided"))
-    def test_complete_chain(self, device, factory):
+    def test_nonfunctional_chain(self, device, factory):
         def fn(head, middle, tail):
             if factory == "empty":
                 out = torch.empty((6, 4), device=head.device, dtype=head.dtype)
@@ -62,10 +63,77 @@ class TestSliceScatterChunking(TestCase):
         gm = self._run_pass(fn, head, middle, tail)
         targets = [node.target for node in gm.graph.nodes]
 
-        self.assertNotIn(aten.slice_scatter.default, targets)
+        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
         self.assertEqual(targets.count(aten.cat.default), 1)
         self.assertEqual(targets.count(aten.copy_.default), 0)
         self.assertEqual(gm(head, middle, tail), torch.cat((head, middle, tail)))
+
+    @parametrize("dim", (0, -1))
+    def test_realized_chunks_use_copies(self, device, dim):
+        def fn(a, b, c, d):
+            head = a @ b
+            tail = c @ d
+            shape = list(head.shape)
+            chunk_size = shape[dim]
+            shape[dim] *= 2
+            out = torch.empty(shape, device=a.device, dtype=a.dtype)
+            out = aten.slice_scatter.default(out, head, dim, 0, chunk_size)
+            return aten.slice_scatter.default(
+                out, tail, dim, chunk_size, chunk_size * 2
+            )
+
+        args = tuple(
+            torch.randn(shape, device=device)
+            for shape in ((2, 4), (4, 3), (2, 4), (4, 3))
+        )
+        gm = self._run_pass(fn, *args)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), 2)
+        self.assertEqual(gm(*args), fn(*args))
+        self.assertEqual(gm(*args).stride(), fn(*args).stride())
+
+    @onlyCPU
+    def test_cpu_nested_region_output_not_fusible(self, device):
+        graph = torch.fx.Graph()
+        region = graph.call_function(
+            torch.ops.higher_order.invoke_subgraph, args=(None, "region")
+        )
+        source = graph.call_function(operator.getitem, args=(region, 0))
+        source.meta["val"] = torch.empty(1)
+
+        self.assertFalse(
+            slice_scatter_chunking._is_nested_compile_region_output(source)
+        )
+
+    @parametrize("consumer", ("matmul", "pointwise"))
+    def test_realized_pointwise_chunk_uses_copies(self, device, consumer):
+        def fn(x, weight, tail):
+            out = torch.empty((4, 4), device=x.device, dtype=x.dtype)
+            head = x.cos()
+            tail = tail.sin()
+            if consumer == "matmul":
+                aux = head @ weight + tail @ weight
+            else:
+                aux = head.sin() + tail.cos()
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            out = aten.slice_scatter.default(out, tail, 0, 2, 4)
+            return out, aux
+
+        args = (
+            torch.randn(2, 4, device=device),
+            torch.randn(4, 4, device=device),
+            torch.randn(2, 4, device=device),
+        )
+        gm = self._run_pass(fn, *args)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), 2)
+        self.assertEqual(gm(*args), fn(*args))
 
     @parametrize("with_aliases", (False, True))
     def test_functionalized_copy_chain(self, device, with_aliases):
@@ -199,7 +267,7 @@ class TestSliceScatterChunking(TestCase):
         self.assertEqual(last, torch.cat((head, tail)))
 
     @parametrize("base_kind", ("input", "pointwise", "offset", "extra_capacity"))
-    def test_cat_rejects_non_factory_base(self, device, base_kind):
+    def test_rejects_non_factory_base(self, device, base_kind):
         def fn(head, tail, storage):
             if base_kind == "input":
                 out = storage
@@ -265,19 +333,20 @@ class TestSliceScatterChunking(TestCase):
         gm = self._run_pass(fn, head, tail, tracing_mode="symbolic")
 
         targets = [node.target for node in gm.graph.nodes]
-        self.assertNotIn(aten.slice_scatter.default, targets)
+        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), 2)
         self.assertEqual(gm(head, tail), torch.cat((head, tail)))
 
     @parametrize(
         "case",
         (
-            subtest(((4, 4), (0, 1), None), name="overlapping"),
-            subtest(((4, 4), (1, 4), (1, 4)), name="noncontiguous"),
-            subtest(((4, 1), (1, 99), (1, 99)), name="noncanonical"),
+            subtest(((4, 4), (0, 1), None, 0), name="overlapping"),
+            subtest(((4, 4), (1, 4), (1, 4), 2), name="noncontiguous"),
+            subtest(((4, 1), (1, 99), (1, 99), 2), name="noncanonical"),
         ),
     )
-    def test_rejects_unsupported_factory_layout(self, device, case):
-        shape, stride, expected_stride = case
+    def test_factory_layout(self, device, case):
+        shape, stride, expected_stride, expected_copies = case
 
         def fn(head, tail):
             out = torch.empty_strided(
@@ -292,8 +361,10 @@ class TestSliceScatterChunking(TestCase):
         gm = self._run_pass(fn, head, tail)
 
         targets = [node.target for node in gm.graph.nodes]
-        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
-        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(
+            targets.count(aten.slice_scatter.default), 0 if expected_copies else 2
+        )
+        self.assertEqual(targets.count(aten.copy_.default), expected_copies)
         if expected_stride is not None:
             self.assertEqual(gm(head, tail).stride(), expected_stride)
 
@@ -312,7 +383,7 @@ class TestSliceScatterChunking(TestCase):
         self.assertEqual(targets.count(aten.copy_.default), 0)
         self.assertEqual(gm(head, tail).dtype, torch.float32)
 
-    def test_skips_noncontiguous_sources(self, device):
+    def test_noncontiguous_sources(self, device):
         def fn(head, tail):
             out = torch.empty((2, 3, 1, 1), device=head.device, dtype=head.dtype)
             out = aten.slice_scatter.default(out, head, 0, 0, 1)
@@ -330,66 +401,104 @@ class TestSliceScatterChunking(TestCase):
         gm = self._run_pass(fn, head, tail)
 
         targets = [node.target for node in gm.graph.nodes]
-        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
-        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), 2)
         self.assertEqual(gm(head, tail), expected)
 
-    @parametrize(
-        "same_context",
-        (
-            subtest(True, name="matching"),
-            subtest(False, name="different"),
-        ),
-    )
-    def test_custom_context(self, device, same_context):
+    @parametrize("replacement", ("cat", "copy"))
+    @parametrize("same_context", (True, False))
+    def test_custom_context(self, device, replacement, same_context):
+        def write(out, src, start, end):
+            if replacement == "copy":
+                src = aten.copy.default(out[start:end], src)
+            return aten.slice_scatter.default(out, src, 0, start, end)
+
         def fn(head, tail):
             out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
-            out = aten.slice_scatter.default(out, head, 0, 0, 2)
-            return aten.slice_scatter.default(out, tail, 0, 2, 4)
+            if replacement == "cat":
+                head = head.cos()
+                tail = tail.sin()
+            out = write(out, head, 0, 2)
+            return write(out, tail, 2, 4)
 
         head = torch.randn(2, 4, device=device)
         tail = torch.randn(2, 4, device=device)
         custom = {"stream": 1, "mempool": 2, "mempool_device": 0}
         gm = make_fx(fn, tracing_mode="fake")(head, tail)
-        slice_scatters = gm.graph.find_nodes(
-            op="call_function", target=aten.slice_scatter.default
-        )
-        slice_scatters[0].meta["custom"] = custom.copy()
-        slice_scatters[1].meta["custom"] = (
-            custom.copy() if same_context else {**custom, "stream": 2}
-        )
+        nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.target
+            in (
+                aten.empty.memory_format,
+                aten.copy.default,
+                aten.slice_scatter.default,
+            )
+        ]
+        for node in nodes:
+            node.meta["custom"] = custom.copy()
+        if not same_context:
+            nodes[-1].meta["custom"] = {**custom, "stream": 2}
         fake_tensor_updater = FakeTensorUpdater(gm)
         fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
         with V.set_fake_mode(fake_mode):
             slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
             fake_tensor_updater.incremental_update()
         gm.graph.lint()
+        gm.recompile()
 
-        cats = gm.graph.find_nodes(op="call_function", target=aten.cat.default)
         remaining = gm.graph.find_nodes(
             op="call_function", target=aten.slice_scatter.default
         )
-        self.assertEqual(len(cats), 1 if same_context else 0)
+        copies = gm.graph.find_nodes(op="call_function", target=aten.copy_.default)
+        cats = gm.graph.find_nodes(op="call_function", target=aten.cat.default)
+        expected_copies = 2 if same_context and replacement == "copy" else 0
+        expected_cats = 1 if same_context and replacement == "cat" else 0
+        self.assertEqual(len(copies), expected_copies)
+        self.assertEqual(len(cats), expected_cats)
         self.assertEqual(len(remaining), 0 if same_context else 2)
         if same_context:
-            self.assertEqual(cats[0].meta.get("custom"), custom)
+            replacement_node = copies[0] if replacement == "copy" else cats[0]
+            self.assertEqual(replacement_node.meta.get("custom"), custom)
+        self.assertEqual(gm(head, tail), fn(head, tail))
+
+    @onlyCPU
+    @inductor_config.patch(force_disable_caches=True)
+    def test_deep_live_view_chain_compile(self, device):
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            out = aten.slice_scatter.default(out, tail, 0, 2, 4)
+            for _ in range(1100):
+                out = out[1:]
+            return out
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        compiled = torch.compile(fn, fullgraph=True)
+
+        self.assertEqual(compiled(head, tail), fn(head, tail))
 
     def test_ignores_dead_destination_views(self, device):
+        def write(out, src, start, end):
+            copied = aten.copy.default(out[start:end], src)
+            return aten.slice_scatter.default(out, copied, 0, start, end)
+
         def fn(head, tail):
             out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
             aten.slice.Tensor(out, 0, 0, 2)
-            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            out = write(out, head, 0, 2)
             aten.slice.Tensor(out, 0, 2, 4)
-            return aten.slice_scatter.default(out, tail, 0, 2, 4)
+            return write(out, tail, 2, 4)
 
         head = torch.randn(2, 4, device=device)
         tail = torch.randn(2, 4, device=device)
         gm = self._run_pass(fn, head, tail)
 
         targets = [node.target for node in gm.graph.nodes]
-        self.assertNotIn(aten.slice.Tensor, targets)
+        self.assertEqual(targets.count(aten.slice.Tensor), 2)
         self.assertNotIn(aten.slice_scatter.default, targets)
-        self.assertEqual(targets.count(aten.cat.default), 1)
+        self.assertEqual(targets.count(aten.copy_.default), 2)
         self.assertEqual(gm(head, tail), fn(head, tail))
 
     def test_rejects_intervening_mutation(self, device):
@@ -411,7 +520,7 @@ class TestSliceScatterChunking(TestCase):
 
     @onlyCUDA
     @inductor_config.patch(force_disable_caches=True)
-    def test_mm_chunk_codegen(self, device):
+    def test_mm_chunk_codegen_bounded_peak(self, device):
         def fn(a, b, c, d):
             rows = a.shape[0]
             out = torch.empty((rows * 2, b.shape[1]), device=a.device, dtype=a.dtype)
@@ -441,7 +550,7 @@ class TestSliceScatterChunking(TestCase):
         compiled(*args)
         torch.cuda.synchronize()
         peak = torch.cuda.max_memory_allocated() - baseline
-        self.assertLessEqual(peak, 65 * 2**20)
+        self.assertLessEqual(peak, 97 * 2**20)
 
     @inductor_config.patch(force_disable_caches=True)
     def test_functionalized_copy_chain_compile(self, device):
@@ -531,6 +640,21 @@ class TestSliceScatterChunking(TestCase):
             0,
         )
         self.assertEqual(gm(*chunks), fn(*chunks))
+
+    def test_no_candidate_skips_mutation_region_scan(self, device):
+        def fn(x):
+            return x.cos()
+
+        x = torch.randn(4, device=device)
+        with mock.patch.object(
+            slice_scatter_chunking,
+            "compute_mutation_region_ids",
+            wraps=slice_scatter_chunking.compute_mutation_region_ids,
+        ) as compute:
+            gm = self._run_pass(fn, x)
+
+        self.assertEqual(compute.call_count, 0)
+        self.assertEqual(gm(x), fn(x))
 
     def test_rejected_chain_is_scanned_once(self, device):
         chain_length = 20
@@ -711,9 +835,28 @@ class TestSliceScatterChunking(TestCase):
                 (inner, width),
             )
         )
-        compiled = torch.compile(fn, fullgraph=True)
-        actual = compiled(*args)
+        can_fuse_as_cat = slice_scatter_chunking._can_fuse_as_cat
+        saw_regional_cat = False
 
+        def tracked_can_fuse_as_cat(chain):
+            nonlocal saw_regional_cat
+            result = can_fuse_as_cat(chain)
+            if any(
+                slice_scatter_chunking._is_nested_compile_region_output(src)
+                for src in chain.sources
+            ):
+                saw_regional_cat |= result
+            return result
+
+        compiled = torch.compile(fn, fullgraph=True)
+        with mock.patch.object(
+            slice_scatter_chunking,
+            "_can_fuse_as_cat",
+            tracked_can_fuse_as_cat,
+        ):
+            actual = compiled(*args)
+
+        self.assertTrue(saw_regional_cat)
         self.assertEqual(actual, fn(*args))
         del actual
         gc.collect()
@@ -725,18 +868,44 @@ class TestSliceScatterChunking(TestCase):
         peak = torch.cuda.max_memory_allocated() - baseline
         self.assertLessEqual(peak, 129 * 2**20)
 
+    @parametrize("dim", (0, -1))
+    def test_pointwise_chunks_fuse(self, device, dim):
+        def fn(head, tail):
+            shape = list(head.shape)
+            chunk_size = shape[dim]
+            shape[dim] *= 2
+            out = torch.empty(shape, device=head.device, dtype=head.dtype)
+            out = aten.slice_scatter.default(out, head.cos(), dim, 0, chunk_size)
+            return aten.slice_scatter.default(
+                out, tail.sin(), dim, chunk_size, chunk_size * 2
+            )
+
+        head = torch.randn(2, 3, device=device)
+        tail = torch.randn(2, 3, device=device)
+        gm = self._run_pass(fn, head, tail)
+        targets = [node.target for node in gm.graph.nodes]
+        actual = gm(head, tail)
+        expected = fn(head, tail)
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(targets.count(aten.cat.default), 1)
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual.stride(), expected.stride())
+
     @onlyCUDA
-    def test_pointwise_chunks_fuse(self, device):
-        def fn(x):
-            rows = x.shape[0] // 2
-            out = torch.empty(x.shape, device=x.device, dtype=x.dtype)
-            out = aten.slice_scatter.default(out, x[:rows].cos(), 0, 0, rows)
-            return aten.slice_scatter.default(out, x[rows:].sin(), 0, rows, x.shape[0])
+    @inductor_config.patch(force_disable_caches=True)
+    def test_external_chunks_codegen(self, device):
+        def fn(head, middle, tail):
+            out = torch.empty((6, 1024), device=head.device, dtype=head.dtype)
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            out = aten.slice_scatter.default(out, middle, 0, 2, 4)
+            return aten.slice_scatter.default(out, tail, 0, 4, 6)
 
-        x = torch.randn(8192, 1024, device=device)
-        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), x)
+        args = tuple(torch.randn(2, 1024, device=device) for _ in range(3))
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
 
-        self.assertEqual(actual, fn(x))
+        self.assertEqual(actual, fn(*args))
         self.assertEqual(code.count(".run("), 1)
 
     @onlyCUDA

--- a/test/inductor/test_slice_scatter_chunking.py
+++ b/test/inductor/test_slice_scatter_chunking.py
@@ -45,31 +45,46 @@ class TestSliceScatterChunking(TestCase):
         return gm
 
     @parametrize("factory", ("empty", "empty_strided"))
-    def test_nonfunctional_chain(self, device, factory):
-        def fn(head, middle, tail):
+    @parametrize("source_kind", ("distinct", "reused", "views"))
+    def test_nonfunctional_chain(self, device, factory, source_kind):
+        def fn(*inputs):
+            if source_kind == "distinct":
+                chunks = inputs
+            elif source_kind == "reused":
+                chunks = inputs * 3
+            else:
+                chunks = (inputs[0][:2], inputs[0][2:4], inputs[0][4:6])
             if factory == "empty":
-                out = torch.empty((6, 4), device=head.device, dtype=head.dtype)
+                out = torch.empty(
+                    (6, 4), device=inputs[0].device, dtype=inputs[0].dtype
+                )
             else:
                 out = torch.empty_strided(
-                    (6, 4), (4, 1), device=head.device, dtype=head.dtype
+                    (6, 4), (4, 1), device=inputs[0].device, dtype=inputs[0].dtype
                 )
-            out = aten.slice_scatter.default(out, head, 0, 0, 2)
-            out = aten.slice_scatter.default(out, middle, 0, 2, 4)
-            return aten.slice_scatter.default(out, tail, 0, 4, 6)
+            out = aten.slice_scatter.default(out, chunks[0], 0, 0, 2)
+            out = aten.slice_scatter.default(out, chunks[1], 0, 2, 4)
+            return aten.slice_scatter.default(out, chunks[2], 0, 4, 6)
 
-        head = torch.randn(2, 4, device=device)
-        middle = torch.randn(2, 4, device=device)
-        tail = torch.randn(2, 4, device=device)
-        gm = self._run_pass(fn, head, middle, tail)
+        if source_kind == "distinct":
+            args = tuple(torch.randn(2, 4, device=device) for _ in range(3))
+        elif source_kind == "reused":
+            args = (torch.randn(2, 4, device=device),)
+        else:
+            args = (torch.randn(6, 4, device=device),)
+        gm = self._run_pass(fn, *args)
         targets = [node.target for node in gm.graph.nodes]
 
         self.assertEqual(targets.count(aten.slice_scatter.default), 0)
-        self.assertEqual(targets.count(aten.cat.default), 1)
+        # Replacement tracing decomposes cat([x, x, x]) into expand/clone/view.
+        self.assertEqual(
+            targets.count(aten.cat.default), 0 if source_kind == "reused" else 1
+        )
         self.assertEqual(targets.count(aten.copy_.default), 0)
-        self.assertEqual(gm(head, middle, tail), torch.cat((head, middle, tail)))
+        self.assertEqual(gm(*args), fn(*args))
 
     @parametrize("dim", (0, -1))
-    def test_realized_chunks_use_copies(self, device, dim):
+    def test_non_pointwise_intermediates_use_copies(self, device, dim):
         def fn(a, b, c, d):
             head = a @ b
             tail = c @ d
@@ -95,21 +110,21 @@ class TestSliceScatterChunking(TestCase):
         self.assertEqual(gm(*args), fn(*args))
         self.assertEqual(gm(*args).stride(), fn(*args).stride())
 
-    @onlyCPU
-    def test_cpu_nested_region_output_not_fusible(self, device):
+    def test_nested_region_output_fusibility(self, device):
         graph = torch.fx.Graph()
         region = graph.call_function(
             torch.ops.higher_order.invoke_subgraph, args=(None, "region")
         )
         source = graph.call_function(operator.getitem, args=(region, 0))
-        source.meta["val"] = torch.empty(1)
+        source.meta["val"] = torch.empty(1, device=device)
 
-        self.assertFalse(
-            slice_scatter_chunking._is_nested_compile_region_output(source)
+        self.assertEqual(
+            slice_scatter_chunking._is_nested_compile_region_output(source),
+            device != "cpu",
         )
 
     @parametrize("consumer", ("matmul", "pointwise"))
-    def test_realized_pointwise_chunk_uses_copies(self, device, consumer):
+    def test_reused_pointwise_chunks(self, device, consumer):
         def fn(x, weight, tail):
             out = torch.empty((4, 4), device=x.device, dtype=x.dtype)
             head = x.cos()
@@ -130,6 +145,32 @@ class TestSliceScatterChunking(TestCase):
         gm = self._run_pass(fn, *args)
         targets = [node.target for node in gm.graph.nodes]
 
+        expected_copies = 2 if consumer == "matmul" else 0
+        self.assertEqual(
+            targets.count(aten.slice_scatter.default), 0 if expected_copies else 2
+        )
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), expected_copies)
+        self.assertEqual(gm(*args), fn(*args))
+
+    def test_realized_pointwise_chunks_use_copies(self, device):
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=head.device)
+            out = aten.slice_scatter.default(out, aten.angle.default(head), 0, 0, 2)
+            return aten.slice_scatter.default(out, aten.angle.default(tail), 0, 2, 4)
+
+        args = tuple(
+            torch.randn(2, 4, device=device, dtype=torch.complex64) for _ in range(2)
+        )
+        with mock.patch.object(
+            slice_scatter_chunking,
+            "is_node_realized",
+            wraps=slice_scatter_chunking.is_node_realized,
+        ) as is_realized:
+            gm = self._run_pass(fn, *args)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertTrue(is_realized.called)
         self.assertEqual(targets.count(aten.slice_scatter.default), 0)
         self.assertEqual(targets.count(aten.cat.default), 0)
         self.assertEqual(targets.count(aten.copy_.default), 2)
@@ -166,6 +207,46 @@ class TestSliceScatterChunking(TestCase):
         copies = gm.graph.find_nodes(op="call_function", target=aten.copy_.default)
         self.assertEqual([node.args[2] for node in copies], [True, True, True])
         self.assertEqual(gm(head, middle, tail), torch.cat((head, middle, tail)))
+
+    def test_view_inputs_as_kwargs(self, device):
+        def write(out, src, start, end):
+            dst = aten.slice.Tensor(aten.alias.default(out), 0, start, end)
+            copied = aten.copy.default(dst, src)
+            return aten.slice_scatter.default(
+                aten.alias.default(out), copied, 0, start, end
+            )
+
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
+            out = write(out, head, 0, 2)
+            return write(out, tail, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        gm = make_fx(fn, tracing_mode="fake")(head, tail)
+        for node in gm.graph.nodes:
+            if node.target not in (aten.alias.default, aten.slice.Tensor):
+                continue
+            node.kwargs = {
+                argument.name: value
+                for argument, value in zip(
+                    node.target._schema.arguments, node.args, strict=False
+                )
+            }
+            node.args = ()
+
+        fake_tensor_updater = FakeTensorUpdater(gm)
+        fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
+        with V.set_fake_mode(fake_mode):
+            slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
+            fake_tensor_updater.incremental_update()
+        gm.graph.lint()
+        gm.recompile()
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), 2)
+        self.assertEqual(gm(head, tail), fn(head, tail))
 
     @parametrize("base_kind", ("input", "pointwise", "aliasing"))
     def test_functionalized_copy_chain_rejects_base(self, device, base_kind):
@@ -318,15 +399,16 @@ class TestSliceScatterChunking(TestCase):
         self.assertEqual(targets.count(aten.slice_scatter.default), 2)
         self.assertEqual(targets.count(aten.copy_.default), 0)
 
-    def test_dynamic_boundaries(self, device):
+    @parametrize("last_end", (None, 2**63 - 1))
+    def test_dynamic_boundaries(self, device, last_end):
         def fn(head, tail):
             head_rows = head.shape[0]
             total_rows = head_rows + tail.shape[0]
             out = torch.empty(
                 (total_rows, head.shape[1]), device=head.device, dtype=head.dtype
             )
-            out = aten.slice_scatter.default(out, head, 0, 0, head_rows)
-            return aten.slice_scatter.default(out, tail, 0, head_rows, total_rows)
+            out = aten.slice_scatter.default(out, head, 0, None, head_rows)
+            return aten.slice_scatter.default(out, tail, 0, head_rows, last_end)
 
         head = torch.randn(2, 4, device=device)
         tail = torch.randn(3, 4, device=device)
@@ -334,7 +416,8 @@ class TestSliceScatterChunking(TestCase):
 
         targets = [node.target for node in gm.graph.nodes]
         self.assertEqual(targets.count(aten.slice_scatter.default), 0)
-        self.assertEqual(targets.count(aten.copy_.default), 2)
+        self.assertEqual(targets.count(aten.cat.default), 1)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
         self.assertEqual(gm(head, tail), torch.cat((head, tail)))
 
     @parametrize(
@@ -415,9 +498,6 @@ class TestSliceScatterChunking(TestCase):
 
         def fn(head, tail):
             out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
-            if replacement == "cat":
-                head = head.cos()
-                tail = tail.sin()
             out = write(out, head, 0, 2)
             return write(out, tail, 2, 4)
 
@@ -462,9 +542,7 @@ class TestSliceScatterChunking(TestCase):
             self.assertEqual(replacement_node.meta.get("custom"), custom)
         self.assertEqual(gm(head, tail), fn(head, tail))
 
-    @onlyCPU
-    @inductor_config.patch(force_disable_caches=True)
-    def test_deep_live_view_chain_compile(self, device):
+    def test_deep_live_view_chain(self, device):
         def fn(head, tail):
             out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
             out = aten.slice_scatter.default(out, head, 0, 0, 2)
@@ -475,9 +553,9 @@ class TestSliceScatterChunking(TestCase):
 
         head = torch.randn(2, 4, device=device)
         tail = torch.randn(2, 4, device=device)
-        compiled = torch.compile(fn, fullgraph=True)
+        gm = self._run_pass(fn, head, tail)
 
-        self.assertEqual(compiled(head, tail), fn(head, tail))
+        self.assertEqual(gm(head, tail), fn(head, tail))
 
     def test_ignores_dead_destination_views(self, device):
         def write(out, src, start, end):
@@ -585,7 +663,7 @@ class TestSliceScatterChunking(TestCase):
     @inductor_config.patch(force_disable_caches=True)
     def test_rejects_pinned_functionalized_copy_base(self, device):
         def fn(head, tail):
-            out = torch.empty_strided((4, 4), (1, 4), pin_memory=True)
+            out = torch.empty_strided((4, 4), (1, 4), device="cpu", pin_memory=True)
             first = aten.copy.default(out[:2], head)
             out = aten.slice_scatter.default(out, first, 0, 0, 2)
             last = aten.copy.default(out[2:4], tail)
@@ -838,9 +916,9 @@ class TestSliceScatterChunking(TestCase):
         can_fuse_as_cat = slice_scatter_chunking._can_fuse_as_cat
         saw_regional_cat = False
 
-        def tracked_can_fuse_as_cat(chain):
+        def tracked_can_fuse_as_cat(chain, graph_input_storages):
             nonlocal saw_regional_cat
-            result = can_fuse_as_cat(chain)
+            result = can_fuse_as_cat(chain, graph_input_storages)
             if any(
                 slice_scatter_chunking._is_nested_compile_region_output(src)
                 for src in chain.sources
@@ -869,7 +947,7 @@ class TestSliceScatterChunking(TestCase):
         self.assertLessEqual(peak, 129 * 2**20)
 
     @parametrize("dim", (0, -1))
-    def test_pointwise_chunks_fuse(self, device, dim):
+    def test_pointwise_chunks_are_not_rewritten(self, device, dim):
         def fn(head, tail):
             shape = list(head.shape)
             chunk_size = shape[dim]
@@ -887,22 +965,76 @@ class TestSliceScatterChunking(TestCase):
         actual = gm(head, tail)
         expected = fn(head, tail)
 
-        self.assertEqual(targets.count(aten.slice_scatter.default), 0)
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
         self.assertEqual(targets.count(aten.copy_.default), 0)
-        self.assertEqual(targets.count(aten.cat.default), 1)
+        self.assertEqual(targets.count(aten.cat.default), 0)
         self.assertEqual(actual, expected)
         self.assertEqual(actual.stride(), expected.stride())
 
     @onlyCUDA
     @inductor_config.patch(force_disable_caches=True)
-    def test_external_chunks_codegen(self, device):
-        def fn(head, middle, tail):
-            out = torch.empty((6, 1024), device=head.device, dtype=head.dtype)
-            out = aten.slice_scatter.default(out, head, 0, 0, 2)
-            out = aten.slice_scatter.default(out, middle, 0, 2, 4)
-            return aten.slice_scatter.default(out, tail, 0, 4, 6)
+    @parametrize("source_kind", ("distinct", "reused", "views", "getitem"))
+    def test_many_pointwise_chunks_preserve_fusion(self, device, source_kind):
+        chunk_count = 16 if source_kind == "distinct" else 3
 
-        args = tuple(torch.randn(2, 1024, device=device) for _ in range(3))
+        def fn(*chunks):
+            out = torch.empty(
+                (2 * chunk_count, 1024),
+                device=chunks[0].device,
+                dtype=chunks[0].dtype,
+            )
+            if source_kind == "distinct":
+                sources = tuple(chunk.cos() for chunk in chunks)
+            elif source_kind == "reused":
+                sources = (chunks[0].cos(),) * chunk_count
+            elif source_kind == "views":
+                source = chunks[0].cos()
+                sources = tuple(source[2 * i : 2 * i + 2] for i in range(chunk_count))
+            else:
+                sources = tuple(aten.frexp.Tensor(chunk)[0] for chunk in chunks)
+            for index, source in enumerate(sources):
+                out = aten.slice_scatter.default(
+                    out, source, 0, 2 * index, 2 * index + 2
+                )
+            return out
+
+        args = tuple(
+            torch.randn(
+                (2 * chunk_count, 1024) if source_kind == "views" else (2, 1024),
+                device=device,
+            )
+            for _ in range(chunk_count if source_kind in ("distinct", "getitem") else 1)
+        )
+        gm = self._run_pass(fn, *args)
+        targets = [node.target for node in gm.graph.nodes]
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), chunk_count)
+        self.assertEqual(actual, fn(*args))
+        self.assertEqual(code.count(".run("), 1)
+
+    @onlyCUDA
+    @inductor_config.patch(force_disable_caches=True)
+    @parametrize("source_kind", ("distinct", "reused", "views"))
+    def test_external_chunks_codegen(self, device, source_kind):
+        def fn(*inputs):
+            if source_kind == "distinct":
+                chunks = inputs
+            elif source_kind == "reused":
+                chunks = inputs * 3
+            else:
+                chunks = (inputs[0][:2], inputs[0][2:4], inputs[0][4:6])
+            out = torch.empty((6, 1024), device=inputs[0].device, dtype=inputs[0].dtype)
+            out = aten.slice_scatter.default(out, chunks[0], 0, 0, 2)
+            out = aten.slice_scatter.default(out, chunks[1], 0, 2, 4)
+            return aten.slice_scatter.default(out, chunks[2], 0, 4, 6)
+
+        if source_kind == "distinct":
+            args = tuple(torch.randn(2, 1024, device=device) for _ in range(3))
+        elif source_kind == "reused":
+            args = (torch.randn(2, 1024, device=device),)
+        else:
+            args = (torch.randn(6, 1024, device=device),)
         actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
 
         self.assertEqual(actual, fn(*args))
@@ -924,7 +1056,8 @@ class TestSliceScatterChunking(TestCase):
 instantiate_device_type_tests(
     TestSliceScatterChunking,
     globals(),
-    only_for=("cpu", "cuda"),
+    only_for=("cpu", "cuda", "xpu"),
+    allow_xpu=True,
 )
 
 

--- a/test/inductor/test_slice_scatter_chunking.py
+++ b/test/inductor/test_slice_scatter_chunking.py
@@ -892,7 +892,7 @@ class TestSliceScatterChunking(TestCase):
 
     @onlyCUDA
     @inductor_config.patch(reorder_for_locality=False, force_disable_caches=True)
-    def test_nested_compile_region_peak(self, device):
+    def test_nested_compile_region_uses_cat(self, device):
         @torch.compiler.nested_compile_region
         def chunk(a, b):
             return a @ b
@@ -936,15 +936,6 @@ class TestSliceScatterChunking(TestCase):
 
         self.assertTrue(saw_regional_cat)
         self.assertEqual(actual, fn(*args))
-        del actual
-        gc.collect()
-        torch.cuda.empty_cache()
-        baseline = torch.cuda.memory_allocated()
-        torch.cuda.reset_peak_memory_stats()
-        compiled(*args)
-        torch.cuda.synchronize()
-        peak = torch.cuda.max_memory_allocated() - baseline
-        self.assertLessEqual(peak, 129 * 2**20)
 
     @parametrize("dim", (0, -1))
     def test_pointwise_chunks_are_not_rewritten(self, device, dim):
@@ -1035,10 +1026,9 @@ class TestSliceScatterChunking(TestCase):
             args = (torch.randn(2, 1024, device=device),)
         else:
             args = (torch.randn(6, 1024, device=device),)
-        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
+        actual = torch.compile(fn, fullgraph=True)(*args)
 
         self.assertEqual(actual, fn(*args))
-        self.assertEqual(code.count(".run("), 1)
 
     @onlyCUDA
     def test_does_not_block_cos_fusion(self, device):

--- a/test/inductor/test_slice_scatter_chunking.py
+++ b/test/inductor/test_slice_scatter_chunking.py
@@ -1,0 +1,763 @@
+# Owner(s): ["module: inductor"]
+
+import gc
+from unittest import mock, skipIf
+
+import torch
+import torch._inductor.config as inductor_config
+from functorch import make_fx
+from torch._guards import detect_fake_mode
+from torch._inductor.compile_fx import compile_fx
+from torch._inductor.fx_passes import slice_scatter_chunking
+from torch._inductor.fx_utils import FakeTensorUpdater
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
+from torch._inductor.virtualized import V
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyCPU,
+    onlyCUDA,
+)
+from torch.testing._internal.common_utils import IS_MACOS, parametrize, subtest
+from torch.testing._internal.inductor_utils import requires_gpu
+from torch.utils._ordered_set import OrderedSet
+
+
+aten = torch.ops.aten
+
+
+class TestSliceScatterChunking(TestCase):
+    def _run_pass(self, fn, *args, tracing_mode="fake", custom=None):
+        gm = make_fx(fn, tracing_mode=tracing_mode)(*args)
+        if custom is not None:
+            for node in gm.graph.find_nodes(
+                op="call_function", target=aten.slice_scatter.default
+            ):
+                node.meta["custom"] = custom.copy()
+        fake_tensor_updater = FakeTensorUpdater(gm)
+        fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
+        with V.set_fake_mode(fake_mode):
+            slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
+            fake_tensor_updater.incremental_update()
+        gm.graph.lint()
+        gm.recompile()
+        return gm
+
+    @parametrize("factory", ("empty", "empty_strided"))
+    def test_complete_chain(self, device, factory):
+        def fn(head, middle, tail):
+            if factory == "empty":
+                out = torch.empty((6, 4), device=head.device, dtype=head.dtype)
+            else:
+                out = torch.empty_strided(
+                    (6, 4), (4, 1), device=head.device, dtype=head.dtype
+                )
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            out = aten.slice_scatter.default(out, middle, 0, 2, 4)
+            return aten.slice_scatter.default(out, tail, 0, 4, 6)
+
+        head = torch.randn(2, 4, device=device)
+        middle = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        gm = self._run_pass(fn, head, middle, tail)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertNotIn(aten.slice_scatter.default, targets)
+        self.assertEqual(targets.count(aten.cat.default), 1)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(gm(head, middle, tail), torch.cat((head, middle, tail)))
+
+    @parametrize("with_aliases", (False, True))
+    def test_functionalized_copy_chain(self, device, with_aliases):
+        def alias(value):
+            return aten.alias.default(value) if with_aliases else value
+
+        def write(out, src, start, end):
+            dst = aten.slice.Tensor(alias(out), 0, start, end)
+            copied = aten.copy.default(dst, src, non_blocking=True)
+            return alias(
+                aten.slice_scatter.default(alias(alias(out)), copied, 0, start, end)
+            )
+
+        def fn(head, middle, tail):
+            out = torch.empty((6, 4), device=head.device, dtype=head.dtype)
+            out = write(out, head, 0, 2)
+            out = write(out, middle, 2, 4)
+            return write(out, tail, 4, 6)
+
+        head = torch.randn(2, 4, device=device)
+        middle = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        gm = self._run_pass(fn, head, middle, tail)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertNotIn(aten.slice_scatter.default, targets)
+        self.assertNotIn(aten.copy.default, targets)
+        self.assertEqual(targets.count(aten.copy_.default), 3)
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        copies = gm.graph.find_nodes(op="call_function", target=aten.copy_.default)
+        self.assertEqual([node.args[2] for node in copies], [True, True, True])
+        self.assertEqual(gm(head, middle, tail), torch.cat((head, middle, tail)))
+
+    @parametrize("base_kind", ("input", "pointwise", "aliasing"))
+    def test_functionalized_copy_chain_rejects_base(self, device, base_kind):
+        def write(out, src, start, end):
+            copied = aten.copy.default(out[start:end], src)
+            return aten.slice_scatter.default(out, copied, 0, start, end)
+
+        def fn(head, tail, base):
+            if base_kind == "pointwise":
+                out = base.cos()
+            elif base_kind == "aliasing":
+                out = aten._unsafe_view.default(base, (4, 4))
+            else:
+                out = base
+            out = write(out, head, 0, 2)
+            return write(out, tail, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        base_shape = (16,) if base_kind == "aliasing" else (4, 4)
+        base = torch.randn(base_shape, device=device)
+        original = base.clone()
+        gm = self._run_pass(fn, head, tail, base)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(gm(head, tail, base), torch.cat((head, tail)))
+        self.assertEqual(base, original)
+
+    @onlyCUDA
+    def test_rejects_cross_device_functional_copy(self, device):
+        def write(out, src, start, end):
+            copied = aten.copy.default(torch.empty_like(src), src, non_blocking=True)
+            return aten.slice_scatter.default(out, copied, 0, start, end)
+
+        def fn(head, tail):
+            out = torch.empty((4, 4), device="cpu", pin_memory=True)
+            out = write(out, head, 0, 2)
+            return write(out, tail, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        gm = self._run_pass(fn, head, tail)
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(gm(head, tail), fn(head, tail))
+
+    @parametrize("case", ("broadcast", "dtype"))
+    def test_rejects_copy_that_changes_payload_metadata(self, device, case):
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=device)
+            first = aten.copy.default(out[:2], head)
+            out = aten.slice_scatter.default(out, first, 0, 0, 2)
+            last = aten.copy.default(out[2:], tail)
+            return aten.slice_scatter.default(out, last, 0, 2, 4)
+
+        shape = (1, 4) if case == "broadcast" else (2, 4)
+        dtype = torch.float64 if case == "dtype" else torch.float32
+        head = torch.randn(shape, device=device, dtype=dtype)
+        tail = torch.randn(shape, device=device, dtype=dtype)
+        gm = self._run_pass(fn, head, tail)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        self.assertEqual(gm(head, tail), fn(head, tail))
+
+    @parametrize("functionalized", (False, True))
+    def test_rejects_live_intermediate(self, device, functionalized):
+        def write(out, src, start, end):
+            if not functionalized:
+                return aten.slice_scatter.default(out, src, 0, start, end)
+            dst = aten.slice.Tensor(aten.alias.default(out), 0, start, end)
+            copied = aten.copy.default(dst, src)
+            return aten.slice_scatter.default(
+                aten.alias.default(out), copied, 0, start, end
+            )
+
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
+            first = write(out, head, 0, 2)
+            last = write(first, tail, 2, 4)
+            live = aten.alias.default(first) if functionalized else first
+            return live, last
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        gm = self._run_pass(fn, head, tail)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        first, last = gm(head, tail)
+        self.assertEqual(first[:2], head)
+        self.assertEqual(last, torch.cat((head, tail)))
+
+    @parametrize("base_kind", ("input", "pointwise", "offset", "extra_capacity"))
+    def test_cat_rejects_non_factory_base(self, device, base_kind):
+        def fn(head, tail, storage):
+            if base_kind == "input":
+                out = storage
+            elif base_kind == "pointwise":
+                out = storage.cos()
+            else:
+                view = storage[1:5] if base_kind == "offset" else storage[:4]
+                out = aten.select_scatter.default(view, storage[-1], 0, 0)
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            return aten.slice_scatter.default(out, tail, 0, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        rows = 4 if base_kind in ("input", "pointwise") else 6
+        storage = torch.randn(rows, 4, device=device)
+        expected = fn(head, tail, storage)
+        gm = self._run_pass(fn, head, tail, storage)
+        actual = gm(head, tail, storage)
+        targets = [node.target for node in gm.graph.nodes]
+
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        self.assertEqual(actual, expected)
+        if base_kind in ("offset", "extra_capacity"):
+            self.assertEqual(actual.storage_offset(), expected.storage_offset())
+            self.assertEqual(
+                actual.untyped_storage().nbytes(), expected.untyped_storage().nbytes()
+            )
+
+    @parametrize("case", ("partial", "gap"))
+    def test_requires_complete_chain(self, device, case):
+        def fn(head, tail, base):
+            out = torch.empty(base.shape, device=base.device, dtype=base.dtype)
+            if case == "partial":
+                out = aten.slice_scatter.default(out, head[:1], 0, 0, 1)
+                return aten.slice_scatter.default(out, tail[:1], 0, 1, 2)
+            if case == "gap":
+                out = aten.slice_scatter.default(out, head[:1], 0, 0, 1)
+                return aten.slice_scatter.default(out, tail[:1], 0, 2, 3)
+            raise AssertionError(f"unexpected case: {case}")
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        base = torch.randn(4, 4, device=device)
+        gm = self._run_pass(fn, head, tail, base)
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+
+    def test_dynamic_boundaries(self, device):
+        def fn(head, tail):
+            head_rows = head.shape[0]
+            total_rows = head_rows + tail.shape[0]
+            out = torch.empty(
+                (total_rows, head.shape[1]), device=head.device, dtype=head.dtype
+            )
+            out = aten.slice_scatter.default(out, head, 0, 0, head_rows)
+            return aten.slice_scatter.default(out, tail, 0, head_rows, total_rows)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(3, 4, device=device)
+        gm = self._run_pass(fn, head, tail, tracing_mode="symbolic")
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertNotIn(aten.slice_scatter.default, targets)
+        self.assertEqual(gm(head, tail), torch.cat((head, tail)))
+
+    @parametrize(
+        "case",
+        (
+            subtest(((4, 4), (0, 1), None), name="overlapping"),
+            subtest(((4, 4), (1, 4), (1, 4)), name="noncontiguous"),
+            subtest(((4, 1), (1, 99), (1, 99)), name="noncanonical"),
+        ),
+    )
+    def test_rejects_unsupported_factory_layout(self, device, case):
+        shape, stride, expected_stride = case
+
+        def fn(head, tail):
+            out = torch.empty_strided(
+                shape, stride, device=head.device, dtype=head.dtype
+            )
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            return aten.slice_scatter.default(out, tail, 0, 2, 4)
+
+        chunk_shape = (2, *shape[1:])
+        head = torch.randn(chunk_shape, device=device)
+        tail = torch.randn(chunk_shape, device=device)
+        gm = self._run_pass(fn, head, tail)
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        if expected_stride is not None:
+            self.assertEqual(gm(head, tail).stride(), expected_stride)
+
+    def test_requires_matching_dtype(self, device):
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=head.device, dtype=torch.float32)
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            return aten.slice_scatter.default(out, tail, 0, 2, 4)
+
+        head = torch.randn(2, 4, device=device, dtype=torch.float16)
+        tail = torch.randn(2, 4, device=device, dtype=torch.float16)
+        gm = self._run_pass(fn, head, tail)
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(gm(head, tail).dtype, torch.float32)
+
+    def test_skips_noncontiguous_sources(self, device):
+        def fn(head, tail):
+            out = torch.empty((2, 3, 1, 1), device=head.device, dtype=head.dtype)
+            out = aten.slice_scatter.default(out, head, 0, 0, 1)
+            out = aten.slice_scatter.default(out, tail, 0, 1, 2)
+            return aten.as_strided.default(out, (6,), (1,), 0)
+
+        head = torch.randn(1, 3, 1, 1, device=device).to(
+            memory_format=torch.channels_last
+        )
+        tail = torch.randn(1, 3, 1, 1, device=device).to(
+            memory_format=torch.channels_last
+        )
+        self.assertTrue(head.is_contiguous())
+        expected = fn(head, tail)
+        gm = self._run_pass(fn, head, tail)
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.copy_.default), 0)
+        self.assertEqual(gm(head, tail), expected)
+
+    @parametrize(
+        "same_context",
+        (
+            subtest(True, name="matching"),
+            subtest(False, name="different"),
+        ),
+    )
+    def test_custom_context(self, device, same_context):
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            return aten.slice_scatter.default(out, tail, 0, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        custom = {"stream": 1, "mempool": 2, "mempool_device": 0}
+        gm = make_fx(fn, tracing_mode="fake")(head, tail)
+        slice_scatters = gm.graph.find_nodes(
+            op="call_function", target=aten.slice_scatter.default
+        )
+        slice_scatters[0].meta["custom"] = custom.copy()
+        slice_scatters[1].meta["custom"] = (
+            custom.copy() if same_context else {**custom, "stream": 2}
+        )
+        fake_tensor_updater = FakeTensorUpdater(gm)
+        fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
+        with V.set_fake_mode(fake_mode):
+            slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
+            fake_tensor_updater.incremental_update()
+        gm.graph.lint()
+
+        cats = gm.graph.find_nodes(op="call_function", target=aten.cat.default)
+        remaining = gm.graph.find_nodes(
+            op="call_function", target=aten.slice_scatter.default
+        )
+        self.assertEqual(len(cats), 1 if same_context else 0)
+        self.assertEqual(len(remaining), 0 if same_context else 2)
+        if same_context:
+            self.assertEqual(cats[0].meta.get("custom"), custom)
+
+    def test_ignores_dead_destination_views(self, device):
+        def fn(head, tail):
+            out = torch.empty((4, 4), device=head.device, dtype=head.dtype)
+            aten.slice.Tensor(out, 0, 0, 2)
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            aten.slice.Tensor(out, 0, 2, 4)
+            return aten.slice_scatter.default(out, tail, 0, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        gm = self._run_pass(fn, head, tail)
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertNotIn(aten.slice.Tensor, targets)
+        self.assertNotIn(aten.slice_scatter.default, targets)
+        self.assertEqual(targets.count(aten.cat.default), 1)
+        self.assertEqual(gm(head, tail), fn(head, tail))
+
+    def test_rejects_intervening_mutation(self, device):
+        def fn(x):
+            x = x.clone()
+            head = x[:2]
+            out = torch.empty(x.shape, device=x.device, dtype=x.dtype)
+            out = aten.slice_scatter.default(out, head, 0, 0, 2)
+            x.add_(10)
+            return aten.slice_scatter.default(out, x[2:], 0, 2, 4)
+
+        x = torch.randn(4, 4, device=device)
+        gm = self._run_pass(fn, x)
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertEqual(targets.count(aten.slice_scatter.default), 2)
+        self.assertEqual(targets.count(aten.cat.default), 0)
+        self.assertEqual(gm(x), fn(x))
+
+    @onlyCUDA
+    @inductor_config.patch(force_disable_caches=True)
+    def test_mm_chunk_codegen(self, device):
+        def fn(a, b, c, d):
+            rows = a.shape[0]
+            out = torch.empty((rows * 2, b.shape[1]), device=a.device, dtype=a.dtype)
+            out[:rows].copy_(a @ b)
+            out[rows : rows * 2].copy_(c @ d)
+            return out
+
+        rows, width, inner = 2048, 4096, 8
+        args = tuple(
+            torch.randn(shape, device=device)
+            for shape in (
+                (rows, inner),
+                (inner, width),
+                (rows, inner),
+                (inner, width),
+            )
+        )
+        compiled = torch.compile(fn, fullgraph=True)
+        actual = compiled(*args)
+
+        self.assertEqual(actual, fn(*args))
+        del actual
+        gc.collect()
+        torch.cuda.empty_cache()
+        baseline = torch.cuda.memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
+        compiled(*args)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated() - baseline
+        self.assertLessEqual(peak, 65 * 2**20)
+
+    @inductor_config.patch(force_disable_caches=True)
+    def test_functionalized_copy_chain_compile(self, device):
+        def fn(head, tail):
+            out = torch.empty_strided(
+                (4, 4), (1, 4), device=head.device, dtype=head.dtype
+            )
+            first = aten.copy.default(out[:2], head)
+            out = aten.slice_scatter.default(out, first, 0, 0, 2)
+            last = aten.copy.default(out[2:4], tail)
+            return aten.slice_scatter.default(out, last, 0, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        gm = make_fx(fn, tracing_mode="fake")(head, tail)
+        with mock.patch.object(
+            slice_scatter_chunking,
+            "_replace_with_inplace_copies",
+            wraps=slice_scatter_chunking._replace_with_inplace_copies,
+        ) as replace:
+            compiled = compile_fx(gm, [head, tail])
+
+        self.assertEqual(replace.call_count, 1)
+        actual = compiled(head, tail)
+        expected = fn(head, tail)
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual.stride(), expected.stride())
+
+    @onlyCPU
+    @requires_gpu()
+    @skipIf(IS_MACOS, "pinned memory is not available on macOS")
+    @inductor_config.patch(force_disable_caches=True)
+    def test_rejects_pinned_functionalized_copy_base(self, device):
+        def fn(head, tail):
+            out = torch.empty_strided((4, 4), (1, 4), pin_memory=True)
+            first = aten.copy.default(out[:2], head)
+            out = aten.slice_scatter.default(out, first, 0, 0, 2)
+            last = aten.copy.default(out[2:4], tail)
+            return aten.slice_scatter.default(out, last, 0, 2, 4)
+
+        head = torch.randn(2, 4, device=device)
+        tail = torch.randn(2, 4, device=device)
+        expected = fn(head, tail)
+        gm = make_fx(fn, tracing_mode="fake")(head, tail)
+        with mock.patch.object(
+            slice_scatter_chunking,
+            "_replace_with_inplace_copies",
+            wraps=slice_scatter_chunking._replace_with_inplace_copies,
+        ) as replace:
+            compiled = compile_fx(gm, [head, tail])
+
+        self.assertEqual(replace.call_count, 0)
+        actual = compiled(head, tail)
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual.stride(), expected.stride())
+        self.assertEqual(actual.is_pinned(), expected.is_pinned())
+
+    def test_mutation_regions_computed_once_after_rewrites(self, device):
+        def fn(*chunks):
+            states = []
+            for head in chunks[::2]:
+                out = torch.empty((2, 4), device=head.device, dtype=head.dtype)
+                copied = aten.copy.default(out[:1], head)
+                states.append(aten.slice_scatter.default(out, copied, 0, 0, 1))
+
+            outputs = []
+            for state, tail in zip(states, chunks[1::2], strict=True):
+                copied = aten.copy.default(state[1:2], tail)
+                outputs.append(aten.slice_scatter.default(state, copied, 0, 1, 2))
+            return outputs
+
+        chunks = tuple(torch.randn(1, 4, device=device) for _ in range(6))
+        with mock.patch.object(
+            slice_scatter_chunking,
+            "compute_mutation_region_ids",
+            wraps=slice_scatter_chunking.compute_mutation_region_ids,
+        ) as compute:
+            gm = self._run_pass(fn, *chunks)
+
+        self.assertEqual(compute.call_count, 2)
+        self.assertEqual(
+            len(
+                gm.graph.find_nodes(
+                    op="call_function", target=aten.slice_scatter.default
+                )
+            ),
+            0,
+        )
+        self.assertEqual(gm(*chunks), fn(*chunks))
+
+    def test_rejected_chain_is_scanned_once(self, device):
+        chain_length = 20
+
+        def fn(base, chunks):
+            out = base
+            for index in range(chain_length):
+                out = aten.slice_scatter.default(
+                    out, chunks[index : index + 1], 0, index, index + 1
+                )
+            return out
+
+        base = torch.randn(chain_length, device=device)
+        chunks = torch.randn(chain_length, device=device)
+        gm = make_fx(fn, tracing_mode="fake")(base, chunks)
+        fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
+        with mock.patch.object(
+            slice_scatter_chunking,
+            "_normalize_slice_scatter_args",
+            wraps=slice_scatter_chunking._normalize_slice_scatter_args,
+        ) as normalize:
+            with V.set_fake_mode(fake_mode):
+                slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
+
+        gm.graph.lint()
+        gm.recompile()
+        self.assertLessEqual(normalize.call_count, chain_length * 3)
+        self.assertEqual(
+            len(
+                gm.graph.find_nodes(
+                    op="call_function", target=aten.slice_scatter.default
+                )
+            ),
+            chain_length,
+        )
+        self.assertEqual(gm(base, chunks), fn(base, chunks))
+
+    def test_graph_order_is_computed_once(self, device):
+        chain_count = 8
+
+        def fn(*chunks):
+            outputs = []
+            for head, tail in zip(chunks[::2], chunks[1::2], strict=True):
+                out = torch.empty((2, 4), device=head.device, dtype=head.dtype)
+                out = aten.slice_scatter.default(out, head, 0, 0, 1)
+                outputs.append(aten.slice_scatter.default(out, tail, 0, 1, 2))
+            return outputs
+
+        chunks = tuple(torch.randn(1, 4, device=device) for _ in range(chain_count * 2))
+        gm = make_fx(fn, tracing_mode="fake")(*chunks)
+        fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
+        original_nodes = torch.fx.Graph.nodes
+        graph_node_accesses = 0
+
+        def counted_nodes(graph):
+            nonlocal graph_node_accesses
+            if graph is gm.graph:
+                graph_node_accesses += 1
+            return original_nodes.__get__(graph, torch.fx.Graph)
+
+        with mock.patch.object(torch.fx.Graph, "nodes", property(counted_nodes)):
+            with V.set_fake_mode(fake_mode):
+                slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
+
+        gm.graph.lint()
+        gm.recompile()
+        self.assertLessEqual(graph_node_accesses, 3)
+        self.assertEqual(gm(*chunks), fn(*chunks))
+
+    def test_shared_alias_path_is_scanned_once(self, device):
+        alias_length = 12
+        chain_count = 8
+
+        def fn(*chunks):
+            base = torch.empty((2, 4), device=device)
+            for _ in range(alias_length):
+                base = aten.alias.default(base)
+            outputs = []
+            for head, tail in zip(chunks[::2], chunks[1::2], strict=True):
+                out = aten.slice_scatter.default(base, head, 0, 0, 1)
+                outputs.append(aten.slice_scatter.default(out, tail, 0, 1, 2))
+            return outputs
+
+        chunks = tuple(torch.randn(1, 4, device=device) for _ in range(chain_count * 2))
+        gm = make_fx(fn, tracing_mode="fake")(*chunks)
+        fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
+        ordered_set_add = OrderedSet.add
+        alias_adds = 0
+
+        def counted_add(values, value):
+            nonlocal alias_adds
+            if isinstance(value, torch.fx.Node) and value.target is aten.alias.default:
+                alias_adds += 1
+            return ordered_set_add(values, value)
+
+        with mock.patch.object(OrderedSet, "add", counted_add):
+            with V.set_fake_mode(fake_mode):
+                slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
+
+        gm.graph.lint()
+        gm.recompile()
+        self.assertLessEqual(alias_adds, alias_length * 3)
+        self.assertEqual(
+            len(
+                gm.graph.find_nodes(
+                    op="call_function", target=aten.slice_scatter.default
+                )
+            ),
+            chain_count * 2,
+        )
+        self.assertEqual(gm(*chunks), fn(*chunks))
+
+    def test_shared_copy_view_path_is_scanned_once(self, device):
+        alias_length = 12
+        chain_length = 8
+
+        def fn(*chunks):
+            base = torch.empty((chain_length, 4), device=device)
+            dst = base[:1]
+            for _ in range(alias_length):
+                dst = aten.alias.default(dst)
+            out = base
+            for index, chunk in enumerate(chunks):
+                copied = aten.copy.default(dst, chunk)
+                out = aten.slice_scatter.default(out, copied, 0, index, index + 1)
+            return out
+
+        chunks = tuple(torch.randn(1, 4, device=device) for _ in range(chain_length))
+        gm = make_fx(fn, tracing_mode="fake")(*chunks)
+        fake_mode = detect_fake_mode([node.meta.get("val") for node in gm.graph.nodes])
+        is_view_op = slice_scatter_chunking._is_view_op
+        view_checks = 0
+
+        def counted_is_view_op(target):
+            nonlocal view_checks
+            view_checks += 1
+            return is_view_op(target)
+
+        with mock.patch.object(
+            slice_scatter_chunking, "_is_view_op", counted_is_view_op
+        ):
+            with V.set_fake_mode(fake_mode):
+                slice_scatter_chunking.slice_scatter_chunking_pass(gm.graph)
+
+        gm.graph.lint()
+        gm.recompile()
+        self.assertLessEqual(view_checks, (alias_length + chain_length) * 3)
+        self.assertEqual(
+            len(
+                gm.graph.find_nodes(
+                    op="call_function", target=aten.slice_scatter.default
+                )
+            ),
+            chain_length,
+        )
+        self.assertEqual(gm(*chunks), fn(*chunks))
+
+    @onlyCUDA
+    @inductor_config.patch(reorder_for_locality=False, force_disable_caches=True)
+    def test_nested_compile_region_peak(self, device):
+        @torch.compiler.nested_compile_region
+        def chunk(a, b):
+            return a @ b
+
+        def fn(a, b, c, d):
+            rows = a.shape[0]
+            out = torch.empty((rows * 2, b.shape[1]), device=a.device, dtype=a.dtype)
+            out = aten.slice_scatter.default(out, chunk(a, b), 0, 0, rows)
+            return aten.slice_scatter.default(out, chunk(c, d), 0, rows, rows * 2)
+
+        rows, width, inner = 2048, 4096, 8
+        args = tuple(
+            torch.randn(shape, device=device)
+            for shape in (
+                (rows, inner),
+                (inner, width),
+                (rows, inner),
+                (inner, width),
+            )
+        )
+        compiled = torch.compile(fn, fullgraph=True)
+        actual = compiled(*args)
+
+        self.assertEqual(actual, fn(*args))
+        del actual
+        gc.collect()
+        torch.cuda.empty_cache()
+        baseline = torch.cuda.memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
+        compiled(*args)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated() - baseline
+        self.assertLessEqual(peak, 129 * 2**20)
+
+    @onlyCUDA
+    def test_pointwise_chunks_fuse(self, device):
+        def fn(x):
+            rows = x.shape[0] // 2
+            out = torch.empty(x.shape, device=x.device, dtype=x.dtype)
+            out = aten.slice_scatter.default(out, x[:rows].cos(), 0, 0, rows)
+            return aten.slice_scatter.default(out, x[rows:].sin(), 0, rows, x.shape[0])
+
+        x = torch.randn(8192, 1024, device=device)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), x)
+
+        self.assertEqual(actual, fn(x))
+        self.assertEqual(code.count(".run("), 1)
+
+    @onlyCUDA
+    def test_does_not_block_cos_fusion(self, device):
+        def fn(x, src):
+            return aten.slice_scatter.default(x.cos(), src, 0, 1, 3)
+
+        x = torch.randn(4, 1024, device=device)
+        src = torch.randn(2, 1024, device=device)
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), x, src)
+
+        self.assertEqual(actual, fn(x, src))
+        self.assertEqual(code.count(".run("), 1)
+
+
+instantiate_device_type_tests(
+    TestSliceScatterChunking,
+    globals(),
+    only_for=("cpu", "cuda"),
+)
+
+
+if __name__ == "__main__":
+    run_tests(needs="filelock")

--- a/torch/_inductor/fx_passes/README.md
+++ b/torch/_inductor/fx_passes/README.md
@@ -7,9 +7,12 @@ The current way we do this is through FakeTensorUpdater (in _inductor/fx_utils.p
 ## Mutations throughout the stack
 The invariant about mutation we have is:
 
-**After AOTDispatch tracing and before Inductor, we have no mutation in our graph, except for a copy_ epilogue at the end of the graph.**
+**After AOTDispatch tracing, we have no mutation in our graph, except for a
+copy_ epilogue at the end of the graph, until the final post-grad passes
+described below.**
 
-For example, passes operating on the joint_graph and post_grad graph do not need to worry about mutation at all.
+For example, most passes operating on the joint_graph and post_grad graph do
+not need to worry about mutation.
 
 However, we do still have aliasing in the graph. This does not matter most of the time, but it does mean that **our passes are not allowed to cause any additional inputs/outputs to alias if they did not alias in the original graph**.
 
@@ -35,4 +38,8 @@ inputs and outputs have any aliasing, it suffices to check whether the
 storages of the input and the storages of the output have any overlap. See
 `remove_noop_ops` for an example of how to do this.
 
-Additionally, we do have one pass that *does* introduce mutation - `reinplace_inplaceable_ops`. This pass must run *just before Inductor lowering*, as otherwise this breaks our invariant.
+The final post-grad passes are exceptions: `slice_scatter_chunking_pass` may
+replace a fully overwriting functional chain with writes into a fresh base,
+then `reinplace_inplaceable_ops` may introduce further mutation. These passes
+must run in that order *just before Inductor lowering*, as otherwise this breaks
+our invariant.

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -68,6 +68,7 @@ from .micro_pipeline_tp import micro_pipeline_tp_pass
 from .pre_grad import is_same_dict, save_inductor_dict
 from .reduced_atomic_contention import partitioned_scatter_optimization_pass
 from .reinplace import reinplace_inplaceable_ops
+from .slice_scatter_chunking import slice_scatter_chunking_pass
 from .split_cat import POST_GRAD_PATTERNS
 
 
@@ -461,6 +462,14 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
     # Keep these last, since they introduce mutation. Look at
     # ./fx_passes/README.md for a discussion of mutation invariants.
+    if config.pattern_matcher:
+        introduced_mutation = GraphTransformObserver(
+            gm, "slice_scatter_chunking"
+        ).apply_graph_pass(
+            slice_scatter_chunking_pass,
+        )
+        if introduced_mutation:
+            fake_tensor_updater.incremental_update()
     GraphTransformObserver(gm, "reinplace_inplaceable_ops").apply_graph_pass(
         functools.partial(reinplace_inplaceable_ops, fake_tensor_updater),
     )

--- a/torch/_inductor/fx_passes/slice_scatter_chunking.py
+++ b/torch/_inductor/fx_passes/slice_scatter_chunking.py
@@ -1,0 +1,448 @@
+# mypy: allow-untyped-defs
+"""
+Optimize complete chains that assemble a tensor from slices.
+
+Match and replace contiguous chunks as follows:
+
+    out = base
+    out = aten.slice_scatter(out, chunk0, dim, 0, end0)
+    out = aten.slice_scatter(out, chunk1, dim, end0, end1)
+    out = aten.slice_scatter(out, chunk2, dim, end1, size)
+
+    out = aten.cat([chunk0, chunk1, chunk2], dim)
+
+Functionalization can additionally wrap a chunk in a fully overwriting
+``copy(slice(out), chunk)`` and insert aliases around ``out``. For that form,
+reuse an ``empty`` or ``empty_strided`` base allocation and replace the chain
+with ``copy_`` into its slices. This consumes each chunk where its original
+``slice_scatter`` occurred instead of keeping every chunk live until a final
+``cat``.
+
+The writes must replace every value from ``base``. The output and chunks must
+have the same dtype, and ``cat`` must preserve the output layout. Other chains
+are left unchanged for normal lowering.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch._inductor.pattern_matcher import (
+    CallFunctionVarArgs,
+    compute_mutation_region_ids,
+    Match,
+    MULTIPLE,
+)
+from torch._prims_common import make_contiguous_strides_for
+from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
+from torch.fx.operator_schemas import normalize_function
+from torch.fx.passes.reinplace import _is_view_op
+from torch.utils._ordered_set import OrderedSet
+
+
+aten = torch.ops.aten
+_SLICE_SCATTER_PATTERN = CallFunctionVarArgs(aten.slice_scatter.default, users=MULTIPLE)
+_SUPPORTED_BASE_FACTORIES = (
+    aten.empty.memory_format,
+    aten.empty_strided.default,
+)
+
+
+@dataclass
+class _SliceScatterChain:
+    base: torch.fx.Node
+    slice_scatters: list[torch.fx.Node]
+    dim: int
+    sources: list[torch.fx.Node]
+    removable_nodes: OrderedSet[torch.fx.Node]
+    functional_copies: list[torch.fx.Node]
+    non_blocking: list[Any]
+
+
+def _normalize_slice_scatter_args(node: torch.fx.Node) -> dict[str, Any]:
+    normalized = normalize_function(
+        aten.slice_scatter.default,
+        args=node.args,
+        kwargs=node.kwargs,
+        normalize_to_only_use_kwargs=True,
+    )
+    if normalized is None:
+        raise AssertionError(f"failed to normalize arguments for {node}")
+    return normalized.kwargs
+
+
+def _get_val(value: Any) -> Any:
+    return value.meta.get("val") if isinstance(value, torch.fx.Node) else value
+
+
+def _statically_known_eq(lhs: Any, rhs: Any) -> bool:
+    lhs = _get_val(lhs)
+    rhs = _get_val(rhs)
+    if lhs is None or rhs is None:
+        return False
+    return statically_known_true(sym_eq(lhs, rhs))
+
+
+def _statically_known_same_shape(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    return lhs.dim() == rhs.dim() and all(
+        _statically_known_eq(lhs_size, rhs_size)
+        for lhs_size, rhs_size in zip(lhs.shape, rhs.shape, strict=True)
+    )
+
+
+def _custom_context(node: torch.fx.Node) -> tuple[Any, Any, Any]:
+    custom = node.meta.get("custom", {})
+    return (
+        custom.get("stream", 0),
+        custom.get("mempool"),
+        custom.get("mempool_device"),
+    )
+
+
+def _strip_aliases(
+    node: Any,
+    removable_nodes: OrderedSet[torch.fx.Node],
+    examined: OrderedSet[torch.fx.Node],
+) -> Any:
+    while isinstance(node, torch.fx.Node) and node.target is aten.alias.default:
+        if node in examined:
+            return None
+        examined.add(node)
+        removable_nodes.add(node)
+        node = node.args[0]
+    return node
+
+
+def _copy_source(
+    node: torch.fx.Node,
+) -> tuple[torch.fx.Node, torch.fx.Node, Any] | None:
+    """Return the payload of a non-broadcasting, non-converting functional copy.
+
+    A functional copy completely overwrites its first argument. When its payload
+    already has the output shape, dtype, and device, the result has the same
+    values as the payload without reading the destination.
+    """
+    normalized = normalize_function(
+        aten.copy.default,
+        args=node.args,
+        kwargs=node.kwargs,
+        normalize_to_only_use_kwargs=True,
+    )
+    if normalized is None:
+        raise AssertionError(f"failed to normalize arguments for {node}")
+    copy_input = normalized.kwargs["input"]
+    payload = normalized.kwargs["src"]
+    result_val = node.meta.get("val")
+    payload_val = (
+        payload.meta.get("val") if isinstance(payload, torch.fx.Node) else None
+    )
+    if (
+        not isinstance(payload, torch.fx.Node)
+        or not isinstance(copy_input, torch.fx.Node)
+        or not isinstance(result_val, torch.Tensor)
+        or not isinstance(payload_val, torch.Tensor)
+        or result_val.dtype != payload_val.dtype
+        or result_val.device != payload_val.device
+        or not _statically_known_same_shape(result_val, payload_val)
+    ):
+        return None
+    return payload, copy_input, normalized.kwargs["non_blocking"]
+
+
+def _view_path_to_state(
+    node: Any,
+    state_nodes: OrderedSet[torch.fx.Node],
+    examined: OrderedSet[torch.fx.Node],
+) -> list[torch.fx.Node] | None:
+    path = []
+    while isinstance(node, torch.fx.Node) and _is_view_op(node.target):
+        if node in examined:
+            return None
+        examined.add(node)
+        path.append(node)
+        node = node.args[0]
+    return path if node in state_nodes else None
+
+
+def _collect_dead_view_nodes(
+    node: torch.fx.Node, removable_nodes: OrderedSet[torch.fx.Node]
+) -> bool:
+    if node in removable_nodes:
+        return True
+    if not _is_view_op(node.target) or any(
+        not _collect_dead_view_nodes(user, removable_nodes) for user in node.users
+    ):
+        return False
+    removable_nodes.add(node)
+    return True
+
+
+def _get_full_tensor_slice_scatter_chain(
+    slice_scatter: torch.fx.Node,
+    examined: OrderedSet[torch.fx.Node],
+) -> _SliceScatterChain | None:
+    """Return a chain whose adjacent slices overwrite the entire base tensor."""
+    removable_nodes = OrderedSet[torch.fx.Node]()
+    slice_scatters = []
+    current = slice_scatter
+    while (
+        isinstance(current, torch.fx.Node)
+        and current.target is aten.slice_scatter.default
+    ):
+        if current in examined:
+            return None
+        examined.add(current)
+        slice_scatters.append(current)
+        removable_nodes.add(current)
+        current = _strip_aliases(
+            _normalize_slice_scatter_args(current)["input"], removable_nodes, examined
+        )
+    slice_scatters.reverse()
+
+    if not isinstance(current, torch.fx.Node) or len(slice_scatters) < 2:
+        return None
+
+    base_val = current.meta.get("val")
+    if (
+        not isinstance(base_val, torch.Tensor)
+        or base_val.dim() == 0
+        or torch._debug_has_internal_overlap(base_val) != 0
+    ):
+        return None
+
+    dim = _normalize_slice_scatter_args(slice_scatters[0])["dim"]
+    if not isinstance(dim, int):
+        return None
+    dim %= base_val.dim()
+
+    cursor = 0
+    sources = []
+    functional_copies = []
+    non_blocking = []
+    state_nodes = OrderedSet([current, *slice_scatters[:-1]])
+    copy_view_nodes = OrderedSet[torch.fx.Node]()
+    for matched_slice_scatter in slice_scatters:
+        args = _normalize_slice_scatter_args(matched_slice_scatter)
+        node_dim = args["dim"]
+        start = args["start"]
+        end = args["end"]
+        step = args["step"]
+        src = args["src"]
+        if isinstance(src, torch.fx.Node) and src.target is aten.copy.default:
+            copy_source = _copy_source(src)
+            if copy_source is None:
+                return None
+            src, copy_input, copy_non_blocking = copy_source
+            functional_copies.append(args["src"])
+            removable_nodes.add(args["src"])
+            view_path = _view_path_to_state(copy_input, state_nodes, copy_view_nodes)
+            if view_path is None:
+                return None
+            removable_nodes.update(view_path)
+        else:
+            copy_non_blocking = False
+        start_val = _get_val(start)
+        end_val = _get_val(end)
+        if not isinstance(node_dim, int) or not isinstance(src, torch.fx.Node):
+            return None
+        node_dim %= base_val.dim()
+        src_val = src.meta.get("val")
+        if (
+            node_dim != dim
+            or start_val is None
+            or end_val is None
+            or step != 1
+            or not _statically_known_eq(start_val, cursor)
+            or not isinstance(src_val, torch.Tensor)
+            or src_val.dim() != base_val.dim()
+            or src_val.dtype != base_val.dtype
+            or src_val.device != base_val.device
+            or any(
+                not _statically_known_eq(src_size, base_size)
+                for index, (src_size, base_size) in enumerate(
+                    zip(src_val.shape, base_val.shape, strict=True)
+                )
+                if index != dim
+            )
+            or not _statically_known_eq(src_val.shape[dim], end_val - start_val)
+        ):
+            return None
+        cursor = end_val
+        sources.append(src)
+        non_blocking.append(copy_non_blocking)
+
+    if not _statically_known_eq(cursor, base_val.shape[dim]):
+        return None
+
+    for node in [current, *removable_nodes]:
+        for user in list(node.users):
+            _collect_dead_view_nodes(user, removable_nodes)
+
+    if any(src is current or src in removable_nodes for src in sources) or any(
+        node is not slice_scatter
+        and any(user not in removable_nodes for user in node.users)
+        for node in [current, *removable_nodes]
+    ):
+        return None
+
+    custom_context = _custom_context(slice_scatter)
+    mutation_region = slice_scatter.meta.get("mutation_region_id")
+    if any(
+        _custom_context(node) != custom_context
+        or node.meta.get("mutation_region_id") != mutation_region
+        for node in [*slice_scatters[:-1], *functional_copies]
+    ):
+        return None
+
+    return _SliceScatterChain(
+        current,
+        slice_scatters,
+        dim,
+        sources,
+        removable_nodes,
+        functional_copies,
+        non_blocking,
+    )
+
+
+def _is_supported_base_factory(node: torch.fx.Node) -> bool:
+    return node.op == "call_function" and node.target in _SUPPORTED_BASE_FACTORIES
+
+
+def _is_reusable_base_factory(node: torch.fx.Node) -> bool:
+    if not _is_supported_base_factory(node):
+        return False
+    target = node.target
+    if not callable(target):
+        return False
+    normalized = normalize_function(
+        target,
+        args=node.args,
+        kwargs=node.kwargs,
+        normalize_to_only_use_kwargs=True,
+    )
+    if normalized is None:
+        return False
+    pin_memory = normalized.kwargs.get("pin_memory")
+    return pin_memory is None or pin_memory is False
+
+
+def _replace_with_inplace_copies(match: Match, chain: _SliceScatterChain) -> None:
+    graph = chain.base.graph
+    for slice_scatter, source, non_blocking in zip(
+        chain.slice_scatters, chain.sources, chain.non_blocking, strict=True
+    ):
+        args = _normalize_slice_scatter_args(slice_scatter)
+        with graph.inserting_before(slice_scatter):
+            dst = graph.call_function(
+                aten.slice.Tensor,
+                args=(
+                    chain.base,
+                    chain.dim,
+                    args["start"],
+                    args["end"],
+                    args["step"],
+                ),
+            )
+            copy = graph.call_function(
+                aten.copy_.default, args=(dst, source, non_blocking)
+            )
+        if custom := slice_scatter.meta.get("custom"):
+            dst.meta["custom"] = custom.copy()
+            copy.meta["custom"] = custom.copy()
+
+    chain.slice_scatters[-1].replace_all_uses_with(chain.base)
+    match.erase_nodes()
+
+
+def _is_inductor_optimizable_cat(
+    base: torch.fx.Node, sources: list[torch.fx.Node]
+) -> bool:
+    # cat is usable only when it preserves the factory's tensor metadata and
+    # presents ordinary contiguous inputs to Inductor's fusion machinery.
+    base_val = base.meta.get("val")
+    if not isinstance(base_val, torch.Tensor):
+        return False
+    if (
+        not _is_supported_base_factory(base)
+        or base_val.layout != torch.strided
+        or not _has_contiguous_memory_format_strides(base_val)
+    ):
+        return False
+    return all(
+        isinstance(src_val := src.meta.get("val"), torch.Tensor)
+        and src_val.device == base_val.device
+        and src_val.dtype == base_val.dtype
+        and src_val.layout == base_val.layout
+        and _has_contiguous_memory_format_strides(src_val)
+        for src in sources
+    )
+
+
+def _has_contiguous_memory_format_strides(tensor: torch.Tensor) -> bool:
+    return all(
+        _statically_known_eq(actual, expected)
+        for actual, expected in zip(
+            tensor.stride(), make_contiguous_strides_for(tensor.shape), strict=True
+        )
+    )
+
+
+def slice_scatter_chunking_pass(graph: torch.fx.Graph) -> bool:
+    """Rewrite complete slice_scatter chains as cat or bounded-lifetime copies."""
+    compute_mutation_region_ids(graph)
+    introduced_mutation = False
+    slice_scatters = graph.find_nodes(
+        op="call_function", target=aten.slice_scatter.default
+    )
+    node_order = {node: index for index, node in enumerate(graph.nodes)}
+    examined = OrderedSet[torch.fx.Node]()
+    for slice_scatter in reversed(slice_scatters):
+        # Only consider maximal chains. Retrying every rejected prefix makes a
+        # long unsupported chain quadratic and is not needed by the target use case.
+        if slice_scatter._erased or slice_scatter in examined:
+            continue
+        match = _SLICE_SCATTER_PATTERN.match(slice_scatter)
+        # A full-tensor chain overwrites the base through adjacent slices with
+        # no gaps or overlaps, so the original base values are unobservable.
+        if not isinstance(match, Match):
+            continue
+
+        result = _get_full_tensor_slice_scatter_chain(slice_scatter, examined)
+        if result is None:
+            continue
+
+        match.nodes = sorted(result.removable_nodes, key=node_order.__getitem__)
+
+        # A functional copy snapshots each chunk at its original write. Keep
+        # that lifetime by writing into a proven-fresh base at the same point;
+        # cat would retain every chunk until the end of the chain.
+        if result.functional_copies:
+            if not _is_reusable_base_factory(result.base):
+                continue
+            if _custom_context(result.base) != _custom_context(
+                result.slice_scatters[-1]
+            ):
+                continue
+            _replace_with_inplace_copies(match, result)
+            introduced_mutation = True
+            continue
+
+        if not _is_inductor_optimizable_cat(result.base, result.sources):
+            continue
+
+        def replacement(*chunks):
+            return torch.cat(chunks, dim=result.dim)
+
+        match.replace_by_example(replacement, result.sources)
+        if (
+            result.base.op == "call_function"
+            and not result.base.users
+            and not result.base.is_impure()
+        ):
+            graph.erase_node(result.base)
+    if introduced_mutation:
+        # Each mutated base is writable storage disjoint from its inputs and has
+        # no users outside its chain, so rewrites cannot invalidate later matches.
+        compute_mutation_region_ids(graph)
+    return introduced_mutation

--- a/torch/_inductor/fx_passes/slice_scatter_chunking.py
+++ b/torch/_inductor/fx_passes/slice_scatter_chunking.py
@@ -1,31 +1,31 @@
 # mypy: allow-untyped-defs
 """
-Optimize complete chains that assemble a tensor from slices.
+Rewrite slice_scatter chains that fill an entire tensor into cat or bounded copies.
 
-Match and replace contiguous chunks as follows:
+Functionalizing chunking results in a chain of slice_scatter nodes,
+holding full-sized intermediate by the end of the chain.
 
-    out = base
-    copied0 = aten.copy(aten.slice(out, dim, 0, end0), chunk0)
-    out = aten.slice_scatter(out, copied0, dim, 0, end0)
-    copied1 = aten.copy(aten.slice(out, dim, end0, size), chunk1)
-    out = aten.slice_scatter(out, copied1, dim, end0, size)
+The goal is to remove the full-sized intermediates without regressing producer fusion.
+
+Input:
+
+    base = aten.empty(size)
+    out = aten.slice_scatter(base, chunk0, dim, 0, end0)
+    out = aten.slice_scatter(out, chunk1, dim, end0, size)
+
+Output:
+1. cat, when chunks are backed by graph inputs or supported nested regions.
+
+    out = aten.cat([chunk0, chunk1], dim)
+
+2. copies into the reused base, so each chunk dies at its own write:
 
     aten.copy_(aten.slice(base, dim, 0, end0), chunk0)
     aten.copy_(aten.slice(base, dim, end0, size), chunk1)
     out = base
 
-The source may be the chunk directly, or functionalization may wrap it in a
-fully overwriting ``copy(slice(out), chunk)`` and insert aliases around
-``out``. Reuse an ``empty`` or ``empty_strided`` base allocation and replace
-the chain with ``copy_`` into its slices. This consumes each chunk where its
-original ``slice_scatter`` occurred instead of keeping every chunk live until
-the end of the chain. Canonical single-use graph inputs, non-realized contiguous
-pointwise chunks, and CUDA outputs of nested compile regions instead become
-``cat`` so they can use one output copy.
-
-The writes must replace every value from ``base``, and the output and chunks
-must have the same dtype and device. Other chains are left unchanged for normal
-lowering.
+Unrealized pointwise intermediate storages are left unchanged. Their fusion
+behavior depends on IR-level decisions that are unavailable here.
 """
 
 import operator
@@ -33,13 +33,14 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-from torch._inductor.fx_utils import is_node_realized
+from torch._inductor.fx_utils import get_node_storage, is_node_realized
 from torch._inductor.pattern_matcher import (
     CallFunctionVarArgs,
     compute_mutation_region_ids,
     Match,
     MULTIPLE,
 )
+from torch._inductor.utils import is_gpu
 from torch._prims_common import make_contiguous_strides_for
 from torch.fx.experimental.symbolic_shapes import statically_known_true, sym_eq
 from torch.fx.operator_schemas import normalize_function
@@ -106,6 +107,15 @@ def _custom_context(node: torch.fx.Node) -> tuple[Any, Any, Any]:
     )
 
 
+def _get_tensor_input(node: torch.fx.Node) -> Any:
+    if node.args:
+        return node.args[0]
+    target = node.target
+    if not isinstance(target, torch._ops.OpOverload) or not target._schema.arguments:
+        return None
+    return node.kwargs.get(target._schema.arguments[0].name)
+
+
 def _strip_aliases(
     node: Any,
     removable_nodes: OrderedSet[torch.fx.Node],
@@ -116,7 +126,7 @@ def _strip_aliases(
             return None
         examined.add(node)
         removable_nodes.add(node)
-        node = node.args[0]
+        node = _get_tensor_input(node)
     return node
 
 
@@ -167,7 +177,7 @@ def _view_path_to_state(
             return None
         examined.add(node)
         path.append(node)
-        node = node.args[0]
+        node = _get_tensor_input(node)
     return path if node in state_nodes else None
 
 
@@ -264,8 +274,12 @@ def _get_full_tensor_slice_scatter_chain(
             removable_nodes.update(view_path)
         else:
             copy_non_blocking = False
-        start_val = _get_val(start)
+        start_val = 0 if start is None else _get_val(start)
         end_val = _get_val(end)
+        if end is None or (
+            end_val is not None and statically_known_true(end_val >= 2**63 - 1)
+        ):
+            end_val = base_val.shape[dim]
         if not isinstance(node_dim, int) or not isinstance(src, torch.fx.Node):
             return None
         node_dim %= base_val.dim()
@@ -388,11 +402,46 @@ def _is_nested_compile_region_output(node: torch.fx.Node) -> bool:
         and region.op == "call_function"
         and region.target is torch.ops.higher_order.invoke_subgraph
         and isinstance(value, torch.Tensor)
-        and value.device.type == "cuda"
+        and is_gpu(value.device.type)
     )
 
 
-def _can_fuse_as_cat(chain: _SliceScatterChain) -> bool:
+def _is_pointwise_output(node: torch.fx.Node) -> bool:
+    producer = node
+    if (
+        node.op == "call_function"
+        and node.target is operator.getitem
+        and node.args
+        and isinstance(node.args[0], torch.fx.Node)
+    ):
+        producer = node.args[0]
+    return (
+        isinstance(producer.target, torch._ops.OpOverload)
+        and torch.Tag.pointwise in producer.target.tags
+    )
+
+
+def _requires_preserving_chain(
+    chain: _SliceScatterChain,
+    graph_input_storages: OrderedSet[int],
+    pointwise_intermediate_storages: OrderedSet[int],
+) -> bool:
+    if chain.functional_copies:
+        return False
+    for src in chain.sources:
+        storage = get_node_storage(src)
+        if storage is not None and storage in graph_input_storages:
+            continue
+        if storage is not None and storage in pointwise_intermediate_storages:
+            # Rewriting an unrealized pointwise storage may split its producer
+            # into one kernel per chunk. Leave that decision to IR lowering.
+            return True
+    return False
+
+
+def _can_fuse_as_cat(
+    chain: _SliceScatterChain, graph_input_storages: OrderedSet[int]
+) -> bool:
     base_val = chain.base.meta.get("val")
     if (
         chain.functional_copies
@@ -402,16 +451,18 @@ def _can_fuse_as_cat(chain: _SliceScatterChain) -> bool:
         return False
 
     for src in chain.sources:
-        is_input = src.op == "placeholder"
-        is_pointwise = (
-            isinstance(src.target, torch._ops.OpOverload)
-            and torch.Tag.pointwise in src.target.tags
-        )
-        if (
-            len(src.users) != 1
-            or not (is_input or is_pointwise or _is_nested_compile_region_output(src))
-            or (not is_input and is_node_realized(src))
-        ):
+        storage = get_node_storage(src)
+        is_input_storage = storage is not None and storage in graph_input_storages
+        if is_input_storage:
+            continue
+        # A shared source cannot disappear into cat.
+        if len(src.users) != 1:
+            return False
+        # Nested-region outputs have a supported one-copy cat path.
+        if not _is_nested_compile_region_output(src):
+            return False
+        # Only unrealized region outputs can use that path without an extra buffer.
+        if is_node_realized(src):
             return False
 
     tensors = [base_val, *(src.meta.get("val") for src in chain.sources)]
@@ -442,14 +493,22 @@ def slice_scatter_chunking_pass(graph: torch.fx.Graph) -> bool:
 
     compute_mutation_region_ids(graph)
     introduced_mutation = False
-    node_order = {node: index for index, node in enumerate(graph.nodes)}
+    node_order = {}
+    graph_input_storages: OrderedSet[int] = OrderedSet()
+    pointwise_intermediate_storages: OrderedSet[int] = OrderedSet()
+    for index, node in enumerate(graph.nodes):
+        node_order[node] = index
+        if (storage := get_node_storage(node)) is not None:
+            if node.op == "placeholder":
+                graph_input_storages.add(storage)
+            elif _is_pointwise_output(node) and not is_node_realized(node):
+                pointwise_intermediate_storages.add(storage)
     examined = OrderedSet[torch.fx.Node]()
     for slice_scatter in reversed(slice_scatters):
-        # Only consider maximal chains. Retrying every rejected prefix makes a
-        # long unsupported chain quadratic and is not needed by the target use case.
         if slice_scatter._erased or slice_scatter in examined:
             continue
         match = _SLICE_SCATTER_PATTERN.match(slice_scatter)
+
         # A full-tensor chain overwrites the base through adjacent slices with
         # no gaps or overlaps, so the original base values are unobservable.
         if not isinstance(match, Match):
@@ -466,7 +525,12 @@ def slice_scatter_chunking_pass(graph: torch.fx.Graph) -> bool:
         if _custom_context(result.base) != _custom_context(result.slice_scatters[-1]):
             continue
 
-        if _can_fuse_as_cat(result):
+        if _requires_preserving_chain(
+            result, graph_input_storages, pointwise_intermediate_storages
+        ):
+            continue
+
+        if _can_fuse_as_cat(result, graph_input_storages):
 
             def replacement(*chunks):
                 return torch.cat(chunks, dim=result.dim)

--- a/torch/_inductor/fx_passes/slice_scatter_chunking.py
+++ b/torch/_inductor/fx_passes/slice_scatter_chunking.py
@@ -5,28 +5,35 @@ Optimize complete chains that assemble a tensor from slices.
 Match and replace contiguous chunks as follows:
 
     out = base
-    out = aten.slice_scatter(out, chunk0, dim, 0, end0)
-    out = aten.slice_scatter(out, chunk1, dim, end0, end1)
-    out = aten.slice_scatter(out, chunk2, dim, end1, size)
+    copied0 = aten.copy(aten.slice(out, dim, 0, end0), chunk0)
+    out = aten.slice_scatter(out, copied0, dim, 0, end0)
+    copied1 = aten.copy(aten.slice(out, dim, end0, size), chunk1)
+    out = aten.slice_scatter(out, copied1, dim, end0, size)
 
-    out = aten.cat([chunk0, chunk1, chunk2], dim)
+    aten.copy_(aten.slice(base, dim, 0, end0), chunk0)
+    aten.copy_(aten.slice(base, dim, end0, size), chunk1)
+    out = base
 
-Functionalization can additionally wrap a chunk in a fully overwriting
-``copy(slice(out), chunk)`` and insert aliases around ``out``. For that form,
-reuse an ``empty`` or ``empty_strided`` base allocation and replace the chain
-with ``copy_`` into its slices. This consumes each chunk where its original
-``slice_scatter`` occurred instead of keeping every chunk live until a final
-``cat``.
+The source may be the chunk directly, or functionalization may wrap it in a
+fully overwriting ``copy(slice(out), chunk)`` and insert aliases around
+``out``. Reuse an ``empty`` or ``empty_strided`` base allocation and replace
+the chain with ``copy_`` into its slices. This consumes each chunk where its
+original ``slice_scatter`` occurred instead of keeping every chunk live until
+the end of the chain. Canonical single-use graph inputs, non-realized contiguous
+pointwise chunks, and CUDA outputs of nested compile regions instead become
+``cat`` so they can use one output copy.
 
-The writes must replace every value from ``base``. The output and chunks must
-have the same dtype, and ``cat`` must preserve the output layout. Other chains
-are left unchanged for normal lowering.
+The writes must replace every value from ``base``, and the output and chunks
+must have the same dtype and device. Other chains are left unchanged for normal
+lowering.
 """
 
+import operator
 from dataclasses import dataclass
 from typing import Any
 
 import torch
+from torch._inductor.fx_utils import is_node_realized
 from torch._inductor.pattern_matcher import (
     CallFunctionVarArgs,
     compute_mutation_region_ids,
@@ -167,14 +174,30 @@ def _view_path_to_state(
 def _collect_dead_view_nodes(
     node: torch.fx.Node, removable_nodes: OrderedSet[torch.fx.Node]
 ) -> bool:
-    if node in removable_nodes:
-        return True
-    if not _is_view_op(node.target) or any(
-        not _collect_dead_view_nodes(user, removable_nodes) for user in node.users
-    ):
-        return False
-    removable_nodes.add(node)
-    return True
+    postorder = []
+    is_view = {}
+    seen = OrderedSet[torch.fx.Node]()
+    stack = [(node, False)]
+    while stack:
+        current, expanded = stack.pop()
+        if current in removable_nodes:
+            continue
+        if expanded:
+            postorder.append(current)
+            continue
+        if current in seen:
+            continue
+        seen.add(current)
+        current_is_view = _is_view_op(current.target)
+        is_view[current] = current_is_view
+        stack.append((current, True))
+        if current_is_view:
+            stack.extend((user, False) for user in current.users)
+
+    for current in postorder:
+        if is_view[current] and all(user in removable_nodes for user in current.users):
+            removable_nodes.add(current)
+    return node in removable_nodes
 
 
 def _get_full_tensor_slice_scatter_chain(
@@ -355,46 +378,70 @@ def _replace_with_inplace_copies(match: Match, chain: _SliceScatterChain) -> Non
     match.erase_nodes()
 
 
-def _is_inductor_optimizable_cat(
-    base: torch.fx.Node, sources: list[torch.fx.Node]
-) -> bool:
-    # cat is usable only when it preserves the factory's tensor metadata and
-    # presents ordinary contiguous inputs to Inductor's fusion machinery.
-    base_val = base.meta.get("val")
-    if not isinstance(base_val, torch.Tensor):
+def _is_nested_compile_region_output(node: torch.fx.Node) -> bool:
+    if node.op != "call_function" or node.target is not operator.getitem:
         return False
-    if (
-        not _is_supported_base_factory(base)
-        or base_val.layout != torch.strided
-        or not _has_contiguous_memory_format_strides(base_val)
-    ):
-        return False
-    return all(
-        isinstance(src_val := src.meta.get("val"), torch.Tensor)
-        and src_val.device == base_val.device
-        and src_val.dtype == base_val.dtype
-        and src_val.layout == base_val.layout
-        and _has_contiguous_memory_format_strides(src_val)
-        for src in sources
+    region = node.args[0]
+    value = node.meta.get("val")
+    return (
+        isinstance(region, torch.fx.Node)
+        and region.op == "call_function"
+        and region.target is torch.ops.higher_order.invoke_subgraph
+        and isinstance(value, torch.Tensor)
+        and value.device.type == "cuda"
     )
 
 
-def _has_contiguous_memory_format_strides(tensor: torch.Tensor) -> bool:
-    return all(
-        _statically_known_eq(actual, expected)
-        for actual, expected in zip(
-            tensor.stride(), make_contiguous_strides_for(tensor.shape), strict=True
+def _can_fuse_as_cat(chain: _SliceScatterChain) -> bool:
+    base_val = chain.base.meta.get("val")
+    if (
+        chain.functional_copies
+        or not isinstance(base_val, torch.Tensor)
+        or base_val.layout != torch.strided
+    ):
+        return False
+
+    for src in chain.sources:
+        is_input = src.op == "placeholder"
+        is_pointwise = (
+            isinstance(src.target, torch._ops.OpOverload)
+            and torch.Tag.pointwise in src.target.tags
         )
+        if (
+            len(src.users) != 1
+            or not (is_input or is_pointwise or _is_nested_compile_region_output(src))
+            or (not is_input and is_node_realized(src))
+        ):
+            return False
+
+    tensors = [base_val, *(src.meta.get("val") for src in chain.sources)]
+    return all(
+        isinstance(tensor, torch.Tensor)
+        and tensor.device == base_val.device
+        and tensor.dtype == base_val.dtype
+        and tensor.layout == base_val.layout
+        and all(
+            _statically_known_eq(actual, expected)
+            for actual, expected in zip(
+                tensor.stride(),
+                make_contiguous_strides_for(tensor.shape),
+                strict=True,
+            )
+        )
+        for tensor in tensors
     )
 
 
 def slice_scatter_chunking_pass(graph: torch.fx.Graph) -> bool:
-    """Rewrite complete slice_scatter chains as cat or bounded-lifetime copies."""
-    compute_mutation_region_ids(graph)
-    introduced_mutation = False
+    """Rewrite complete slice_scatter chains without full-sized intermediates."""
     slice_scatters = graph.find_nodes(
         op="call_function", target=aten.slice_scatter.default
     )
+    if len(slice_scatters) < 2:
+        return False
+
+    compute_mutation_region_ids(graph)
+    introduced_mutation = False
     node_order = {node: index for index, node in enumerate(graph.nodes)}
     examined = OrderedSet[torch.fx.Node]()
     for slice_scatter in reversed(slice_scatters):
@@ -414,33 +461,23 @@ def slice_scatter_chunking_pass(graph: torch.fx.Graph) -> bool:
 
         match.nodes = sorted(result.removable_nodes, key=node_order.__getitem__)
 
-        # A functional copy snapshots each chunk at its original write. Keep
-        # that lifetime by writing into a proven-fresh base at the same point;
-        # cat would retain every chunk until the end of the chain.
-        if result.functional_copies:
-            if not _is_reusable_base_factory(result.base):
-                continue
-            if _custom_context(result.base) != _custom_context(
-                result.slice_scatters[-1]
-            ):
-                continue
-            _replace_with_inplace_copies(match, result)
-            introduced_mutation = True
+        if not _is_reusable_base_factory(result.base):
+            continue
+        if _custom_context(result.base) != _custom_context(result.slice_scatters[-1]):
             continue
 
-        if not _is_inductor_optimizable_cat(result.base, result.sources):
+        if _can_fuse_as_cat(result):
+
+            def replacement(*chunks):
+                return torch.cat(chunks, dim=result.dim)
+
+            match.replace_by_example(replacement, result.sources)
+            if not result.base.users and not result.base.is_impure():
+                graph.erase_node(result.base)
             continue
 
-        def replacement(*chunks):
-            return torch.cat(chunks, dim=result.dim)
-
-        match.replace_by_example(replacement, result.sources)
-        if (
-            result.base.op == "call_function"
-            and not result.base.users
-            and not result.base.is_impure()
-        ):
-            graph.erase_node(result.base)
+        _replace_with_inplace_copies(match, result)
+        introduced_mutation = True
     if introduced_mutation:
         # Each mutated base is writable storage disjoint from its inputs and has
         # no users outside its chain, so rewrites cannot invalidate later matches.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #195748
* #190344
* __->__ #195631

<p>The following summary was prepared with assistance from Codex and reviewed by the author.</p>
<p>Rewrite slice_scatter chains that fill an entire tensor into peak memory efficient cat or copy_.</p>
<p>Functionalizing chunking results in a chain of slice_scatter nodes, holding full-sized intermediate by the end of the chain.</p>
<p>The main goal of this pass is to make the "chunking" region the most peak memory efficient, as this is the main goal of the user when they use "chunking".</p>
<p>Input:</p>
<pre><code class="language-python">base = aten.empty(size)
out = aten.slice_scatter(base, chunk0, dim, 0, end0)
out = aten.slice_scatter(out, chunk1, dim, end0, size)
</code></pre>
<p>Output 1: cat, when Inductor's cat lowering will not have the output and chunk allocations overlap.</p>
<pre><code class="language-python">out = aten.cat([chunk0, chunk1], dim)
</code></pre>
<p>Output 2: copies into the reused base, so each chunk dies at its own write.</p>
<pre><code class="language-python">aten.copy_(aten.slice(base, dim, 0, end0), chunk0)
aten.copy_(aten.slice(base, dim, end0, size), chunk1)
out = base
</code></pre>
<p>Storage identity comes from FakeTensor metadata rather than an operation allowlist, so graph-input views do not depend on which view operations constructed them.</p>
<p>The transformation requires complete coverage and compatible shape, stride, dtype, device, layout, execution context, and liveness. Unsupported chains are left unchanged.</p>



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo