### PR TITLE
PlateauLR, a composable version of ReduceLROnPlateau (and extensible LRSchedule step API to support it)

### DIFF
--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -442,8 +442,10 @@ hooks that apply to every optimizer instead of one optimizer instance.
 ## How to adjust learning rate
 
 {class}`torch.optim.lr_scheduler.LRScheduler` provides several methods to adjust the learning
-rate based on the number of epochs. {class}`torch.optim.lr_scheduler.ReduceLROnPlateau`
-allows dynamic learning rate reducing based on some validation measurements.
+rate based on the number of epochs. {class}`torch.optim.lr_scheduler.PlateauLR`
+allows dynamic learning rate reducing based on some validation measurements, and unlike the
+deprecated {class}`torch.optim.lr_scheduler.ReduceLROnPlateau` it can be composed with
+{class}`~torch.optim.lr_scheduler.SequentialLR` and {class}`~torch.optim.lr_scheduler.ChainedScheduler`.
 
 Learning rate scheduling should be applied after optimizer's update; e.g., you
 should write your code this way:
@@ -522,6 +524,7 @@ if you are calling `scheduler.step()` at the wrong time.
     lr_scheduler.ChainedScheduler
     lr_scheduler.SequentialLR
     lr_scheduler.ReduceLROnPlateau
+    lr_scheduler.PlateauLR
     lr_scheduler.CyclicLR
     lr_scheduler.OneCycleLR
     lr_scheduler.CosineAnnealingWarmRestarts

--- a/docs/source/optim.md
+++ b/docs/source/optim.md
@@ -443,9 +443,7 @@ hooks that apply to every optimizer instead of one optimizer instance.
 
 {class}`torch.optim.lr_scheduler.LRScheduler` provides several methods to adjust the learning
 rate based on the number of epochs. {class}`torch.optim.lr_scheduler.PlateauLR`
-allows dynamic learning rate reducing based on some validation measurements, and unlike the
-deprecated {class}`torch.optim.lr_scheduler.ReduceLROnPlateau` it can be composed with
-{class}`~torch.optim.lr_scheduler.SequentialLR` and {class}`~torch.optim.lr_scheduler.ChainedScheduler`.
+allows dynamic learning rate reducing based on some validation measurements.
 
 Learning rate scheduling should be applied after optimizer's update; e.g., you
 should write your code this way:

--- a/docs/source/scripts/build_lr_scheduler_images.py
+++ b/docs/source/scripts/build_lr_scheduler_images.py
@@ -17,8 +17,8 @@ from torch.optim.lr_scheduler import (
     MultiplicativeLR,
     MultiStepLR,
     OneCycleLR,
+    PlateauLR,
     PolynomialLR,
-    ReduceLROnPlateau,
     SequentialLR,
     StepLR,
 )
@@ -56,7 +56,7 @@ schedulers = [
     (lambda opt: CosineAnnealingWarmRestarts(opt, T_0=20)),
     (lambda opt: CyclicLR(opt, base_lr=0.01, max_lr=0.1, step_size_up=10)),
     (lambda opt: OneCycleLR(opt, max_lr=0.01, epochs=10, steps_per_epoch=10)),
-    (lambda opt: ReduceLROnPlateau(opt, mode="min")),
+    (lambda opt: PlateauLR(opt, mode="min")),
     (lambda opt: ChainedScheduler(constant_exponential_schedulers(opt))),
     (
         lambda opt: SequentialLR(
@@ -79,9 +79,9 @@ def plot_function(scheduler):
 
     for _ in range(num_epochs):
         lrs.append(optimizer.param_groups[0]["lr"])
-        if isinstance(scheduler, ReduceLROnPlateau):
+        if isinstance(scheduler, PlateauLR):
             val_loss = torch.randn(1).item()
-            scheduler.step(val_loss)
+            scheduler.step(metrics=val_loss)
         else:
             scheduler.step()
 

--- a/docs/source/scripts/build_lr_scheduler_images.py
+++ b/docs/source/scripts/build_lr_scheduler_images.py
@@ -19,6 +19,7 @@ from torch.optim.lr_scheduler import (
     OneCycleLR,
     PlateauLR,
     PolynomialLR,
+    ReduceLROnPlateau,
     SequentialLR,
     StepLR,
 )
@@ -57,6 +58,7 @@ schedulers = [
     (lambda opt: CyclicLR(opt, base_lr=0.01, max_lr=0.1, step_size_up=10)),
     (lambda opt: OneCycleLR(opt, max_lr=0.01, epochs=10, steps_per_epoch=10)),
     (lambda opt: PlateauLR(opt, mode="min")),
+    (lambda opt: ReduceLROnPlateau(opt, mode="min")),
     (lambda opt: ChainedScheduler(constant_exponential_schedulers(opt))),
     (
         lambda opt: SequentialLR(
@@ -79,7 +81,7 @@ def plot_function(scheduler):
 
     for _ in range(num_epochs):
         lrs.append(optimizer.param_groups[0]["lr"])
-        if isinstance(scheduler, PlateauLR):
+        if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
             val_loss = torch.randn(1).item()
             scheduler.step(metrics=val_loss)
         else:

--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -167,8 +167,8 @@ LR_SCHEDULER_TO_KWARGS = {
     },
     ConstantLR: {"factor": 0.001},
     LinearLR: {},
-    ReduceLROnPlateau: {"factor": 0.99, "patience": 1},
     PlateauLR: {"factor": 0.99, "patience": 0},
+    ReduceLROnPlateau: {"factor": 0.99, "patience": 1},
     PolynomialLR: {},
 }
 
@@ -365,13 +365,7 @@ except (unittest.SkipTest, ImportError) as e:
 
 
 def call_scheduler(scheduler):
-    if isinstance(
-        scheduler,
-        (torch.optim.lr_scheduler.PlateauLR, torch.optim.lr_scheduler.ReduceLROnPlateau),
-    ):
-        scheduler.step(metrics=1.0)
-    else:
-        scheduler.step()
+    scheduler.step(metrics=1.0)
 
 
 def compile_opt(opt_compiled, closure=None, fullgraph=True):

--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -44,8 +44,8 @@ from torch.optim.lr_scheduler import (
     MultiplicativeLR,
     MultiStepLR,
     OneCycleLR,
+    PlateauLR,
     PolynomialLR,
-    ReduceLROnPlateau,
     SequentialLR,
     StepLR,
 )
@@ -166,7 +166,7 @@ LR_SCHEDULER_TO_KWARGS = {
     },
     ConstantLR: {"factor": 0.001},
     LinearLR: {},
-    ReduceLROnPlateau: {"factor": 0.99, "patience": 1},
+    PlateauLR: {"factor": 0.99, "patience": 0},
     PolynomialLR: {},
 }
 
@@ -363,8 +363,8 @@ except (unittest.SkipTest, ImportError) as e:
 
 
 def call_scheduler(scheduler):
-    if isinstance(scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
-        scheduler.step(1.0)  # we won't reduce the metric over two iters anyway
+    if isinstance(scheduler, torch.optim.lr_scheduler.PlateauLR):
+        scheduler.step(metrics=1.0)
     else:
         scheduler.step()
 

--- a/test/inductor/test_compiled_optimizers.py
+++ b/test/inductor/test_compiled_optimizers.py
@@ -46,6 +46,7 @@ from torch.optim.lr_scheduler import (
     OneCycleLR,
     PlateauLR,
     PolynomialLR,
+    ReduceLROnPlateau,
     SequentialLR,
     StepLR,
 )
@@ -166,6 +167,7 @@ LR_SCHEDULER_TO_KWARGS = {
     },
     ConstantLR: {"factor": 0.001},
     LinearLR: {},
+    ReduceLROnPlateau: {"factor": 0.99, "patience": 1},
     PlateauLR: {"factor": 0.99, "patience": 0},
     PolynomialLR: {},
 }
@@ -363,7 +365,10 @@ except (unittest.SkipTest, ImportError) as e:
 
 
 def call_scheduler(scheduler):
-    if isinstance(scheduler, torch.optim.lr_scheduler.PlateauLR):
+    if isinstance(
+        scheduler,
+        (torch.optim.lr_scheduler.PlateauLR, torch.optim.lr_scheduler.ReduceLROnPlateau),
+    ):
         scheduler.step(metrics=1.0)
     else:
         scheduler.step()

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -908,6 +908,9 @@ class TestLRScheduler(TestCase):
             scheduler.step()
         with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
             scheduler.step(metrics=None)
+        error = r"Did you mean `step\(metrics=\.\.\.\)`\?"
+        with self.assertRaisesRegex(ValueError, error):
+            scheduler.step(1.0)
 
     def test_plateau_lr_initial_step_no_metrics(self):
         # Construction performs an implicit initial step with no metric

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -849,6 +849,10 @@ class TestLRScheduler(TestCase):
     # identical to ReduceLROnPlateau's hand-rolled step() body, so these
     # standalone tests reuse the exact metrics/target vectors from
     # test_reduce_lr_on_plateau1-8 above as a regression check.
+    def test_plateau_lr_rejects_invalid_optimizer(self):
+        with self.assertRaisesRegex(TypeError, "object is not an Optimizer"):
+            PlateauLR(object())  # type: ignore[arg-type]
+
     def test_plateau_lr1(self):
         epochs = 10
         for param_group in self.opt.param_groups:

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -1013,6 +1013,21 @@ class TestLRScheduler(TestCase):
         scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=milestones)
         self._test(scheduler, targets, epochs)
 
+    def test_sequentiallr_update_lr_uses_stage_local_epoch(self):
+        optimizer = SGD([torch.tensor(0.5)], lr=1.0)
+        second_scheduler = ExponentialLR(optimizer, gamma=0.1)
+        scheduler = SequentialLR(
+            optimizer,
+            schedulers=[ConstantLR(optimizer, factor=1.0), second_scheduler],
+            milestones=[3],
+        )
+
+        scheduler._update_lr(5)
+
+        self.assertEqual(scheduler.last_epoch, 5)
+        self.assertEqual(second_scheduler.last_epoch, 2)
+        self.assertEqual(optimizer.param_groups[0]["lr"], 0.1**2)
+
     def test_sequentiallr_no_warnings(self):
         scheduler1 = LinearLR(self.opt, start_factor=0.5, end_factor=0.1, total_iters=5)
         scheduler2 = ExponentialLR(self.opt, gamma=0.9)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -871,6 +871,61 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs=2)
         self.opt = old_opt
 
+    def test_nested_sequentiallr_does_not_skip_an_epoch(self):
+        """A nested SequentialLR runs the same schedule as it does on its own."""
+        epochs = 8
+        # The first five values are exactly what the inner scheduler produces
+        # when it is used directly: two epochs of ConstantLR, then ExponentialLR
+        # from its epoch 0. Nesting must not consume one of those epochs.
+        inner_targets = [0.5, 0.5, 1.0, 0.9, 0.81]
+        outer_targets = [1.0, 1.0, 0.5]
+        single_targets = inner_targets + outer_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        inner = SequentialLR(
+            self.opt,
+            schedulers=[
+                ConstantLR(self.opt, factor=0.5, total_iters=2),
+                ExponentialLR(self.opt, gamma=0.9),
+            ],
+            milestones=[2],
+        )
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
+            milestones=[5],
+        )
+        self._test(scheduler, targets, epochs)
+
+    def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
+        """A nested ChainedScheduler runs the same schedule as it does on its own."""
+        epochs = 8
+        # The first five values are exactly what the chained scheduler produces
+        # when it is used directly: ConstantLR and ExponentialLR both scaling
+        # the lr from its epoch 0. Nesting must not apply either of them twice.
+        inner_targets = [0.5, 0.45, 0.81, 0.729, 0.6561]
+        outer_targets = [1.0, 1.0, 0.5]
+        single_targets = inner_targets + outer_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        inner = ChainedScheduler(
+            [
+                ConstantLR(self.opt, factor=0.5, total_iters=2),
+                ExponentialLR(self.opt, gamma=0.9),
+            ],
+            optimizer=self.opt,
+        )
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
+            milestones=[5],
+        )
+        self._test(scheduler, targets, epochs)
+
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [
             LinearLR(self.opt, start_factor=0.4, total_iters=3),

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -121,6 +121,23 @@ class TestLRScheduler(TestCase):
             self.update_kwargs.append(kwargs)
             super()._update_lr(epoch)
 
+    class LegacyGetLRScheduler(LRScheduler):
+        """A third-party scheduler using the previous ``get_lr`` API."""
+
+        def get_lr(self):
+            return [group["lr"] for group in self.optimizer.param_groups]
+
+    class KwargsGetLRScheduler(LRScheduler):
+        """A third-party scheduler consuming kwargs in ``get_lr``."""
+
+        def __init__(self, optimizer):
+            self.get_lr_kwargs = []
+            super().__init__(optimizer)
+
+        def get_lr(self, **kwargs):
+            self.get_lr_kwargs.append(kwargs)
+            return [group["lr"] for group in self.optimizer.param_groups]
+
     exact_dtype = True
 
     def setUp(self):
@@ -812,6 +829,20 @@ class TestLRScheduler(TestCase):
         scheduler.step(metrics=2.0)
         self.assertEqual(handoff.update_kwargs[-1], {"metrics": 2.0})
 
+    def test_lrscheduler_kwargs_support_legacy_get_lr(self):
+        scheduler = self.LegacyGetLRScheduler(self.opt)
+        self.opt.step()
+        scheduler.step(metrics=1.0)
+
+        self.assertEqual(scheduler.last_epoch, 1)
+
+    def test_kwargs_reach_get_lr(self):
+        scheduler = self.KwargsGetLRScheduler(self.opt)
+        self.opt.step()
+        scheduler.step(metrics=1.0)
+
+        self.assertEqual(scheduler.get_lr_kwargs[-1], {"metrics": 1.0})
+
     # PlateauLR is ReduceLROnPlateau's composable replacement (properly
     # implements get_lr(), so it can be used inside SequentialLR/
     # ChainedScheduler). Its get_lr()-driven logic is meant to be numerically
@@ -984,6 +1015,7 @@ class TestLRScheduler(TestCase):
         for key in scheduler.__dict__:
             if key != "optimizer":
                 self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+        self.assertNotIn("_metrics", scheduler.state_dict())
 
     def test_sequentiallr1(self):
         epochs = 19
@@ -1341,7 +1373,7 @@ class TestLRScheduler(TestCase):
         scheduler.step(some_future_input=1.0)
 
     def test_plateau_lr_rejects_misspelled_metrics(self):
-        """`metrics` is named explicitly, so a typo is not silently ignored."""
+        """A misspelled `metrics` argument is not silently ignored."""
         scheduler = PlateauLR(self.opt)
         self.opt.step()
         with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -7,6 +7,7 @@ import tempfile
 import types
 import warnings
 from functools import partial
+from unittest import expectedFailure
 
 import torch
 import torch.nn.functional as F
@@ -73,70 +74,50 @@ class TestLRScheduler(TestCase):
             else:
                 return False
 
-    class LegacyScheduler(LRScheduler):
-        """A third-party scheduler using the pre-metrics step signature."""
+    class LegacyGetLRScheduler(LRScheduler):
+        """A third-party scheduler whose `get_lr` predates keyword arguments."""
 
         def get_lr(self):
             return [group["lr"] for group in self.optimizer.param_groups]
 
-        def step(self, epoch=None):
-            super().step(epoch)
-
-    class KwargsRecordingScheduler(LRScheduler):
-        """A third-party scheduler collecting its step arguments in
-        ``**kwargs``.
-        """
-
-        def __init__(self, optimizer):
-            self.step_kwargs = []
-            super().__init__(optimizer)
-
-        def get_lr(self):
-            return [group["lr"] for group in self.optimizer.param_groups]
-
-        def step(self, epoch=None, **kwargs):
-            self.step_kwargs.append(kwargs)
-            super().step(epoch)
-
-    class LegacyUpdateScheduler(LRScheduler):
-        """A third-party scheduler overriding the previous private hook."""
-
-        def get_lr(self):
-            return [group["lr"] for group in self.optimizer.param_groups]
+    class LegacyUpdateLRScheduler(LegacyGetLRScheduler):
+        """A third-party scheduler whose `_update_lr` predates keyword arguments."""
 
         def _update_lr(self, epoch=None):
             super()._update_lr(epoch)
 
-    class KwargsUpdateScheduler(LRScheduler):
-        """A third-party scheduler consuming kwargs in the update hook."""
+    class LegacyStepScheduler(LegacyUpdateLRScheduler):
+        """A third-party scheduler whose `step` predates keyword arguments."""
+
+        def step(self, epoch=None):
+            super().step(epoch)
+
+    class RecordingScheduler(LRScheduler):
+        """A third-party scheduler that records inputs at every update hook."""
 
         def __init__(self, optimizer):
+            self.step_kwargs = []
             self.update_kwargs = []
-            super().__init__(optimizer)
-
-        def get_lr(self):
-            return [group["lr"] for group in self.optimizer.param_groups]
-
-        def _update_lr(self, epoch=None, **kwargs):
-            self.update_kwargs.append(kwargs)
-            super()._update_lr(epoch)
-
-    class LegacyGetLRScheduler(LRScheduler):
-        """A third-party scheduler using the previous ``get_lr`` API."""
-
-        def get_lr(self):
-            return [group["lr"] for group in self.optimizer.param_groups]
-
-    class KwargsGetLRScheduler(LRScheduler):
-        """A third-party scheduler consuming kwargs in ``get_lr``."""
-
-        def __init__(self, optimizer):
             self.get_lr_kwargs = []
             super().__init__(optimizer)
 
         def get_lr(self, **kwargs):
             self.get_lr_kwargs.append(kwargs)
             return [group["lr"] for group in self.optimizer.param_groups]
+
+        def _update_lr(self, epoch=None, **kwargs):
+            self.update_kwargs.append(kwargs)
+            super()._update_lr(epoch, **kwargs)
+
+        def step(self, epoch=None, **kwargs):
+            self.step_kwargs.append(kwargs)
+            super().step(epoch, **kwargs)
+
+        def clear(self):
+            """Forget the inputs recorded so far, including the initial step."""
+            self.step_kwargs.clear()
+            self.update_kwargs.clear()
+            self.get_lr_kwargs.clear()
 
     exact_dtype = True
 
@@ -656,204 +637,93 @@ class TestLRScheduler(TestCase):
         new_lrs = new_scheduler._last_lr
         torch.testing.assert_close(original_lrs, new_lrs, rtol=1e-4, atol=1e-5)
 
-    def test_reduce_lr_on_plateau1(self):
-        epochs = 10
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 20]
-        metrics = [10 - i * 0.0167 for i in range(20)]
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            threshold_mode="abs",
-            mode="min",
-            threshold=0.01,
-            patience=5,
-            cooldown=5,
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau2(self):
-        epochs = 22
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 6 + [0.05] * 7 + [0.005] * 7 + [0.0005] * 2]
-        metrics = [10 - i * 0.0165 for i in range(22)]
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            patience=5,
-            cooldown=0,
-            threshold_mode="abs",
-            mode="min",
-            threshold=0.1,
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau3(self):
-        epochs = 22
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * (2 + 6) + [0.05] * (5 + 6) + [0.005] * 4]
-        metrics = [-0.8] * 2 + [-0.234] * 20
-        scheduler = ReduceLROnPlateau(
-            self.opt, mode="max", patience=5, cooldown=5, threshold_mode="abs"
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau4(self):
-        epochs = 20
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 20]
-        metrics = [1.5 * (1.025**i) for i in range(20)]  # 1.025 > 1.1**0.25
-        scheduler = ReduceLROnPlateau(
-            self.opt, mode="max", patience=3, threshold_mode="rel", threshold=0.1
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau5(self):
-        epochs = 20
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
-        metrics = [1.5 * (1.005**i) for i in range(20)]
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            mode="max",
-            threshold_mode="rel",
-            threshold=0.1,
-            patience=5,
-            cooldown=5,
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau6(self):
-        epochs = 20
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 20]
-        metrics = [1.5 * (0.85**i) for i in range(20)]
-        scheduler = ReduceLROnPlateau(
-            self.opt, mode="min", threshold_mode="rel", threshold=0.1
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau7(self):
-        epochs = 20
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
-        metrics = [1] * 7 + [0.6] + [0.5] * 12
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            mode="min",
-            threshold_mode="rel",
-            threshold=0.1,
-            patience=5,
-            cooldown=5,
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau8(self):
-        epochs = 20
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 6 + [0.4] * 14, [0.5] * 6 + [0.3] * 14]
-        metrics = [1.5 * (1.005**i) for i in range(20)]
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            mode="max",
-            threshold_mode="rel",
-            min_lr=[0.4, 0.3],
-            threshold=0.1,
-            patience=5,
-            cooldown=5,
-        )
-        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
-
-    def test_reduce_lr_on_plateau_get_last_lr_before_step(self):
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-        )
-        self.assertEqual(
-            scheduler.get_last_lr(), [0.5 for param_group in self.opt.param_groups]
-        )
-
-    def test_reduce_lr_on_plateau_preserves_lr_type(self):
-        # Ensures that tensor lrs are preserved, preventing recompilations.
-        types = [type(group["lr"]) for group in self.opt.param_groups]
-        scheduler = ReduceLROnPlateau(self.opt, mode="min", patience=0)
-        scheduler.step(1.0)
-        scheduler.step(2.0)  # Triggers scheduler._reduce_lr
-        for group, type_ in zip(self.opt.param_groups, types):
-            self.assertEqual(type(group["lr"]), type_)
-
-    def test_reduce_lr_on_plateau_is_deprecated(self):
-        with self.assertWarnsRegex(FutureWarning, "PlateauLR"):
-            ReduceLROnPlateau(self.opt)
-
-    def test_lrscheduler_kwargs_support_legacy_update_hook(self):
-        scheduler = self.LegacyUpdateScheduler(self.opt)
+    def test_scheduler_step_forwards_kwargs_to_update_hooks(self):
+        scheduler = self.RecordingScheduler(self.opt)
         self.opt.step()
-        scheduler.step(metrics=1.0)
+        scheduler.step(metrics=1.0, extra=2.0)
 
-        self.assertEqual(scheduler.last_epoch, 1)
+        expected = {"metrics": 1.0, "extra": 2.0}
+        # The initial step performed on construction carries no inputs.
+        self.assertEqual(scheduler.step_kwargs, [{}, expected])
+        self.assertEqual(scheduler.update_kwargs, [{}, expected])
+        self.assertEqual(scheduler.get_lr_kwargs, [{}, expected])
 
-    def test_sequentiallr_kwargs_support_legacy_update_hook_at_handoff(self):
-        legacy = self.LegacyUpdateScheduler(self.opt)
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[ConstantLR(self.opt), legacy],
-            milestones=[1],
-        )
-
-        self.opt.step()
-        scheduler.step(metrics=1.0)
-
-        self.assertEqual(legacy.last_epoch, 0)
-
-    def test_kwargs_reach_update_hook_directly_and_at_handoff(self):
-        direct = self.KwargsUpdateScheduler(self.opt)
-        self.opt.step()
-        direct.step(metrics=1.0)
-        self.assertEqual(direct.update_kwargs[-1], {"metrics": 1.0})
-
-        handoff = self.KwargsUpdateScheduler(self.opt)
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[ConstantLR(self.opt), handoff],
-            milestones=[1],
-        )
-        self.opt.step()
-        scheduler.step(metrics=2.0)
-        self.assertEqual(handoff.update_kwargs[-1], {"metrics": 2.0})
-
-    def test_lrscheduler_kwargs_support_legacy_get_lr(self):
+    def test_scheduler_step_supports_legacy_get_lr(self):
         scheduler = self.LegacyGetLRScheduler(self.opt)
+        initial_lrs = [float(group["lr"]) for group in self.opt.param_groups]
+
+        # The inputs cannot reach a `get_lr` that predates them, but the step
+        # still goes through.
         self.opt.step()
         scheduler.step(metrics=1.0)
 
         self.assertEqual(scheduler.last_epoch, 1)
+        self.assertEqual(
+            [float(group["lr"]) for group in self.opt.param_groups], initial_lrs
+        )
 
-    def test_kwargs_reach_get_lr(self):
-        scheduler = self.KwargsGetLRScheduler(self.opt)
+    def test_scheduler_step_supports_legacy_update_lr(self):
+        scheduler = self.LegacyUpdateLRScheduler(self.opt)
+        initial_lrs = [float(group["lr"]) for group in self.opt.param_groups]
+
+        # The inputs cannot reach an `_update_lr` that predates them, but the
+        # step still goes through.
         self.opt.step()
         scheduler.step(metrics=1.0)
 
-        self.assertEqual(scheduler.get_lr_kwargs[-1], {"metrics": 1.0})
+        self.assertEqual(scheduler.last_epoch, 1)
+        self.assertEqual(
+            [float(group["lr"]) for group in self.opt.param_groups], initial_lrs
+        )
 
-    # PlateauLR is ReduceLROnPlateau's composable replacement (properly
-    # implements get_lr(), so it can be used inside SequentialLR/
-    # ChainedScheduler). Its get_lr()-driven logic is meant to be numerically
-    # identical to ReduceLROnPlateau's hand-rolled step() body, so these
-    # standalone tests reuse the exact metrics/target vectors from
-    # test_reduce_lr_on_plateau1-8 above as a regression check.
+    @parametrize(
+        "scheduler_factory",
+        [
+            partial(LambdaLR, lr_lambda=lambda epoch: 1.0),
+            partial(MultiplicativeLR, lr_lambda=lambda epoch: 1.0),
+            partial(StepLR, step_size=2),
+            partial(MultiStepLR, milestones=[2]),
+            ConstantLR,
+            LinearLR,
+            partial(ExponentialLR, gamma=0.9),
+            PolynomialLR,
+            partial(CosineAnnealingLR, T_max=4),
+            partial(CyclicLR, base_lr=0.01, max_lr=0.1, cycle_momentum=False),
+            partial(OneCycleLR, max_lr=0.1, total_steps=4, cycle_momentum=False),
+            partial(CosineAnnealingWarmRestarts, T_0=2),
+            partial(SWALR, swa_lr=0.01),
+        ],
+    )
+    def test_scheduler_step_ignores_unused_kwargs(self, scheduler_factory):
+        optimizer = SGD([torch.nn.Parameter(torch.ones(1))], lr=0.05)
+        reference_optimizer = SGD([torch.nn.Parameter(torch.ones(1))], lr=0.05)
+        scheduler = scheduler_factory(optimizer)
+        reference = scheduler_factory(reference_optimizer)
+
+        for _ in range(3):
+            optimizer.step()
+            scheduler.step(unused=True)
+            reference_optimizer.step()
+            reference.step()
+
+            self.assertEqual(scheduler.get_last_lr(), reference.get_last_lr())
+
     def test_plateau_lr_rejects_invalid_optimizer(self):
         with self.assertRaisesRegex(TypeError, "object is not an Optimizer"):
             PlateauLR(object())  # type: ignore[arg-type]
 
