### PR TITLE
[inductor-opt]allow horizontal fusion of copies from dynamic inputs into concat operation

### DIFF
--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -770,6 +770,32 @@ class ForeachTests(TestCase):
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 2)
 
     @requires_gpu
+    def test_fuse_concat_dynamic_shapes(self):
+        # Horizontal fusion of the cat copies must survive dynamic shapes.
+        #
+        # Two things this test is sensitive to:
+        #  - the number of inputs must exceed config.max_pointwise_cat_inputs, or cat
+        #    is lowered as a single pointwise kernel with masked loads and never
+        #    builds a ConcatKernel, so the foreach grouping is never exercised.
+        #  - check_model_gpu is deliberately not used: it clones the inputs and does a
+        #    second, static compile, whose kernel count would mask the dynamic one.
+        n = config.max_pointwise_cat_inputs + 4
+
+        def fn(*args):
+            return torch.stack(args)
+
+        args = tuple(torch.randn(5, 4).to(GPU_TYPE) for _ in range(n))
+        for arg in args:
+            torch._dynamo.mark_dynamic(arg, 0)
+
+        torch._dynamo.reset()
+        torch._inductor.metrics.reset()
+        actual = torch.compile(fn, fullgraph=True)(*args)
+        self.assertEqual(actual, fn(*args))
+
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_gpu
     def test_zero_elems(self):
         def fn(a0, a1, b0, b1):
             return torch._foreach_add([a0, a1], [b0, b1])

--- a/test/inductor/test_foreach.py
+++ b/test/inductor/test_foreach.py
@@ -770,30 +770,39 @@ class ForeachTests(TestCase):
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 2)
 
     @requires_gpu
+    @torch._dynamo.config.patch("automatic_dynamic_shapes", False)
+    @torch._dynamo.config.patch("assume_static_by_default", False)
+    @torch._inductor.config.patch("combo_kernel_foreach_dynamic_shapes", True)
     def test_fuse_concat_dynamic_shapes(self):
-        # Horizontal fusion of the cat copies must survive dynamic shapes.
-        #
-        # Two things this test is sensitive to:
-        #  - the number of inputs must exceed config.max_pointwise_cat_inputs, or cat
-        #    is lowered as a single pointwise kernel with masked loads and never
-        #    builds a ConcatKernel, so the foreach grouping is never exercised.
-        #  - check_model_gpu is deliberately not used: it clones the inputs and does a
-        #    second, static compile, whose kernel count would mask the dynamic one.
+        # The number of inputs has to exceed config.max_pointwise_cat_inputs, or cat
+        # is lowered as a single pointwise kernel with masked loads and never builds a
+        # ConcatKernel, so the foreach grouping is never exercised.
         n = config.max_pointwise_cat_inputs + 4
 
         def fn(*args):
             return torch.stack(args)
 
-        args = tuple(torch.randn(5, 4).to(GPU_TYPE) for _ in range(n))
-        for arg in args:
-            torch._dynamo.mark_dynamic(arg, 0)
+        args = tuple(torch.rand(5, 4, device=GPU_TYPE) for _ in range(n))
 
