### PR TITLE
[Profiler] Add support for memory profiling with profile_all_threads

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -1,11 +1,23 @@
 #include <c10/core/Allocator.h>
 #include <array>
+#include <atomic>
 
 #include <c10/util/ThreadLocalDebugInfo.h>
 
 #include <cstring>
 
 namespace c10 {
+
+static std::atomic<MemoryReportingInfoBase*> global_memory_reporter{nullptr};
+
+static MemoryReportingInfoBase* getMemoryReportingInfo() {
+  MemoryReportingInfoBase* reporter = static_cast<MemoryReportingInfoBase*>(
+      ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
+  if (reporter) {
+    return reporter;
+  }
+  return global_memory_reporter.load(std::memory_order_relaxed);
+}
 
 DataPtr Allocator::clone(const void* data, std::size_t n) {
   DataPtr new_data = allocate(n);
@@ -58,9 +70,12 @@ at::Allocator* GetAllocator(const at::DeviceType& t) {
 }
 
 bool memoryProfilingEnabled() {
-  auto* reporter_ptr = static_cast<MemoryReportingInfoBase*>(
-      ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
-  return reporter_ptr && reporter_ptr->memoryProfilingEnabled();
+  MemoryReportingInfoBase* reporter = getMemoryReportingInfo();
+  return reporter && reporter->memoryProfilingEnabled();
+}
+
+void SetGlobalMemoryReportingInfo(MemoryReportingInfoBase* reporter) {
+  global_memory_reporter.store(reporter, std::memory_order_relaxed);
 }
 
 void reportMemoryUsageToProfiler(
@@ -69,10 +84,9 @@ void reportMemoryUsageToProfiler(
     size_t total_allocated,
     size_t total_reserved,
     Device device) {
-  auto* reporter_ptr = static_cast<MemoryReportingInfoBase*>(
-      ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
-  if (reporter_ptr) {
-    reporter_ptr->reportMemoryUsage(
+  MemoryReportingInfoBase* reporter = getMemoryReportingInfo();
+  if (reporter) {
+    reporter->reportMemoryUsage(
         ptr, alloc_size, total_allocated, total_reserved, device);
   }
 }
@@ -82,10 +96,9 @@ void reportOutOfMemoryToProfiler(
     size_t total_allocated,
     size_t total_reserved,
     Device device) {
-  auto* reporter_ptr = static_cast<MemoryReportingInfoBase*>(
-      ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
-  if (reporter_ptr) {
-    reporter_ptr->reportOutOfMemory(
+  MemoryReportingInfoBase* reporter = getMemoryReportingInfo();
+  if (reporter) {
+    reporter->reportOutOfMemory(
         alloc_size, total_allocated, total_reserved, device);
   }
 }

--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -74,7 +74,7 @@ bool memoryProfilingEnabled() {
   return reporter && reporter->memoryProfilingEnabled();
 }
 
-void SetGlobalMemoryReportingInfo(MemoryReportingInfoBase* reporter) {
+void setGlobalMemoryReportingInfo(MemoryReportingInfoBase* reporter) {
   global_memory_reporter.store(reporter, std::memory_order_relaxed);
 }
 

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -328,7 +328,7 @@ struct C10_API MemoryReportingInfoBase : public c10::DebugInfoBase {
   virtual bool memoryProfilingEnabled() const = 0;
 };
 
-C10_API void SetGlobalMemoryReportingInfo(MemoryReportingInfoBase* reporter);
+C10_API void setGlobalMemoryReportingInfo(MemoryReportingInfoBase* reporter);
 C10_API bool memoryProfilingEnabled();
 C10_API void reportMemoryUsageToProfiler(
     void* ptr,

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -328,6 +328,7 @@ struct C10_API MemoryReportingInfoBase : public c10::DebugInfoBase {
   virtual bool memoryProfilingEnabled() const = 0;
 };
 
+C10_API void SetGlobalMemoryReportingInfo(MemoryReportingInfoBase* reporter);
 C10_API bool memoryProfilingEnabled();
 C10_API void reportMemoryUsageToProfiler(
     void* ptr,

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2820,6 +2820,31 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
         else:
             os.waitpid(pid, 0)
 
+    @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    @onlyOn("cpu")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_profile_memory_all_threads(self, device):
+        allocation_size = 123457
+
+        def allocate_on_worker():
+            tensor = torch.empty(allocation_size, dtype=torch.uint8, device=device)
+            del tensor
+
+        experimental_config = torch._C._profiler._ExperimentalConfig(
+            profile_all_threads=True
+        )
+        with torch.profiler.profile(
+            activities=[ProfilerActivity.CPU],
+            profile_memory=True,
+            experimental_config=experimental_config,
+        ) as prof:
+            worker = threading.Thread(target=allocate_on_worker)
+            worker.start()
+            worker.join()
+
+        memory_sizes = {event.cpu_memory_usage for event in prof.events()}
+        self.assertTrue({allocation_size, -allocation_size}.issubset(memory_sizes))
+
     @onlyAccelerator
     @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
     @unittest.skipIf(not kineto_available(), "Kineto is required")

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -260,7 +260,8 @@ struct KinetoThreadLocalState : public ProfilerStateBase {
 // Coordinates one global RecordFunction callback session (KINETO_ONDEMAND, or
 // KINETO with profile_all_threads) against teardown. Those callbacks fire on
 // every thread and touch the profiler state while disableProfiler() finalizes
-// and frees it on another thread.
+// and frees it on another thread. Memory-reporting writes also participate in
+// this session.
 //
 // While the session is active, each callback invocation brackets only its own
 // short critical section - getGlobal() plus the RecordQueue access - with
@@ -376,6 +377,57 @@ class GlobalCallbackSession {
 };
 
 GlobalCallbackSession global_callback_session;
+
+class GlobalMemoryReportingInfo final : public c10::MemoryReportingInfoBase {
+ public:
+  void reportMemoryUsage(
+      void* ptr,
+      int64_t alloc_size,
+      size_t total_allocated,
+      size_t total_reserved,
+      c10::Device device) override {
+    report([&](KinetoThreadLocalState& state) {
+      state.reportMemoryUsage(
+          ptr, alloc_size, total_allocated, total_reserved, device);
+    });
+  }
+
+  void reportOutOfMemory(
+      int64_t alloc_size,
+      size_t total_allocated,
+      size_t total_reserved,
+      c10::Device device) override {
+    report([&](KinetoThreadLocalState& state) {
+      state.reportOutOfMemory(
+          alloc_size, total_allocated, total_reserved, device);
+    });
+  }
+
+  bool memoryProfilingEnabled() const override {
+    return global_callback_session.isActive();
+  }
+
+ private:
+  template <typename F>
+  void report(F&& report_event) {
+    if (!global_callback_session.isActive()) {
+      return;
+    }
+    global_callback_session.enter();
+    auto in_flight_guard =
+        c10::make_scope_exit([] { global_callback_session.exit(); });
+    if (!global_callback_session.isActive()) {
+      return;
+    }
+    std::shared_ptr<KinetoThreadLocalState> state =
+        KinetoThreadLocalState::getGlobal();
+    if (state) {
+      report_event(*state);
+    }
+  }
+};
+
+GlobalMemoryReportingInfo global_memory_reporting_info;
 
 std::unique_ptr<at::ObserverContext> onFunctionEnterGlobal(
     const at::RecordFunction& fn) {
@@ -838,6 +890,15 @@ void enableProfiler(
         : pushTLSProfilingCallbacks(scopes);
   }
 
+  if (config.pushGlobalCallbacks() && config.profile_memory) {
+    // Without CPU activity, pushGlobalProfilingCallbacks() did not activate
+    // the session, so activate it for memory reporting.
+    if (!has_cpu) {
+      global_callback_session.activate(/*new_session=*/true);
+    }
+    c10::SetGlobalMemoryReportingInfo(&global_memory_reporting_info);
+  }
+
   if (!config.global()) {
     torch::profiler::impl::kineto::startTrace();
   }
@@ -876,6 +937,9 @@ void disableProfilerInChildThread() {
 std::unique_ptr<ProfilerResult> disableProfiler() {
   // releasing to inform child threads to stop profiling
   profiler_state_info_ptr = nullptr;
+
+  // Stop new memory reports before draining the global callback session.
+  c10::SetGlobalMemoryReportingInfo(nullptr);
 
   // If global callbacks were installed (KINETO_ONDEMAND, or KINETO with
   // profile_all_threads), they may be running on other threads right now. Wait

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -896,7 +896,7 @@ void enableProfiler(
     if (!has_cpu) {
       global_callback_session.activate(/*new_session=*/true);
     }
-    c10::SetGlobalMemoryReportingInfo(&global_memory_reporting_info);
+    c10::setGlobalMemoryReportingInfo(&global_memory_reporting_info);
   }
 
   if (!config.global()) {
@@ -939,7 +939,7 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
   profiler_state_info_ptr = nullptr;
 
   // Stop new memory reports before draining the global callback session.
-  c10::SetGlobalMemoryReportingInfo(nullptr);
+  c10::setGlobalMemoryReportingInfo(nullptr);
 
   // If global callbacks were installed (KINETO_ONDEMAND, or KINETO with
   // profile_all_threads), they may be running on other threads right now. Wait


### PR DESCRIPTION
A follow-up for https://github.com/pytorch/pytorch/pull/190871, which reports the problem.

Add memory profiling support when `profile_all_threads` is used. Previously, memory profiling only checked the thread local state (`ThreadLocalDebugInfo`) to fetch the memory reporter object, but Profiler uses `GlobalStateManager` for profiling on all threads. As a result, the logic in Allocator.cpp would check the thread local state, see NULL, and report nothing.

To fix this, we:
1.  Add a new `global_memory_reporter` pointer object to Allocator.cpp which is set using `SetGlobalMemoryReportingInfo`. During memory report events, if we can't find thread local state, we fall back to the `global_memory_reporter`.
2. In profiler, we call `SetGlobalMemoryReportingInfo` with a new class `GlobalMemoryReportingInfo`, which extends `MemoryReportingInfoBase`. 
3. Guard the lifecycle of global memory profiling with `GlobalCallbackSession`. The main risk is that any thread can report memory events to `RecordQueue`, but only one thread tears down `RecordQueue`. If we don't add a guard, `RecordQueue` can be torn down by one thread, then a mistimed memory report can come in from another thread which tries to access the already torn down resources, leading to segfault. `GlobalCallbackSession` is the existing profiler solution for this and already guards `RecordQueue` when it listens for Pytorch op callbacks.

Testing:
New unit test with profile_all_threads passes

I also had Codex build and run a stress test on the changes:

> Yes. A larger black-box lifecycle stress passed:
> 
>   - 200 enable/disable cycles
>   - 20 continuously allocating threads
>   - 1,224,876 allocation/free pairs
>   - Worker progress overlapped every profiler exit
>   - No crash, hang, or drain timeout
>   - Exit latency: 45.6 ms median, 77.1 ms p95, 135.0 ms max
>   - 32,000/32,000 controlled CPU raw memory records captured
>   - 4,000/4,000 CUDA-only raw records captured
>   - 50 session-isolation cycles passed