-    def test_plateau_lr1(self):
+    def test_plateau_lr_rejects_invalid_configuration(self):
+        cases = [
+            ({"factor": 1.0}, "Factor should be < 1.0"),
+            ({"min_lr": [0.0]}, "expected 2 min_lrs"),
+            ({"mode": "median"}, "mode median is unknown"),
+            ({"threshold_mode": "percentage"}, "threshold mode percentage is unknown"),
+        ]
+        for kwargs, error in cases:
+            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, error):
+                PlateauLR(self.opt, **kwargs)
+
+    def test_plateau_lr_absolute_min_tracks_improvements(self):
         epochs = 10
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -869,7 +739,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr2(self):
+    def test_plateau_lr_absolute_min_respects_patience(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -885,7 +755,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr3(self):
+    def test_plateau_lr_absolute_max_respects_cooldown(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -896,7 +766,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr4(self):
+    def test_plateau_lr_relative_max_tracks_improvements(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -907,7 +777,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr5(self):
+    def test_plateau_lr_relative_max_respects_cooldown(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -923,7 +793,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr6(self):
+    def test_plateau_lr_relative_min_tracks_improvements(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -932,7 +802,7 @@ class TestLRScheduler(TestCase):
         scheduler = PlateauLR(self.opt, mode="min", threshold_mode="rel", threshold=0.1)
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr7(self):
+    def test_plateau_lr_relative_min_respects_cooldown(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -948,7 +818,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr8(self):
+    def test_plateau_lr_respects_per_group_min_lr(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -965,10 +835,11 @@ class TestLRScheduler(TestCase):
         )
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr_get_last_lr_before_step(self):
+    def test_plateau_lr_initial_state(self):
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
         scheduler = PlateauLR(self.opt)
+        self.assertEqual(scheduler.last_epoch, 0)
         self.assertEqual(
             scheduler.get_last_lr(), [0.5 for param_group in self.opt.param_groups]
         )
@@ -984,42 +855,193 @@ class TestLRScheduler(TestCase):
         for group, type_ in zip(self.opt.param_groups, types):
             self.assertEqual(type(group["lr"]), type_)
 
-    def test_plateau_lr_get_lr_warns(self):
-        scheduler = PlateauLR(self.opt, factor=0.5, patience=0)
+    def test_plateau_lr_skips_reduction_smaller_than_eps(self):
+        initial_lrs = [group["lr"] for group in self.opt.param_groups]
+        scheduler = PlateauLR(self.opt, factor=0.5, patience=0, eps=0.3)
+        for metric in [1.0, 2.0]:
+            self.opt.step()
+            scheduler.step(metrics=metric)
+        self.assertEqual(scheduler.get_last_lr(), initial_lrs)
+
+    def test_plateau_lr_warns_when_get_lr_is_called_directly(self):
+        scheduler = PlateauLR(self.opt)
         with self.assertWarnsRegex(UserWarning, r"please use `get_last_lr\(\)`"):
-            self.assertEqual(scheduler.get_lr(), scheduler.get_last_lr())
+            scheduler.get_lr()
 
     def test_plateau_lr_requires_metrics(self):
         scheduler = PlateauLR(self.opt)
         self.opt.step()
-        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
-            scheduler.step()
-        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
-            scheduler.step(metrics=None)
+        for kwargs in [{}, {"metrics": None}, {"metric": 1.0}]:
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(ValueError, "requires the metric it monitors"),
+            ):
+                scheduler.step(**kwargs)
+
+    def test_plateau_lr_rejects_metrics_passed_positionally(self):
+        scheduler = PlateauLR(self.opt)
+        self.opt.step()
         error = r"Did you mean `step\(metrics=\.\.\.\)`\?"
         with self.assertRaisesRegex(ValueError, error):
             scheduler.step(1.0)
 
-    def test_plateau_lr_initial_step_no_metrics(self):
-        # Construction performs an implicit initial step with no metric
-        # available; it must not raise, and must leave the lr unchanged.
+    def test_reduce_lr_on_plateau_rejects_invalid_optimizer(self):
+        with self.assertRaisesRegex(TypeError, "object is not an Optimizer"):
+            ReduceLROnPlateau(object())  # type: ignore[arg-type]
+
+    def test_reduce_lr_on_plateau_rejects_invalid_configuration(self):
+        cases = [
+            ({"factor": 1.0}, "Factor should be < 1.0"),
+            ({"min_lr": [0.0]}, "expected 2 min_lrs"),
+            ({"mode": "median"}, "mode median is unknown"),
+            ({"threshold_mode": "percentage"}, "threshold mode percentage is unknown"),
+        ]
+        for kwargs, error in cases:
+            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, error):
+                ReduceLROnPlateau(self.opt, **kwargs)
+
+    def test_reduce_lr_on_plateau_absolute_min_tracks_improvements(self):
+        epochs = 10
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
-        scheduler = PlateauLR(self.opt)
-        self.assertEqual(scheduler.last_epoch, 0)
-        self.assertEqual(scheduler.get_last_lr(), [0.5 for _ in self.opt.param_groups])
+        targets = [[0.5] * 20]
+        metrics = [10 - i * 0.0167 for i in range(20)]
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+            threshold_mode="abs",
+            mode="min",
+            threshold=0.01,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_plateau_lr_state_dict(self):
-        scheduler = PlateauLR(self.opt, mode="min", factor=0.1, patience=2)
-        for score in [1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0, 3.0, 2.0, 1.0]:
-            self.opt.step()
-            scheduler.step(metrics=score)
-        scheduler_copy = PlateauLR(self.opt, mode="max", factor=0.5, patience=10)
-        scheduler_copy.load_state_dict(scheduler.state_dict())
-        for key in scheduler.__dict__:
-            if key != "optimizer":
-                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
-        self.assertNotIn("_metrics", scheduler.state_dict())
+    def test_reduce_lr_on_plateau_absolute_min_respects_patience(self):
+        epochs = 22
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.05] * 7 + [0.005] * 7 + [0.0005] * 2]
+        metrics = [10 - i * 0.0165 for i in range(22)]
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+            patience=5,
+            cooldown=0,
+            threshold_mode="abs",
+            mode="min",
+            threshold=0.1,
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
+
+    def test_reduce_lr_on_plateau_absolute_max_respects_cooldown(self):
+        epochs = 22
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * (2 + 6) + [0.05] * (5 + 6) + [0.005] * 4]
+        metrics = [-0.8] * 2 + [-0.234] * 20
+        scheduler = ReduceLROnPlateau(
+            self.opt, mode="max", patience=5, cooldown=5, threshold_mode="abs"
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
+
+    def test_reduce_lr_on_plateau_relative_max_tracks_improvements(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 20]
+        metrics = [1.5 * (1.025**i) for i in range(20)]  # 1.025 > 1.1**0.25
+        scheduler = ReduceLROnPlateau(
+            self.opt, mode="max", patience=3, threshold_mode="rel", threshold=0.1
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
+
+    def test_reduce_lr_on_plateau_relative_max_respects_cooldown(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
+        metrics = [1.5 * (1.005**i) for i in range(20)]
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+            mode="max",
+            threshold_mode="rel",
+            threshold=0.1,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
+
+    def test_reduce_lr_on_plateau_relative_min_tracks_improvements(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 20]
+        metrics = [1.5 * (0.85**i) for i in range(20)]
+        scheduler = ReduceLROnPlateau(
+            self.opt, mode="min", threshold_mode="rel", threshold=0.1
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
+
+    def test_reduce_lr_on_plateau_relative_min_respects_cooldown(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
+        metrics = [1] * 7 + [0.6] + [0.5] * 12
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+            mode="min",
+            threshold_mode="rel",
+            threshold=0.1,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
+
+    def test_reduce_lr_on_plateau_respects_per_group_min_lr(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.4] * 14, [0.5] * 6 + [0.3] * 14]
+        metrics = [1.5 * (1.005**i) for i in range(20)]
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+            mode="max",
+            threshold_mode="rel",
+            min_lr=[0.4, 0.3],
+            threshold=0.1,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
+
+    def test_reduce_lr_on_plateau_initial_state(self):
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        scheduler = ReduceLROnPlateau(self.opt)
+        self.assertEqual(scheduler.last_epoch, 0)
+        self.assertEqual(
+            scheduler.get_last_lr(), [0.5 for param_group in self.opt.param_groups]
+        )
+
+    def test_reduce_lr_on_plateau_preserves_lr_type(self):
+        # Ensures that tensor lrs are preserved, preventing recompilations.
+        types = [type(group["lr"]) for group in self.opt.param_groups]
+        scheduler = ReduceLROnPlateau(self.opt, mode="min", patience=0)
+        scheduler.step(1.0)
+        scheduler.step(2.0)  # Triggers scheduler._reduce_lr
+        for group, type_ in zip(self.opt.param_groups, types):
+            self.assertEqual(type(group["lr"]), type_)
+
+    def test_reduce_lr_on_plateau_skips_reduction_smaller_than_eps(self):
+        initial_lrs = [group["lr"] for group in self.opt.param_groups]
+        scheduler = ReduceLROnPlateau(self.opt, factor=0.5, patience=0, eps=0.3)
+        scheduler.step(1.0)
+        scheduler.step(2.0)
+        self.assertEqual(scheduler.get_last_lr(), initial_lrs)
+
+    def test_reduce_lr_on_plateau_is_deprecated(self):
+        with self.assertWarnsRegex(FutureWarning, "PlateauLR"):
+            ReduceLROnPlateau(self.opt)
 
     def test_sequentiallr1(self):
         epochs = 19
@@ -1300,19 +1322,84 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs)
         self.assertEqual(scheduler.get_last_lr(), schedulers[-1].get_last_lr())
 
-    def test_sequentiallr_with_plateau_lr(self):
-        """Warm up with a fixed schedule, then hand off to PlateauLR."""
+    def test_sequential_lr_forwards_kwargs_to_the_active_scheduler(self):
+        first = self.RecordingScheduler(self.opt)
+        second = self.RecordingScheduler(self.opt)
+        scheduler = SequentialLR(self.opt, [first, second], milestones=[2])
+        first.clear()
+        second.clear()
+
+        self.opt.step()
+        scheduler.step(metrics=1.0, extra=2.0)
+
+        expected = {"metrics": 1.0, "extra": 2.0}
+        self.assertEqual(first.step_kwargs, [expected])
+        self.assertEqual(first.update_kwargs, [expected])
+        self.assertEqual(first.get_lr_kwargs, [expected])
+        self.assertEqual(second.step_kwargs, [])
+        self.assertEqual(second.update_kwargs, [])
+
+    def test_sequential_lr_forwards_kwargs_at_the_handoff(self):
+        first = self.RecordingScheduler(self.opt)
+        second = self.RecordingScheduler(self.opt)
+        scheduler = SequentialLR(self.opt, [first, second], milestones=[2])
+        second.clear()
+
+        for metric in [1.0, 2.0]:
+            self.opt.step()
+            scheduler.step(metrics=metric)
+
+        # A milestone updates the incoming scheduler through `_update_lr`
+        # rather than `step`, so the inputs have to reach it along that path.
+        self.assertEqual(second.step_kwargs, [])
+        self.assertEqual(second.update_kwargs, [{"metrics": 2.0}])
+        self.assertEqual(second.get_lr_kwargs, [{"metrics": 2.0}])
+
+    def test_sequential_lr_supports_legacy_children(self):
+        first = self.LegacyStepScheduler(self.opt)
+        second = self.LegacyStepScheduler(self.opt)
+        scheduler = SequentialLR(self.opt, [first, second], milestones=[2])
+
+        for metric in [1.0, 2.0, 3.0]:
+            self.opt.step()
+            scheduler.step(metrics=metric)
+
+        # `first` ran once, then `second` took over at the milestone and ran
+        # once, neither ever handed the metric it cannot accept.
+        self.assertEqual(first.last_epoch, 1)
+        self.assertEqual(second.last_epoch, 1)
+
+    def test_sequential_lr_state_dict_omits_kwargs_support(self):
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt), PlateauLR(self.opt)],
+            milestones=[2],
+        )
+        # Which schedulers accept scheduling inputs is rederived on
+        # construction, so it must stay out of the checkpoint.
+        self.assertNotIn("_schedulers_accept_kwargs", scheduler.state_dict())
+
+    def test_sequential_lr_starts_with_plateau_lr(self):
         epochs = 8
         for param_group in self.opt.param_groups:
             param_group["lr"] = 1.0
-        # The metric never improves after its first sighting, so with
-        # patience=0 the plateau scheduler reduces every subsequent epoch;
-        # its first sighting always counts as an improvement over `inf`.
+        metrics = [1.0] * epochs
+        plateau_targets = [1.0, 0.5]
+        step_targets = [1.0, 1.0, 0.1, 0.1, 0.01, 0.01]
+        targets = [plateau_targets + step_targets]
+        schedulers = [
+            PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
+            StepLR(self.opt, step_size=2, gamma=0.1),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[3])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_sequential_lr_hands_off_to_plateau_lr(self):
+        epochs = 8
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 1.0
         metrics = [1.0] * epochs
         warmup_targets = [0.625, 0.75, 0.875]
-        # At the milestone PlateauLR applies its epoch-0 lr, which is
-        # whatever the warmup left behind, and records that step's metric as
-        # its first observation.
         handoff_and_plateau_targets = [0.875, 0.4375, 0.21875, 0.109375, 0.0546875]
         targets = [warmup_targets + handoff_and_plateau_targets]
         schedulers = [
@@ -1323,114 +1410,34 @@ class TestLRScheduler(TestCase):
         self._test_with_metrics(scheduler, targets, metrics, epochs)
         self.assertEqual(scheduler.get_last_lr(), schedulers[1].get_last_lr())
 
-    def test_sequentiallr_forwards_metrics_at_plateau_lr_handoff(self):
-        plateau = PlateauLR(self.opt)
+    def test_sequential_lr_hands_off_to_plateau_lr_without_metrics(self):
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 1.0
+        plateau = PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0)
         scheduler = SequentialLR(
             self.opt,
-            schedulers=[ConstantLR(self.opt), plateau],
+            schedulers=[ConstantLR(self.opt, factor=1.0), plateau],
             milestones=[1],
         )
 
+        # A handoff without a metric leaves the learning rate and the plateau
+        # state alone.
         self.opt.step()
-        scheduler.step(metrics=0.5)
+        scheduler.step()
+        self.assertEqual(plateau.best, math.inf)
+        self.assertEqual(scheduler.get_last_lr(), [1.0, 1.0])
 
-        self.assertEqual(plateau.best, 0.5)
-
-    def test_composite_schedulers_support_legacy_children(self):
-        chained = ChainedScheduler([self.LegacyScheduler(self.opt)], optimizer=self.opt)
+        # The first later call carrying a metric establishes the baseline.
         self.opt.step()
-        chained.step()
-        self.opt.step()
-        chained.step(metrics=1.0)
-
-        sequential = SequentialLR(
-            self.opt,
-            schedulers=[self.LegacyScheduler(self.opt), PlateauLR(self.opt)],
-            milestones=[2],
-        )
-        self.opt.step()
-        sequential.step(metrics=1.0)
-
-    def test_composite_schedulers_forward_all_kwargs_to_children(self):
-        """Composites pass their step kwargs through, not just `metrics`."""
-        chained_child = self.KwargsRecordingScheduler(self.opt)
-        chained = ChainedScheduler([chained_child], optimizer=self.opt)
-        self.opt.step()
-        chained.step(metrics=1.0, other=2)
-
-        self.assertEqual(chained_child.step_kwargs[-1], {"metrics": 1.0, "other": 2})
-
-        sequential_child = self.KwargsRecordingScheduler(self.opt)
-        sequential = SequentialLR(
-            self.opt,
-            schedulers=[sequential_child, ConstantLR(self.opt)],
-            milestones=[2],
-        )
-        self.opt.step()
-        sequential.step(metrics=3.0, other=4)
-
-        self.assertEqual(sequential_child.step_kwargs[-1], {"metrics": 3.0, "other": 4})
-
-    def test_scheduler_ignores_kwargs_it_does_not_use(self):
-        scheduler = StepLR(self.opt, step_size=1)
-        self.opt.step()
-        scheduler.step(some_future_input=1.0)
-
-    def test_plateau_lr_rejects_misspelled_metrics(self):
-        """A misspelled `metrics` argument is not silently ignored."""
-        scheduler = PlateauLR(self.opt)
-        self.opt.step()
-        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
-            scheduler.step(metric=1.0)
-
-    def test_chained_scheduler_forwards_kwargs_to_update_hook(self):
-        child = self.KwargsUpdateScheduler(self.opt)
-        scheduler = ChainedScheduler([child], optimizer=self.opt)
+        scheduler.step(metrics=1.0)
+        self.assertEqual(plateau.best, 1.0)
+        self.assertEqual(scheduler.get_last_lr(), [1.0, 1.0])
 
         self.opt.step()
         scheduler.step(metrics=1.0)
+        self.assertEqual(scheduler.get_last_lr(), [0.5, 0.5])
 
-        self.assertEqual(child.update_kwargs[-1], {"metrics": 1.0})
-
-    def test_chained_scheduler_supports_duck_typed_children(self):
-        class DuckTypedScheduler:
-            def __init__(self, optimizer):
-                self.optimizer = optimizer
-                self._last_lr = [group["lr"] for group in optimizer.param_groups]
-
-            def step(self):
-                self._last_lr = [group["lr"] for group in self.optimizer.param_groups]
-
-            def get_last_lr(self):
-                return self._last_lr
-
-        child = DuckTypedScheduler(self.opt)
-        scheduler = ChainedScheduler([child], optimizer=self.opt)
-        self.opt.step()
-        scheduler.step(metrics=1.0)
-
-        self.assertEqual(scheduler.get_last_lr(), child.get_last_lr())
-
-    def test_sequentiallr_with_plateau_lr_first(self):
-        """PlateauLR as the scheduler a SequentialLR starts with."""
-        epochs = 8
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 1.0
-        metrics = [1.0] * epochs
-        plateau_targets = [1.0, 0.5]
-        # At the milestone StepLR takes over from its own epoch 0, i.e. from
-        # `initial_lr` again -- not from whatever PlateauLR left behind.
-        step_targets = [1.0, 1.0, 0.1, 0.1, 0.01, 0.01]
-        targets = [plateau_targets + step_targets]
-        schedulers = [
-            PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
-            StepLR(self.opt, step_size=2, gamma=0.1),
-        ]
-        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[3])
-        self._test_with_metrics(scheduler, targets, metrics, epochs)
-
-    def test_sequentiallr_with_only_plateau_lr(self):
-        """SequentialLR initializes the optimizer from a PlateauLR stage."""
+    def test_sequential_lr_hands_off_between_plateau_lr_schedulers(self):
         epochs = 5
         for param_group in self.opt.param_groups:
             param_group["lr"] = 1.0
@@ -1443,39 +1450,23 @@ class TestLRScheduler(TestCase):
         scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[2])
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
-    def test_composed_plateau_lr_without_metrics(self):
-        """Stepping a composer without a metric while PlateauLR is active
-        is an error.
-        """
+    def test_sequential_lr_requires_metrics_for_the_active_plateau_lr(self):
         scheduler = SequentialLR(
             self.opt,
-            schedulers=[
-                LinearLR(self.opt, total_iters=2),
-                PlateauLR(self.opt),
-            ],
+            schedulers=[LinearLR(self.opt, total_iters=2), PlateauLR(self.opt)],
             milestones=[2],
         )
-        # The milestone is PlateauLR's epoch-0 initialization update. Without
-        # a metric, it leaves the plateau state unchanged; subsequent active
-        # steps require one.
+        # Stepping without a metric is fine while the warmup is active, and at
+        # the milestone, where the handoff does not need one.
         for _ in range(2):
             self.opt.step()
             scheduler.step()
+
         self.opt.step()
         with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
             scheduler.step()
 
-        chained = ChainedScheduler(
-            [ConstantLR(self.opt), PlateauLR(self.opt)], optimizer=self.opt
-        )
-        self.opt.step()
-        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
-            chained.step()
-
-    def test_sequentiallr_with_plateau_lr_state_dict(self):
-        """Resuming from a checkpoint taken while the plateau stage is
-        active.
-        """
+    def test_sequential_lr_restores_plateau_lr_state(self):
         base_lr = 0.1
         milestone = 2
         total_steps = 8
@@ -1528,7 +1519,7 @@ class TestLRScheduler(TestCase):
 
         self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
 