-        torch._dynamo.reset()
-        torch._inductor.metrics.reset()
-        actual = torch.compile(fn, fullgraph=True)(*args)
-        self.assertEqual(actual, fn(*args))
+        self.check_model_gpu(fn, args)
 
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_gpu
+    @torch._dynamo.config.patch("automatic_dynamic_shapes", False)
+    @torch._dynamo.config.patch("assume_static_by_default", False)
+    @torch._inductor.config.patch("combo_kernel_foreach_dynamic_shapes", False)
+    def test_fuse_concat_dynamic_shapes_fallback(self):
+        n = config.max_pointwise_cat_inputs + 4
+
+        def fn(*args):
+            return torch.stack(args)
+
+        args = tuple(torch.rand(5, 4, device=GPU_TYPE) for _ in range(n))
+
+        self.check_model_gpu(fn, args)
+
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, n)
 
     @requires_gpu
     def test_zero_elems(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -127,6 +127,7 @@ from .utils import (
     get_kernel_metadata,
     GPU_ALIGN_BYTES,
     ir_dataclass,
+    is_dynamic,
     is_gpu,
     sympy_dot,
     sympy_index_symbol,
@@ -7029,6 +7030,10 @@ class ConcatKernel(NopKernel):
                 and input_unwrapped.is_input_buffer()
                 and (dev := inp.get_device()) is not None
                 and is_gpu(dev.type)
+                and (
+                    not is_dynamic(input_buffer)
+                    or config.combo_kernel_foreach_dynamic_shapes
+                )
             ):
                 op_names.append(input_buffer.get_operation_name())
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -127,7 +127,6 @@ from .utils import (
     get_kernel_metadata,
     GPU_ALIGN_BYTES,
     ir_dataclass,
-    is_dynamic,
     is_gpu,
     sympy_dot,
     sympy_index_symbol,
@@ -7025,13 +7024,11 @@ class ConcatKernel(NopKernel):
                 input_unwrapped = inp.data.unwrap_view()
             else:
                 input_unwrapped = inp.data
-
             if (
                 isinstance(input_unwrapped, StorageBox)
                 and input_unwrapped.is_input_buffer()
                 and (dev := inp.get_device()) is not None
                 and is_gpu(dev.type)
-                and not is_dynamic(input_buffer)
             ):
                 op_names.append(input_buffer.get_operation_name())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195635

`ConcatKernel.create` drops any cat input with a symbolic size from the foreach operation
list, so `Scheduler.create_foreach_nodes` never groups the copies and each becomes its own
kernel launch. With static shapes the same op is one foreach kernel launch
(`triton_for_fused_*`). 

The optimization for static shapes, is Not shape dependent ( there is no checks on sizes of inputs)
 hence there is no reason why not to enable it for dynamic shapes as well. 

```python
# torch/_inductor/ir.py, ConcatKernel.create
and is_gpu(dev.type)
and not is_dynamic(input_buffer)      # <-- removed
```

The clause shipped in the original feature commit (`543dc757463a`, #111437, Oct 2023) with
no comment and no test. The other two producers of `register_operation_list`
(`foreach_group_loop`, `_foreach_map`) later gained an explicit dynamic-shapes escape hatch
via `config.combo_kernel_foreach_dynamic_shapes` (default `True`); this call site never got
the same update.

Found on a recsys job that moved from static batch 768 to variable batch size. One frame
stacked 299 tangents of `f32[768, 192]` in fwd and bwd: static emitted 3 foreach kernel
launches, dynamic emitted 299 — roughly **+590 kernel launches per iteration**, 589 of the
607 extra launches across the whole model.

Also removes the now-unused `is_dynamic` import (the other use in `ir.py` is a local in
`_pad_strides` that shadowed it).

## Numbers
[perf expirment done by AI]
`stack` of N x `f32[768, 192]`, H100, dynamic dim 0:

| N | launches before | launches after | ms before | ms after |
|---|---|---|---|---|
| 16 | 16 | 1 | 0.104 | 0.041 |
| 64 | 64 | 1 | 0.336 | 0.178 |
| 256 | 256 | 3 | 1.297 | 0.577 |

Benefit tapers with tensor size — 1.7x at 0.02 MiB/input down to 1.07x at 64 MiB, once each
copy saturates HBM. `N <= config.max_pointwise_cat_inputs` (8) is unaffected: no
`ConcatKernel` is built there.

<details>
<summary>Benchmark method</summary>

`torch.compile(lambda xs: torch.stack(xs, 0), fullgraph=True)` with `mark_dynamic(x, 0)` on
each input; launch counts from `run_and_get_code`, timing from CUDA events over 200 iters
after 50 warmup.

Run-to-run variance put the N=64 ratio at 2.4x-2.8x. The residual dynamic-vs-static gap
after the fix (~1.45x) is symbolic index arithmetic inside the kernel, not launch overhead.

```python 
Benchmark for: restore foreach fusion for cat/stack under dynamic shapes.
Run once on unpatched torch and once with the ConcatKernel.create gate removed.
    python bench_cat_foreach.py            # table 1: launches + time vs N
    python bench_cat_foreach.py --sizes    # table 2: effect vs tensor size, N=12
"""
import re
import sys
import torch
import torch._dynamo
import torch._inductor.config as inductor_config
from torch._inductor.utils import run_and_get_code
# Without this the FX graph cache serves a prior compile and hides the difference.
inductor_config.force_disable_caches = True
def fn(xs):
    return torch.stack(xs, dim=0)
def measure(n, rows, cols, dynamic, iters=200, warmup=50):
    torch._dynamo.reset()
    xs = [torch.randn(rows, cols, device="cuda") for _ in range(n)]
    if dynamic:
        for x in xs:
            torch._dynamo.mark_dynamic(x, 0)
    compiled = torch.compile(fn, fullgraph=True)
    out, codes = run_and_get_code(compiled, xs)
    torch.testing.assert_close(out, fn(xs))
    call = re.search(r"^    def call\(self, args\):(.*?)(?=\Z)", codes[0], re.S | re.M)
    body = call.group(1) if call else codes[0]
    launches = len(re.findall(r"(triton_\w+)\.run\(", body))
    for _ in range(warmup):
        compiled(xs)
    torch.cuda.synchronize()
    start, end = torch.cuda.Event(True), torch.cuda.Event(True)
    start.record()
    for _ in range(iters):
        compiled(xs)
    end.record()
    torch.cuda.synchronize()
    return launches, start.elapsed_time(end) / iters
def table_vs_n():
    print(f"stack(N x f32[768, 192]) on {torch.cuda.get_device_name(0)}\n")
    hdr = (
        f"{'N':>5}{'static launch':>15}{'dyn launch':>12}"
        f"{'static ms':>11}{'dyn ms':>9}{'ratio':>8}"
    )
    print(hdr)
    print("-" * len(hdr))
    for n in (4, 8, 16, 32, 64, 128, 256):
        sl, sm = measure(n, 768, 192, dynamic=False)
        dl, dm = measure(n, 768, 192, dynamic=True)
        print(f"{n:>5}{sl:>15}{dl:>12}{sm:>11.3f}{dm:>9.3f}{dm / sm:>7.2f}x")
def table_vs_size():
    print(f"stack(12 x f32[rows, cols]), dynamic dim 0, on {torch.cuda.get_device_name(0)}\n")
    hdr = f"{'MiB/input':>11}{'launches':>10}{'ms':>10}"
    print(hdr)
    print("-" * len(hdr))
    for rows, cols in ((4, 8), (64, 64), (768, 192), (4096, 512), (16384, 1024)):
        dl, dm = measure(12, rows, cols, dynamic=True)
        print(f"{rows * cols * 4 / 2**20:>11.2f}{dl:>10}{dm:>10.3f}")
if __name__ == "__main__":
    assert torch.cuda.is_available(), "needs a GPU"
    table_vs_size() if "--sizes" in sys.argv else table_vs_n()
```
</details>

## Test plan
`test/inductor/test_foreach.py::ForeachTests::test_fuse_concat_dynamic_shapes` — fails with
`Expected 1 but got 12` before, passes after.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo