### PR TITLE
Minimal way to make ReduceLROnPlateau composable with SequentialLR and ChainedScheduler

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -871,6 +871,61 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs=2)
         self.opt = old_opt
 
+    def test_nested_sequentiallr_does_not_skip_an_epoch(self):
+        """A nested SequentialLR runs the same schedule as it does on its own."""
+        epochs = 8
+        # The first five values are exactly what the inner scheduler produces
+        # when it is used directly: two epochs of ConstantLR, then ExponentialLR
+        # from its epoch 0. Nesting must not consume one of those epochs.
+        inner_targets = [0.5, 0.5, 1.0, 0.9, 0.81]
+        outer_targets = [1.0, 1.0, 0.5]
+        single_targets = inner_targets + outer_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        inner = SequentialLR(
+            self.opt,
+            schedulers=[
+                ConstantLR(self.opt, factor=0.5, total_iters=2),
+                ExponentialLR(self.opt, gamma=0.9),
+            ],
+            milestones=[2],
+        )
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
+            milestones=[5],
+        )
+        self._test(scheduler, targets, epochs)
+
+    def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
+        """A nested ChainedScheduler runs the same schedule as it does on its own."""
+        epochs = 8
+        # The first five values are exactly what the chained scheduler produces
+        # when it is used directly: ConstantLR and ExponentialLR both scaling
+        # the lr from its epoch 0. Nesting must not apply either of them twice.
+        inner_targets = [0.5, 0.45, 0.81, 0.729, 0.6561]
+        outer_targets = [1.0, 1.0, 0.5]
+        single_targets = inner_targets + outer_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        inner = ChainedScheduler(
+            [
+                ConstantLR(self.opt, factor=0.5, total_iters=2),
+                ExponentialLR(self.opt, gamma=0.9),
+            ],
+            optimizer=self.opt,
+        )
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
+            milestones=[5],
+        )
+        self._test(scheduler, targets, epochs)
+
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [
             LinearLR(self.opt, start_factor=0.4, total_iters=3),

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -880,62 +880,51 @@ class TestLRScheduler(TestCase):
         return lrs
 
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
+        def make_scheduler(optimizer):
+            """Construct the SequentialLR used at both nesting depths."""
+            return SequentialLR(
+                optimizer,
+                [
+                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ConstantLR(optimizer, factor=0.2, total_iters=10),
+                ],
+                milestones=[2],
+            )
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
-            [
-                SequentialLR(
-                    two_level_optimizer,
-                    [
-                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
-                        ConstantLR(two_level_optimizer, factor=0.2, total_iters=10),
-                    ],
-                    milestones=[2],
-                ),
-            ],
+            [make_scheduler(two_level_optimizer)],
             milestones=[],
         )
 
         one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        # Same schedule as above, with one composite level instead of two.
-        one_level_scheduler = SequentialLR(
-            one_level_optimizer,
-            [
-                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
-                ConstantLR(one_level_optimizer, factor=0.2, total_iters=10),
-            ],
-            milestones=[2],
-        )
+        one_level_scheduler = make_scheduler(one_level_optimizer)
 
         two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
+        def make_scheduler(optimizer):
+            """Construct the ChainedScheduler used at both nesting depths."""
+            return ChainedScheduler(
+                [
+                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ExponentialLR(optimizer, gamma=0.9),
+                ],
+                optimizer=optimizer,
+            )
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
-            [
-                ChainedScheduler(
-                    [
-                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
-                        ExponentialLR(two_level_optimizer, gamma=0.9),
-                    ],
-                    optimizer=two_level_optimizer,
-                ),
-            ],
+            [make_scheduler(two_level_optimizer)],
             milestones=[],
         )
 
         one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        # Same schedule as above, with one composite level instead of two.
-        one_level_scheduler = ChainedScheduler(
-            [
-                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
-                ExponentialLR(one_level_optimizer, gamma=0.9),
-            ],
-            optimizer=one_level_optimizer,
-        )
+        one_level_scheduler = make_scheduler(one_level_optimizer)
 
         two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -715,6 +715,16 @@ class TestLRScheduler(TestCase):
             scheduler.get_last_lr(), [0.5 for param_group in self.opt.param_groups]
         )
 
+    def test_reduce_lr_on_plateau_get_lr(self):
+        scheduler = ReduceLROnPlateau(self.opt, factor=0.5, patience=0)
+        with self.assertWarnsRegex(UserWarning, r"please use `get_last_lr\(\)`"):
+            self.assertEqual(scheduler.get_lr(), scheduler.get_last_lr())
+
+        scheduler.step(1.0)
+        scheduler.step(2.0)
+        with self.assertWarnsRegex(UserWarning, r"please use `get_last_lr\(\)`"):
+            self.assertEqual(scheduler.get_lr(), scheduler.get_last_lr())
+
     def test_reduce_lr_on_plateau_preserves_lr_type(self):
         # Ensures that tensor lrs are preserved, preventing recompilations.
         types = [type(group["lr"]) for group in self.opt.param_groups]
@@ -723,6 +733,19 @@ class TestLRScheduler(TestCase):
         scheduler.step(2.0)  # Triggers scheduler._reduce_lr
         for group, type_ in zip(self.opt.param_groups, types):
             self.assertEqual(type(group["lr"]), type_)
+
+    def test_reduce_lr_on_plateau_requires_metrics(self):
+        scheduler = ReduceLROnPlateau(self.opt)
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step(None)
+
+    def test_reduce_lr_on_plateau_initial_step(self):
+        scheduler = ReduceLROnPlateau(self.opt)
+        self.assertEqual(scheduler.last_epoch, 0)
+        scheduler.step(1.0)
+        self.assertEqual(scheduler.last_epoch, 1)
 
     def test_sequentiallr1(self):
         epochs = 19
@@ -879,6 +902,127 @@ class TestLRScheduler(TestCase):
             scheduler.step()
         return lrs
 
+    def test_sequentiallr_with_reduce_lr_on_plateau(self):
+        """Warm up with a fixed schedule, then hand off to ReduceLROnPlateau."""
+        epochs = 8
+        # The metric never improves after the first epoch it is seen, so with
+        # `patience=0` the plateau scheduler reduces on every epoch but its
+        # first one, which always counts as an improvement over `inf`.
+        metrics = [1.0] * epochs
+        warmup_targets = [0.5, 0.625, 0.75, 0.875]
+        # The step at the milestone only hands over, as it does for any other
+        # scheduler: `ReduceLROnPlateau` applies its epoch 0 lrs, which are the
+        # ones the warmup left behind, and starts watching the metric after it.
+        plateau_targets = [0.875, 0.875, 0.4375, 0.21875]
+        single_targets = warmup_targets + plateau_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        schedulers = [
+            LinearLR(self.opt, start_factor=0.5, total_iters=4),
+            ReduceLROnPlateau(
+                self.opt, mode="min", factor=0.5, patience=0, threshold=0
+            ),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[4])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+        self.assertEqual(scheduler.get_last_lr(), schedulers[1].get_last_lr())
+
+    def test_sequentiallr_with_reduce_lr_on_plateau_first(self):
+        """ReduceLROnPlateau as the scheduler a SequentialLR starts with."""
+        epochs = 8
+        metrics = [1.0] * epochs
+        # ReduceLROnPlateau leaves the lr alone until it is given a metric, so
+        # there is no initial step to perform for it. At the milestone StepLR
+        # takes over from its own epoch 0, i.e. from `initial_lr` again.
+        plateau_targets = [1.0, 1.0, 0.5]
+        step_targets = [1.0, 1.0, 0.1, 0.1, 0.01]
+        single_targets = plateau_targets + step_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        schedulers = [
+            ReduceLROnPlateau(
+                self.opt, mode="min", factor=0.5, patience=0, threshold=0
+            ),
+            StepLR(self.opt, step_size=2, gamma=0.1),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[3])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_sequentiallr_with_only_reduce_lr_on_plateau(self):
+        """SequentialLR initializes the optimizer from a plateau scheduler."""
+        epochs = 5
+        metrics = [1.0] * epochs
+        targets = [
+            [0.05, 0.05, 0.05, 0.05, 0.025],
+            [0.5, 0.5, 0.5, 0.5, 0.25],
+        ]
+        schedulers = [
+            ReduceLROnPlateau(
+                self.opt, mode="min", factor=0.5, patience=0, threshold=0
+            ),
+            ReduceLROnPlateau(
+                self.opt, mode="min", factor=0.5, patience=0, threshold=0
+            ),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[2])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_sequentiallr_forwards_metrics_to_nested_chained_scheduler(self):
+        """A metric reaches a ReduceLROnPlateau nested two containers deep."""
+        epochs = 6
+        metrics = [1.0] * epochs
+        single_targets = [1.0, 1.0, 0.5] + [1.0, 1.0, 0.5]
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        plateau = ReduceLROnPlateau(
+            self.opt, mode="min", factor=0.5, patience=0, threshold=0
+        )
+        schedulers = [
+            ChainedScheduler([plateau], optimizer=self.opt),
+            StepLR(self.opt, step_size=2, gamma=0.5),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[3])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_sequentiallr_forwards_metrics_to_nested_sequentiallr(self):
+        """A metric reaches a ReduceLROnPlateau a nested SequentialLR starts with."""
+        epochs = 9
+        metrics = [1.0] * epochs
+        # The inner SequentialLR hands over from the plateau scheduler to a
+        # StepLR at its own milestone, and the outer one hands over from the
+        # whole inner scheduler to another StepLR at epoch 6. Each handover
+        # restarts the incoming scheduler from its epoch 0, i.e. `initial_lr`.
+        plateau_targets = [1.0, 1.0, 0.5]
+        inner_step_targets = [1.0, 1.0, 0.5]
+        outer_step_targets = [1.0, 1.0, 0.1]
+        single_targets = plateau_targets + inner_step_targets + outer_step_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        inner = SequentialLR(
+            self.opt,
+            schedulers=[
+                ReduceLROnPlateau(
+                    self.opt, mode="min", factor=0.5, patience=0, threshold=0
+                ),
+                StepLR(self.opt, step_size=2, gamma=0.5),
+            ],
+            milestones=[3],
+        )
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.1)],
+            milestones=[6],
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
         def make_scheduler(optimizer):
             """Construct the SequentialLR used at both nesting depths."""
@@ -929,6 +1073,107 @@ class TestLRScheduler(TestCase):
         one_level_lrs = self._get_lrs(one_level_scheduler)
         two_level_lrs = self._get_lrs(two_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
+
+    def test_chained_scheduler_with_reduce_lr_on_plateau(self):
+        """A chained ReduceLROnPlateau composes with the other schedulers."""
+        epochs = 5
+        metrics = [1.0] * epochs
+        # Both schedulers scale the lr they find on the optimizer: the plateau
+        # scheduler halves it from epoch 1 on, StepLR halves it every 2 epochs.
+        single_targets = [1.0, 1.0, 0.25, 0.125, 0.03125]
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        schedulers = [
+            ReduceLROnPlateau(
+                self.opt, mode="min", factor=0.5, patience=0, threshold=0
+            ),
+            StepLR(self.opt, step_size=2, gamma=0.5),
+        ]
+        scheduler = ChainedScheduler(schedulers, optimizer=self.opt)
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+        self.assertEqual(scheduler.get_last_lr(), schedulers[-1].get_last_lr())
+
+    def test_composed_reduce_lr_on_plateau_without_metrics(self):
+        """Stepping a ReduceLROnPlateau without a metric is an error."""
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[
+                LinearLR(self.opt, total_iters=2),
+                ReduceLROnPlateau(self.opt),
+            ],
+            milestones=[2],
+        )
+        # No metric is needed while the plateau scheduler is not the active
+        # one, nor for the step at the milestone, which only hands over to it.
+        for _ in range(2):
+            self.opt.step()
+            scheduler.step()
+        self.opt.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step()
+
+        chained = ChainedScheduler(
+            [ConstantLR(self.opt), ReduceLROnPlateau(self.opt)], optimizer=self.opt
+        )
+        self.opt.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            chained.step()
+
+    def test_sequentiallr_with_reduce_lr_on_plateau_state_dict(self):
+        """Resuming from a checkpoint taken while the plateau stage is active."""
+        base_lr = 0.1
+        milestone = 2
+        total_steps = 8
+        resume_step = 5
+        metrics = [1.0] * total_steps
+
+        def make_scheduler(optim):
+            return SequentialLR(
+                optim,
+                [
+                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
+                    ReduceLROnPlateau(optim, factor=0.5, patience=1, threshold=0),
+                ],
+                milestones=[milestone],
+            )
+
+        model = torch.nn.Linear(1, 1)
+        optim = SGD(model.parameters(), lr=base_lr)
+        sched = make_scheduler(optim)
+
+        reference_lrs = []
+        for step in range(total_steps):
+            optim.step()
+            sched.step(metrics[step])
+            reference_lrs.append(sched.get_last_lr()[0])
+
+        model2 = torch.nn.Linear(1, 1)
+        optim2 = SGD(model2.parameters(), lr=base_lr)
+        sched2 = make_scheduler(optim2)
+        for step in range(resume_step):
+            optim2.step()
+            sched2.step(metrics[step])
+
+        optim_state = optim2.state_dict()
+        sched_state = sched2.state_dict()
+
+        model3 = torch.nn.Linear(1, 1)
+        optim3 = SGD(model3.parameters(), lr=base_lr)
+        # Building the scheduler overwrites the optimizer's lrs, so it has to
+        # come before restoring the optimizer, as `LRScheduler` documents.
+        sched3 = make_scheduler(optim3)
+        optim3.load_state_dict(optim_state)
+        sched3.load_state_dict(sched_state)
+
+        resumed_lrs = []
+        for step in range(resume_step, total_steps):
+            optim3.step()
+            sched3.step(metrics[step])
+            resumed_lrs.append(sched3.get_last_lr()[0])
+
+        self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
 
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [
@@ -2326,6 +2571,25 @@ class TestLRScheduler(TestCase):
                     rtol=0,
                 )
             [scheduler.step() for scheduler in schedulers]
+
+    def _test_with_metrics(self, scheduler, targets, metrics, epochs=10):
+        """Like `_test`, but for a scheduler whose `step` takes a metric."""
+        for epoch in range(epochs):
+            for param_group, target in zip(self.opt.param_groups, targets):
+                self.assertEqual(
+                    target[epoch],
+                    param_group["lr"],
+                    msg=lambda msg: f"{msg}\n"
+                    + (
+                        "LR is wrong in epoch {}: expected {}, got {}".format(
+                            epoch, target[epoch], param_group["lr"]
+                        )
+                    ),
+                    atol=1e-8,
+                    rtol=1e-5,
+                )
+            self.opt.step()
+            scheduler.step(metrics[epoch])
 
     def _test_CosineAnnealingWarmRestarts(self, scheduler, targets, epochs=10):
         for index, epoch in enumerate(torch.arange(0, epochs, 0.1)):

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -871,60 +871,73 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs=2)
         self.opt = old_opt
 
+    def _get_lrs(self, scheduler):
+        lrs = []
+        for _ in range(5):
+            lrs.append(scheduler.get_last_lr())
+            scheduler.optimizer.step()
+            scheduler.step()
+        return lrs
+
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
-        """A nested SequentialLR runs the same schedule as it does on its own."""
-        epochs = 8
-        # The first five values are exactly what the inner scheduler produces
-        # when it is used directly: two epochs of ConstantLR, then ExponentialLR
-        # from its epoch 0. Nesting must not consume one of those epochs.
-        inner_targets = [0.5, 0.5, 1.0, 0.9, 0.81]
-        outer_targets = [1.0, 1.0, 0.5]
-        single_targets = inner_targets + outer_targets
-        targets = [
-            [0.05 * x for x in single_targets],
-            [0.5 * x for x in single_targets],
-        ]
-        inner = SequentialLR(
-            self.opt,
-            schedulers=[
-                ConstantLR(self.opt, factor=0.5, total_iters=2),
-                ExponentialLR(self.opt, gamma=0.9),
+        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        nested_scheduler = SequentialLR(
+            nested_optimizer,
+            [
+                SequentialLR(
+                    nested_optimizer,
+                    [
+                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
+                        ConstantLR(nested_optimizer, factor=0.2, total_iters=10),
+                    ],
+                    milestones=[2],
+                ),
+            ],
+            milestones=[],
+        )
+
+        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        standalone_scheduler = SequentialLR(
+            standalone_optimizer,
+            [
+                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
+                ConstantLR(standalone_optimizer, factor=0.2, total_iters=10),
             ],
             milestones=[2],
         )
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
-            milestones=[5],
-        )
-        self._test(scheduler, targets, epochs)
+
+        nested_lrs = self._get_lrs(nested_scheduler)
+        standalone_lrs = self._get_lrs(standalone_scheduler)
+        self.assertEqual(nested_lrs, standalone_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
-        """A nested ChainedScheduler runs the same schedule as it does on its own."""
-        epochs = 8
-        # The first five values are exactly what the chained scheduler produces
-        # when it is used directly: ConstantLR and ExponentialLR both scaling
-        # the lr from its epoch 0. Nesting must not apply either of them twice.
-        inner_targets = [0.5, 0.45, 0.81, 0.729, 0.6561]
-        outer_targets = [1.0, 1.0, 0.5]
-        single_targets = inner_targets + outer_targets
-        targets = [
-            [0.05 * x for x in single_targets],
-            [0.5 * x for x in single_targets],
-        ]
-        inner = ChainedScheduler(
+        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        nested_scheduler = SequentialLR(
+            nested_optimizer,
             [
-                ConstantLR(self.opt, factor=0.5, total_iters=2),
-                ExponentialLR(self.opt, gamma=0.9),
+                ChainedScheduler(
+                    [
+                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
+                        ExponentialLR(nested_optimizer, gamma=0.9),
+                    ],
+                    optimizer=nested_optimizer,
+                ),
             ],
-            optimizer=self.opt,
+            milestones=[],
         )
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
-            milestones=[5],
+
+        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        standalone_scheduler = ChainedScheduler(
+            [
+                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
+                ExponentialLR(standalone_optimizer, gamma=0.9),
+            ],
+            optimizer=standalone_optimizer,
         )
-        self._test(scheduler, targets, epochs)
+
+        nested_lrs = self._get_lrs(nested_scheduler)
+        standalone_lrs = self._get_lrs(standalone_scheduler)
+        self.assertEqual(nested_lrs, standalone_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -891,6 +891,9 @@ class TestLRScheduler(TestCase):
                 milestones=[2],
             )
 
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        one_level_scheduler = make_scheduler(one_level_optimizer)
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
@@ -898,11 +901,8 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        one_level_scheduler = make_scheduler(one_level_optimizer)
-
-        two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
@@ -916,6 +916,9 @@ class TestLRScheduler(TestCase):
                 optimizer=optimizer,
             )
 
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        one_level_scheduler = make_scheduler(one_level_optimizer)
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
@@ -923,11 +926,8 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        one_level_scheduler = make_scheduler(one_level_optimizer)
-
-        two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -880,15 +880,15 @@ class TestLRScheduler(TestCase):
         return lrs
 
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
-        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        nested_scheduler = SequentialLR(
-            nested_optimizer,
+        two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        two_level_scheduler = SequentialLR(
+            two_level_optimizer,
             [
                 SequentialLR(
-                    nested_optimizer,
+                    two_level_optimizer,
                     [
-                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
-                        ConstantLR(nested_optimizer, factor=0.2, total_iters=10),
+                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
+                        ConstantLR(two_level_optimizer, factor=0.2, total_iters=10),
                     ],
                     milestones=[2],
                 ),
@@ -896,48 +896,50 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        standalone_scheduler = SequentialLR(
-            standalone_optimizer,
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        # Same schedule as above, with one composite level instead of two.
+        one_level_scheduler = SequentialLR(
+            one_level_optimizer,
             [
-                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
-                ConstantLR(standalone_optimizer, factor=0.2, total_iters=10),
+                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
+                ConstantLR(one_level_optimizer, factor=0.2, total_iters=10),
             ],
             milestones=[2],
         )
 
-        nested_lrs = self._get_lrs(nested_scheduler)
-        standalone_lrs = self._get_lrs(standalone_scheduler)
-        self.assertEqual(nested_lrs, standalone_lrs)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
+        one_level_lrs = self._get_lrs(one_level_scheduler)
+        self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
-        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        nested_scheduler = SequentialLR(
-            nested_optimizer,
+        two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        two_level_scheduler = SequentialLR(
+            two_level_optimizer,
             [
                 ChainedScheduler(
                     [
-                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
-                        ExponentialLR(nested_optimizer, gamma=0.9),
+                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
+                        ExponentialLR(two_level_optimizer, gamma=0.9),
                     ],
-                    optimizer=nested_optimizer,
+                    optimizer=two_level_optimizer,
                 ),
             ],
             milestones=[],
         )
 
-        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        standalone_scheduler = ChainedScheduler(
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        # Same schedule as above, with one composite level instead of two.
+        one_level_scheduler = ChainedScheduler(
             [
-                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
-                ExponentialLR(standalone_optimizer, gamma=0.9),
+                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
+                ExponentialLR(one_level_optimizer, gamma=0.9),
             ],
-            optimizer=standalone_optimizer,
+            optimizer=one_level_optimizer,
         )
 
-        nested_lrs = self._get_lrs(nested_scheduler)
-        standalone_lrs = self._get_lrs(standalone_scheduler)
-        self.assertEqual(nested_lrs, standalone_lrs)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
+        one_level_lrs = self._get_lrs(one_level_scheduler)
+        self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -885,8 +885,8 @@ class TestLRScheduler(TestCase):
             return SequentialLR(
                 optimizer,
                 [
-                    ConstantLR(optimizer, factor=0.5, total_iters=2),
-                    ConstantLR(optimizer, factor=0.2, total_iters=10),
+                    ConstantLR(optimizer, factor=0.2),
+                    ConstantLR(optimizer, factor=0.5),
                 ],
                 milestones=[2],
             )
@@ -910,7 +910,7 @@ class TestLRScheduler(TestCase):
             """Construct the ChainedScheduler used at both nesting depths."""
             return ChainedScheduler(
                 [
-                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ConstantLR(optimizer, factor=0.5),
                     ExponentialLR(optimizer, gamma=0.9),
                 ],
                 optimizer=optimizer,

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1165,10 +1165,13 @@ class SequentialLR(LRScheduler):
         self.recursive_undo()
 
         # Perform the initial step for only the scheduler meant to run at step 0.
+        self._initial_step()
+
+    def _initial_step(self) -> None:
         idx = bisect_right(self._milestones, 0)
         self._schedulers[idx]._initial_step()
 
-        self._last_lr = schedulers[idx].get_last_lr()
+        self._last_lr = self._schedulers[idx].get_last_lr()
 
     def recursive_undo(self, sched=None) -> None:
         """
@@ -1534,6 +1537,17 @@ class ChainedScheduler(LRScheduler):
                 )
         self._schedulers = schedulers
         self.optimizer = optimizer
+        # Unlike the other schedulers, this does not end with
+        # `self._initial_step()`: every scheduler in `schedulers` already took
+        # its own initial step when it was constructed, and those compose into
+        # the chained learning rate. Calling it here would apply each factor a
+        # second time. `_initial_step` is for an enclosing composite scheduler
+        # to call once it has undone those constructor steps.
+        self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
+
+    def _initial_step(self) -> None:
+        for scheduler in self._schedulers:
+            scheduler._initial_step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     def step(self) -> None:  # type: ignore[override]

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1550,11 +1550,6 @@ class ChainedScheduler(LRScheduler):
             scheduler._initial_step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
-    def _initial_step(self) -> None:
-        for scheduler in self._schedulers:
-            scheduler._initial_step()
-        self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
-
     def step(self, metrics: SupportsFloat | None = None) -> None:  # type: ignore[override]
         """Perform a step.
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1193,6 +1193,8 @@ class SequentialLR(LRScheduler):
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
             scheduler._update_lr(0)
         else:
+            # Every composite scheduler needs to pass `metrics` to all
+            # schedulers that may read it.
             if isinstance(
                 scheduler, (ReduceLROnPlateau, SequentialLR, ChainedScheduler)
             ):
@@ -1561,6 +1563,8 @@ class ChainedScheduler(LRScheduler):
                 currently active scheduler. :class:`ReduceLROnPlateau` makes use of it.
         """
         for scheduler in self._schedulers:
+            # Every composite scheduler needs to pass `metrics` to all
+            # schedulers that may read it.
             if isinstance(
                 scheduler, (ReduceLROnPlateau, SequentialLR, ChainedScheduler)
             ):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1133,12 +1133,6 @@ class SequentialLR(LRScheduler):
                 raise TypeError(
                     f"{self.__class__.__name__} at index {scheduler_idx} should have `optimizer` as its attribute."
                 )
-            if isinstance(scheduler, ReduceLROnPlateau):
-                raise ValueError(
-                    f"{self.__class__.__name__} does not support `ReduceLROnPlateau` scheduler as it "
-                    "requires additional kwargs to be specified when calling `step`, "
-                    f"but got one at index {scheduler_idx} in the given schedulers sequence."
-                )
             if optimizer != scheduler.optimizer:
                 raise ValueError(
                     f"{self.__class__.__name__} expects all schedulers to belong to the same optimizer, but "
@@ -1186,15 +1180,25 @@ class SequentialLR(LRScheduler):
         elif hasattr(scheds, "last_epoch"):
             scheds.last_epoch -= 1
 
-    def step(self) -> None:  # type: ignore[override]
-        """Perform a step."""
+    def step(self, metrics: SupportsFloat | None = None) -> None:  # type: ignore[override]
+        """Perform a step.
+
+        Args:
+            metrics (SupportsFloat, optional): The metric to pass on to the
+                currently active scheduler. :class:`ReduceLROnPlateau` makes use of it.
+        """
         self.last_epoch += 1
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
             scheduler._update_lr(0)
         else:
-            scheduler.step()
+            if isinstance(
+                scheduler, (ReduceLROnPlateau, SequentialLR, ChainedScheduler)
+            ):
+                scheduler.step(metrics)
+            else:
+                scheduler.step()
 
         self._last_lr = scheduler.get_last_lr()
 
@@ -1523,12 +1527,6 @@ class ChainedScheduler(LRScheduler):
                 raise TypeError(
                     f"{self.__class__.__name__} at index {scheduler_idx} should have `optimizer` as its attribute."
                 )
-            if isinstance(scheduler, ReduceLROnPlateau):
-                raise ValueError(
-                    f"{self.__class__.__name__} does not support `ReduceLROnPlateau` scheduler as it "
-                    "requires additional kwargs to be specified when calling `step`, "
-                    f"but got one at index {scheduler_idx} in the given schedulers sequence."
-                )
             if optimizer != scheduler.optimizer:
                 raise ValueError(
                     f"{self.__class__.__name__} expects all schedulers to belong to the same optimizer, but "
@@ -1550,10 +1548,25 @@ class ChainedScheduler(LRScheduler):
             scheduler._initial_step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
-    def step(self) -> None:  # type: ignore[override]
-        """Perform a step."""
+    def _initial_step(self) -> None:
         for scheduler in self._schedulers:
-            scheduler.step()
+            scheduler._initial_step()
+        self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
+
+    def step(self, metrics: SupportsFloat | None = None) -> None:  # type: ignore[override]
+        """Perform a step.
+
+        Args:
+            metrics (SupportsFloat, optional): The metric to pass on to the
+                currently active scheduler. :class:`ReduceLROnPlateau` makes use of it.
+        """
+        for scheduler in self._schedulers:
+            if isinstance(
+                scheduler, (ReduceLROnPlateau, SequentialLR, ChainedScheduler)
+            ):
+                scheduler.step(metrics)
+            else:
+                scheduler.step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     @override
@@ -1679,6 +1692,11 @@ class ReduceLROnPlateau(LRScheduler):
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
         self.optimizer = optimizer
+        for group in optimizer.param_groups:
+            initial_lr = group["lr"]
+            if isinstance(initial_lr, Tensor):
+                initial_lr = initial_lr.clone()
+            group.setdefault("initial_lr", initial_lr)
 
         if isinstance(min_lr, (list, tuple)):
             if len(min_lr) != len(optimizer.param_groups):
@@ -1694,12 +1712,17 @@ class ReduceLROnPlateau(LRScheduler):
         self.patience = patience
         self.cooldown = cooldown
         self.eps = eps
-        self.last_epoch = 0
+        self.last_epoch = -1
         self._last_lr = _param_groups_val_list(self.optimizer, "lr")
         self._init_is_better(
             mode=mode, threshold=threshold, threshold_mode=threshold_mode
         )
         self._reset()
+        self._initial_step()
+
+    def _initial_step(self) -> None:
+        self.last_epoch += 1
+        self._last_lr = _param_groups_val_list(self.optimizer, "lr")
 
     def _reset(self) -> None:
         """Reset num_bad_epochs counter and cooldown counter."""
@@ -1707,8 +1730,22 @@ class ReduceLROnPlateau(LRScheduler):
         self.cooldown_counter = 0
         self.num_bad_epochs = 0
 
-    def step(self, metrics: SupportsFloat, epoch=None) -> None:  # type: ignore[override]
-        """Perform a step."""
+    def step(self, metrics: SupportsFloat | None = None, epoch=None) -> None:  # type: ignore[override]
+        """Perform a step.
+
+        Args:
+            metrics (SupportsFloat): The current value of the quantity being
+                monitored, such as a validation loss. This is actually required.
+        """
+        if metrics is None:
+            raise ValueError(
+                "`ReduceLROnPlateau` requires the metric it monitors to be passed "
+                "to `step`, but got `metrics=None`. Pass the quantity you are "
+                "monitoring, e.g. `scheduler.step(val_loss)`. When this scheduler "
+                "is held by a `SequentialLR` or a `ChainedScheduler`, pass the "
+                "metric to that scheduler's `step` instead and it reaches this one "
+                "from there."
+            )
         # convert `metrics` to float, in case it's a zero-dim Tensor
         current = float(metrics)
         if epoch is None:
@@ -1733,6 +1770,19 @@ class ReduceLROnPlateau(LRScheduler):
             self.num_bad_epochs = 0
 
         self._last_lr = _param_groups_val_list(self.optimizer, "lr")
+
+    def get_lr(self) -> list[float | Tensor]:
+        r""":class:`ReduceLROnPlateau` needs a metric to decide whether to adjust
+        the learning rate, so without a new metric its next learning rate is
+        the current one.
+
+        Returns:
+            list[float | Tensor]: A :class:`list` of learning rates for each of
+            the optimizer's :attr:`~torch.optim.Optimizer.param_groups` with the
+            same types as their current ``group["lr"]``\s.
+        """
+        _warn_get_lr_called_within_step(self)
+        return _param_groups_val_list(self.optimizer, "lr")
 
     def _reduce_lr(self, epoch) -> None:
         if len(self.optimizer.param_groups) != len(self.min_lrs):


### PR DESCRIPTION
Fixes #68978  
Fixes #110761

Video overview to try to save you some time and hassle reviewing: https://youtu.be/oHZofnGd_AQ

Fixes `ReduceLROnPlateau` composition with `SequentialLR` and `ChainedScheduler`.

Both composition schedulers previously rejected `ReduceLROnPlateau` because it requires a metric in `step()`. This change removes that restriction and adds an optional `metrics` argument to each composer’s `step()`, forwarding it only to schedulers that can consume it. Existing zero-argument calls remain unchanged.

To make `ReduceLROnPlateau` participate correctly in the existing scheduler-composition lifecycle, this also:

- aligns its initial-step state with `LRScheduler` conventions
- preserves `initial_lr` when it is constructed
- implements `get_lr()` as the current learning rates, allowing `SequentialLR`  milestone handoffs to work
- raises a clear error when a plateau scheduler is stepped without its required  metric

Nested `SequentialLR`/`ChainedScheduler` compositions forward metrics through their containers, so a plateau scheduler can be nested within either composition type.

You can find the sample code here: https://github.com/pupeno/pytorch-workspace/tree/main/195633_minimal_reduce_lr_on_plateau_composable

An alternative approach is available in #195634. The two PRs are mutually exclusive.

This PR depends on https://github.com/pytorch/pytorch/pull/196242