-    def test_sequentiallr_does_not_accept_explicit_epoch(self):
+    def test_sequential_lr_rejects_explicit_epoch(self):
         scheduler = SequentialLR(
             self.opt,
             schedulers=[ConstantLR(self.opt), ConstantLR(self.opt)],
@@ -1537,38 +1528,45 @@ class TestLRScheduler(TestCase):
         with self.assertRaises(TypeError):
             scheduler.step(5)
 
-    def test_chained_scheduler_does_not_accept_explicit_epoch(self):
+    def test_chained_scheduler_forwards_kwargs_to_children(self):
+        first = self.RecordingScheduler(self.opt)
+        second = self.RecordingScheduler(self.opt)
+        scheduler = ChainedScheduler([first, second], optimizer=self.opt)
+        first.clear()
+        second.clear()
+
+        self.opt.step()
+        scheduler.step(metrics=1.0, extra=2.0)
+
+        expected = {"metrics": 1.0, "extra": 2.0}
+        for child in [first, second]:
+            self.assertEqual(child.step_kwargs, [expected])
+            self.assertEqual(child.update_kwargs, [expected])
+            self.assertEqual(child.get_lr_kwargs, [expected])
+
+    def test_chained_scheduler_supports_legacy_children(self):
+        recording = self.RecordingScheduler(self.opt)
+        legacy = self.LegacyStepScheduler(self.opt)
+        scheduler = ChainedScheduler([recording, legacy], optimizer=self.opt)
+        recording.clear()
+
+        self.opt.step()
+        scheduler.step(metrics=1.0)
+
+        # The legacy child is stepped without the metric it cannot accept,
+        # while the one that can still receives it.
+        self.assertEqual(recording.step_kwargs, [{"metrics": 1.0}])
+        self.assertEqual(legacy.last_epoch, 1)
+
+    def test_chained_scheduler_state_dict_omits_kwargs_support(self):
         scheduler = ChainedScheduler(
-            [ConstantLR(self.opt), ConstantLR(self.opt)], optimizer=self.opt
+            [ConstantLR(self.opt), PlateauLR(self.opt)], optimizer=self.opt
         )
-        with self.assertRaises(TypeError):
-            scheduler.step(5)
+        # Which schedulers accept scheduling inputs is rederived on
+        # construction, so it must stay out of the checkpoint.
+        self.assertNotIn("_schedulers_accept_kwargs", scheduler.state_dict())
 
-    def test_sequentiallr_still_rejects_reduce_lr_on_plateau(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            with self.assertRaisesRegex(
-                ValueError, "does not support `ReduceLROnPlateau`"
-            ):
-                SequentialLR(
-                    self.opt,
-                    schedulers=[ConstantLR(self.opt), ReduceLROnPlateau(self.opt)],
-                    milestones=[2],
-                )
-
-    def test_chained_scheduler_still_rejects_reduce_lr_on_plateau(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            with self.assertRaisesRegex(
-                ValueError, "does not support `ReduceLROnPlateau`"
-            ):
-                ChainedScheduler(
-                    [ConstantLR(self.opt), ReduceLROnPlateau(self.opt)],
-                    optimizer=self.opt,
-                )
-
-    def test_chained_scheduler_with_plateau_lr(self):
-        """A chained PlateauLR composes with the other schedulers."""
+    def test_chained_scheduler_composes_with_plateau_lr(self):
         epochs = 5
         for param_group in self.opt.param_groups:
             param_group["lr"] = 1.0
@@ -1582,16 +1580,43 @@ class TestLRScheduler(TestCase):
         self._test_with_metrics(scheduler, targets, metrics, epochs)
         self.assertEqual(scheduler.get_last_lr(), schedulers[-1].get_last_lr())
 
-    def test_cosine_annealing_warm_restarts_ignores_metrics(self):
-        """The new keyword-only `metrics` param is inert for this scheduler."""
-        opt_a = SGD(self.SchedulerTestNet().parameters(), lr=0.05)
-        opt_b = SGD(self.SchedulerTestNet().parameters(), lr=0.05)
-        scheduler_a = CosineAnnealingWarmRestarts(opt_a, T_0=4, T_mult=2)
-        scheduler_b = CosineAnnealingWarmRestarts(opt_b, T_0=4, T_mult=2)
-        for epoch in range(10):
-            scheduler_a.step()
-            scheduler_b.step(metrics=1.0 + epoch)
-            self.assertEqual(scheduler_a.get_last_lr(), scheduler_b.get_last_lr())
+    def test_chained_scheduler_requires_metrics_for_plateau_lr(self):
+        scheduler = ChainedScheduler(
+            [ConstantLR(self.opt), PlateauLR(self.opt)], optimizer=self.opt
+        )
+        self.opt.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step()
+
+    def test_chained_scheduler_rejects_explicit_epoch(self):
+        scheduler = ChainedScheduler(
+            [ConstantLR(self.opt), ConstantLR(self.opt)], optimizer=self.opt
+        )
+        with self.assertRaises(TypeError):
+            scheduler.step(5)
+
+    def test_sequential_lr_rejects_reduce_lr_on_plateau(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            with self.assertRaisesRegex(
+                ValueError, "does not support `ReduceLROnPlateau`"
+            ):
+                SequentialLR(
+                    self.opt,
+                    schedulers=[ConstantLR(self.opt), ReduceLROnPlateau(self.opt)],
+                    milestones=[2],
+                )
+
+    def test_chained_scheduler_rejects_reduce_lr_on_plateau(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            with self.assertRaisesRegex(
+                ValueError, "does not support `ReduceLROnPlateau`"
+            ):
+                ChainedScheduler(
+                    [ConstantLR(self.opt), ReduceLROnPlateau(self.opt)],
+                    optimizer=self.opt,
+                )
 
     def test_compound_step_and_multistep_lr(self):
         epochs = 10
@@ -1737,7 +1762,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = ExponentialLR(self.opt, gamma=0.1)
         self._test(schedulers, targets, epochs)
 
-    def test_compound_reduce_lr_on_plateau1(self):
+    def test_compound_reduce_lr_on_plateau_and_step_lr(self):
         epochs = 10
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -1759,7 +1784,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = StepLR(self.opt, gamma=0.1, step_size=3)
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau2(self):
+    def test_compound_reduce_lr_on_plateau_and_multi_step_lr(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -1781,7 +1806,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = MultiStepLR(self.opt, gamma=0.1, milestones=[3, 8, 12])
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau3(self):
+    def test_compound_reduce_lr_on_plateau_and_exponential_lr(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -1798,7 +1823,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = ExponentialLR(self.opt, gamma=0.1)
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau4(self):
+    def test_compound_reduce_lr_on_plateau_and_cosine_annealing_lr(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.05
@@ -1818,7 +1843,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = CosineAnnealingLR(self.opt, epochs, eta_min)
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau5(self):
+    def test_compound_reduce_lr_on_plateau_and_linear_lr(self):
         iters = 4
         start_factor = 0.4
         epochs = 22
@@ -2793,6 +2818,17 @@ class TestLRScheduler(TestCase):
             epochs=epochs,
         )
 
+    def test_plateau_lr_state_dict(self):
+        scheduler = PlateauLR(self.opt, mode="min", factor=0.1, patience=2)
+        for score in [1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0, 3.0, 2.0, 1.0]:
+            self.opt.step()
+            scheduler.step(metrics=score)
+        scheduler_copy = PlateauLR(self.opt, mode="max", factor=0.5, patience=10)
+        scheduler_copy.load_state_dict(scheduler.state_dict())
+        for key in scheduler.__dict__:
+            if key != "optimizer":
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+
     def test_reduce_lr_on_plateau_state_dict(self):
         scheduler = ReduceLROnPlateau(self.opt, mode="min", factor=0.1, patience=2)
         for score in [1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0, 3.0, 2.0, 1.0]:
@@ -2979,20 +3015,10 @@ class TestLRScheduler(TestCase):
                     rtol=0,
                 )
 
-    def _test_reduce_lr_on_plateau(
-        self, schedulers, targets, metrics, epochs=10, verbose=False
-    ):
-        if isinstance(schedulers, (LRScheduler, ReduceLROnPlateau)):
-            schedulers = [schedulers]
+    def _test_with_metrics(self, scheduler, targets, metrics, epochs=10):
         for epoch in range(epochs):
             self.opt.step()
-            for scheduler in schedulers:
-                if isinstance(scheduler, ReduceLROnPlateau):
-                    scheduler.step(metrics[epoch])
-                else:
-                    scheduler.step()
-            if verbose:
-                print("epoch{}:\tlr={}".format(epoch, self.opt.param_groups[0]["lr"]))
+            scheduler.step(metrics=metrics[epoch])
             for param_group, target in zip(self.opt.param_groups, targets):
                 self.assertEqual(
                     target[epoch],
@@ -3007,19 +3033,20 @@ class TestLRScheduler(TestCase):
                     rtol=0,
                 )
 
-    def _test_with_metrics(self, schedulers, targets, metrics, epochs=10):
-        """Like `_test`, but forwards `metrics` to every scheduler's `step`.
-
-        Unlike `_test_reduce_lr_on_plateau`, this needs no isinstance dispatch:
-        every scheduler now accepts the keyword-only `metrics` argument, plain
-        schedulers just ignore it.
-        """
-        if isinstance(schedulers, LRScheduler):
+    def _test_reduce_lr_on_plateau(
+        self, schedulers, targets, metrics, epochs=10, verbose=False
+    ):
+        if isinstance(schedulers, (LRScheduler, ReduceLROnPlateau)):
             schedulers = [schedulers]
         for epoch in range(epochs):
             self.opt.step()
             for scheduler in schedulers:
-                scheduler.step(metrics=metrics[epoch])
+                if isinstance(scheduler, ReduceLROnPlateau):
+                    scheduler.step(metrics[epoch])
+                else:
+                    scheduler.step()
+            if verbose:
+                print("epoch{}:\tlr={}".format(epoch, self.opt.param_groups[0]["lr"]))
             for param_group, target in zip(self.opt.param_groups, targets):
                 self.assertEqual(
                     target[epoch],
@@ -3164,8 +3191,8 @@ class TestLRScheduler(TestCase):
                 milestones=[2],
                 **kwargs,
             ),
-            ReduceLROnPlateau,
             PlateauLR,
+            ReduceLROnPlateau,
             partial(CyclicLR, base_lr=0.01, max_lr=0.1),
             partial(OneCycleLR, max_lr=0.01, total_steps=10, anneal_strategy="linear"),
             partial(CosineAnnealingWarmRestarts, T_0=20),
@@ -3187,103 +3214,31 @@ class TestLRScheduler(TestCase):
             scheduler2.load_state_dict(state_dict_loaded)
             self.assertEqual(scheduler2.state_dict(), state_dict)
 
-    @parametrize("min_lr", ["scalar", "list"])
-    def test_add_param_group_does_not_break_reduce_lr_on_plateau(self, min_lr):
-        epochs = 20
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
-        metrics = [1] * 7 + [0.6] + [0.5] * 12
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            mode="min",
-            threshold_mode="rel",
-            threshold=0.1,
-            patience=5,
-            cooldown=5,
-            min_lr=0 if min_lr == "scalar" else [1e-5, 1e-4],
-        )
-        for epoch in range(epochs):
-            # Point is to test the use case in #104361
-            if epoch == 8:
-                param = torch.nn.Parameter(torch.rand(2, 3))
-                self.opt.add_param_group({"params": [param], "lr": 0.05})
-                if min_lr == "list":
-                    scheduler.min_lrs.append(1e-6)
-            self.opt.step()
-            scheduler.step(metrics[epoch])
-            for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertEqual(
-                    target[epoch],
-                    param_group["lr"],
-                    msg=lambda msg: f"{msg}\n"
-                    + (
-                        "LR is wrong in epoch {}: expected {}, got {}".format(
-                            epoch, target[epoch], param_group["lr"]
-                        )
-                    ),
-                    atol=1e-5,
-                    rtol=0,
-                )
-
-    def test_add_param_group_errors_reduce_lr_on_plateau(self):
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            mode="min",
-            threshold_mode="rel",
-            threshold=1e-5,
-            patience=0,
-            cooldown=0,
-            min_lr=[1e-5, 1e-4],
-        )
-        param = torch.nn.Parameter(torch.rand(2, 3))
-        self.opt.add_param_group({"params": [param], "lr": 0.05})
-        self.opt.step()
-        scheduler.step(1)
-        with self.assertRaisesRegex(RuntimeError, "The number of param groups in the"):
-            self.opt.step()
-            scheduler.step(1.3)
-
-    @parametrize("min_lr", ["scalar", "list"])
-    def test_add_param_group_does_not_break_plateau_lr(self, min_lr):
-        epochs = 20
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 0.5
-        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
-        metrics = [1] * 7 + [0.6] + [0.5] * 12
+    @parametrize("min_lr", [0, [1e-5, 1e-4]])
+    def test_plateau_lr_supports_added_param_group(self, min_lr):
         scheduler = PlateauLR(
             self.opt,
-            mode="min",
-            threshold_mode="rel",
-            threshold=0.1,
-            patience=5,
-            cooldown=5,
-            min_lr=0 if min_lr == "scalar" else [1e-5, 1e-4],
+            factor=0.1,
+            patience=0,
+            min_lr=min_lr,
         )
-        for epoch in range(epochs):
-            # Point is to test the use case in #104361
-            if epoch == 8:
-                param = torch.nn.Parameter(torch.rand(2, 3))
-                self.opt.add_param_group({"params": [param], "lr": 0.05})
-                if min_lr == "list":
-                    scheduler.min_lrs.append(1e-6)
-            self.opt.step()
-            scheduler.step(metrics=metrics[epoch])
-            for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertEqual(
-                    target[epoch],
-                    param_group["lr"],
-                    msg=lambda msg: f"{msg}\n"
-                    + (
-                        "LR is wrong in epoch {}: expected {}, got {}".format(
-                            epoch, target[epoch], param_group["lr"]
-                        )
-                    ),
-                    atol=1e-5,
-                    rtol=0,
-                )
+        self.opt.step()
+        scheduler.step(metrics=1.0)
 
-    def test_add_param_group_errors_plateau_lr(self):
+        self.opt.add_param_group(
+            {"params": [torch.nn.Parameter(torch.rand(2, 3))], "lr": 0.05}
+        )
+        if isinstance(min_lr, list):
+            scheduler.min_lrs.append(1e-6)
+        self.opt.step()
+        scheduler.step(metrics=2.0)
+
+        self.assertEqual(
+            [group["lr"] for group in self.opt.param_groups],
+            [0.005, 0.05, 0.005],
+        )
+
+    def test_plateau_lr_requires_min_lr_for_added_param_group(self):
         scheduler = PlateauLR(
             self.opt,
             mode="min",
@@ -3300,6 +3255,48 @@ class TestLRScheduler(TestCase):
         with self.assertRaisesRegex(RuntimeError, "The number of param groups in the"):
             self.opt.step()
             scheduler.step(metrics=1.3)
+
+    @parametrize("min_lr", [0, [1e-5, 1e-4]])
+    def test_reduce_lr_on_plateau_supports_added_param_group(self, min_lr):
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+            factor=0.1,
+            patience=0,
+            min_lr=min_lr,
+        )
+        self.opt.step()
+        scheduler.step(1.0)
+
+        self.opt.add_param_group(
+            {"params": [torch.nn.Parameter(torch.rand(2, 3))], "lr": 0.05}
+        )
+        if isinstance(min_lr, list):
+            scheduler.min_lrs.append(1e-6)
+        self.opt.step()
+        scheduler.step(2.0)
+
+        self.assertEqual(
+            [group["lr"] for group in self.opt.param_groups],
+            [0.005, 0.05, 0.005],
+        )
+
+    def test_reduce_lr_on_plateau_requires_min_lr_for_added_param_group(self):
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+            mode="min",
+            threshold_mode="rel",
+            threshold=1e-5,
+            patience=0,
+            cooldown=0,
+            min_lr=[1e-5, 1e-4],
+        )
+        param = torch.nn.Parameter(torch.rand(2, 3))
+        self.opt.add_param_group({"params": [param], "lr": 0.05})
+        self.opt.step()
+        scheduler.step(1)
+        with self.assertRaisesRegex(RuntimeError, "The number of param groups in the"):
+            self.opt.step()
+            scheduler.step(1.3)
 
     @parametrize(
         "LRClass",
@@ -3449,6 +3446,17 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+    def test_lr_scheduler_checkpoint_on_plateau_lr(self):
+        model = torch.nn.Linear(3, 3)
+        optim = torch.optim.AdamW(model.parameters())
+        sch = PlateauLR(optim, mode="min")
+        optim.step()
+        sch.step(metrics=1)
+        optim2 = torch.optim.AdamW(model.parameters())
+        optim2.load_state_dict(optim.state_dict())
+        sch2 = PlateauLR(optim2, mode="min")
+        self.assertEqual(sch2.get_last_lr()[0], optim.param_groups[0]["lr"])
+
     def test_lr_scheduler_checkpoint_on_plateau(self):
         model = torch.nn.Linear(3, 3)
         optim = torch.optim.AdamW(model.parameters())
@@ -3465,21 +3473,94 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
-    def test_lr_scheduler_checkpoint_on_plateau_lr(self):
-        model = torch.nn.Linear(3, 3)
-        optim = torch.optim.AdamW(model.parameters())
-        sch = PlateauLR(optim, mode="min")
-        optim.step()
-        sch.step(metrics=1)
-        optim2 = torch.optim.AdamW(model.parameters())
-        optim2.load_state_dict(optim.state_dict())
-        sch2 = PlateauLR(optim2, mode="min")
-        self.assertEqual(
-            sch2._get_closed_form_lr()[0]
-            if hasattr(self, "_get_closed_form_lr")
-            else sch2.get_last_lr()[0],
-            optim.param_groups[0]["lr"],
-        )
+    # NOTE: Expected-failure tests for known scheduler issues.
+    #
+    # These tests should be converted to normal regression tests once
+    # the underlying behavior is fixed.
+
+    @expectedFailure
+    def test_sequentiallr_resume_reproducibility(self):
+        # Note: Saving and restoring both the optimizer and SequentialLR
+        # state mid training should reproduce the same LR sequence as a
+        # continuous uninterrupted run.
+        #
+        # This currently fails around scheduler transition boundaries after
+        # restoring from checkpoint state.
+        #
+        # The problematic state transition comes from SequentialLR's restore
+        # model:
+        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
+        #    lr back to initial_lr, calls recursive_undo(), and then replays
+        #    _schedulers[0]._initial_step().
+        # 2. At this resume point, that constructor path leaves the optimizer
+        #    lr at 0.05 even though the saved scheduler state corresponds to
+        #    an effective lr of 0.08.
+        # 3. SequentialLR.load_state_dict() restores scheduler fields like
+        #    last_epoch and _last_lr, but it does not re-synchronize the
+        #    optimizer param-group lr with that loaded scheduler state.
+        # 4. LinearLR.get_lr() is recursive: it multiplies the current
+        #    optimizer lr, so the next resumed step advances
+        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
+
+        base_lr = 0.1
+        milestone = 5
+        total_steps = 8
+        resume_step = 3
+
+        def make_scheduler(optim):
+            return SequentialLR(
+                optim,
+                [
+                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
+                    ExponentialLR(optim, gamma=0.5),
+                ],
+                milestones=[milestone],
+            )
+
+        # run the full schedule and record the LR.
+        model = torch.nn.Linear(1, 1)
+        optim = torch.optim.SGD(model.parameters(), lr=base_lr)
+        sched = make_scheduler(optim)
+
+        reference_lrs = []
+        for _ in range(total_steps):
+            optim.step()
+            sched.step()
+            reference_lrs.append(sched.get_last_lr()[0])
+
+        # run a fresh optimizer/scheduler pair up to an intermediate step
+        model2 = torch.nn.Linear(1, 1)
+        optim2 = torch.optim.SGD(model2.parameters(), lr=base_lr)
+        sched2 = make_scheduler(optim2)
+
+        for _ in range(resume_step):
+            optim2.step()
+            sched2.step()
+
+        # save state to simulate checkpointing.
+        optim_state = optim2.state_dict()
+        sched_state = sched2.state_dict()
+
+        # restore into a new optimizer/scheduler pair
+        model3 = torch.nn.Linear(1, 1)
+        optim3 = torch.optim.SGD(model3.parameters(), lr=base_lr)
+        optim3.load_state_dict(optim_state)
+
+        sched3 = make_scheduler(optim3)
+        sched3.load_state_dict(sched_state)
+
+        loaded_optimizer_lr = optim3.param_groups[0]["lr"]
+        loaded_scheduler_lr = sched3.get_last_lr()[0]
+
+        resumed_lrs = []
+        for _ in range(resume_step, total_steps):
+            optim3.step()
+            sched3.step()
+            resumed_lrs.append(sched3.get_last_lr()[0])
+
+        self.assertEqual(loaded_optimizer_lr, loaded_scheduler_lr)
+        self.assertEqual(resumed_lrs[0], reference_lrs[resume_step])
+        self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
 
 
 instantiate_parametrized_tests(TestLRScheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -96,19 +96,28 @@ class TestLRScheduler(TestCase):
             self.step_kwargs.append(kwargs)
             super().step(epoch)
 
-    class MetricsUpdateScheduler(LRScheduler):
-        """A scheduler using the metrics-aware private update hook."""
+    class LegacyUpdateScheduler(LRScheduler):
+        """A third-party scheduler overriding the previous private hook."""
+
+        def get_lr(self):
+            return [group["lr"] for group in self.optimizer.param_groups]
+
+        def _update_lr(self, epoch=None):
+            super()._update_lr(epoch)
+
+    class KwargsUpdateScheduler(LRScheduler):
+        """A third-party scheduler consuming kwargs in the update hook."""
 
         def __init__(self, optimizer):
-            self.metrics = []
+            self.update_kwargs = []
             super().__init__(optimizer)
 
         def get_lr(self):
             return [group["lr"] for group in self.optimizer.param_groups]
 
-        def _update_lr(self, epoch=None, *, metrics=None):
-            self.metrics.append(metrics)
-            super()._update_lr(epoch, metrics=metrics)
+        def _update_lr(self, epoch=None, **kwargs):
+            self.update_kwargs.append(kwargs)
+            super()._update_lr(epoch)
 
     exact_dtype = True
 
@@ -765,12 +774,41 @@ class TestLRScheduler(TestCase):
         with self.assertWarnsRegex(FutureWarning, "PlateauLR"):
             ReduceLROnPlateau(self.opt)
 
-    def test_lrscheduler_forwards_metrics_to_update_hook(self):
-        scheduler = self.MetricsUpdateScheduler(self.opt)
+    def test_lrscheduler_kwargs_support_legacy_update_hook(self):
+        scheduler = self.LegacyUpdateScheduler(self.opt)
         self.opt.step()
         scheduler.step(metrics=1.0)
 
-        self.assertEqual(scheduler.metrics, [None, 1.0])
+        self.assertEqual(scheduler.last_epoch, 1)
+
+    def test_sequentiallr_kwargs_support_legacy_update_hook_at_handoff(self):
+        legacy = self.LegacyUpdateScheduler(self.opt)
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt), legacy],
+            milestones=[1],
+        )
+
+        self.opt.step()
+        scheduler.step(metrics=1.0)
+
+        self.assertEqual(legacy.last_epoch, 0)
+
+    def test_kwargs_reach_update_hook_directly_and_at_handoff(self):
+        direct = self.KwargsUpdateScheduler(self.opt)
+        self.opt.step()
+        direct.step(metrics=1.0)
+        self.assertEqual(direct.update_kwargs[-1], {"metrics": 1.0})
+
+        handoff = self.KwargsUpdateScheduler(self.opt)
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt), handoff],
+            milestones=[1],
+        )
+        self.opt.step()
+        scheduler.step(metrics=2.0)
+        self.assertEqual(handoff.update_kwargs[-1], {"metrics": 2.0})
 
     # PlateauLR is ReduceLROnPlateau's composable replacement (properly
     # implements get_lr(), so it can be used inside SequentialLR/
@@ -1307,14 +1345,14 @@ class TestLRScheduler(TestCase):
         with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
             scheduler.step(metric=1.0)
 
-    def test_chained_scheduler_forwards_metrics_to_update_hook(self):
-        child = self.MetricsUpdateScheduler(self.opt)
+    def test_chained_scheduler_forwards_kwargs_to_update_hook(self):
+        child = self.KwargsUpdateScheduler(self.opt)
         scheduler = ChainedScheduler([child], optimizer=self.opt)
 
         self.opt.step()
         scheduler.step(metrics=1.0)
 
-        self.assertEqual(child.metrics, [None, 1.0])
+        self.assertEqual(child.update_kwargs[-1], {"metrics": 1.0})
 
     def test_chained_scheduler_supports_duck_typed_children(self):
         class DuckTypedScheduler:

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -880,62 +880,51 @@ class TestLRScheduler(TestCase):
         return lrs
 
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
+        def make_scheduler(optimizer):
+            """Construct the SequentialLR used at both nesting depths."""
+            return SequentialLR(
+                optimizer,
+                [
+                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ConstantLR(optimizer, factor=0.2, total_iters=10),
+                ],
+                milestones=[2],
+            )
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
-            [
-                SequentialLR(
-                    two_level_optimizer,
-                    [
-                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
-                        ConstantLR(two_level_optimizer, factor=0.2, total_iters=10),
-                    ],
-                    milestones=[2],
-                ),
-            ],
+            [make_scheduler(two_level_optimizer)],
             milestones=[],
         )
 
         one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        # Same schedule as above, with one composite level instead of two.
-        one_level_scheduler = SequentialLR(
-            one_level_optimizer,
-            [
-                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
-                ConstantLR(one_level_optimizer, factor=0.2, total_iters=10),
-            ],
-            milestones=[2],
-        )
+        one_level_scheduler = make_scheduler(one_level_optimizer)
 
         two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
+        def make_scheduler(optimizer):
+            """Construct the ChainedScheduler used at both nesting depths."""
+            return ChainedScheduler(
+                [
+                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ExponentialLR(optimizer, gamma=0.9),
+                ],
+                optimizer=optimizer,
+            )
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
-            [
-                ChainedScheduler(
-                    [
-                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
-                        ExponentialLR(two_level_optimizer, gamma=0.9),
-                    ],
-                    optimizer=two_level_optimizer,
-                ),
-            ],
+            [make_scheduler(two_level_optimizer)],
             milestones=[],
         )
 
         one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        # Same schedule as above, with one composite level instead of two.
-        one_level_scheduler = ChainedScheduler(
-            [
-                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
-                ExponentialLR(one_level_optimizer, gamma=0.9),
-            ],
-            optimizer=one_level_optimizer,
-        )
+        one_level_scheduler = make_scheduler(one_level_optimizer)
 
         two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -871,60 +871,73 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs=2)
         self.opt = old_opt
 
+    def _get_lrs(self, scheduler):
+        lrs = []
+        for _ in range(5):
+            lrs.append(scheduler.get_last_lr())
+            scheduler.optimizer.step()
+            scheduler.step()
+        return lrs
+
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
-        """A nested SequentialLR runs the same schedule as it does on its own."""
-        epochs = 8
-        # The first five values are exactly what the inner scheduler produces
-        # when it is used directly: two epochs of ConstantLR, then ExponentialLR
-        # from its epoch 0. Nesting must not consume one of those epochs.
-        inner_targets = [0.5, 0.5, 1.0, 0.9, 0.81]
-        outer_targets = [1.0, 1.0, 0.5]
-        single_targets = inner_targets + outer_targets
-        targets = [
-            [0.05 * x for x in single_targets],
-            [0.5 * x for x in single_targets],
-        ]
-        inner = SequentialLR(
-            self.opt,
-            schedulers=[
-                ConstantLR(self.opt, factor=0.5, total_iters=2),
-                ExponentialLR(self.opt, gamma=0.9),
+        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        nested_scheduler = SequentialLR(
+            nested_optimizer,
+            [
+                SequentialLR(
+                    nested_optimizer,
+                    [
+                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
+                        ConstantLR(nested_optimizer, factor=0.2, total_iters=10),
+                    ],
+                    milestones=[2],
+                ),
+            ],
+            milestones=[],
+        )
+
+        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        standalone_scheduler = SequentialLR(
+            standalone_optimizer,
+            [
+                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
+                ConstantLR(standalone_optimizer, factor=0.2, total_iters=10),
             ],
             milestones=[2],
         )
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
-            milestones=[5],
-        )
-        self._test(scheduler, targets, epochs)
+
+        nested_lrs = self._get_lrs(nested_scheduler)
+        standalone_lrs = self._get_lrs(standalone_scheduler)
+        self.assertEqual(nested_lrs, standalone_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
-        """A nested ChainedScheduler runs the same schedule as it does on its own."""
-        epochs = 8
-        # The first five values are exactly what the chained scheduler produces
-        # when it is used directly: ConstantLR and ExponentialLR both scaling
-        # the lr from its epoch 0. Nesting must not apply either of them twice.
-        inner_targets = [0.5, 0.45, 0.81, 0.729, 0.6561]
-        outer_targets = [1.0, 1.0, 0.5]
-        single_targets = inner_targets + outer_targets
-        targets = [
-            [0.05 * x for x in single_targets],
-            [0.5 * x for x in single_targets],
-        ]
-        inner = ChainedScheduler(
+        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        nested_scheduler = SequentialLR(
+            nested_optimizer,
             [
-                ConstantLR(self.opt, factor=0.5, total_iters=2),
-                ExponentialLR(self.opt, gamma=0.9),
+                ChainedScheduler(
+                    [
+                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
+                        ExponentialLR(nested_optimizer, gamma=0.9),
+                    ],
+                    optimizer=nested_optimizer,
+                ),
             ],
-            optimizer=self.opt,
+            milestones=[],
         )
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
-            milestones=[5],
+
+        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        standalone_scheduler = ChainedScheduler(
+            [
+                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
+                ExponentialLR(standalone_optimizer, gamma=0.9),
+            ],
+            optimizer=standalone_optimizer,
         )
-        self._test(scheduler, targets, epochs)
+
+        nested_lrs = self._get_lrs(nested_scheduler)
+        standalone_lrs = self._get_lrs(standalone_scheduler)
+        self.assertEqual(nested_lrs, standalone_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -891,6 +891,9 @@ class TestLRScheduler(TestCase):
                 milestones=[2],
             )
 
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        one_level_scheduler = make_scheduler(one_level_optimizer)
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
@@ -898,11 +901,8 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        one_level_scheduler = make_scheduler(one_level_optimizer)
-
-        two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
@@ -916,6 +916,9 @@ class TestLRScheduler(TestCase):
                 optimizer=optimizer,
             )
 
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        one_level_scheduler = make_scheduler(one_level_optimizer)
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
@@ -923,11 +926,8 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        one_level_scheduler = make_scheduler(one_level_optimizer)
-
-        two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -880,15 +880,15 @@ class TestLRScheduler(TestCase):
         return lrs
 
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
-        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        nested_scheduler = SequentialLR(
-            nested_optimizer,
+        two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        two_level_scheduler = SequentialLR(
+            two_level_optimizer,
             [
                 SequentialLR(
-                    nested_optimizer,
+                    two_level_optimizer,
                     [
-                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
-                        ConstantLR(nested_optimizer, factor=0.2, total_iters=10),
+                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
+                        ConstantLR(two_level_optimizer, factor=0.2, total_iters=10),
                     ],
                     milestones=[2],
                 ),
@@ -896,48 +896,50 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        standalone_scheduler = SequentialLR(
-            standalone_optimizer,
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        # Same schedule as above, with one composite level instead of two.
+        one_level_scheduler = SequentialLR(
+            one_level_optimizer,
             [
-                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
-                ConstantLR(standalone_optimizer, factor=0.2, total_iters=10),
+                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
+                ConstantLR(one_level_optimizer, factor=0.2, total_iters=10),
             ],
             milestones=[2],
         )
 
-        nested_lrs = self._get_lrs(nested_scheduler)
-        standalone_lrs = self._get_lrs(standalone_scheduler)
-        self.assertEqual(nested_lrs, standalone_lrs)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
+        one_level_lrs = self._get_lrs(one_level_scheduler)
+        self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
-        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        nested_scheduler = SequentialLR(
-            nested_optimizer,
+        two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        two_level_scheduler = SequentialLR(
+            two_level_optimizer,
             [
                 ChainedScheduler(
                     [
-                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
-                        ExponentialLR(nested_optimizer, gamma=0.9),
+                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
+                        ExponentialLR(two_level_optimizer, gamma=0.9),
                     ],
-                    optimizer=nested_optimizer,
+                    optimizer=two_level_optimizer,
                 ),
             ],
             milestones=[],
         )
 
-        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        standalone_scheduler = ChainedScheduler(
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        # Same schedule as above, with one composite level instead of two.
+        one_level_scheduler = ChainedScheduler(
             [
-                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
-                ExponentialLR(standalone_optimizer, gamma=0.9),
+                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
+                ExponentialLR(one_level_optimizer, gamma=0.9),
             ],
-            optimizer=standalone_optimizer,
+            optimizer=one_level_optimizer,
         )
 
-        nested_lrs = self._get_lrs(nested_scheduler)
-        standalone_lrs = self._get_lrs(standalone_scheduler)
-        self.assertEqual(nested_lrs, standalone_lrs)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
+        one_level_lrs = self._get_lrs(one_level_scheduler)
+        self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -3163,12 +3163,7 @@ class TestLRScheduler(TestCase):
 
     @parametrize("min_lr", [0, [1e-5, 1e-4]])
     def test_plateau_lr_supports_added_param_group(self, min_lr):
-        scheduler = PlateauLR(
-            self.opt,
-            factor=0.1,
-            patience=0,
-            min_lr=min_lr,
-        )
+        scheduler = PlateauLR(self.opt, factor=0.1, patience=0, min_lr=min_lr)
         self.opt.step()
         scheduler.step(metrics=1.0)
 
@@ -3205,12 +3200,7 @@ class TestLRScheduler(TestCase):
 
     @parametrize("min_lr", [0, [1e-5, 1e-4]])
     def test_add_param_group_does_not_break_reduce_lr_on_plateau(self, min_lr):
-        scheduler = ReduceLROnPlateau(
-            self.opt,
-            factor=0.1,
-            patience=0,
-            min_lr=min_lr,
-        )
+        scheduler = ReduceLROnPlateau(self.opt, factor=0.1, patience=0, min_lr=min_lr)
         self.opt.step()
         scheduler.step(1.0)
 

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -83,7 +83,9 @@ class TestLRScheduler(TestCase):
             super().step(epoch)
 
     class KwargsRecordingScheduler(LRScheduler):
-        """A third-party scheduler collecting its step arguments in ``**kwargs``."""
+        """A third-party scheduler collecting its step arguments in
+        ``**kwargs``.
+        """
 
         def __init__(self, optimizer):
             self.step_kwargs = []
@@ -1406,7 +1408,9 @@ class TestLRScheduler(TestCase):
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
     def test_composed_plateau_lr_without_metrics(self):
-        """Stepping a composer without a metric while PlateauLR is active is an error."""
+        """Stepping a composer without a metric while PlateauLR is active
+        is an error.
+        """
         scheduler = SequentialLR(
             self.opt,
             schedulers=[
@@ -1433,7 +1437,9 @@ class TestLRScheduler(TestCase):
             chained.step()
 
     def test_sequentiallr_with_plateau_lr_state_dict(self):
-        """Resuming from a checkpoint taken while the plateau stage is active."""
+        """Resuming from a checkpoint taken while the plateau stage is
+        active.
+        """
         base_lr = 0.1
         milestone = 2
         total_steps = 8

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -676,38 +676,6 @@ class TestLRScheduler(TestCase):
             [float(group["lr"]) for group in self.opt.param_groups], initial_lrs
         )
 
-    @parametrize(
-        "scheduler_factory",
-        [
-            partial(LambdaLR, lr_lambda=lambda epoch: 1.0),
-            partial(MultiplicativeLR, lr_lambda=lambda epoch: 1.0),
-            partial(StepLR, step_size=2),
-            partial(MultiStepLR, milestones=[2]),
-            ConstantLR,
-            LinearLR,
-            partial(ExponentialLR, gamma=0.9),
-            PolynomialLR,
-            partial(CosineAnnealingLR, T_max=4),
-            partial(CyclicLR, base_lr=0.01, max_lr=0.1, cycle_momentum=False),
-            partial(OneCycleLR, max_lr=0.1, total_steps=4, cycle_momentum=False),
-            partial(CosineAnnealingWarmRestarts, T_0=2),
-            partial(SWALR, swa_lr=0.01),
-        ],
-    )
-    def test_scheduler_step_ignores_unused_kwargs(self, scheduler_factory):
-        optimizer = SGD([torch.nn.Parameter(torch.ones(1))], lr=0.05)
-        reference_optimizer = SGD([torch.nn.Parameter(torch.ones(1))], lr=0.05)
-        scheduler = scheduler_factory(optimizer)
-        reference = scheduler_factory(reference_optimizer)
-
-        for _ in range(3):
-            optimizer.step()
-            scheduler.step(unused=True)
-            reference_optimizer.step()
-            reference.step()
-
-            self.assertEqual(scheduler.get_last_lr(), reference.get_last_lr())
-
     def test_plateau_lr_rejects_invalid_optimizer(self):
         with self.assertRaisesRegex(TypeError, "object is not an Optimizer"):
             PlateauLR(object())  # type: ignore[arg-type]
@@ -885,22 +853,7 @@ class TestLRScheduler(TestCase):
         with self.assertRaisesRegex(ValueError, error):
             scheduler.step(1.0)
 
-    def test_reduce_lr_on_plateau_rejects_invalid_optimizer(self):
-        with self.assertRaisesRegex(TypeError, "object is not an Optimizer"):
-            ReduceLROnPlateau(object())  # type: ignore[arg-type]
-
-    def test_reduce_lr_on_plateau_rejects_invalid_configuration(self):
-        cases = [
-            ({"factor": 1.0}, "Factor should be < 1.0"),
-            ({"min_lr": [0.0]}, "expected 2 min_lrs"),
-            ({"mode": "median"}, "mode median is unknown"),
-            ({"threshold_mode": "percentage"}, "threshold mode percentage is unknown"),
-        ]
-        for kwargs, error in cases:
-            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, error):
-                ReduceLROnPlateau(self.opt, **kwargs)
-
-    def test_reduce_lr_on_plateau_absolute_min_tracks_improvements(self):
+    def test_reduce_lr_on_plateau1(self):
         epochs = 10
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -916,7 +869,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_absolute_min_respects_patience(self):
+    def test_reduce_lr_on_plateau2(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -932,7 +885,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_absolute_max_respects_cooldown(self):
+    def test_reduce_lr_on_plateau3(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -943,7 +896,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_relative_max_tracks_improvements(self):
+    def test_reduce_lr_on_plateau4(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -954,7 +907,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_relative_max_respects_cooldown(self):
+    def test_reduce_lr_on_plateau5(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -970,7 +923,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_relative_min_tracks_improvements(self):
+    def test_reduce_lr_on_plateau6(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -981,7 +934,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_relative_min_respects_cooldown(self):
+    def test_reduce_lr_on_plateau7(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -997,7 +950,7 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_respects_per_group_min_lr(self):
+    def test_reduce_lr_on_plateau8(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -1014,11 +967,12 @@ class TestLRScheduler(TestCase):
         )
         self._test_reduce_lr_on_plateau(scheduler, targets, metrics, epochs)
 
-    def test_reduce_lr_on_plateau_initial_state(self):
+    def test_reduce_lr_on_plateau_get_last_lr_before_step(self):
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
-        scheduler = ReduceLROnPlateau(self.opt)
-        self.assertEqual(scheduler.last_epoch, 0)
+        scheduler = ReduceLROnPlateau(
+            self.opt,
+        )
         self.assertEqual(
             scheduler.get_last_lr(), [0.5 for param_group in self.opt.param_groups]
         )
@@ -1031,13 +985,6 @@ class TestLRScheduler(TestCase):
         scheduler.step(2.0)  # Triggers scheduler._reduce_lr
         for group, type_ in zip(self.opt.param_groups, types):
             self.assertEqual(type(group["lr"]), type_)
-
-    def test_reduce_lr_on_plateau_skips_reduction_smaller_than_eps(self):
-        initial_lrs = [group["lr"] for group in self.opt.param_groups]
-        scheduler = ReduceLROnPlateau(self.opt, factor=0.5, patience=0, eps=0.3)
-        scheduler.step(1.0)
-        scheduler.step(2.0)
-        self.assertEqual(scheduler.get_last_lr(), initial_lrs)
 
     def test_reduce_lr_on_plateau_is_deprecated(self):
         with self.assertWarnsRegex(FutureWarning, "PlateauLR"):
@@ -1762,7 +1709,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = ExponentialLR(self.opt, gamma=0.1)
         self._test(schedulers, targets, epochs)
 
-    def test_compound_reduce_lr_on_plateau_and_step_lr(self):
+    def test_compound_reduce_lr_on_plateau1(self):
         epochs = 10
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -1784,7 +1731,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = StepLR(self.opt, gamma=0.1, step_size=3)
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau_and_multi_step_lr(self):
+    def test_compound_reduce_lr_on_plateau2(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -1806,7 +1753,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = MultiStepLR(self.opt, gamma=0.1, milestones=[3, 8, 12])
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau_and_exponential_lr(self):
+    def test_compound_reduce_lr_on_plateau3(self):
         epochs = 22
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.5
@@ -1823,7 +1770,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = ExponentialLR(self.opt, gamma=0.1)
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau_and_cosine_annealing_lr(self):
+    def test_compound_reduce_lr_on_plateau4(self):
         epochs = 20
         for param_group in self.opt.param_groups:
             param_group["lr"] = 0.05
@@ -1843,7 +1790,7 @@ class TestLRScheduler(TestCase):
         schedulers[1] = CosineAnnealingLR(self.opt, epochs, eta_min)
         self._test_reduce_lr_on_plateau(schedulers, targets, metrics, epochs)
 
-    def test_compound_reduce_lr_on_plateau_and_linear_lr(self):
+    def test_compound_reduce_lr_on_plateau5(self):
         iters = 4
         start_factor = 0.4
         epochs = 22
@@ -3257,7 +3204,7 @@ class TestLRScheduler(TestCase):
             scheduler.step(metrics=1.3)
 
     @parametrize("min_lr", [0, [1e-5, 1e-4]])
-    def test_reduce_lr_on_plateau_supports_added_param_group(self, min_lr):
+    def test_add_param_group_does_not_break_reduce_lr_on_plateau(self, min_lr):
         scheduler = ReduceLROnPlateau(
             self.opt,
             factor=0.1,
@@ -3280,7 +3227,7 @@ class TestLRScheduler(TestCase):
             [0.005, 0.05, 0.005],
         )
 
-    def test_reduce_lr_on_plateau_requires_min_lr_for_added_param_group(self):
+    def test_add_param_group_errors_reduce_lr_on_plateau(self):
         scheduler = ReduceLROnPlateau(
             self.opt,
             mode="min",

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -83,6 +83,20 @@ class TestLRScheduler(TestCase):
         def step(self, epoch=None):
             super().step(epoch)
 
+    class KwargsRecordingScheduler(LRScheduler):
+        """A third-party scheduler collecting its step arguments in ``**kwargs``."""
+
+        def __init__(self, optimizer):
+            self.step_kwargs = []
+            super().__init__(optimizer)
+
+        def get_lr(self):
+            return [group["lr"] for group in self.optimizer.param_groups]
+
+        def step(self, epoch=None, **kwargs):
+            self.step_kwargs.append(kwargs)
+            super().step(epoch)
+
     class MetricsUpdateScheduler(LRScheduler):
         """A scheduler using the metrics-aware private update hook."""
 
@@ -1299,7 +1313,10 @@ class TestLRScheduler(TestCase):
     def test_sequentiallr_initializes_nested_chained_sequentiallr(self):
         inner = SequentialLR(
             self.opt,
-            schedulers=[LinearLR(self.opt, start_factor=0.5, total_iters=4), ConstantLR(self.opt)],
+            schedulers=[
+                LinearLR(self.opt, start_factor=0.5, total_iters=4),
+                ConstantLR(self.opt),
+            ],
             milestones=[4],
         )
         chained = ChainedScheduler([inner], optimizer=self.opt)
@@ -1358,6 +1375,38 @@ class TestLRScheduler(TestCase):
         )
         self.opt.step()
         sequential.step(metrics=1.0)
+
+    def test_composite_schedulers_forward_all_kwargs_to_children(self):
+        """Composites pass their step kwargs through, not just `metrics`."""
+        chained_child = self.KwargsRecordingScheduler(self.opt)
+        chained = ChainedScheduler([chained_child], optimizer=self.opt)
+        self.opt.step()
+        chained.step(metrics=1.0, other=2)
+
+        self.assertEqual(chained_child.step_kwargs[-1], {"metrics": 1.0, "other": 2})
+
+        sequential_child = self.KwargsRecordingScheduler(self.opt)
+        sequential = SequentialLR(
+            self.opt,
+            schedulers=[sequential_child, ConstantLR(self.opt)],
+            milestones=[2],
+        )
+        self.opt.step()
+        sequential.step(metrics=3.0, other=4)
+
+        self.assertEqual(sequential_child.step_kwargs[-1], {"metrics": 3.0, "other": 4})
+
+    def test_scheduler_ignores_kwargs_it_does_not_use(self):
+        scheduler = StepLR(self.opt, step_size=1)
+        self.opt.step()
+        scheduler.step(some_future_input=1.0)
+
+    def test_plateau_lr_rejects_misspelled_metrics(self):
+        """`metrics` is named explicitly, so a typo is not silently ignored."""
+        scheduler = PlateauLR(self.opt)
+        self.opt.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step(metric=1.0)
 
     def test_chained_scheduler_forwards_metrics_to_update_hook(self):
         child = self.MetricsUpdateScheduler(self.opt)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -27,6 +27,7 @@ from torch.optim.lr_scheduler import (
     MultiplicativeLR,
     MultiStepLR,
     OneCycleLR,
+    PlateauLR,
     PolynomialLR,
     ReduceLROnPlateau,
     SequentialLR,
@@ -72,6 +73,24 @@ class TestLRScheduler(TestCase):
                 return self.__dict__ == other.__dict__
             else:
                 return False
+
+    class LegacyScheduler(LRScheduler):
+        """A third-party scheduler using the pre-metrics step signature."""
+
+        def get_lr(self):
+            return [group["lr"] for group in self.optimizer.param_groups]
+
+        def step(self, epoch=None):
+            super().step(epoch)
+
+    class LegacyUpdateScheduler(LRScheduler):
+        """A third-party scheduler overriding the previous private hook."""
+
+        def get_lr(self):
+            return [group["lr"] for group in self.optimizer.param_groups]
+
+        def _update_lr(self, epoch=None):
+            super()._update_lr(epoch)
 
     exact_dtype = True
 
@@ -724,6 +743,187 @@ class TestLRScheduler(TestCase):
         for group, type_ in zip(self.opt.param_groups, types):
             self.assertEqual(type(group["lr"]), type_)
 
+    def test_reduce_lr_on_plateau_is_deprecated(self):
+        with self.assertWarnsRegex(FutureWarning, "PlateauLR"):
+            ReduceLROnPlateau(self.opt)
+
+    def test_lrscheduler_metrics_supports_legacy_update_hook(self):
+        scheduler = self.LegacyUpdateScheduler(self.opt)
+        self.opt.step()
+        scheduler.step(metrics=1.0)
+
+        self.assertEqual(scheduler.last_epoch, 1)
+
+    # PlateauLR is ReduceLROnPlateau's composable replacement (properly
+    # implements get_lr(), so it can be used inside SequentialLR/
+    # ChainedScheduler). Its get_lr()-driven logic is meant to be numerically
+    # identical to ReduceLROnPlateau's hand-rolled step() body, so these
+    # standalone tests reuse the exact metrics/target vectors from
+    # test_reduce_lr_on_plateau1-8 above as a regression check.
+    def test_plateau_lr1(self):
+        epochs = 10
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 20]
+        metrics = [10 - i * 0.0167 for i in range(20)]
+        scheduler = PlateauLR(
+            self.opt,
+            threshold_mode="abs",
+            mode="min",
+            threshold=0.01,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr2(self):
+        epochs = 22
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.05] * 7 + [0.005] * 7 + [0.0005] * 2]
+        metrics = [10 - i * 0.0165 for i in range(22)]
+        scheduler = PlateauLR(
+            self.opt,
+            patience=5,
+            cooldown=0,
+            threshold_mode="abs",
+            mode="min",
+            threshold=0.1,
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr3(self):
+        epochs = 22
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * (2 + 6) + [0.05] * (5 + 6) + [0.005] * 4]
+        metrics = [-0.8] * 2 + [-0.234] * 20
+        scheduler = PlateauLR(
+            self.opt, mode="max", patience=5, cooldown=5, threshold_mode="abs"
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr4(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 20]
+        metrics = [1.5 * (1.025**i) for i in range(20)]  # 1.025 > 1.1**0.25
+        scheduler = PlateauLR(
+            self.opt, mode="max", patience=3, threshold_mode="rel", threshold=0.1
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr5(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
+        metrics = [1.5 * (1.005**i) for i in range(20)]
+        scheduler = PlateauLR(
+            self.opt,
+            mode="max",
+            threshold_mode="rel",
+            threshold=0.1,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr6(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 20]
+        metrics = [1.5 * (0.85**i) for i in range(20)]
+        scheduler = PlateauLR(self.opt, mode="min", threshold_mode="rel", threshold=0.1)
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr7(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
+        metrics = [1] * 7 + [0.6] + [0.5] * 12
+        scheduler = PlateauLR(
+            self.opt,
+            mode="min",
+            threshold_mode="rel",
+            threshold=0.1,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr8(self):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.4] * 14, [0.5] * 6 + [0.3] * 14]
+        metrics = [1.5 * (1.005**i) for i in range(20)]
+        scheduler = PlateauLR(
+            self.opt,
+            mode="max",
+            threshold_mode="rel",
+            min_lr=[0.4, 0.3],
+            threshold=0.1,
+            patience=5,
+            cooldown=5,
+        )
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_plateau_lr_get_last_lr_before_step(self):
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        scheduler = PlateauLR(self.opt)
+        self.assertEqual(
+            scheduler.get_last_lr(), [0.5 for param_group in self.opt.param_groups]
+        )
+
+    def test_plateau_lr_preserves_lr_type(self):
+        # Ensures that tensor lrs are preserved, preventing recompilations.
+        types = [type(group["lr"]) for group in self.opt.param_groups]
+        scheduler = PlateauLR(self.opt, mode="min", patience=0)
+        self.opt.step()
+        scheduler.step(metrics=1.0)
+        self.opt.step()
+        scheduler.step(metrics=2.0)  # Triggers scheduler._reduce
+        for group, type_ in zip(self.opt.param_groups, types):
+            self.assertEqual(type(group["lr"]), type_)
+
+    def test_plateau_lr_get_lr_warns(self):
+        scheduler = PlateauLR(self.opt, factor=0.5, patience=0)
+        with self.assertWarnsRegex(UserWarning, r"please use `get_last_lr\(\)`"):
+            self.assertEqual(scheduler.get_lr(), scheduler.get_last_lr())
+
+    def test_plateau_lr_requires_metrics(self):
+        scheduler = PlateauLR(self.opt)
+        self.opt.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step(metrics=None)
+
+    def test_plateau_lr_initial_step_no_metrics(self):
+        # Construction performs an implicit initial step with no metric
+        # available; it must not raise, and must leave the lr unchanged.
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        scheduler = PlateauLR(self.opt)
+        self.assertEqual(scheduler.last_epoch, 0)
+        self.assertEqual(scheduler.get_last_lr(), [0.5 for _ in self.opt.param_groups])
+
+    def test_plateau_lr_state_dict(self):
+        scheduler = PlateauLR(self.opt, mode="min", factor=0.1, patience=2)
+        for score in [1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0, 3.0, 2.0, 1.0]:
+            self.opt.step()
+            scheduler.step(metrics=score)
+        scheduler_copy = PlateauLR(self.opt, mode="max", factor=0.5, patience=10)
+        scheduler_copy.load_state_dict(scheduler.state_dict())
+        for key in scheduler.__dict__:
+            if key != "optimizer":
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+
     def test_sequentiallr1(self):
         epochs = 19
         schedulers = [None] * 2
@@ -1002,6 +1202,362 @@ class TestLRScheduler(TestCase):
         scheduler = ChainedScheduler(schedulers)
         self._test(scheduler, targets, epochs)
         self.assertEqual(scheduler.get_last_lr(), schedulers[-1].get_last_lr())
+
+    def test_sequentiallr_with_plateau_lr(self):
+        """Warm up with a fixed schedule, then hand off to PlateauLR."""
+        epochs = 8
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 1.0
+        # The metric never improves after its first sighting, so with
+        # patience=0 the plateau scheduler reduces every subsequent epoch;
+        # its first sighting always counts as an improvement over `inf`.
+        metrics = [1.0] * epochs
+        warmup_targets = [0.625, 0.75, 0.875]
+        # At the milestone PlateauLR applies its epoch-0 lr, which is
+        # whatever the warmup left behind, and records that step's metric as
+        # its first observation.
+        handoff_and_plateau_targets = [0.875, 0.4375, 0.21875, 0.109375, 0.0546875]
+        targets = [warmup_targets + handoff_and_plateau_targets]
+        schedulers = [
+            LinearLR(self.opt, start_factor=0.5, total_iters=4),
+            PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[4])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+        self.assertEqual(scheduler.get_last_lr(), schedulers[1].get_last_lr())
+
+    def test_sequentiallr_forwards_metrics_at_plateau_lr_handoff(self):
+        plateau = PlateauLR(self.opt)
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt), plateau],
+            milestones=[1],
+        )
+
+        self.opt.step()
+        scheduler.step(metrics=0.5)
+
+        self.assertEqual(plateau.best, 0.5)
+
+    def test_sequentiallr_handoff_to_chained_plateau_lr(self):
+        plateau = PlateauLR(self.opt)
+        chained = ChainedScheduler([plateau], optimizer=self.opt)
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt), chained],
+            milestones=[1],
+        )
+
+        self.opt.step()
+        scheduler.step(metrics=0.5)
+
+        self.assertEqual(plateau.best, 0.5)
+
+    def test_sequentiallr_handoff_to_chained_sequentiallr(self):
+        inner = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt, factor=0.5), StepLR(self.opt, 2)],
+            milestones=[3],
+        )
+        chained = ChainedScheduler([inner], optimizer=self.opt)
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt, factor=1.0), chained],
+            milestones=[1],
+        )
+
+        self.opt.step()
+        scheduler.step()
+
+        self.assertEqual(inner.last_epoch, 0)
+        self.assertEqual(inner._schedulers[0].last_epoch, 0)
+        self.assertEqual(self.opt.param_groups[0]["lr"], 0.025)
+
+    def test_sequentiallr_initializes_nested_chained_sequentiallr(self):
+        inner = SequentialLR(
+            self.opt,
+            schedulers=[LinearLR(self.opt, start_factor=0.5, total_iters=4), ConstantLR(self.opt)],
+            milestones=[4],
+        )
+        chained = ChainedScheduler([inner], optimizer=self.opt)
+        outer = SequentialLR(
+            self.opt,
+            schedulers=[chained, ConstantLR(self.opt)],
+            milestones=[8],
+        )
+
+        self.assertEqual(inner.last_epoch, 0)
+        self.assertEqual(inner._schedulers[0].last_epoch, 0)
+
+        for _ in range(3):
+            self.opt.step()
+            outer.step()
+        self.assertEqual(inner.last_epoch, 3)
+        self.assertEqual(inner._schedulers[0].last_epoch, 3)
+
+        self.opt.step()
+        outer.step()
+        self.assertEqual(inner.last_epoch, 4)
+        self.assertEqual(inner._schedulers[1].last_epoch, 0)
+
+    def test_sequentiallr_initializes_nested_chained_plateau_lr(self):
+        plateau = PlateauLR(self.opt)
+        inner = SequentialLR(
+            self.opt,
+            schedulers=[plateau, ConstantLR(self.opt)],
+            milestones=[3],
+        )
+        chained = ChainedScheduler([inner], optimizer=self.opt)
+        outer = SequentialLR(
+            self.opt,
+            schedulers=[chained, ConstantLR(self.opt)],
+            milestones=[5],
+        )
+
+        self.assertEqual(inner.last_epoch, 0)
+        self.assertEqual(plateau.last_epoch, 0)
+
+        self.opt.step()
+        outer.step(metrics=0.5)
+        self.assertEqual(plateau.best, 0.5)
+
+    def test_composite_schedulers_support_legacy_children(self):
+        chained = ChainedScheduler([self.LegacyScheduler(self.opt)], optimizer=self.opt)
+        self.opt.step()
+        chained.step()
+        self.opt.step()
+        chained.step(metrics=1.0)
+
+        sequential = SequentialLR(
+            self.opt,
+            schedulers=[self.LegacyScheduler(self.opt), PlateauLR(self.opt)],
+            milestones=[2],
+        )
+        self.opt.step()
+        sequential.step(metrics=1.0)
+
+        legacy_update = ChainedScheduler(
+            [self.LegacyUpdateScheduler(self.opt)], optimizer=self.opt
+        )
+        nested_sequential = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt), legacy_update],
+            milestones=[1],
+        )
+        self.opt.step()
+        nested_sequential.step(metrics=1.0)
+
+    def test_chained_scheduler_supports_duck_typed_children(self):
+        class DuckTypedScheduler:
+            def __init__(self, optimizer):
+                self.optimizer = optimizer
+                self._last_lr = [group["lr"] for group in optimizer.param_groups]
+
+            def step(self):
+                self._last_lr = [group["lr"] for group in self.optimizer.param_groups]
+
+            def get_last_lr(self):
+                return self._last_lr
+
+        child = DuckTypedScheduler(self.opt)
+        scheduler = ChainedScheduler([child], optimizer=self.opt)
+        self.opt.step()
+        scheduler.step(metrics=1.0)
+
+        self.assertEqual(scheduler.get_last_lr(), child.get_last_lr())
+
+    def test_sequentiallr_with_plateau_lr_first(self):
+        """PlateauLR as the scheduler a SequentialLR starts with."""
+        epochs = 8
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 1.0
+        metrics = [1.0] * epochs
+        plateau_targets = [1.0, 0.5]
+        # At the milestone StepLR takes over from its own epoch 0, i.e. from
+        # `initial_lr` again -- not from whatever PlateauLR left behind.
+        step_targets = [1.0, 1.0, 0.1, 0.1, 0.01, 0.01]
+        targets = [plateau_targets + step_targets]
+        schedulers = [
+            PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
+            StepLR(self.opt, step_size=2, gamma=0.1),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[3])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_sequentiallr_with_only_plateau_lr(self):
+        """SequentialLR initializes the optimizer from a PlateauLR stage."""
+        epochs = 5
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 1.0
+        metrics = [1.0] * epochs
+        targets = [[1.0, 1.0, 0.5, 0.25, 0.125]]
+        schedulers = [
+            PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
+            PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[2])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_sequentiallr_forwards_metrics_to_nested_chained_scheduler(self):
+        """A metric reaches a PlateauLR nested two containers deep."""
+        epochs = 6
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 1.0
+        metrics = [1.0] * epochs
+        targets = [[1.0, 0.5, 1.0, 1.0, 0.5, 0.5]]
+        plateau = PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0)
+        schedulers = [
+            ChainedScheduler([plateau], optimizer=self.opt),
+            StepLR(self.opt, step_size=2, gamma=0.5),
+        ]
+        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[3])
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+
+    def test_composed_plateau_lr_without_metrics(self):
+        """Stepping a composer without a metric while PlateauLR is active is an error."""
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[
+                LinearLR(self.opt, total_iters=2),
+                PlateauLR(self.opt),
+            ],
+            milestones=[2],
+        )
+        # The milestone is PlateauLR's epoch-0 initialization update. Without
+        # a metric, it leaves the plateau state unchanged; subsequent active
+        # steps require one.
+        for _ in range(2):
+            self.opt.step()
+            scheduler.step()
+        self.opt.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            scheduler.step()
+
+        chained = ChainedScheduler(
+            [ConstantLR(self.opt), PlateauLR(self.opt)], optimizer=self.opt
+        )
+        self.opt.step()
+        with self.assertRaisesRegex(ValueError, "requires the metric it monitors"):
+            chained.step()
+
+    def test_sequentiallr_with_plateau_lr_state_dict(self):
+        """Resuming from a checkpoint taken while the plateau stage is active."""
+        base_lr = 0.1
+        milestone = 2
+        total_steps = 8
+        resume_step = 5
+        metrics = [1.0] * total_steps
+
+        def make_scheduler(optim):
+            return SequentialLR(
+                optim,
+                [
+                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
+                    PlateauLR(optim, factor=0.5, patience=1, threshold=0),
+                ],
+                milestones=[milestone],
+            )
+
+        model = torch.nn.Linear(1, 1)
+        optim = SGD(model.parameters(), lr=base_lr)
+        sched = make_scheduler(optim)
+
+        reference_lrs = []
+        for step in range(total_steps):
+            optim.step()
+            sched.step(metrics=metrics[step])
+            reference_lrs.append(sched.get_last_lr()[0])
+
+        model2 = torch.nn.Linear(1, 1)
+        optim2 = SGD(model2.parameters(), lr=base_lr)
+        sched2 = make_scheduler(optim2)
+        for step in range(resume_step):
+            optim2.step()
+            sched2.step(metrics=metrics[step])
+
+        optim_state = optim2.state_dict()
+        sched_state = sched2.state_dict()
+
+        model3 = torch.nn.Linear(1, 1)
+        optim3 = SGD(model3.parameters(), lr=base_lr)
+        # Building the scheduler overwrites the optimizer's lrs, so it has to
+        # come before restoring the optimizer, as `LRScheduler` documents.
+        sched3 = make_scheduler(optim3)
+        optim3.load_state_dict(optim_state)
+        sched3.load_state_dict(sched_state)
+
+        resumed_lrs = []
+        for step in range(resume_step, total_steps):
+            optim3.step()
+            sched3.step(metrics=metrics[step])
+            resumed_lrs.append(sched3.get_last_lr()[0])
+
+        self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
+
+    def test_sequentiallr_does_not_accept_explicit_epoch(self):
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[ConstantLR(self.opt), ConstantLR(self.opt)],
+            milestones=[2],
+        )
+        with self.assertRaises(TypeError):
+            scheduler.step(5)
+
+    def test_chained_scheduler_does_not_accept_explicit_epoch(self):
+        scheduler = ChainedScheduler(
+            [ConstantLR(self.opt), ConstantLR(self.opt)], optimizer=self.opt
+        )
+        with self.assertRaises(TypeError):
+            scheduler.step(5)
+
+    def test_sequentiallr_still_rejects_reduce_lr_on_plateau(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            with self.assertRaisesRegex(
+                ValueError, "does not support `ReduceLROnPlateau`"
+            ):
+                SequentialLR(
+                    self.opt,
+                    schedulers=[ConstantLR(self.opt), ReduceLROnPlateau(self.opt)],
+                    milestones=[2],
+                )
+
+    def test_chained_scheduler_still_rejects_reduce_lr_on_plateau(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            with self.assertRaisesRegex(
+                ValueError, "does not support `ReduceLROnPlateau`"
+            ):
+                ChainedScheduler(
+                    [ConstantLR(self.opt), ReduceLROnPlateau(self.opt)],
+                    optimizer=self.opt,
+                )
+
+    def test_chained_scheduler_with_plateau_lr(self):
+        """A chained PlateauLR composes with the other schedulers."""
+        epochs = 5
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 1.0
+        metrics = [1.0] * epochs
+        targets = [[1.0, 0.25, 0.125, 0.03125, 0.015625]]
+        schedulers = [
+            PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
+            StepLR(self.opt, step_size=2, gamma=0.5),
+        ]
+        scheduler = ChainedScheduler(schedulers, optimizer=self.opt)
+        self._test_with_metrics(scheduler, targets, metrics, epochs)
+        self.assertEqual(scheduler.get_last_lr(), schedulers[-1].get_last_lr())
+
+    def test_cosine_annealing_warm_restarts_ignores_metrics(self):
+        """The new keyword-only `metrics` param is inert for this scheduler."""
+        opt_a = SGD(self.SchedulerTestNet().parameters(), lr=0.05)
+        opt_b = SGD(self.SchedulerTestNet().parameters(), lr=0.05)
+        scheduler_a = CosineAnnealingWarmRestarts(opt_a, T_0=4, T_mult=2)
+        scheduler_b = CosineAnnealingWarmRestarts(opt_b, T_0=4, T_mult=2)
+        for epoch in range(10):
+            scheduler_a.step()
+            scheduler_b.step(metrics=1.0 + epoch)
+            self.assertEqual(scheduler_a.get_last_lr(), scheduler_b.get_last_lr())
 
     def test_compound_step_and_multistep_lr(self):
         epochs = 10
@@ -2417,6 +2973,33 @@ class TestLRScheduler(TestCase):
                     rtol=0,
                 )
 
+    def _test_with_metrics(self, schedulers, targets, metrics, epochs=10):
+        """Like `_test`, but forwards `metrics` to every scheduler's `step`.
+
+        Unlike `_test_reduce_lr_on_plateau`, this needs no isinstance dispatch:
+        every scheduler now accepts the keyword-only `metrics` argument, plain
+        schedulers just ignore it.
+        """
+        if isinstance(schedulers, LRScheduler):
+            schedulers = [schedulers]
+        for epoch in range(epochs):
+            self.opt.step()
+            for scheduler in schedulers:
+                scheduler.step(metrics=metrics[epoch])
+            for param_group, target in zip(self.opt.param_groups, targets):
+                self.assertEqual(
+                    target[epoch],
+                    param_group["lr"],
+                    msg=lambda msg: f"{msg}\n"
+                    + (
+                        "LR is wrong in epoch {}: expected {}, got {}".format(
+                            epoch, target[epoch], param_group["lr"]
+                        )
+                    ),
+                    atol=1e-5,
+                    rtol=0,
+                )
+
     def _test_cycle_lr(
         self,
         scheduler,
@@ -2548,6 +3131,7 @@ class TestLRScheduler(TestCase):
                 **kwargs,
             ),
             ReduceLROnPlateau,
+            PlateauLR,
             partial(CyclicLR, base_lr=0.01, max_lr=0.1),
             partial(OneCycleLR, max_lr=0.01, total_steps=10, anneal_strategy="linear"),
             partial(CosineAnnealingWarmRestarts, T_0=20),
@@ -2625,6 +3209,63 @@ class TestLRScheduler(TestCase):
         with self.assertRaisesRegex(RuntimeError, "The number of param groups in the"):
             self.opt.step()
             scheduler.step(1.3)
+
+    @parametrize("min_lr", ["scalar", "list"])
+    def test_add_param_group_does_not_break_plateau_lr(self, min_lr):
+        epochs = 20
+        for param_group in self.opt.param_groups:
+            param_group["lr"] = 0.5
+        targets = [[0.5] * 6 + [0.05] * (5 + 6) + [0.005] * 4]
+        metrics = [1] * 7 + [0.6] + [0.5] * 12
+        scheduler = PlateauLR(
+            self.opt,
+            mode="min",
+            threshold_mode="rel",
+            threshold=0.1,
+            patience=5,
+            cooldown=5,
+            min_lr=0 if min_lr == "scalar" else [1e-5, 1e-4],
+        )
+        for epoch in range(epochs):
+            # Point is to test the use case in #104361
+            if epoch == 8:
+                param = torch.nn.Parameter(torch.rand(2, 3))
+                self.opt.add_param_group({"params": [param], "lr": 0.05})
+                if min_lr == "list":
+                    scheduler.min_lrs.append(1e-6)
+            self.opt.step()
+            scheduler.step(metrics=metrics[epoch])
+            for param_group, target in zip(self.opt.param_groups, targets):
+                self.assertEqual(
+                    target[epoch],
+                    param_group["lr"],
+                    msg=lambda msg: f"{msg}\n"
+                    + (
+                        "LR is wrong in epoch {}: expected {}, got {}".format(
+                            epoch, target[epoch], param_group["lr"]
+                        )
+                    ),
+                    atol=1e-5,
+                    rtol=0,
+                )
+
+    def test_add_param_group_errors_plateau_lr(self):
+        scheduler = PlateauLR(
+            self.opt,
+            mode="min",
+            threshold_mode="rel",
+            threshold=1e-5,
+            patience=0,
+            cooldown=0,
+            min_lr=[1e-5, 1e-4],
+        )
+        param = torch.nn.Parameter(torch.rand(2, 3))
+        self.opt.add_param_group({"params": [param], "lr": 0.05})
+        self.opt.step()
+        scheduler.step(metrics=1)
+        with self.assertRaisesRegex(RuntimeError, "The number of param groups in the"):
+            self.opt.step()
+            scheduler.step(metrics=1.3)
 
     @parametrize(
         "LRClass",
@@ -2783,6 +3424,22 @@ class TestLRScheduler(TestCase):
         optim2 = torch.optim.AdamW(model.parameters())
         optim2.load_state_dict(optim.state_dict())
         sch2 = ReduceLROnPlateau(optim2, mode="min")
+        self.assertEqual(
+            sch2._get_closed_form_lr()[0]
+            if hasattr(self, "_get_closed_form_lr")
+            else sch2.get_last_lr()[0],
+            optim.param_groups[0]["lr"],
+        )
+
+    def test_lr_scheduler_checkpoint_on_plateau_lr(self):
+        model = torch.nn.Linear(3, 3)
+        optim = torch.optim.AdamW(model.parameters())
+        sch = PlateauLR(optim, mode="min")
+        optim.step()
+        sch.step(metrics=1)
+        optim2 = torch.optim.AdamW(model.parameters())
+        optim2.load_state_dict(optim.state_dict())
+        sch2 = PlateauLR(optim2, mode="min")
         self.assertEqual(
             sch2._get_closed_form_lr()[0]
             if hasattr(self, "_get_closed_form_lr")

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -7,7 +7,6 @@ import tempfile
 import types
 import warnings
 from functools import partial
-from unittest import expectedFailure
 
 import torch
 import torch.nn.functional as F
@@ -1030,21 +1029,6 @@ class TestLRScheduler(TestCase):
         scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=milestones)
         self._test(scheduler, targets, epochs)
 
-    def test_sequentiallr_update_lr_uses_stage_local_epoch(self):
-        optimizer = SGD([torch.tensor(0.5)], lr=1.0)
-        second_scheduler = ExponentialLR(optimizer, gamma=0.1)
-        scheduler = SequentialLR(
-            optimizer,
-            schedulers=[ConstantLR(optimizer, factor=1.0), second_scheduler],
-            milestones=[3],
-        )
-
-        scheduler._update_lr(5)
-
-        self.assertEqual(scheduler.last_epoch, 5)
-        self.assertEqual(second_scheduler.last_epoch, 2)
-        self.assertEqual(optimizer.param_groups[0]["lr"], 0.1**2)
-
     def test_sequentiallr_no_warnings(self):
         scheduler1 = LinearLR(self.opt, start_factor=0.5, end_factor=0.1, total_iters=5)
         scheduler2 = ExponentialLR(self.opt, gamma=0.9)
@@ -1276,91 +1260,6 @@ class TestLRScheduler(TestCase):
 
         self.assertEqual(plateau.best, 0.5)
 
-    def test_sequentiallr_handoff_to_chained_plateau_lr(self):
-        plateau = PlateauLR(self.opt)
-        chained = ChainedScheduler([plateau], optimizer=self.opt)
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[ConstantLR(self.opt), chained],
-            milestones=[1],
-        )
-
-        self.opt.step()
-        scheduler.step(metrics=0.5)
-
-        self.assertEqual(plateau.best, 0.5)
-
-    def test_sequentiallr_handoff_to_chained_sequentiallr(self):
-        inner = SequentialLR(
-            self.opt,
-            schedulers=[ConstantLR(self.opt, factor=0.5), StepLR(self.opt, 2)],
-            milestones=[3],
-        )
-        chained = ChainedScheduler([inner], optimizer=self.opt)
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[ConstantLR(self.opt, factor=1.0), chained],
-            milestones=[1],
-        )
-
-        self.opt.step()
-        scheduler.step()
-
-        self.assertEqual(inner.last_epoch, 0)
-        self.assertEqual(inner._schedulers[0].last_epoch, 0)
-        self.assertEqual(self.opt.param_groups[0]["lr"], 0.025)
-
-    def test_sequentiallr_initializes_nested_chained_sequentiallr(self):
-        inner = SequentialLR(
-            self.opt,
-            schedulers=[
-                LinearLR(self.opt, start_factor=0.5, total_iters=4),
-                ConstantLR(self.opt),
-            ],
-            milestones=[4],
-        )
-        chained = ChainedScheduler([inner], optimizer=self.opt)
-        outer = SequentialLR(
-            self.opt,
-            schedulers=[chained, ConstantLR(self.opt)],
-            milestones=[8],
-        )
-
-        self.assertEqual(inner.last_epoch, 0)
-        self.assertEqual(inner._schedulers[0].last_epoch, 0)
-
-        for _ in range(3):
-            self.opt.step()
-            outer.step()
-        self.assertEqual(inner.last_epoch, 3)
-        self.assertEqual(inner._schedulers[0].last_epoch, 3)
-
-        self.opt.step()
-        outer.step()
-        self.assertEqual(inner.last_epoch, 4)
-        self.assertEqual(inner._schedulers[1].last_epoch, 0)
-
-    def test_sequentiallr_initializes_nested_chained_plateau_lr(self):
-        plateau = PlateauLR(self.opt)
-        inner = SequentialLR(
-            self.opt,
-            schedulers=[plateau, ConstantLR(self.opt)],
-            milestones=[3],
-        )
-        chained = ChainedScheduler([inner], optimizer=self.opt)
-        outer = SequentialLR(
-            self.opt,
-            schedulers=[chained, ConstantLR(self.opt)],
-            milestones=[5],
-        )
-
-        self.assertEqual(inner.last_epoch, 0)
-        self.assertEqual(plateau.last_epoch, 0)
-
-        self.opt.step()
-        outer.step(metrics=0.5)
-        self.assertEqual(plateau.best, 0.5)
-
     def test_composite_schedulers_support_legacy_children(self):
         chained = ChainedScheduler([self.LegacyScheduler(self.opt)], optimizer=self.opt)
         self.opt.step()
@@ -1466,21 +1365,6 @@ class TestLRScheduler(TestCase):
             PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0),
         ]
         scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[2])
-        self._test_with_metrics(scheduler, targets, metrics, epochs)
-
-    def test_sequentiallr_forwards_metrics_to_nested_chained_scheduler(self):
-        """A metric reaches a PlateauLR nested two containers deep."""
-        epochs = 6
-        for param_group in self.opt.param_groups:
-            param_group["lr"] = 1.0
-        metrics = [1.0] * epochs
-        targets = [[1.0, 0.5, 1.0, 1.0, 0.5, 0.5]]
-        plateau = PlateauLR(self.opt, mode="min", factor=0.5, patience=0, threshold=0)
-        schedulers = [
-            ChainedScheduler([plateau], optimizer=self.opt),
-            StepLR(self.opt, step_size=2, gamma=0.5),
-        ]
-        scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=[3])
         self._test_with_metrics(scheduler, targets, metrics, epochs)
 
     def test_composed_plateau_lr_without_metrics(self):
@@ -3516,95 +3400,6 @@ class TestLRScheduler(TestCase):
             else sch2.get_last_lr()[0],
             optim.param_groups[0]["lr"],
         )
-
-    # NOTE: Expected-failure tests for known scheduler issues.
-    #
-    # These tests should be converted to normal regression tests once
-    # the underlying behavior is fixed.
-
-    @expectedFailure
-    def test_sequentiallr_resume_reproducibility(self):
-        # Note: Saving and restoring both the optimizer and SequentialLR
-        # state mid training should reproduce the same LR sequence as a
-        # continuous uninterrupted run.
-        #
-        # This currently fails around scheduler transition boundaries after
-        # restoring from checkpoint state.
-        #
-        # The problematic state transition comes from SequentialLR's restore
-        # model:
-        # 1. SequentialLR.__init__() sets last_epoch, resets each param group
-        #    lr back to initial_lr, calls recursive_undo(), and then replays
-        #    _schedulers[0]._initial_step().
-        # 2. At this resume point, that constructor path leaves the optimizer
-        #    lr at 0.05 even though the saved scheduler state corresponds to
-        #    an effective lr of 0.08.
-        # 3. SequentialLR.load_state_dict() restores scheduler fields like
-        #    last_epoch and _last_lr, but it does not re-synchronize the
-        #    optimizer param-group lr with that loaded scheduler state.
-        # 4. LinearLR.get_lr() is recursive: it multiplies the current
-        #    optimizer lr, so the next resumed step advances
-        #    0.05 -> 0.05625 instead of the uninterrupted run's 0.08 -> 0.09.
-
-        base_lr = 0.1
-        milestone = 5
-        total_steps = 8
-        resume_step = 3
-
-        def make_scheduler(optim):
-            return SequentialLR(
-                optim,
-                [
-                    LinearLR(optim, start_factor=0.5, total_iters=milestone),
-                    ExponentialLR(optim, gamma=0.5),
-                ],
-                milestones=[milestone],
-            )
-
-        # run the full schedule and record the LR.
-        model = torch.nn.Linear(1, 1)
-        optim = torch.optim.SGD(model.parameters(), lr=base_lr)
-        sched = make_scheduler(optim)
-
-        reference_lrs = []
-        for _ in range(total_steps):
-            optim.step()
-            sched.step()
-            reference_lrs.append(sched.get_last_lr()[0])
-
-        # run a fresh optimizer/scheduler pair up to an intermediate step
-        model2 = torch.nn.Linear(1, 1)
-        optim2 = torch.optim.SGD(model2.parameters(), lr=base_lr)
-        sched2 = make_scheduler(optim2)
-
-        for _ in range(resume_step):
-            optim2.step()
-            sched2.step()
-
-        # save state to simulate checkpointing.
-        optim_state = optim2.state_dict()
-        sched_state = sched2.state_dict()
-
-        # restore into a new optimizer/scheduler pair
-        model3 = torch.nn.Linear(1, 1)
-        optim3 = torch.optim.SGD(model3.parameters(), lr=base_lr)
-        optim3.load_state_dict(optim_state)
-
-        sched3 = make_scheduler(optim3)
-        sched3.load_state_dict(sched_state)
-
-        loaded_optimizer_lr = optim3.param_groups[0]["lr"]
-        loaded_scheduler_lr = sched3.get_last_lr()[0]
-
-        resumed_lrs = []
-        for _ in range(resume_step, total_steps):
-            optim3.step()
-            sched3.step()
-            resumed_lrs.append(sched3.get_last_lr()[0])
-
-        self.assertEqual(loaded_optimizer_lr, loaded_scheduler_lr)
-        self.assertEqual(resumed_lrs[0], reference_lrs[resume_step])
-        self.assertEqual(resumed_lrs, reference_lrs[resume_step:])
 
 
 instantiate_parametrized_tests(TestLRScheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -885,8 +885,8 @@ class TestLRScheduler(TestCase):
             return SequentialLR(
                 optimizer,
                 [
-                    ConstantLR(optimizer, factor=0.5, total_iters=2),
-                    ConstantLR(optimizer, factor=0.2, total_iters=10),
+                    ConstantLR(optimizer, factor=0.2),
+                    ConstantLR(optimizer, factor=0.5),
                 ],
                 milestones=[2],
             )
@@ -910,7 +910,7 @@ class TestLRScheduler(TestCase):
             """Construct the ChainedScheduler used at both nesting depths."""
             return ChainedScheduler(
                 [
-                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ConstantLR(optimizer, factor=0.5),
                     ExponentialLR(optimizer, gamma=0.9),
                 ],
                 optimizer=optimizer,

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -83,14 +83,19 @@ class TestLRScheduler(TestCase):
         def step(self, epoch=None):
             super().step(epoch)
 
-    class LegacyUpdateScheduler(LRScheduler):
-        """A third-party scheduler overriding the previous private hook."""
+    class MetricsUpdateScheduler(LRScheduler):
+        """A scheduler using the metrics-aware private update hook."""
+
+        def __init__(self, optimizer):
+            self.metrics = []
+            super().__init__(optimizer)
 
         def get_lr(self):
             return [group["lr"] for group in self.optimizer.param_groups]
 
-        def _update_lr(self, epoch=None):
-            super()._update_lr(epoch)
+        def _update_lr(self, epoch=None, *, metrics=None):
+            self.metrics.append(metrics)
+            super()._update_lr(epoch, metrics=metrics)
 
     exact_dtype = True
 
@@ -747,12 +752,12 @@ class TestLRScheduler(TestCase):
         with self.assertWarnsRegex(FutureWarning, "PlateauLR"):
             ReduceLROnPlateau(self.opt)
 
-    def test_lrscheduler_metrics_supports_legacy_update_hook(self):
-        scheduler = self.LegacyUpdateScheduler(self.opt)
+    def test_lrscheduler_forwards_metrics_to_update_hook(self):
+        scheduler = self.MetricsUpdateScheduler(self.opt)
         self.opt.step()
         scheduler.step(metrics=1.0)
 
-        self.assertEqual(scheduler.last_epoch, 1)
+        self.assertEqual(scheduler.metrics, [None, 1.0])
 
     # PlateauLR is ReduceLROnPlateau's composable replacement (properly
     # implements get_lr(), so it can be used inside SequentialLR/
@@ -1336,16 +1341,14 @@ class TestLRScheduler(TestCase):
         self.opt.step()
         sequential.step(metrics=1.0)
 
-        legacy_update = ChainedScheduler(
-            [self.LegacyUpdateScheduler(self.opt)], optimizer=self.opt
-        )
-        nested_sequential = SequentialLR(
-            self.opt,
-            schedulers=[ConstantLR(self.opt), legacy_update],
-            milestones=[1],
-        )
+    def test_chained_scheduler_forwards_metrics_to_update_hook(self):
+        child = self.MetricsUpdateScheduler(self.opt)
+        scheduler = ChainedScheduler([child], optimizer=self.opt)
+
         self.opt.step()
-        nested_sequential.step(metrics=1.0)
+        scheduler.step(metrics=1.0)
+
+        self.assertEqual(child.metrics, [None, 1.0])
 
     def test_chained_scheduler_supports_duck_typed_children(self):
         class DuckTypedScheduler:

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -15,7 +15,7 @@ from optim.test_swa_utils import TestSWAUtils
 import torch
 from torch.nn import Parameter
 from torch.optim import Optimizer, SGD
-from torch.optim.lr_scheduler import PlateauLR
+from torch.optim.lr_scheduler import PlateauLR, ReduceLROnPlateau
 from torch.optim.optimizer import (
     register_optimizer_step_post_hook,
     register_optimizer_step_pre_hook,
@@ -264,7 +264,7 @@ class TestOptimRenewed(TestCase):
                         optimizer.step()
 
                     for scheduler in schedulers:
-                        if isinstance(scheduler, PlateauLR):
+                        if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
                             scheduler.step(metrics=loss)
                         else:
                             scheduler.step()
@@ -324,7 +324,7 @@ class TestOptimRenewed(TestCase):
                 for _ in range(20):
                     loss = optimizer.step(closure)
                     for scheduler in schedulers:
-                        if isinstance(scheduler, PlateauLR):
+                        if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
                             scheduler.step(metrics=loss)
                         else:
                             scheduler.step()
@@ -367,7 +367,7 @@ class TestOptimRenewed(TestCase):
             for _ in range(20):
                 loss = optimizer.step(closure)
                 for scheduler in schedulers:
-                    if isinstance(scheduler, PlateauLR):
+                    if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
                         scheduler.step(metrics=loss)
                     else:
                         scheduler.step()
@@ -552,14 +552,14 @@ class TestOptimRenewed(TestCase):
                 w = i % 2
                 optimizer.step(functools.partial(eval, params, True, w))
                 for scheduler in schedulers:
-                    if isinstance(scheduler, PlateauLR):
+                    if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
                         scheduler.step(metrics=rosenbrock(params[0]))
                     else:
                         scheduler.step()
                 if not optim_info.only_supports_sparse_grads:
                     optimizer_c.step(functools.partial(eval, params_c, False, w))
                     for scheduler in schedulers_c:
-                        if isinstance(scheduler, PlateauLR):
+                        if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
                             scheduler.step(metrics=rosenbrock(params_c[0]))
                         else:
                             scheduler.step()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -15,7 +15,6 @@ from optim.test_swa_utils import TestSWAUtils
 import torch
 from torch.nn import Parameter
 from torch.optim import Optimizer, SGD
-from torch.optim.lr_scheduler import PlateauLR, ReduceLROnPlateau
 from torch.optim.optimizer import (
     register_optimizer_step_post_hook,
     register_optimizer_step_pre_hook,
@@ -264,10 +263,7 @@ class TestOptimRenewed(TestCase):
                         optimizer.step()
 
                     for scheduler in schedulers:
-                        if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
-                            scheduler.step(metrics=loss)
-                        else:
-                            scheduler.step()
+                        scheduler.step(metrics=loss)
 
                 if optim_input.kwargs.get("maximize", False):
                     self.assertGreater(closure().item(), initial_value)
@@ -324,10 +320,7 @@ class TestOptimRenewed(TestCase):
                 for _ in range(20):
                     loss = optimizer.step(closure)
                     for scheduler in schedulers:
-                        if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
-                            scheduler.step(metrics=loss)
-                        else:
-                            scheduler.step()
+                        scheduler.step(metrics=loss)
 
                 if optim_input.kwargs.get("maximize", False):
                     self.assertGreater(closure().item(), initial_value)
@@ -367,10 +360,7 @@ class TestOptimRenewed(TestCase):
             for _ in range(20):
                 loss = optimizer.step(closure)
                 for scheduler in schedulers:
-                    if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
-                        scheduler.step(metrics=loss)
-                    else:
-                        scheduler.step()
+                    scheduler.step(metrics=loss)
 
             self.assertLess(closure().item(), initial_value)
 
@@ -552,17 +542,11 @@ class TestOptimRenewed(TestCase):
                 w = i % 2
                 optimizer.step(functools.partial(eval, params, True, w))
                 for scheduler in schedulers:
-                    if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
-                        scheduler.step(metrics=rosenbrock(params[0]))
-                    else:
-                        scheduler.step()
+                    scheduler.step(metrics=rosenbrock(params[0]))
                 if not optim_info.only_supports_sparse_grads:
                     optimizer_c.step(functools.partial(eval, params_c, False, w))
                     for scheduler in schedulers_c:
-                        if isinstance(scheduler, (PlateauLR, ReduceLROnPlateau)):
-                            scheduler.step(metrics=rosenbrock(params_c[0]))
-                        else:
-                            scheduler.step()
+                        scheduler.step(metrics=rosenbrock(params_c[0]))
                     # Tolerance is increased due to floating point error from different
                     # code path for dense case: x v.s. x - x / 4.0 + x / 4.0
                     self.assertEqual(params, params_c, atol=5e-6, rtol=5e-6)

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -15,7 +15,7 @@ from optim.test_swa_utils import TestSWAUtils
 import torch
 from torch.nn import Parameter
 from torch.optim import Optimizer, SGD
-from torch.optim.lr_scheduler import ReduceLROnPlateau
+from torch.optim.lr_scheduler import PlateauLR
 from torch.optim.optimizer import (
     register_optimizer_step_post_hook,
     register_optimizer_step_pre_hook,
@@ -264,8 +264,8 @@ class TestOptimRenewed(TestCase):
                         optimizer.step()
 
                     for scheduler in schedulers:
-                        if isinstance(scheduler, ReduceLROnPlateau):
-                            scheduler.step(loss)
+                        if isinstance(scheduler, PlateauLR):
+                            scheduler.step(metrics=loss)
                         else:
                             scheduler.step()
 
@@ -324,8 +324,8 @@ class TestOptimRenewed(TestCase):
                 for _ in range(20):
                     loss = optimizer.step(closure)
                     for scheduler in schedulers:
-                        if isinstance(scheduler, ReduceLROnPlateau):
-                            scheduler.step(loss)
+                        if isinstance(scheduler, PlateauLR):
+                            scheduler.step(metrics=loss)
                         else:
                             scheduler.step()
 
@@ -367,8 +367,8 @@ class TestOptimRenewed(TestCase):
             for _ in range(20):
                 loss = optimizer.step(closure)
                 for scheduler in schedulers:
-                    if isinstance(scheduler, ReduceLROnPlateau):
-                        scheduler.step(loss)
+                    if isinstance(scheduler, PlateauLR):
+                        scheduler.step(metrics=loss)
                     else:
                         scheduler.step()
 
@@ -552,15 +552,15 @@ class TestOptimRenewed(TestCase):
                 w = i % 2
                 optimizer.step(functools.partial(eval, params, True, w))
                 for scheduler in schedulers:
-                    if isinstance(scheduler, ReduceLROnPlateau):
-                        scheduler.step(rosenbrock(params[0]))
+                    if isinstance(scheduler, PlateauLR):
+                        scheduler.step(metrics=rosenbrock(params[0]))
                     else:
                         scheduler.step()
                 if not optim_info.only_supports_sparse_grads:
                     optimizer_c.step(functools.partial(eval, params_c, False, w))
                     for scheduler in schedulers_c:
-                        if isinstance(scheduler, ReduceLROnPlateau):
-                            scheduler.step(rosenbrock(params_c[0]))
+                        if isinstance(scheduler, PlateauLR):
+                            scheduler.step(metrics=rosenbrock(params_c[0]))
                         else:
                             scheduler.step()
                     # Tolerance is increased due to floating point error from different

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -34,8 +34,8 @@ __all__ = [
     "SequentialLR",
     "CosineAnnealingLR",
     "ChainedScheduler",
-    "ReduceLROnPlateau",
     "PlateauLR",
+    "ReduceLROnPlateau",
     "CyclicLR",
     "CosineAnnealingWarmRestarts",
     "OneCycleLR",
@@ -98,10 +98,8 @@ def _step_accepts_kwargs(scheduler: LRScheduler) -> bool:
     """Whether ``scheduler.step`` collects arbitrary keyword arguments.
 
     Every scheduler in this module does. A third-party scheduler still written
-    against the older API -- ``def step(self)`` or
-    ``def step(self, epoch=None)`` -- does not, and the composite schedulers
-    call its ``step`` without keyword arguments so that it keeps working until
-    it is updated.
+    against the older API, ``def step(self)`` or ``def step(self, epoch=None)``,
+    does not, and this function helps us tell them apart.
     """
     # The bound method, so that `self` is not one of the parameters.
     return any(
@@ -263,12 +261,8 @@ class LRScheduler:
                     :meth:`_get_closed_form_lr` if it is available. This is not
                     universally supported. Use :meth:`step` without arguments
                     instead.
-            **kwargs: Extra scheduling inputs, ignored by any scheduler that
-                does not use them. The composite schedulers
-                (:class:`SequentialLR`, :class:`ChainedScheduler`) forward
-                these to the schedulers they hold, so a caller can pass an
-                input that only one of them consumes -- as
-                :class:`PlateauLR` does with ``metrics``.
+            **kwargs: Extra scheduling inputs. It's up to each scheduler how to
+                use them. See :class:`PlateauLR` for an example.
 
         .. note::
             Call this method after calling the optimizer's
@@ -1138,11 +1132,12 @@ class SequentialLR(LRScheduler):
         >>>     scheduler.step()
 
         >>> # xdoctest: +SKIP
-        >>> # A PlateauLR stage receives the monitored metric through the
-        >>> # keyword-only `metrics` argument, forwarded here unchanged:
+        >>> # SequentialLR can pass extra keyword arguments to the schedulers it holds:
+        >>> scheduler1 = LinearLR(optimizer, total_iters=5)
+        >>> scheduler2 = PlateauLR(optimizer)
         >>> scheduler = SequentialLR(
         ...     optimizer,
-        ...     schedulers=[LinearLR(optimizer, total_iters=5), PlateauLR(optimizer)],
+        ...     schedulers=[scheduler1, scheduler2],
         ...     milestones=[5],
         ... )
         >>> for epoch in range(100):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1165,10 +1165,13 @@ class SequentialLR(LRScheduler):
         self.recursive_undo()
 
         # Perform the initial step for only the scheduler meant to run at step 0.
+        self._initial_step()
+
+    def _initial_step(self) -> None:
         idx = bisect_right(self._milestones, 0)
         self._schedulers[idx]._initial_step()
 
-        self._last_lr = schedulers[idx].get_last_lr()
+        self._last_lr = self._schedulers[idx].get_last_lr()
 
     def recursive_undo(self, sched=None) -> None:
         """
@@ -1534,6 +1537,17 @@ class ChainedScheduler(LRScheduler):
                 )
         self._schedulers = schedulers
         self.optimizer = optimizer
+        # Unlike the other schedulers, this does not end with
+        # `self._initial_step()`: every scheduler in `schedulers` already took
+        # its own initial step when it was constructed, and those compose into
+        # the chained learning rate. Calling it here would apply each factor a
+        # second time. `_initial_step` is for an enclosing composite scheduler
+        # to call once it has undone those constructor steps.
+        self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
+
+    def _initial_step(self) -> None:
+        for scheduler in self._schedulers:
+            scheduler._initial_step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     def step(self) -> None:  # type: ignore[override]

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1244,8 +1244,9 @@ class SequentialLR(LRScheduler):
     def state_dict(self) -> dict[str, Any]:
         """Return the state of the scheduler as a :class:`dict`.
 
-        It contains an entry for every variable in ``self.__dict__`` which
-        is not the optimizer.
+        It contains an entry for every variable in ``self.__dict__`` except
+        the optimizer and derived scheduler metadata.
+
         The wrapped scheduler states will also be saved.
         """
         state_dict = {
@@ -1628,8 +1629,9 @@ class ChainedScheduler(LRScheduler):
     def state_dict(self) -> dict[str, Any]:
         """Return the state of the scheduler as a :class:`dict`.
 
-        It contains an entry for every variable in ``self.__dict__`` which
-        is not the optimizer.
+        It contains an entry for every variable in ``self.__dict__`` except
+        the optimizer and derived scheduler metadata.
+
         The wrapped scheduler states will also be saved.
         """
         state_dict = {

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -298,7 +298,7 @@ class LRScheduler:
         if kwargs and _accepts_kwargs(self._update_lr):
             self._update_lr(epoch, **kwargs)
         else:
-            self._update_lr(epoch)
+            self._update_lr(epoch)  # For backwards compatibility
 
     def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
         with _enable_get_lr_call(self):
@@ -307,7 +307,7 @@ class LRScheduler:
                 if kwargs and _accepts_kwargs(self.get_lr):
                     values = self.get_lr(**kwargs)
                 else:
-                    values = self.get_lr()
+                    values = self.get_lr()  # For backwards compatibility
             else:
                 self.last_epoch = epoch
                 if hasattr(self, "_get_closed_form_lr"):
@@ -316,7 +316,7 @@ class LRScheduler:
                     if kwargs and _accepts_kwargs(self.get_lr):
                         values = self.get_lr(**kwargs)
                     else:
-                        values = self.get_lr()
+                        values = self.get_lr()  # For backwards compatibility
 
         for param_group, lr in zip(self.optimizer.param_groups, values, strict=True):
             _update_param_group_val(param_group, "lr", lr)
@@ -1242,12 +1242,12 @@ class SequentialLR(LRScheduler):
             if kwargs and _accepts_kwargs(scheduler._update_lr):
                 scheduler._update_lr(0, **kwargs)
             else:
-                scheduler._update_lr(0)
+                scheduler._update_lr(0)  # For backwards compatibility
         else:
             if self._schedulers_accept_kwargs[idx]:
                 scheduler.step(**kwargs)
             else:
-                scheduler.step()
+                scheduler.step()  # For backwards compatibility
 
         self._last_lr = scheduler.get_last_lr()
 
@@ -1633,7 +1633,7 @@ class ChainedScheduler(LRScheduler):
             if accepts_kwargs:
                 scheduler.step(**kwargs)
             else:
-                scheduler.step()
+                scheduler.step()  # For backwards compatibility
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     @override

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -2055,6 +2055,11 @@ class PlateauLR(LRScheduler):
                 monitored, such as a validation loss. Required on every call
                 except the implicit one performed at construction.
         """
+        if epoch is not None and metrics is None:
+            raise ValueError(
+                "`PlateauLR.step` received an `epoch` argument but no "
+                "`metrics` argument. Did you mean `step(metrics=...)`?"
+            )
         if metrics is None and not self._is_initial:
             raise ValueError(
                 "`PlateauLR` requires the metric it monitors to be passed "

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1689,9 +1689,9 @@ class ChainedScheduler(LRScheduler):
 
 
 @deprecated(
-    "`ReduceLROnPlateau` is deprecated. Use `torch.optim.lr_scheduler.PlateauLR` instead. "
-    "The constructor arguments are the same, but call its `step` method with a keyword "
-    "argument: `scheduler.step(metrics=metric)`.",
+    "`ReduceLROnPlateau` is deprecated. Use `torch.optim.lr_scheduler.PlateauLR` "
+    "instead: replace `ReduceLROnPlateau(...)` with `PlateauLR(...)` and call "
+    "`scheduler.step(metrics=metric)`.",
     category=FutureWarning,
 )
 class ReduceLROnPlateau(LRScheduler):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1230,10 +1230,10 @@ class SequentialLR(LRScheduler):
         self.last_epoch = epoch
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
-        if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
-            scheduler._update_lr(0, metrics=metrics)
-        else:
-            scheduler._update_lr(epoch, metrics=metrics)
+        child_epoch = self.last_epoch
+        if idx > 0:
+            child_epoch -= self._milestones[idx - 1]
+        scheduler._update_lr(child_epoch, metrics=metrics)
 
         self._last_lr = scheduler.get_last_lr()
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1129,7 +1129,8 @@ class SequentialLR(LRScheduler):
         >>>     scheduler.step()
 
         >>> # xdoctest: +SKIP
-        >>> # SequentialLR can pass extra keyword arguments to the schedulers it holds:
+        >>> # SequentialLR can pass extra keyword arguments to the schedulers it
+        >>> # holds:
         >>> scheduler1 = LinearLR(optimizer, total_iters=5)
         >>> scheduler2 = PlateauLR(optimizer)
         >>> scheduler = SequentialLR(
@@ -1668,20 +1669,20 @@ class ChainedScheduler(LRScheduler):
 class PlateauLR(LRScheduler):
     """Reduce learning rate when a metric has stopped improving.
 
-    Models often benefit from reducing the learning rate by a factor
-    of 2-10 once learning stagnates. This scheduler reads a metrics
-    quantity and if no improvement is seen for a 'patience' number
-    of epochs, the learning rate is reduced.
+    Models often benefit from reducing the learning rate by a factor of 2-10
+    once learning stagnates. This scheduler reads a metrics quantity and if
+    no improvement is seen for a 'patience' number of epochs, the learning
+    rate is reduced.
 
-    Unlike :class:`ReduceLROnPlateau`, this scheduler implements
-    :meth:`get_lr` and can be used as one of the schedulers inside
-    :class:`SequentialLR` or :class:`ChainedScheduler`.
+    Unlike :class:`ReduceLROnPlateau`, this scheduler implements :meth:`get_lr`
+    and can be used as one of the schedulers inside :class:`SequentialLR`
+    or :class:`ChainedScheduler`.
 
-    When :class:`SequentialLR` activates this scheduler at a milestone, it
-    performs its epoch-0 update as it does for every other scheduler. If that
-    call receives a metric, it establishes the initial best value; otherwise,
-    it leaves the learning rate and plateau state unchanged. The first later
-    call with a metric then establishes the initial best value.
+    When :class:`SequentialLR` activates this scheduler at a milestone,
+    it performs its epoch-0 update as it does for every other scheduler.
+    If that call receives a metric, it establishes the initial best value;
+    otherwise, it leaves the learning rate and plateau state unchanged. The
+    first later call with a metric then establishes the initial best value.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -1693,16 +1694,17 @@ class PlateauLR(LRScheduler):
             reduced. new_lr = lr * factor. Default: 0.1.
         patience (int): The number of allowed epochs with no improvement after
             which the learning rate will be reduced.
-            For example, consider the case of having no patience (`patience = 0`).
-            In the first epoch, a baseline is established and is always considered good as there's no previous baseline.
-            In the second epoch, if the performance is worse than the baseline,
-            we have what is considered an intolerable epoch.
-            Since the count of intolerable epochs (1) is greater than the patience level (0),
-            the learning rate is reduced at the end of this epoch.
-            From the third epoch onwards, the learning rate continues to be reduced at the end of each epoch
-            if the performance is worse than the baseline. If the performance improves or remains the same,
-            the learning rate is not adjusted.
-            Default: 10.
+            For example, consider the case of having no patience
+            (`patience = 0`). In the first epoch, a baseline is established
+            and is always considered good as there's no previous baseline.
+            In the second epoch, if the performance is worse than the
+            baseline, we have what is considered an intolerable epoch. Since
+            the count of intolerable epochs (1) is greater than the patience
+            level (0), the learning rate is reduced at the end of this epoch.
+            From the third epoch onwards, the learning rate continues to be
+            reduced at the end of each epoch if the performance is worse than
+            the baseline. If the performance improves or remains the same,
+            the learning rate is not adjusted. Default: 10.
         threshold (float): Threshold for measuring the new optimum,
             to only focus on significant changes. Default: 1e-4.
         threshold_mode (str): One of `rel`, `abs`.
@@ -1731,7 +1733,11 @@ class PlateauLR(LRScheduler):
 
     Example:
         >>> # xdoctest: +SKIP
-        >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        >>> optimizer = torch.optim.SGD(
+        ...     model.parameters(),
+        ...     lr=0.1,
+        ...     momentum=0.9,
+        ... )
         >>> scheduler = PlateauLR(optimizer, "min")
         >>> for epoch in range(10):
         >>>     train(...)
@@ -1743,7 +1749,10 @@ class PlateauLR(LRScheduler):
         >>> # Composed with a warmup schedule:
         >>> scheduler = SequentialLR(
         ...     optimizer,
-        ...     schedulers=[LinearLR(optimizer, total_iters=5), PlateauLR(optimizer)],
+        ...     schedulers=[
+        ...         LinearLR(optimizer, total_iters=5),
+        ...         PlateauLR(optimizer),
+        ...     ],
         ...     milestones=[5],
         ... )
         >>> for epoch in range(100):
@@ -1861,7 +1870,7 @@ class PlateauLR(LRScheduler):
 
     @override
     def get_lr(self) -> list[float | Tensor]:
-        r"""Compute the next learning rate for each of the optimizer's param groups.
+        r"""Compute the next learning rate for each optimizer parameter group.
 
         Without a metric for this update, the current learning rate is
         returned unchanged; no reduction is attempted.

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1733,11 +1733,7 @@ class PlateauLR(LRScheduler):
 
     Example:
         >>> # xdoctest: +SKIP
-        >>> optimizer = torch.optim.SGD(
-        ...     model.parameters(),
-        ...     lr=0.1,
-        ...     momentum=0.9,
-        ... )
+        >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
         >>> scheduler = PlateauLR(optimizer, "min")
         >>> for epoch in range(10):
         >>>     train(...)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -10,7 +10,7 @@ from bisect import bisect_right
 from collections import Counter
 from functools import partial, wraps
 from typing import Any, cast, Literal, SupportsFloat, TYPE_CHECKING, TypedDict
-from typing_extensions import override, Self
+from typing_extensions import deprecated, override, Self
 from weakref import ref
 
 from torch import inf, Tensor
@@ -34,6 +34,7 @@ __all__ = [
     "CosineAnnealingLR",
     "ChainedScheduler",
     "ReduceLROnPlateau",
+    "PlateauLR",
     "CyclicLR",
     "CosineAnnealingWarmRestarts",
     "OneCycleLR",
@@ -115,6 +116,10 @@ class LRScheduler:
 
     _get_lr_called_within_step: bool = False
     _is_initial: bool = False
+    # Composite schedulers use this temporary capability marker to preserve
+    # compatibility with third-party schedulers that override step() without
+    # accepting metrics.
+    _requires_metrics: bool = False
 
     def __init__(
         self,
@@ -235,7 +240,9 @@ class LRScheduler:
         """
         raise NotImplementedError
 
-    def step(self, epoch: int | None = None) -> None:
+    def step(
+        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+    ) -> None:
         """Step the scheduler.
 
         Args:
@@ -245,6 +252,10 @@ class LRScheduler:
                     :meth:`_get_closed_form_lr` if it is available. This is not
                     universally supported. Use :meth:`step` without arguments
                     instead.
+            metrics (SupportsFloat, optional): Accepted for signature parity
+                with :class:`PlateauLR` and the composite schedulers
+                (:class:`SequentialLR`, :class:`ChainedScheduler`); ignored
+                unless a subclass sets ``_requires_metrics``.
 
         .. note::
             Call this method after calling the optimizer's
@@ -279,9 +290,14 @@ class LRScheduler:
         self._step_count += 1
         if epoch is not None:
             warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning, stacklevel=2)
-        self._update_lr(epoch)
+        if self._requires_metrics:
+            self._update_lr(epoch, metrics=metrics)
+        else:
+            self._update_lr(epoch)
 
-    def _update_lr(self, epoch: int | None = None) -> None:
+    def _update_lr(
+        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+    ) -> None:
         with _enable_get_lr_call(self):
             if epoch is None:
                 self.last_epoch += 1
@@ -1113,8 +1129,23 @@ class SequentialLR(LRScheduler):
         >>>     validate(...)
         >>>     scheduler.step()
 
+        >>> # xdoctest: +SKIP
+        >>> # A PlateauLR stage receives the monitored metric through the
+        >>> # keyword-only `metrics` argument, forwarded here unchanged:
+        >>> scheduler = SequentialLR(
+        ...     optimizer,
+        ...     schedulers=[LinearLR(optimizer, total_iters=5), PlateauLR(optimizer)],
+        ...     milestones=[5],
+        ... )
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     val_loss = validate(...)
+        >>>     scheduler.step(metrics=val_loss)
+
     .. image:: ../scripts/lr_scheduler_images/SequentialLR.png
     """
+
+    _requires_metrics: bool = True
 
     def __init__(
         self,
@@ -1172,7 +1203,6 @@ class SequentialLR(LRScheduler):
         self._schedulers[idx]._initial_step()
 
         self._last_lr = self._schedulers[idx].get_last_lr()
-
     def recursive_undo(self, sched=None) -> None:
         """
         Recursively undo any step performed by the initialization of
@@ -1186,15 +1216,60 @@ class SequentialLR(LRScheduler):
         elif hasattr(scheds, "last_epoch"):
             scheds.last_epoch -= 1
 
-    def step(self) -> None:  # type: ignore[override]
-        """Perform a step."""
+    @override
+    def _initial_step(self) -> None:
+        """Initialize the scheduler subtree active at step 0."""
+        idx = bisect_right(self._milestones, 0)
+        scheduler = self._schedulers[idx]
+        scheduler._initial_step()
+        self._last_lr = scheduler.get_last_lr()
+
+    @override
+    def _update_lr(
+        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+    ) -> None:
+        if epoch is None:
+            self.step(metrics=metrics)
+            return
+
+        self.last_epoch = epoch
+        idx = bisect_right(self._milestones, self.last_epoch)
+        scheduler = self._schedulers[idx]
+        if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
+            if getattr(scheduler, "_requires_metrics", False):
+                scheduler._update_lr(0, metrics=metrics)
+            else:
+                scheduler._update_lr(0)
+        else:
+            if getattr(scheduler, "_requires_metrics", False):
+                scheduler._update_lr(epoch, metrics=metrics)
+            else:
+                scheduler._update_lr(epoch)
+
+        self._last_lr = scheduler.get_last_lr()
+
+    def step(self, *, metrics: SupportsFloat | None = None) -> None:
+        """Perform a step.
+
+        Args:
+            metrics (SupportsFloat, optional): Forwarded to the currently
+                active sub-scheduler when it requires a metric. Only
+                :class:`PlateauLR` among the built-in schedulers makes use of
+                it.
+        """
         self.last_epoch += 1
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
-            scheduler._update_lr(0)
+            if getattr(scheduler, "_requires_metrics", False):
+                scheduler._update_lr(0, metrics=metrics)
+            else:
+                scheduler._update_lr(0)
         else:
-            scheduler.step()
+            if getattr(scheduler, "_requires_metrics", False):
+                scheduler.step(metrics=metrics)
+            else:
+                scheduler.step()
 
         self._last_lr = scheduler.get_last_lr()
 
@@ -1506,8 +1581,22 @@ class ChainedScheduler(LRScheduler):
         >>>     validate(...)
         >>>     scheduler.step()
 
+        >>> # xdoctest: +SKIP
+        >>> # A contained PlateauLR receives the monitored metric through the
+        >>> # keyword-only `metrics` argument, forwarded here unchanged:
+        >>> scheduler = ChainedScheduler(
+        ...     [ExponentialLR(optimizer, gamma=0.9), PlateauLR(optimizer)],
+        ...     optimizer=optimizer,
+        ... )
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     val_loss = validate(...)
+        >>>     scheduler.step(metrics=val_loss)
+
     .. image:: ../scripts/lr_scheduler_images/ChainedScheduler.png
     """
+
+    _requires_metrics: bool = True
 
     def __init__(
         self, schedulers: Sequence[LRScheduler], optimizer: Optimizer | None = None
@@ -1550,10 +1639,30 @@ class ChainedScheduler(LRScheduler):
             scheduler._initial_step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
-    def step(self) -> None:  # type: ignore[override]
-        """Perform a step."""
+    @override
+    def _update_lr(
+        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+    ) -> None:
         for scheduler in self._schedulers:
-            scheduler.step()
+            if getattr(scheduler, "_requires_metrics", False):
+                scheduler._update_lr(epoch, metrics=metrics)
+            else:
+                scheduler._update_lr(epoch)
+        self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
+
+    def step(self, *, metrics: SupportsFloat | None = None) -> None:
+        """Perform a step.
+
+        Args:
+            metrics (SupportsFloat, optional): Forwarded to every contained
+                scheduler that requires a metric. Only :class:`PlateauLR`
+                among the built-in schedulers makes use of it.
+        """
+        for scheduler in self._schedulers:
+            if getattr(scheduler, "_requires_metrics", False):
+                scheduler.step(metrics=metrics)
+            else:
+                scheduler.step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     @override
@@ -1595,6 +1704,12 @@ class ChainedScheduler(LRScheduler):
             self._schedulers[idx].load_state_dict(s)
 
 
+@deprecated(
+    "`ReduceLROnPlateau` is deprecated. Use `torch.optim.lr_scheduler.PlateauLR` instead. "
+    "The constructor arguments are the same, but call its `step` method with a keyword "
+    "argument: `scheduler.step(metrics=metric)`.",
+    category=FutureWarning,
+)
 class ReduceLROnPlateau(LRScheduler):
     """Reduce learning rate when a metric has stopped improving.
 
@@ -1797,6 +1912,273 @@ class ReduceLROnPlateau(LRScheduler):
         self._init_is_better(
             mode=self.mode, threshold=self.threshold, threshold_mode=self.threshold_mode
         )
+
+
+class PlateauLR(LRScheduler):
+    """Reduce learning rate when a metric has stopped improving.
+
+    Models often benefit from reducing the learning rate by a factor
+    of 2-10 once learning stagnates. This scheduler reads a metrics
+    quantity and if no improvement is seen for a 'patience' number
+    of epochs, the learning rate is reduced.
+
+    Unlike :class:`ReduceLROnPlateau`, this scheduler implements
+    :meth:`get_lr` and can be used as one of the schedulers inside
+    :class:`SequentialLR` or :class:`ChainedScheduler`.
+
+    When :class:`SequentialLR` activates this scheduler at a milestone, it
+    performs its epoch-0 update as it does for every other scheduler. If that
+    call receives a metric, it establishes the initial best value; otherwise,
+    it leaves the learning rate and plateau state unchanged. The first later
+    call with a metric then establishes the initial best value.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        mode (str): One of `min`, `max`. In `min` mode, lr will
+            be reduced when the quantity monitored has stopped
+            decreasing; in `max` mode it will be reduced when the
+            quantity monitored has stopped increasing. Default: 'min'.
+        factor (float): Factor by which the learning rate will be
+            reduced. new_lr = lr * factor. Default: 0.1.
+        patience (int): The number of allowed epochs with no improvement after
+            which the learning rate will be reduced.
+            For example, consider the case of having no patience (`patience = 0`).
+            In the first epoch, a baseline is established and is always considered good as there's no previous baseline.
+            In the second epoch, if the performance is worse than the baseline,
+            we have what is considered an intolerable epoch.
+            Since the count of intolerable epochs (1) is greater than the patience level (0),
+            the learning rate is reduced at the end of this epoch.
+            From the third epoch onwards, the learning rate continues to be reduced at the end of each epoch
+            if the performance is worse than the baseline. If the performance improves or remains the same,
+            the learning rate is not adjusted.
+            Default: 10.
+        threshold (float): Threshold for measuring the new optimum,
+            to only focus on significant changes. Default: 1e-4.
+        threshold_mode (str): One of `rel`, `abs`.
+            In `rel` mode, the dynamic threshold is computed as:
+
+            * best * (1 + threshold) if mode == 'max'
+            * best * (1 - threshold) if mode == 'min'
+
+            In `abs` mode, the dynamic threshold is computed as:
+
+            * best + threshold if mode == 'max'
+            * best - threshold if mode == 'min'
+
+            Default: 'rel'.
+        cooldown (int): Number of epochs to wait before resuming
+            normal operation after lr has been reduced. Default: 0.
+        min_lr (float or list): A scalar or a list of scalars. A
+            lower bound on the learning rate of all param groups
+            or each group respectively. Default: 0.
+        eps (float): Minimal decay applied to lr. If the difference
+            between new and old lr is smaller than eps, the update is
+            ignored. Default: 1e-8.
+        last_epoch (int): Index of the last epoch. Use ``-1`` (default) to
+            initialize the scheduler. Only use a non-default value when
+            restoring this scheduler from a saved checkpoint.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        >>> scheduler = PlateauLR(optimizer, "min")
+        >>> for epoch in range(10):
+        >>>     train(...)
+        >>>     val_loss = validate(...)
+        >>> # Note that step should be called after validate()
+        >>>     scheduler.step(metrics=val_loss)
+
+        >>> # xdoctest: +SKIP
+        >>> # Composed with a warmup schedule:
+        >>> scheduler = SequentialLR(
+        ...     optimizer,
+        ...     schedulers=[LinearLR(optimizer, total_iters=5), PlateauLR(optimizer)],
+        ...     milestones=[5],
+        ... )
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     val_loss = validate(...)
+        >>>     scheduler.step(metrics=val_loss)
+    """
+
+    _requires_metrics: bool = True
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        mode: Literal["min", "max"] = "min",
+        factor: float = 0.1,
+        patience: int = 10,
+        threshold: float = 1e-4,
+        threshold_mode: Literal["rel", "abs"] = "rel",
+        cooldown: int = 0,
+        min_lr: list[float] | float = 0,
+        eps: float = 1e-8,
+        last_epoch: int = -1,
+    ) -> None:
+        if factor >= 1.0:
+            raise ValueError("Factor should be < 1.0.")
+        self.factor = factor
+
+        if isinstance(min_lr, (list, tuple)):
+            if len(min_lr) != len(optimizer.param_groups):
+                raise ValueError(
+                    f"expected {len(optimizer.param_groups)} min_lrs, got {len(min_lr)}"
+                )
+            self.default_min_lr = None
+            self.min_lrs = list(min_lr)
+        else:
+            self.default_min_lr = min_lr
+            self.min_lrs = [min_lr] * len(optimizer.param_groups)
+
+        self.patience = patience
+        self.cooldown = cooldown
+        self.eps = eps
+        # Set by `step`, consumed and cleared by `get_lr`. `None` means "no
+        # metric available for this update" -- true during the implicit
+        # initial step performed by the base class's constructor, or when a
+        # `SequentialLR` milestone handoff receives no metric -- and `get_lr`
+        # then simply carries the current lr forward instead of attempting a
+        # reduction.
+        self._metrics: SupportsFloat | None = None
+        self._init_is_better(
+            mode=mode, threshold=threshold, threshold_mode=threshold_mode
+        )
+        self._reset()
+        super().__init__(optimizer, last_epoch)
+
+    def _reset(self) -> None:
+        """Reset num_bad_epochs counter and cooldown counter."""
+        self.best = self.mode_worse
+        self.cooldown_counter = 0
+        self.num_bad_epochs = 0
+
+    @property
+    def in_cooldown(self) -> bool:
+        return self.cooldown_counter > 0
+
+    @override
+    def step(
+        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+    ) -> None:
+        r"""Perform a step.
+
+        Args:
+            epoch (int, optional):
+                .. deprecated:: 1.4
+                    Use :meth:`step` without this argument instead.
+            metrics (SupportsFloat): The current value of the quantity being
+                monitored, such as a validation loss. Required on every call
+                except the implicit one performed at construction.
+        """
+        if metrics is None and not self._is_initial:
+            raise ValueError(
+                "`PlateauLR` requires the metric it monitors to be passed "
+                "to `step`, but got `metrics=None`. Pass the quantity you "
+                "are monitoring, e.g. `scheduler.step(metrics=val_loss)`. "
+                "When this scheduler is held by a `SequentialLR` or a "
+                "`ChainedScheduler`, pass the metric to that scheduler's "
+                "`step` instead and it reaches this one from there."
+            )
+        super().step(epoch, metrics=metrics)
+
+    @override
+    def _update_lr(
+        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+    ) -> None:
+        self._metrics = metrics
+        super()._update_lr(epoch, metrics=metrics)
+
+    @override
+    def get_lr(self) -> list[float | Tensor]:
+        r"""Compute the next learning rate for each of the optimizer's param groups.
+
+        Without a metric for this update, the current learning rate is
+        returned unchanged; no reduction is attempted.
+
+        Returns:
+            list[float | Tensor]: A :class:`list` of learning rates for each
+            of the optimizer's :attr:`~torch.optim.Optimizer.param_groups`
+            with the same types as their current ``group["lr"]``\s.
+        """
+        _warn_get_lr_called_within_step(self)
+
+        current_lrs = _param_groups_val_list(self.optimizer, "lr")
+        if self._metrics is None:
+            return current_lrs
+
+        current = float(self._metrics)
+        self._metrics = None
+
+        if self._is_better(current, self.best):
+            self.best = current
+            self.num_bad_epochs = 0
+        else:
+            self.num_bad_epochs += 1
+
+        if self.in_cooldown:
+            self.cooldown_counter -= 1
+            self.num_bad_epochs = 0  # ignore any bad epochs in cooldown
+
+        if self.num_bad_epochs > self.patience:
+            current_lrs = self._reduce(current_lrs)
+            self.cooldown_counter = self.cooldown
+            self.num_bad_epochs = 0
+
+        return current_lrs
+
+    def _reduce(self, lrs: list[float | Tensor]) -> list[float | Tensor]:
+        if len(self.optimizer.param_groups) != len(self.min_lrs):
+            if self.default_min_lr is None:
+                raise RuntimeError(
+                    "The number of param groups in the `optimizer` "
+                    f"({len(self.optimizer.param_groups)}) differs "
+                    f"from when `PlateauLR` was initialized "
+                    f"({len(self.min_lrs)}), usually due to a new "
+                    "param group being added to the optimizer. Please "
+                    "modify the `min_lrs` field to match the length "
+                    "of the `optimizer` param groups."
+                )
+            self.min_lrs = [self.default_min_lr] * len(self.optimizer.param_groups)
+
+        new_lrs = list(lrs)
+        for i, lr in enumerate(lrs):
+            old_lr = float(lr)
+            new_lr = max(old_lr * self.factor, self.min_lrs[i])
+            if old_lr - new_lr > self.eps:
+                new_lrs[i] = new_lr
+        return new_lrs
+
+    def _is_better(self, a, best):
+        if self.mode == "min" and self.threshold_mode == "rel":
+            rel_epsilon = 1.0 - self.threshold
+            return a < best * rel_epsilon
+
+        elif self.mode == "min" and self.threshold_mode == "abs":
+            return a < best - self.threshold
+
+        elif self.mode == "max" and self.threshold_mode == "rel":
+            rel_epsilon = self.threshold + 1.0
+            return a > best * rel_epsilon
+
+        else:  # mode == 'max' and epsilon_mode == 'abs':
+            return a > best + self.threshold
+
+    def _init_is_better(self, mode, threshold, threshold_mode) -> None:
+        if mode not in {"min", "max"}:
+            raise ValueError("mode " + mode + " is unknown!")
+        if threshold_mode not in {"rel", "abs"}:
+            raise ValueError("threshold mode " + threshold_mode + " is unknown!")
+
+        # the worse value for the chosen mode
+        if mode == "min":
+            self.mode_worse = inf
+        else:  # mode == 'max':
+            self.mode_worse = -inf
+
+        self.mode = mode
+        self.threshold = threshold
+        self.threshold_mode = threshold_mode
 
 
 class CyclicLR(LRScheduler):
@@ -2222,7 +2604,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         ]
 
     @override
-    def step(self, epoch=None) -> None:
+    def step(self, epoch=None, *, metrics: SupportsFloat | None = None) -> None:
         """Step could be called after every batch update.
 
         Example:
@@ -2248,6 +2630,12 @@ class CosineAnnealingWarmRestarts(LRScheduler):
             >>>     scheduler.step()
             >>> scheduler.step(26)
             >>> scheduler.step()  # scheduler.step(27), instead of scheduler(20)
+
+        Args:
+            metrics (SupportsFloat, optional): Accepted for signature parity
+                with other schedulers so this class can be composed alongside
+                :class:`PlateauLR` inside :class:`SequentialLR`/
+                :class:`ChainedScheduler`; unused here.
         """
         if epoch is None and self.last_epoch < 0:
             epoch = 0

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1983,6 +1983,8 @@ class PlateauLR(LRScheduler):
         >>>     train(...)
         >>>     val_loss = validate(...)
         >>>     scheduler.step(metrics=val_loss)
+
+    .. image:: ../scripts/lr_scheduler_images/PlateauLR.png
     """
 
     def __init__(

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1218,22 +1218,6 @@ class SequentialLR(LRScheduler):
         elif hasattr(scheds, "last_epoch"):
             scheds.last_epoch -= 1
 
-    @override
-    def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
-        if epoch is None:
-            self.step(**kwargs)
-            return
-
-        self.last_epoch = epoch
-        idx = bisect_right(self._milestones, self.last_epoch)
-        scheduler = self._schedulers[idx]
-        child_epoch = self.last_epoch
-        if idx > 0:
-            child_epoch -= self._milestones[idx - 1]
-        scheduler._update_lr(child_epoch, **kwargs)
-
-        self._last_lr = scheduler.get_last_lr()
-
     def step(self, **kwargs: Any) -> None:  # type: ignore[override]
         """Perform a step.
 
@@ -1254,6 +1238,23 @@ class SequentialLR(LRScheduler):
                 scheduler.step()
 
         self._last_lr = scheduler.get_last_lr()
+
+    @override
+    def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
+        if epoch is None:
+            self.step(**kwargs)
+            return
+
+        self.last_epoch = epoch
+        idx = bisect_right(self._milestones, self.last_epoch)
+        scheduler = self._schedulers[idx]
+        child_epoch = self.last_epoch
+        if idx > 0:
+            child_epoch -= self._milestones[idx - 1]
+        scheduler._update_lr(child_epoch, **kwargs)
+
+        self._last_lr = scheduler.get_last_lr()
+
 
     @override
     def state_dict(self) -> dict[str, Any]:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1665,216 +1665,6 @@ class ChainedScheduler(LRScheduler):
             self._schedulers[idx].load_state_dict(s)
 
 
-@deprecated(
-    "`ReduceLROnPlateau` is deprecated. Use `torch.optim.lr_scheduler.PlateauLR` "
-    "instead: replace `ReduceLROnPlateau(...)` with `PlateauLR(...)` and call "
-    "`scheduler.step(metrics=metric)`.",
-    category=FutureWarning,
-)
-class ReduceLROnPlateau(LRScheduler):
-    """Reduce learning rate when a metric has stopped improving.
-
-    Models often benefit from reducing the learning rate by a factor
-    of 2-10 once learning stagnates. This scheduler reads a metrics
-    quantity and if no improvement is seen for a 'patience' number
-    of epochs, the learning rate is reduced.
-
-    Args:
-        optimizer (Optimizer): Wrapped optimizer.
-        mode (str): One of `min`, `max`. In `min` mode, lr will
-            be reduced when the quantity monitored has stopped
-            decreasing; in `max` mode it will be reduced when the
-            quantity monitored has stopped increasing. Default: 'min'.
-        factor (float): Factor by which the learning rate will be
-            reduced. new_lr = lr * factor. Default: 0.1.
-        patience (int): The number of allowed epochs with no improvement after
-            which the learning rate will be reduced.
-            For example, consider the case of having no patience (`patience = 0`).
-            In the first epoch, a baseline is established and is always considered good as there's no previous baseline.
-            In the second epoch, if the performance is worse than the baseline,
-            we have what is considered an intolerable epoch.
-            Since the count of intolerable epochs (1) is greater than the patience level (0),
-            the learning rate is reduced at the end of this epoch.
-            From the third epoch onwards, the learning rate continues to be reduced at the end of each epoch
-            if the performance is worse than the baseline. If the performance improves or remains the same,
-            the learning rate is not adjusted.
-            Default: 10.
-        threshold (float): Threshold for measuring the new optimum,
-            to only focus on significant changes. Default: 1e-4.
-        threshold_mode (str): One of `rel`, `abs`.
-            In `rel` mode, the dynamic threshold is computed as:
-
-            * best * (1 + threshold) if mode == 'max'
-            * best * (1 - threshold) if mode == 'min'
-
-            In `abs` mode, the dynamic threshold is computed as:
-
-            * best + threshold if mode == 'max'
-            * best - threshold if mode == 'min'
-
-            Default: 'rel'.
-        cooldown (int): Number of epochs to wait before resuming
-            normal operation after lr has been reduced. Default: 0.
-        min_lr (float or list): A scalar or a list of scalars. A
-            lower bound on the learning rate of all param groups
-            or each group respectively. Default: 0.
-        eps (float): Minimal decay applied to lr. If the difference
-            between new and old lr is smaller than eps, the update is
-            ignored. Default: 1e-8.
-
-    Example:
-        >>> # xdoctest: +SKIP
-        >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
-        >>> scheduler = ReduceLROnPlateau(optimizer, "min")
-        >>> for epoch in range(10):
-        >>>     train(...)
-        >>>     val_loss = validate(...)
-        >>> # Note that step should be called after validate()
-        >>>     scheduler.step(val_loss)
-
-    .. image:: ../scripts/lr_scheduler_images/ReduceLROnPlateau.png
-    """
-
-    def __init__(
-        self,
-        optimizer: Optimizer,
-        mode: Literal["min", "max"] = "min",
-        factor: float = 0.1,
-        patience: int = 10,
-        threshold: float = 1e-4,
-        threshold_mode: Literal["rel", "abs"] = "rel",
-        cooldown: int = 0,
-        min_lr: list[float] | float = 0,
-        eps: float = 1e-8,
-    ) -> None:
-        if factor >= 1.0:
-            raise ValueError("Factor should be < 1.0.")
-        self.factor = factor
-
-        # Attach optimizer
-        if not isinstance(optimizer, Optimizer):
-            raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
-        self.optimizer = optimizer
-
-        if isinstance(min_lr, (list, tuple)):
-            if len(min_lr) != len(optimizer.param_groups):
-                raise ValueError(
-                    f"expected {len(optimizer.param_groups)} min_lrs, got {len(min_lr)}"
-                )
-            self.default_min_lr = None
-            self.min_lrs = list(min_lr)
-        else:
-            self.default_min_lr = min_lr
-            self.min_lrs = [min_lr] * len(optimizer.param_groups)
-
-        self.patience = patience
-        self.cooldown = cooldown
-        self.eps = eps
-        self.last_epoch = 0
-        self._last_lr = _param_groups_val_list(self.optimizer, "lr")
-        self._init_is_better(
-            mode=mode, threshold=threshold, threshold_mode=threshold_mode
-        )
-        self._reset()
-
-    def _reset(self) -> None:
-        """Reset num_bad_epochs counter and cooldown counter."""
-        self.best = self.mode_worse
-        self.cooldown_counter = 0
-        self.num_bad_epochs = 0
-
-    def step(self, metrics: SupportsFloat, epoch=None) -> None:  # type: ignore[override]
-        """Perform a step."""
-        # convert `metrics` to float, in case it's a zero-dim Tensor
-        current = float(metrics)
-        if epoch is None:
-            epoch = self.last_epoch + 1
-        else:
-            warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning, stacklevel=2)
-        self.last_epoch = epoch
-
-        if self._is_better(current, self.best):
-            self.best = current
-            self.num_bad_epochs = 0
-        else:
-            self.num_bad_epochs += 1
-
-        if self.in_cooldown:
-            self.cooldown_counter -= 1
-            self.num_bad_epochs = 0  # ignore any bad epochs in cooldown
-
-        if self.num_bad_epochs > self.patience:
-            self._reduce_lr(epoch)
-            self.cooldown_counter = self.cooldown
-            self.num_bad_epochs = 0
-
-        self._last_lr = _param_groups_val_list(self.optimizer, "lr")
-
-    def _reduce_lr(self, epoch) -> None:
-        if len(self.optimizer.param_groups) != len(self.min_lrs):
-            if self.default_min_lr is None:
-                raise RuntimeError(
-                    "The number of param groups in the `optimizer` "
-                    f"({len(self.optimizer.param_groups)}) differs "
-                    f"from when `ReduceLROnPlateau` was initialized "
-                    f"({len(self.min_lrs)}), usually due to a new "
-                    "param group being added to the optimizer. Please "
-                    "modify the `min_lrs` field to match the length "
-                    "of the `optimizer` param groups."
-                )
-            else:
-                self.min_lrs = [self.default_min_lr] * len(self.optimizer.param_groups)
-
-        for i, param_group in enumerate(self.optimizer.param_groups):
-            old_lr = float(param_group["lr"])
-            new_lr = max(old_lr * self.factor, self.min_lrs[i])
-            if old_lr - new_lr > self.eps:
-                _update_param_group_val(param_group, "lr", new_lr)
-
-    @property
-    def in_cooldown(self):
-        return self.cooldown_counter > 0
-
-    def _is_better(self, a, best):
-        if self.mode == "min" and self.threshold_mode == "rel":
-            rel_epsilon = 1.0 - self.threshold
-            return a < best * rel_epsilon
-
-        elif self.mode == "min" and self.threshold_mode == "abs":
-            return a < best - self.threshold
-
-        elif self.mode == "max" and self.threshold_mode == "rel":
-            rel_epsilon = self.threshold + 1.0
-            return a > best * rel_epsilon
-
-        else:  # mode == 'max' and epsilon_mode == 'abs':
-            return a > best + self.threshold
-
-    def _init_is_better(self, mode, threshold, threshold_mode) -> None:
-        if mode not in {"min", "max"}:
-            raise ValueError("mode " + mode + " is unknown!")
-        if threshold_mode not in {"rel", "abs"}:
-            raise ValueError("threshold mode " + threshold_mode + " is unknown!")
-
-        # the worse value for the chosen mode
-        if mode == "min":
-            self.mode_worse = inf
-        else:  # mode == 'max':
-            self.mode_worse = -inf
-
-        self.mode = mode
-        self.threshold = threshold
-        self.threshold_mode = threshold_mode
-
-    @override
-    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        """Load the scheduler's state."""
-        self.__dict__.update(state_dict)
-        self._init_is_better(
-            mode=self.mode, threshold=self.threshold, threshold_mode=self.threshold_mode
-        )
-
-
 class PlateauLR(LRScheduler):
     """Reduce learning rate when a metric has stopped improving.
 
@@ -2159,6 +1949,216 @@ class PlateauLR(LRScheduler):
         self.mode = mode
         self.threshold = threshold
         self.threshold_mode = threshold_mode
+
+
+@deprecated(
+    "`ReduceLROnPlateau` is deprecated. Use `torch.optim.lr_scheduler.PlateauLR` "
+    "instead: replace `ReduceLROnPlateau(...)` with `PlateauLR(...)` and call "
+    "`scheduler.step(metrics=metric)`.",
+    category=FutureWarning,
+)
+class ReduceLROnPlateau(LRScheduler):
+    """Reduce learning rate when a metric has stopped improving.
+
+    Models often benefit from reducing the learning rate by a factor
+    of 2-10 once learning stagnates. This scheduler reads a metrics
+    quantity and if no improvement is seen for a 'patience' number
+    of epochs, the learning rate is reduced.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        mode (str): One of `min`, `max`. In `min` mode, lr will
+            be reduced when the quantity monitored has stopped
+            decreasing; in `max` mode it will be reduced when the
+            quantity monitored has stopped increasing. Default: 'min'.
+        factor (float): Factor by which the learning rate will be
+            reduced. new_lr = lr * factor. Default: 0.1.
+        patience (int): The number of allowed epochs with no improvement after
+            which the learning rate will be reduced.
+            For example, consider the case of having no patience (`patience = 0`).
+            In the first epoch, a baseline is established and is always considered good as there's no previous baseline.
+            In the second epoch, if the performance is worse than the baseline,
+            we have what is considered an intolerable epoch.
+            Since the count of intolerable epochs (1) is greater than the patience level (0),
+            the learning rate is reduced at the end of this epoch.
+            From the third epoch onwards, the learning rate continues to be reduced at the end of each epoch
+            if the performance is worse than the baseline. If the performance improves or remains the same,
+            the learning rate is not adjusted.
+            Default: 10.
+        threshold (float): Threshold for measuring the new optimum,
+            to only focus on significant changes. Default: 1e-4.
+        threshold_mode (str): One of `rel`, `abs`.
+            In `rel` mode, the dynamic threshold is computed as:
+
+            * best * (1 + threshold) if mode == 'max'
+            * best * (1 - threshold) if mode == 'min'
+
+            In `abs` mode, the dynamic threshold is computed as:
+
+            * best + threshold if mode == 'max'
+            * best - threshold if mode == 'min'
+
+            Default: 'rel'.
+        cooldown (int): Number of epochs to wait before resuming
+            normal operation after lr has been reduced. Default: 0.
+        min_lr (float or list): A scalar or a list of scalars. A
+            lower bound on the learning rate of all param groups
+            or each group respectively. Default: 0.
+        eps (float): Minimal decay applied to lr. If the difference
+            between new and old lr is smaller than eps, the update is
+            ignored. Default: 1e-8.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        >>> scheduler = ReduceLROnPlateau(optimizer, "min")
+        >>> for epoch in range(10):
+        >>>     train(...)
+        >>>     val_loss = validate(...)
+        >>> # Note that step should be called after validate()
+        >>>     scheduler.step(val_loss)
+
+    .. image:: ../scripts/lr_scheduler_images/ReduceLROnPlateau.png
+    """
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        mode: Literal["min", "max"] = "min",
+        factor: float = 0.1,
+        patience: int = 10,
+        threshold: float = 1e-4,
+        threshold_mode: Literal["rel", "abs"] = "rel",
+        cooldown: int = 0,
+        min_lr: list[float] | float = 0,
+        eps: float = 1e-8,
+    ) -> None:
+        if factor >= 1.0:
+            raise ValueError("Factor should be < 1.0.")
+        self.factor = factor
+
+        # Attach optimizer
+        if not isinstance(optimizer, Optimizer):
+            raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
+        self.optimizer = optimizer
+
+        if isinstance(min_lr, (list, tuple)):
+            if len(min_lr) != len(optimizer.param_groups):
+                raise ValueError(
+                    f"expected {len(optimizer.param_groups)} min_lrs, got {len(min_lr)}"
+                )
+            self.default_min_lr = None
+            self.min_lrs = list(min_lr)
+        else:
+            self.default_min_lr = min_lr
+            self.min_lrs = [min_lr] * len(optimizer.param_groups)
+
+        self.patience = patience
+        self.cooldown = cooldown
+        self.eps = eps
+        self.last_epoch = 0
+        self._last_lr = _param_groups_val_list(self.optimizer, "lr")
+        self._init_is_better(
+            mode=mode, threshold=threshold, threshold_mode=threshold_mode
+        )
+        self._reset()
+
+    def _reset(self) -> None:
+        """Reset num_bad_epochs counter and cooldown counter."""
+        self.best = self.mode_worse
+        self.cooldown_counter = 0
+        self.num_bad_epochs = 0
+
+    def step(self, metrics: SupportsFloat, epoch=None) -> None:  # type: ignore[override]
+        """Perform a step."""
+        # convert `metrics` to float, in case it's a zero-dim Tensor
+        current = float(metrics)
+        if epoch is None:
+            epoch = self.last_epoch + 1
+        else:
+            warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning, stacklevel=2)
+        self.last_epoch = epoch
+
+        if self._is_better(current, self.best):
+            self.best = current
+            self.num_bad_epochs = 0
+        else:
+            self.num_bad_epochs += 1
+
+        if self.in_cooldown:
+            self.cooldown_counter -= 1
+            self.num_bad_epochs = 0  # ignore any bad epochs in cooldown
+
+        if self.num_bad_epochs > self.patience:
+            self._reduce_lr(epoch)
+            self.cooldown_counter = self.cooldown
+            self.num_bad_epochs = 0
+
+        self._last_lr = _param_groups_val_list(self.optimizer, "lr")
+
+    def _reduce_lr(self, epoch) -> None:
+        if len(self.optimizer.param_groups) != len(self.min_lrs):
+            if self.default_min_lr is None:
+                raise RuntimeError(
+                    "The number of param groups in the `optimizer` "
+                    f"({len(self.optimizer.param_groups)}) differs "
+                    f"from when `ReduceLROnPlateau` was initialized "
+                    f"({len(self.min_lrs)}), usually due to a new "
+                    "param group being added to the optimizer. Please "
+                    "modify the `min_lrs` field to match the length "
+                    "of the `optimizer` param groups."
+                )
+            else:
+                self.min_lrs = [self.default_min_lr] * len(self.optimizer.param_groups)
+
+        for i, param_group in enumerate(self.optimizer.param_groups):
+            old_lr = float(param_group["lr"])
+            new_lr = max(old_lr * self.factor, self.min_lrs[i])
+            if old_lr - new_lr > self.eps:
+                _update_param_group_val(param_group, "lr", new_lr)
+
+    @property
+    def in_cooldown(self):
+        return self.cooldown_counter > 0
+
+    def _is_better(self, a, best):
+        if self.mode == "min" and self.threshold_mode == "rel":
+            rel_epsilon = 1.0 - self.threshold
+            return a < best * rel_epsilon
+
+        elif self.mode == "min" and self.threshold_mode == "abs":
+            return a < best - self.threshold
+
+        elif self.mode == "max" and self.threshold_mode == "rel":
+            rel_epsilon = self.threshold + 1.0
+            return a > best * rel_epsilon
+
+        else:  # mode == 'max' and epsilon_mode == 'abs':
+            return a > best + self.threshold
+
+    def _init_is_better(self, mode, threshold, threshold_mode) -> None:
+        if mode not in {"min", "max"}:
+            raise ValueError("mode " + mode + " is unknown!")
+        if threshold_mode not in {"rel", "abs"}:
+            raise ValueError("threshold mode " + threshold_mode + " is unknown!")
+
+        # the worse value for the chosen mode
+        if mode == "min":
+            self.mode_worse = inf
+        else:  # mode == 'max':
+            self.mode_worse = -inf
+
+        self.mode = mode
+        self.threshold = threshold
+        self.threshold_mode = threshold_mode
+
+    @override
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Load the scheduler's state."""
+        self.__dict__.update(state_dict)
+        self._init_is_better(
+            mode=self.mode, threshold=self.threshold, threshold_mode=self.threshold_mode
+        )
 
 
 class CyclicLR(LRScheduler):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -94,17 +94,11 @@ def _update_param_group_val(
         param_group[key] = val
 
 
-def _step_accepts_kwargs(scheduler: LRScheduler) -> bool:
-    """Whether ``scheduler.step`` collects arbitrary keyword arguments.
-
-    Every scheduler in this module does. A third-party scheduler still written
-    against the older API, ``def step(self)`` or ``def step(self, epoch=None)``,
-    does not, and this function helps us tell them apart.
-    """
-    # The bound method, so that `self` is not one of the parameters.
+def _accepts_kwargs(method: Callable[..., Any]) -> bool:
+    """Whether a bound method collects arbitrary keyword arguments."""
     return any(
         parameter.kind is inspect.Parameter.VAR_KEYWORD
-        for parameter in inspect.signature(scheduler.step).parameters.values()
+        for parameter in inspect.signature(method).parameters.values()
     )
 
 
@@ -297,7 +291,10 @@ class LRScheduler:
         self._step_count += 1
         if epoch is not None:
             warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning, stacklevel=2)
-        self._update_lr(epoch, **kwargs)
+        if kwargs and _accepts_kwargs(self._update_lr):
+            self._update_lr(epoch, **kwargs)
+        else:
+            self._update_lr(epoch)
 
     def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
         with _enable_get_lr_call(self):
@@ -1185,7 +1182,7 @@ class SequentialLR(LRScheduler):
                 f"number of milestones to be equal to {len(milestones)}"
             )
         self._schedulers = schedulers
-        self._schedulers_accept_kwargs = [_step_accepts_kwargs(s) for s in schedulers]
+        self._schedulers_accept_kwargs = [_accepts_kwargs(s.step) for s in schedulers]
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
         self.optimizer = optimizer
@@ -1231,7 +1228,10 @@ class SequentialLR(LRScheduler):
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
-            scheduler._update_lr(0, **kwargs)
+            if kwargs and _accepts_kwargs(scheduler._update_lr):
+                scheduler._update_lr(0, **kwargs)
+            else:
+                scheduler._update_lr(0)
         else:
             if self._schedulers_accept_kwargs[idx]:
                 scheduler.step(**kwargs)
@@ -1591,7 +1591,7 @@ class ChainedScheduler(LRScheduler):
                 )
         self._schedulers = schedulers
         self._schedulers_accept_kwargs = [
-            _step_accepts_kwargs(scheduler) for scheduler in schedulers
+            _accepts_kwargs(scheduler.step) for scheduler in schedulers
         ]
         self.optimizer = optimizer
         # Unlike the other schedulers, this does not end with

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -226,9 +226,13 @@ class LRScheduler:
         # corrupt their learning rates by modifying the outputs in place.
         return self._last_lr
 
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
+
+        Args:
+            **kwargs: Extra inputs used to compute the learning rate. It's up
+                to each scheduler how to use them.
 
         Returns:
             list[float | Tensor]: A :class:`list` of learning rates for each of
@@ -300,13 +304,19 @@ class LRScheduler:
         with _enable_get_lr_call(self):
             if epoch is None:
                 self.last_epoch += 1
-                values = self.get_lr()
+                if kwargs and _accepts_kwargs(self.get_lr):
+                    values = self.get_lr(**kwargs)
+                else:
+                    values = self.get_lr()
             else:
                 self.last_epoch = epoch
                 if hasattr(self, "_get_closed_form_lr"):
                     values = cast(list[float | Tensor], self._get_closed_form_lr())
                 else:
-                    values = self.get_lr()
+                    if kwargs and _accepts_kwargs(self.get_lr):
+                        values = self.get_lr(**kwargs)
+                    else:
+                        values = self.get_lr()
 
         for param_group, lr in zip(self.optimizer.param_groups, values, strict=True):
             _update_param_group_val(param_group, "lr", lr)
@@ -453,7 +463,7 @@ class LambdaLR(LRScheduler):
                 self.lr_lambdas[idx].__dict__.update(fn)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -570,7 +580,7 @@ class MultiplicativeLR(LRScheduler):
                 self.lr_lambdas[idx].__dict__.update(fn)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -645,7 +655,7 @@ class StepLR(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -731,7 +741,7 @@ class MultiStepLR(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -835,7 +845,7 @@ class ConstantLR(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -949,7 +959,7 @@ class LinearLR(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -1050,7 +1060,7 @@ class ExponentialLR(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -1320,7 +1330,7 @@ class PolynomialLR(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -1444,7 +1454,7 @@ class CosineAnnealingLR(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -1790,13 +1800,6 @@ class PlateauLR(LRScheduler):
         self.patience = patience
         self.cooldown = cooldown
         self.eps = eps
-        # Set by `step`, consumed and cleared by `get_lr`. `None` means "no
-        # metric available for this update" -- true during the implicit
-        # initial step performed by the base class's constructor, or when a
-        # `SequentialLR` milestone handoff receives no metric -- and `get_lr`
-        # then simply carries the current lr forward instead of attempting a
-        # reduction.
-        self._metrics: SupportsFloat | None = None
         self._init_is_better(
             mode=mode, threshold=threshold, threshold_mode=threshold_mode
         )
@@ -1819,8 +1822,6 @@ class PlateauLR(LRScheduler):
     def step(
         self,
         epoch: int | None = None,
-        *,
-        metrics: SupportsFloat | None = None,
         **kwargs: Any,
     ) -> None:
         r"""Perform a step.
@@ -1829,14 +1830,12 @@ class PlateauLR(LRScheduler):
             epoch (int, optional):
                 .. deprecated:: 1.4
                     Use :meth:`step` without this argument instead.
-            metrics (SupportsFloat): The current value of the quantity being
-                monitored, such as a validation loss. Required on every call
-                except the implicit one performed at construction. Named
-                explicitly, rather than read out of ``**kwargs``, so that
-                omitting it -- including by misspelling it -- raises below
-                instead of passing unnoticed.
-            **kwargs: Other scheduling inputs, unused here.
+            **kwargs: Scheduling inputs. The ``metrics`` entry is the current
+                value of the quantity being monitored, such as a validation
+                loss, and is required on every call except the implicit one
+                performed at construction.
         """
+        metrics = kwargs.get("metrics")
         if epoch is not None and metrics is None:
             raise ValueError(
                 "`PlateauLR.step` received an `epoch` argument but no "
@@ -1851,22 +1850,15 @@ class PlateauLR(LRScheduler):
                 "`ChainedScheduler`, pass the metric to that scheduler's "
                 "`step` instead and it reaches this one from there."
             )
-        super().step(epoch, metrics=metrics, **kwargs)
+        super().step(epoch, **kwargs)
 
     @override
-    def _update_lr(
-        self,
-        epoch: int | None = None,
-        *,
-        metrics: SupportsFloat | None = None,
-        **kwargs: Any,
-    ) -> None:
-        self._metrics = metrics
-        super()._update_lr(epoch, metrics=metrics, **kwargs)
-
-    @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each optimizer parameter group.
+
+        Args:
+            **kwargs: Scheduling inputs. The ``metrics`` entry is the current
+                value of the quantity being monitored.
 
         Without a metric for this update, the current learning rate is
         returned unchanged; no reduction is attempted.
@@ -1879,11 +1871,11 @@ class PlateauLR(LRScheduler):
         _warn_get_lr_called_within_step(self)
 
         current_lrs = _param_groups_val_list(self.optimizer, "lr")
-        if self._metrics is None:
+        metrics = kwargs.get("metrics")
+        if metrics is None:
             return current_lrs
 
-        current = float(self._metrics)
-        self._metrics = None
+        current = float(metrics)
 
         if self._is_better(current, self.best):
             self.best = current
@@ -2379,7 +2371,7 @@ class CyclicLR(LRScheduler):
         return gamma**x
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -2548,7 +2540,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         super().__init__(optimizer, last_epoch)
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 
@@ -2930,7 +2922,7 @@ class OneCycleLR(LRScheduler):
         return (end - start) * pct + start
 
     @override
-    def get_lr(self) -> list[float | Tensor]:
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -3,6 +3,7 @@ r"""Learning Rate Scheduler."""
 
 from __future__ import annotations
 
+import inspect
 import math
 import types
 import warnings
@@ -116,11 +117,6 @@ class LRScheduler:
 
     _get_lr_called_within_step: bool = False
     _is_initial: bool = False
-    # Composite schedulers use this temporary capability marker to preserve
-    # compatibility with third-party schedulers that override step() without
-    # accepting metrics.
-    _requires_metrics: bool = False
-
     def __init__(
         self,
         optimizer: Optimizer,
@@ -255,7 +251,7 @@ class LRScheduler:
             metrics (SupportsFloat, optional): Accepted for signature parity
                 with :class:`PlateauLR` and the composite schedulers
                 (:class:`SequentialLR`, :class:`ChainedScheduler`); ignored
-                unless a subclass sets ``_requires_metrics``.
+                by schedulers that do not use it.
 
         .. note::
             Call this method after calling the optimizer's
@@ -290,10 +286,7 @@ class LRScheduler:
         self._step_count += 1
         if epoch is not None:
             warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning, stacklevel=2)
-        if self._requires_metrics:
-            self._update_lr(epoch, metrics=metrics)
-        else:
-            self._update_lr(epoch)
+        self._update_lr(epoch, metrics=metrics)
 
     def _update_lr(
         self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
@@ -1145,8 +1138,6 @@ class SequentialLR(LRScheduler):
     .. image:: ../scripts/lr_scheduler_images/SequentialLR.png
     """
 
-    _requires_metrics: bool = True
-
     def __init__(
         self,
         optimizer: Optimizer,
@@ -1184,6 +1175,10 @@ class SequentialLR(LRScheduler):
                 f"number of milestones to be equal to {len(milestones)}"
             )
         self._schedulers = schedulers
+        self._schedulers_accept_metrics = [
+            "metrics" in inspect.signature(type(scheduler).step).parameters
+            for scheduler in schedulers
+        ]
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
         self.optimizer = optimizer
@@ -1236,15 +1231,9 @@ class SequentialLR(LRScheduler):
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
-            if getattr(scheduler, "_requires_metrics", False):
-                scheduler._update_lr(0, metrics=metrics)
-            else:
-                scheduler._update_lr(0)
+            scheduler._update_lr(0, metrics=metrics)
         else:
-            if getattr(scheduler, "_requires_metrics", False):
-                scheduler._update_lr(epoch, metrics=metrics)
-            else:
-                scheduler._update_lr(epoch)
+            scheduler._update_lr(epoch, metrics=metrics)
 
         self._last_lr = scheduler.get_last_lr()
 
@@ -1253,20 +1242,15 @@ class SequentialLR(LRScheduler):
 
         Args:
             metrics (SupportsFloat, optional): Forwarded to the currently
-                active sub-scheduler when it requires a metric. Only
-                :class:`PlateauLR` among the built-in schedulers makes use of
-                it.
+                active sub-scheduler when its ``step`` method accepts it.
         """
         self.last_epoch += 1
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
-            if getattr(scheduler, "_requires_metrics", False):
-                scheduler._update_lr(0, metrics=metrics)
-            else:
-                scheduler._update_lr(0)
+            scheduler._update_lr(0, metrics=metrics)
         else:
-            if getattr(scheduler, "_requires_metrics", False):
+            if self._schedulers_accept_metrics[idx]:
                 scheduler.step(metrics=metrics)
             else:
                 scheduler.step()
@@ -1284,7 +1268,7 @@ class SequentialLR(LRScheduler):
         state_dict = {
             key: value
             for key, value in self.__dict__.items()
-            if key not in ("optimizer", "_schedulers")
+            if key not in ("optimizer", "_schedulers", "_schedulers_accept_metrics")
         }
         state_dict["_schedulers"] = [None] * len(self._schedulers)
 
@@ -1596,8 +1580,6 @@ class ChainedScheduler(LRScheduler):
     .. image:: ../scripts/lr_scheduler_images/ChainedScheduler.png
     """
 
-    _requires_metrics: bool = True
-
     def __init__(
         self, schedulers: Sequence[LRScheduler], optimizer: Optimizer | None = None
     ) -> None:
@@ -1625,6 +1607,10 @@ class ChainedScheduler(LRScheduler):
                     f"which is different from {optimizer.__class__.__name__}."
                 )
         self._schedulers = schedulers
+        self._schedulers_accept_metrics = [
+            "metrics" in inspect.signature(type(scheduler).step).parameters
+            for scheduler in schedulers
+        ]
         self.optimizer = optimizer
         # Unlike the other schedulers, this does not end with
         # `self._initial_step()`: every scheduler in `schedulers` already took
@@ -1644,10 +1630,7 @@ class ChainedScheduler(LRScheduler):
         self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
     ) -> None:
         for scheduler in self._schedulers:
-            if getattr(scheduler, "_requires_metrics", False):
-                scheduler._update_lr(epoch, metrics=metrics)
-            else:
-                scheduler._update_lr(epoch)
+            scheduler._update_lr(epoch, metrics=metrics)
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     def step(self, *, metrics: SupportsFloat | None = None) -> None:
@@ -1655,11 +1638,12 @@ class ChainedScheduler(LRScheduler):
 
         Args:
             metrics (SupportsFloat, optional): Forwarded to every contained
-                scheduler that requires a metric. Only :class:`PlateauLR`
-                among the built-in schedulers makes use of it.
+                scheduler whose ``step`` method accepts it.
         """
-        for scheduler in self._schedulers:
-            if getattr(scheduler, "_requires_metrics", False):
+        for scheduler, accepts_metrics in zip(
+            self._schedulers, self._schedulers_accept_metrics, strict=True
+        ):
+            if accepts_metrics:
                 scheduler.step(metrics=metrics)
             else:
                 scheduler.step()
@@ -1676,7 +1660,7 @@ class ChainedScheduler(LRScheduler):
         state_dict = {
             key: value
             for key, value in self.__dict__.items()
-            if key not in ("optimizer", "_schedulers")
+            if key not in ("optimizer", "_schedulers", "_schedulers_accept_metrics")
         }
         state_dict["_schedulers"] = [None] * len(self._schedulers)
 
@@ -2000,8 +1984,6 @@ class PlateauLR(LRScheduler):
         >>>     val_loss = validate(...)
         >>>     scheduler.step(metrics=val_loss)
     """
-
-    _requires_metrics: bool = True
 
     def __init__(
         self,

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1602,9 +1602,7 @@ class ChainedScheduler(LRScheduler):
                     f"which is different from {optimizer.__class__.__name__}."
                 )
         self._schedulers = schedulers
-        self._schedulers_accept_kwargs = [
-            _accepts_kwargs(scheduler.step) for scheduler in schedulers
-        ]
+        self._schedulers_accept_kwargs = [_accepts_kwargs(s.step) for s in schedulers]
         self.optimizer = optimizer
         # Unlike the other schedulers, this does not end with
         # `self._initial_step()`: every scheduler in `schedulers` already took

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -94,6 +94,22 @@ def _update_param_group_val(
         param_group[key] = val
 
 
+def _step_accepts_kwargs(scheduler: LRScheduler) -> bool:
+    """Whether ``scheduler.step`` collects arbitrary keyword arguments.
+
+    Every scheduler in this module does. A third-party scheduler still written
+    against the older API -- ``def step(self)`` or
+    ``def step(self, epoch=None)`` -- does not, and the composite schedulers
+    call its ``step`` without keyword arguments so that it keeps working until
+    it is updated.
+    """
+    # The bound method, so that `self` is not one of the parameters.
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in inspect.signature(scheduler.step).parameters.values()
+    )
+
+
 class LRScheduler:
     r"""Base class for all learning rate schedulers.
 
@@ -117,6 +133,7 @@ class LRScheduler:
 
     _get_lr_called_within_step: bool = False
     _is_initial: bool = False
+
     def __init__(
         self,
         optimizer: Optimizer,
@@ -236,9 +253,7 @@ class LRScheduler:
         """
         raise NotImplementedError
 
-    def step(
-        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
-    ) -> None:
+    def step(self, epoch: int | None = None, **kwargs: Any) -> None:
         """Step the scheduler.
 
         Args:
@@ -248,10 +263,12 @@ class LRScheduler:
                     :meth:`_get_closed_form_lr` if it is available. This is not
                     universally supported. Use :meth:`step` without arguments
                     instead.
-            metrics (SupportsFloat, optional): Accepted for signature parity
-                with :class:`PlateauLR` and the composite schedulers
-                (:class:`SequentialLR`, :class:`ChainedScheduler`); ignored
-                by schedulers that do not use it.
+            **kwargs: Extra scheduling inputs, ignored by any scheduler that
+                does not use them. The composite schedulers
+                (:class:`SequentialLR`, :class:`ChainedScheduler`) forward
+                these to the schedulers they hold, so a caller can pass an
+                input that only one of them consumes -- as
+                :class:`PlateauLR` does with ``metrics``.
 
         .. note::
             Call this method after calling the optimizer's
@@ -286,11 +303,9 @@ class LRScheduler:
         self._step_count += 1
         if epoch is not None:
             warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning, stacklevel=2)
-        self._update_lr(epoch, metrics=metrics)
+        self._update_lr(epoch, **kwargs)
 
-    def _update_lr(
-        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
-    ) -> None:
+    def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
         with _enable_get_lr_call(self):
             if epoch is None:
                 self.last_epoch += 1
@@ -1175,10 +1190,7 @@ class SequentialLR(LRScheduler):
                 f"number of milestones to be equal to {len(milestones)}"
             )
         self._schedulers = schedulers
-        self._schedulers_accept_metrics = [
-            "metrics" in inspect.signature(type(scheduler).step).parameters
-            for scheduler in schedulers
-        ]
+        self._schedulers_accept_kwargs = [_step_accepts_kwargs(s) for s in schedulers]
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
         self.optimizer = optimizer
@@ -1220,11 +1232,9 @@ class SequentialLR(LRScheduler):
         self._last_lr = scheduler.get_last_lr()
 
     @override
-    def _update_lr(
-        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
-    ) -> None:
+    def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
         if epoch is None:
-            self.step(metrics=metrics)
+            self.step(**kwargs)
             return
 
         self.last_epoch = epoch
@@ -1233,25 +1243,26 @@ class SequentialLR(LRScheduler):
         child_epoch = self.last_epoch
         if idx > 0:
             child_epoch -= self._milestones[idx - 1]
-        scheduler._update_lr(child_epoch, metrics=metrics)
+        scheduler._update_lr(child_epoch, **kwargs)
 
         self._last_lr = scheduler.get_last_lr()
 
-    def step(self, *, metrics: SupportsFloat | None = None) -> None:  # type: ignore[override]
+    def step(self, **kwargs: Any) -> None:  # type: ignore[override]
         """Perform a step.
 
         Args:
-            metrics (SupportsFloat, optional): Forwarded to the currently
-                active sub-scheduler when its ``step`` method accepts it.
+            **kwargs: Forwarded to the currently active sub-scheduler. One
+                still written against the older ``step`` API, which cannot
+                take them, is stepped without them.
         """
         self.last_epoch += 1
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
-            scheduler._update_lr(0, metrics=metrics)
+            scheduler._update_lr(0, **kwargs)
         else:
-            if self._schedulers_accept_metrics[idx]:
-                scheduler.step(metrics=metrics)
+            if self._schedulers_accept_kwargs[idx]:
+                scheduler.step(**kwargs)
             else:
                 scheduler.step()
 
@@ -1268,7 +1279,7 @@ class SequentialLR(LRScheduler):
         state_dict = {
             key: value
             for key, value in self.__dict__.items()
-            if key not in ("optimizer", "_schedulers", "_schedulers_accept_metrics")
+            if key not in ("optimizer", "_schedulers", "_schedulers_accept_kwargs")
         }
         state_dict["_schedulers"] = [None] * len(self._schedulers)
 
@@ -1607,9 +1618,8 @@ class ChainedScheduler(LRScheduler):
                     f"which is different from {optimizer.__class__.__name__}."
                 )
         self._schedulers = schedulers
-        self._schedulers_accept_metrics = [
-            "metrics" in inspect.signature(type(scheduler).step).parameters
-            for scheduler in schedulers
+        self._schedulers_accept_kwargs = [
+            _step_accepts_kwargs(scheduler) for scheduler in schedulers
         ]
         self.optimizer = optimizer
         # Unlike the other schedulers, this does not end with
@@ -1626,25 +1636,24 @@ class ChainedScheduler(LRScheduler):
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     @override
-    def _update_lr(
-        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
-    ) -> None:
+    def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
         for scheduler in self._schedulers:
-            scheduler._update_lr(epoch, metrics=metrics)
+            scheduler._update_lr(epoch, **kwargs)
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
-    def step(self, *, metrics: SupportsFloat | None = None) -> None:  # type: ignore[override]
+    def step(self, **kwargs: Any) -> None:  # type: ignore[override]
         """Perform a step.
 
         Args:
-            metrics (SupportsFloat, optional): Forwarded to every contained
-                scheduler whose ``step`` method accepts it.
+            **kwargs: Forwarded to every contained scheduler. One still
+                written against the older ``step`` API, which cannot take
+                them, is stepped without them.
         """
-        for scheduler, accepts_metrics in zip(
-            self._schedulers, self._schedulers_accept_metrics, strict=True
+        for scheduler, accepts_kwargs in zip(
+            self._schedulers, self._schedulers_accept_kwargs, strict=True
         ):
-            if accepts_metrics:
-                scheduler.step(metrics=metrics)
+            if accepts_kwargs:
+                scheduler.step(**kwargs)
             else:
                 scheduler.step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
@@ -1660,7 +1669,7 @@ class ChainedScheduler(LRScheduler):
         state_dict = {
             key: value
             for key, value in self.__dict__.items()
-            if key not in ("optimizer", "_schedulers", "_schedulers_accept_metrics")
+            if key not in ("optimizer", "_schedulers", "_schedulers_accept_kwargs")
         }
         state_dict["_schedulers"] = [None] * len(self._schedulers)
 
@@ -2045,7 +2054,11 @@ class PlateauLR(LRScheduler):
     # being deprecated.
     @override
     def step(
-        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+        self,
+        epoch: int | None = None,
+        *,
+        metrics: SupportsFloat | None = None,
+        **kwargs: Any,
     ) -> None:
         r"""Perform a step.
 
@@ -2055,7 +2068,11 @@ class PlateauLR(LRScheduler):
                     Use :meth:`step` without this argument instead.
             metrics (SupportsFloat): The current value of the quantity being
                 monitored, such as a validation loss. Required on every call
-                except the implicit one performed at construction.
+                except the implicit one performed at construction. Named
+                explicitly, rather than read out of ``**kwargs``, so that
+                omitting it -- including by misspelling it -- raises below
+                instead of passing unnoticed.
+            **kwargs: Other scheduling inputs, unused here.
         """
         if epoch is not None and metrics is None:
             raise ValueError(
@@ -2071,14 +2088,18 @@ class PlateauLR(LRScheduler):
                 "`ChainedScheduler`, pass the metric to that scheduler's "
                 "`step` instead and it reaches this one from there."
             )
-        super().step(epoch, metrics=metrics)
+        super().step(epoch, metrics=metrics, **kwargs)
 
     @override
     def _update_lr(
-        self, epoch: int | None = None, *, metrics: SupportsFloat | None = None
+        self,
+        epoch: int | None = None,
+        *,
+        metrics: SupportsFloat | None = None,
+        **kwargs: Any,
     ) -> None:
         self._metrics = metrics
-        super()._update_lr(epoch, metrics=metrics)
+        super()._update_lr(epoch, metrics=metrics, **kwargs)
 
     @override
     def get_lr(self) -> list[float | Tensor]:
@@ -2595,7 +2616,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         ]
 
     @override
-    def step(self, epoch=None, *, metrics: SupportsFloat | None = None) -> None:
+    def step(self, epoch=None, **kwargs: Any) -> None:
         """Step could be called after every batch update.
 
         Example:
@@ -2623,10 +2644,10 @@ class CosineAnnealingWarmRestarts(LRScheduler):
             >>> scheduler.step()  # scheduler.step(27), instead of scheduler(20)
 
         Args:
-            metrics (SupportsFloat, optional): Accepted for signature parity
-                with other schedulers so this class can be composed alongside
-                :class:`PlateauLR` inside :class:`SequentialLR`/
-                :class:`ChainedScheduler`; unused here.
+            **kwargs: Accepted for signature parity with other schedulers so
+                this class can be composed alongside :class:`PlateauLR`
+                inside :class:`SequentialLR`/:class:`ChainedScheduler`;
+                unused here.
         """
         if epoch is None and self.last_epoch < 0:
             epoch = 0

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -2057,6 +2057,8 @@ class PlateauLR(LRScheduler):
     def in_cooldown(self) -> bool:
         return self.cooldown_counter > 0
 
+    # Keep `epoch` for API parity with LRScheduler while its step argument is
+    # being deprecated.
     @override
     def step(
         self, epoch: int | None = None, *, metrics: SupportsFloat | None = None

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1219,14 +1219,6 @@ class SequentialLR(LRScheduler):
             scheds.last_epoch -= 1
 
     @override
-    def _initial_step(self) -> None:
-        """Initialize the scheduler subtree active at step 0."""
-        idx = bisect_right(self._milestones, 0)
-        scheduler = self._schedulers[idx]
-        scheduler._initial_step()
-        self._last_lr = scheduler.get_last_lr()
-
-    @override
     def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
         if epoch is None:
             self.step(**kwargs)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1815,18 +1815,10 @@ class PlateauLR(LRScheduler):
         self.cooldown_counter = 0
         self.num_bad_epochs = 0
 
-    @property
-    def in_cooldown(self) -> bool:
-        return self.cooldown_counter > 0
-
-    # Keep `epoch` for API parity with LRScheduler while its step argument is
+    # `epoch` was added for API parity with LRScheduler while its step argument is
     # being deprecated.
     @override
-    def step(
-        self,
-        epoch: int | None = None,
-        **kwargs: Any,
-    ) -> None:
+    def step(self, epoch: int | None = None, **kwargs: Any) -> None:
         r"""Perform a step.
 
         Args:
@@ -1918,6 +1910,10 @@ class PlateauLR(LRScheduler):
             if old_lr - new_lr > self.eps:
                 new_lrs[i] = new_lr
         return new_lrs
+
+    @property
+    def in_cooldown(self):
+        return self.cooldown_counter > 0
 
     def _is_better(self, a, best):
         if self.mode == "min" and self.threshold_mode == "rel":

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1237,7 +1237,7 @@ class SequentialLR(LRScheduler):
 
         self._last_lr = scheduler.get_last_lr()
 
-    def step(self, *, metrics: SupportsFloat | None = None) -> None:
+    def step(self, *, metrics: SupportsFloat | None = None) -> None:  # type: ignore[override]
         """Perform a step.
 
         Args:
@@ -1633,7 +1633,7 @@ class ChainedScheduler(LRScheduler):
             scheduler._update_lr(epoch, metrics=metrics)
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
-    def step(self, *, metrics: SupportsFloat | None = None) -> None:
+    def step(self, *, metrics: SupportsFloat | None = None) -> None:  # type: ignore[override]
         """Perform a step.
 
         Args:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1786,6 +1786,9 @@ class PlateauLR(LRScheduler):
             raise ValueError("Factor should be < 1.0.")
         self.factor = factor
 
+        if not isinstance(optimizer, Optimizer):
+            raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
+
         if isinstance(min_lr, (list, tuple)):
             if len(min_lr) != len(optimizer.param_groups):
                 raise ValueError(

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1205,6 +1205,7 @@ class SequentialLR(LRScheduler):
         self._schedulers[idx]._initial_step()
 
         self._last_lr = self._schedulers[idx].get_last_lr()
+
     def recursive_undo(self, sched=None) -> None:
         """
         Recursively undo any step performed by the initialization of
@@ -1238,23 +1239,6 @@ class SequentialLR(LRScheduler):
                 scheduler.step()
 
         self._last_lr = scheduler.get_last_lr()
-
-    @override
-    def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
-        if epoch is None:
-            self.step(**kwargs)
-            return
-
-        self.last_epoch = epoch
-        idx = bisect_right(self._milestones, self.last_epoch)
-        scheduler = self._schedulers[idx]
-        child_epoch = self.last_epoch
-        if idx > 0:
-            child_epoch -= self._milestones[idx - 1]
-        scheduler._update_lr(child_epoch, **kwargs)
-
-        self._last_lr = scheduler.get_last_lr()
-
 
     @override
     def state_dict(self) -> dict[str, Any]:
@@ -1621,12 +1605,6 @@ class ChainedScheduler(LRScheduler):
     def _initial_step(self) -> None:
         for scheduler in self._schedulers:
             scheduler._initial_step()
-        self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
-
-    @override
-    def _update_lr(self, epoch: int | None = None, **kwargs: Any) -> None:
-        for scheduler in self._schedulers:
-            scheduler._update_lr(epoch, **kwargs)
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     def step(self, **kwargs: Any) -> None:  # type: ignore[override]

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -510,7 +510,7 @@ class SWALR(LRScheduler):
         return (lr - alpha * swa_lr) / (1 - alpha)
 
     @override
-    def get_lr(self):
+    def get_lr(self, **kwargs: Any) -> list[float | Tensor]:
         r"""Compute the next learning rate for each of the optimizer's
         :attr:`~torch.optim.Optimizer.param_groups`.
 

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -120,8 +120,8 @@ class OptimizerInfo:
         scheduler_inputs=(
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
+                lambda opt: ReduceLROnPlateau(opt),
             ],
         ),
         # A subset of the global-cliquey flags (fused, foreach, differentiable) the optimizer
@@ -1657,8 +1657,8 @@ optim_db: list[OptimizerInfo] = [
             {"lr": 0.1, "weight_decay": 0, "lr_decay": 0},
             [
                 lambda opt: StepLR(opt, gamma=1 - 1e-5, step_size=500),
-                lambda opt: ReduceLROnPlateau(opt, threshold=1e-4),
                 lambda opt: PlateauLR(opt, threshold=1e-4),
+                lambda opt: ReduceLROnPlateau(opt, threshold=1e-4),
             ],
         ),
         decorators=(
@@ -1717,15 +1717,15 @@ optim_db: list[OptimizerInfo] = [
             ],
             [
                 lambda opt: ExponentialLR(opt, gamma=0.9),
-                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
+                lambda opt: ReduceLROnPlateau(opt),
             ],
             [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
             [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
+                lambda opt: ReduceLROnPlateau(opt),
             ],
         ),
         optim_error_inputs_func=optim_error_inputs_func_adam,
@@ -2121,8 +2121,8 @@ optim_db: list[OptimizerInfo] = [
             [
                 lambda opt: StepLR(opt, gamma=0.99, step_size=10),
                 lambda opt: ExponentialLR(opt, gamma=0.99),
-                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
+                lambda opt: ReduceLROnPlateau(opt),
             ],
             [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
             [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -35,6 +35,7 @@ from torch.optim.lr_scheduler import (
     LinearLR,
     PlateauLR,
     PolynomialLR,
+    ReduceLROnPlateau,
     StepLR,
 )
 from torch.testing._internal.common_device_type import tol, toleranceOverride
@@ -119,6 +120,7 @@ class OptimizerInfo:
         scheduler_inputs=(
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
+                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
             ],
         ),
@@ -1655,6 +1657,7 @@ optim_db: list[OptimizerInfo] = [
             {"lr": 0.1, "weight_decay": 0, "lr_decay": 0},
             [
                 lambda opt: StepLR(opt, gamma=1 - 1e-5, step_size=500),
+                lambda opt: ReduceLROnPlateau(opt, threshold=1e-4),
                 lambda opt: PlateauLR(opt, threshold=1e-4),
             ],
         ),
@@ -1714,12 +1717,14 @@ optim_db: list[OptimizerInfo] = [
             ],
             [
                 lambda opt: ExponentialLR(opt, gamma=0.9),
+                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
             ],
             [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
             [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
+                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
             ],
         ),
@@ -2116,12 +2121,14 @@ optim_db: list[OptimizerInfo] = [
             [
                 lambda opt: StepLR(opt, gamma=0.99, step_size=10),
                 lambda opt: ExponentialLR(opt, gamma=0.99),
+                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
             ],
             [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
             [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
+                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
             ],
         ),

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -33,8 +33,8 @@ from torch.optim.lr_scheduler import (
     ConstantLR,
     ExponentialLR,
     LinearLR,
+    PlateauLR,
     PolynomialLR,
-    ReduceLROnPlateau,
     StepLR,
 )
 from torch.testing._internal.common_device_type import tol, toleranceOverride
@@ -119,7 +119,7 @@ class OptimizerInfo:
         scheduler_inputs=(
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                lambda opt: ReduceLROnPlateau(opt),
+                lambda opt: PlateauLR(opt),
             ],
         ),
         # A subset of the global-cliquey flags (fused, foreach, differentiable) the optimizer
@@ -1655,7 +1655,7 @@ optim_db: list[OptimizerInfo] = [
             {"lr": 0.1, "weight_decay": 0, "lr_decay": 0},
             [
                 lambda opt: StepLR(opt, gamma=1 - 1e-5, step_size=500),
-                lambda opt: ReduceLROnPlateau(opt, threshold=1e-4),
+                lambda opt: PlateauLR(opt, threshold=1e-4),
             ],
         ),
         decorators=(
@@ -1714,13 +1714,13 @@ optim_db: list[OptimizerInfo] = [
             ],
             [
                 lambda opt: ExponentialLR(opt, gamma=0.9),
-                lambda opt: ReduceLROnPlateau(opt),
+                lambda opt: PlateauLR(opt),
             ],
             [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
             [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                lambda opt: ReduceLROnPlateau(opt),
+                lambda opt: PlateauLR(opt),
             ],
         ),
         optim_error_inputs_func=optim_error_inputs_func_adam,
@@ -2116,13 +2116,13 @@ optim_db: list[OptimizerInfo] = [
             [
                 lambda opt: StepLR(opt, gamma=0.99, step_size=10),
                 lambda opt: ExponentialLR(opt, gamma=0.99),
-                lambda opt: ReduceLROnPlateau(opt),
+                lambda opt: PlateauLR(opt),
             ],
             [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
             [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                lambda opt: ReduceLROnPlateau(opt),
+                lambda opt: PlateauLR(opt),
             ],
         ),
         optim_error_inputs_func=optim_error_inputs_func_sgd,

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -2128,8 +2128,8 @@ optim_db: list[OptimizerInfo] = [
             [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
             [
                 lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                lambda opt: ReduceLROnPlateau(opt),
                 lambda opt: PlateauLR(opt),
+                lambda opt: ReduceLROnPlateau(opt),
             ],
         ),
         optim_error_inputs_func=optim_error_inputs_func_sgd,


### PR DESCRIPTION
Fixes #68978  
Fixes #110761

Video overview of this PR to hopefully save you some time and hassle: https://youtu.be/X9ZAnNlwVII

Introduces `PlateauLR`, a composable `LRScheduler`-based replacement for `ReduceLROnPlateau`.

`PlateauLR` preserves the plateau-reduction behavior of `ReduceLROnPlateau`, but follows the normal `LRScheduler` lifecycle: it initializes through the base class, computes learning rates through `get_lr()`, and accepts the monitored value as a keyword-only `metrics` argument:

```python
scheduler = PlateauLR(optimizer)
scheduler.step(metrics=val_loss)
```

The change also:

- deprecates `ReduceLROnPlateau` with migration guidance to `PlateauLR`
- allows built-in schedulers and composition schedulers to accept an optional keyword-only `metrics` argument
- forwards metrics through `SequentialLR` and `ChainedScheduler`, including nested compositions and milestone handoffs
- preserves compatibility with third-party schedulers that retain the pre-`metrics` `step()` signature
- updates scheduler documentation and the scheduler illustration to use `PlateauLR`

`ReduceLROnPlateau` remains rejected by `SequentialLR` and `ChainedScheduler`, users needing composition should migrate to `PlateauLR`.

Sample code in here: https://github.com/pupeno/pytorch-workspace/tree/main/195634_plateau_lr_composable

An alternative approach is available in #195633. The two PRs are mutually exclusive.

This PR depends on https://github.com/pytorch/pytorch/pull/196242

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo