### PR TITLE
Add equal_nan to gradcheck so two NaN Jacobians are not reported as a mismatch

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7893,6 +7893,52 @@ Done""",
                                 with self.assertRaisesRegex(RuntimeError, fail_msg):
                                     run()
 
+    def test_gradcheck_equal_nan(self):
+        """Two NaNs in the same position of both Jacobians are not a mismatch when opted in.
+
+        `torch.acosh` is NaN-valued on [0, 1), so the numerical and the analytical
+        Jacobian are both all-NaN and agree, but the comparison is `torch.allclose`,
+        which reports NaN != NaN. Backward mode is off here because a NaN gradient
+        separately, and correctly, fails `_test_backward_mul_by_grad_output`: it is
+        not zero when grad_output is zero, which `equal_nan` should not hide.
+        """
+        from torch.autograd.gradcheck import GradcheckError
+
+        fwd_mismatch = "Jacobian computed with forward mode mismatch"
+
+        class BadJvp(Function):
+            @staticmethod
+            def forward(ctx, foo):
+                return foo * 2
+
+            @staticmethod
+            def jvp(ctx, gI):
+                return gI * 5
+
+        for fast_mode in (True, False):
+            x = torch.rand(4, dtype=torch.double, requires_grad=True)
+            kwargs = {
+                "check_backward_ad": False,
+                "check_forward_ad": True,
+                "fast_mode": fast_mode,
+            }
+
+            with self.assertRaisesRegex(GradcheckError, fwd_mismatch):
+                gradcheck(torch.acosh, (x,), **kwargs)
+            self.assertTrue(gradcheck(torch.acosh, (x,), equal_nan=True, **kwargs))
+
+            # A wrong formula is still caught, NaN or not
+            y = torch.rand(3, dtype=torch.double, requires_grad=True)
+            with self.assertRaisesRegex(GradcheckError, fwd_mismatch):
+                gradcheck(BadJvp.apply, (y,), equal_nan=True, **kwargs)
+
+            # and a correct function passes either way
+            z = torch.rand(3, dtype=torch.double, requires_grad=True)
+            self.assertTrue(gradcheck(torch.sin, (z,), fast_mode=fast_mode))
+            self.assertTrue(
+                gradcheck(torch.sin, (z,), fast_mode=fast_mode, equal_nan=True)
+            )
+
     def test_gradcheck_forward_ad_batched_grad(self):
         x = torch.rand(2, dtype=torch.double, requires_grad=True)
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1612,6 +1612,7 @@ def _slow_gradcheck(
     complex_indices=None,
     test_imag=False,
     masked=False,
+    equal_nan=False,
 ):
     func_out = _as_tuple(func_out)
     if not outputs:
@@ -1641,7 +1642,9 @@ def _slow_gradcheck(
         for i, n_per_out in enumerate(numerical):
             for j, n in enumerate(n_per_out):
                 a = analytical_forward[j][i]
-                if not _allclose_with_type_promotion(a, n.to(a.device), rtol, atol):
+                if not _allclose_with_type_promotion(
+                    a, n.to(a.device), rtol, atol, equal_nan
+                ):
                     raise GradcheckError(
                         _get_notallclose_msg(
                             a, n, i, j, complex_indices, test_imag, is_forward_ad=True
@@ -1654,7 +1657,9 @@ def _slow_gradcheck(
             )
 
             for j, (a, n) in enumerate(zip(analytical, numerical[i])):
-                if not _allclose_with_type_promotion(a, n.to(a.device), rtol, atol):
+                if not _allclose_with_type_promotion(
+                    a, n.to(a.device), rtol, atol, equal_nan
+                ):
                     raise GradcheckError(
                         _get_notallclose_msg(a, n, i, j, complex_indices, test_imag)
                     )
@@ -1670,11 +1675,11 @@ def _dot_with_type_promotion(u, v):
     return (u * v).sum()
 
 
-def _allclose_with_type_promotion(a, b, rtol, atol):
+def _allclose_with_type_promotion(a, b, rtol, atol, equal_nan=False):
     promoted_type = torch.promote_types(a.dtype, b.dtype)
     a = a.to(dtype=promoted_type)
     b = b.to(dtype=promoted_type)
-    return torch.allclose(a, b, rtol, atol)
+    return torch.allclose(a, b, rtol, atol, equal_nan)
 
 
 def _to_real_dtype(dtype):
@@ -1901,6 +1906,7 @@ def _check_analytical_numerical_equal(
     test_imag,
     *,
     is_forward_ad=False,
+    equal_nan=False,
 ):
     for i, all_numerical_for_input_i in enumerate(all_numerical):
         for j, n in enumerate(all_numerical_for_input_i):
@@ -1911,7 +1917,9 @@ def _check_analytical_numerical_equal(
                 a = all_analytical[j][i]
             n = n.to(device=a.device)
             updated_atol = _adjusted_atol(atol, all_u[i], all_v[j] if all_v else None)
-            if not _allclose_with_type_promotion(a, n.to(a.device), rtol, updated_atol):
+            if not _allclose_with_type_promotion(
+                a, n.to(a.device), rtol, updated_atol, equal_nan
+            ):
                 jacobians_str = _run_slow_mode_and_get_error(
                     func, tupled_inputs, outputs, i, j, rtol, atol, eps, is_forward_ad
                 )
@@ -1938,6 +1946,7 @@ def _fast_gradcheck(
     complex_indices=None,
     test_imag=False,
     masked=False,
+    equal_nan=False,
 ):
     # See https://github.com/pytorch/pytorch/issues/53876 for details
     inp_tensors_idx, inp_tensors = _get_inp_tensors(inputs)
@@ -2000,6 +2009,7 @@ def _fast_gradcheck(
         eps,
         test_imag,
         is_forward_ad=use_forward_ad,
+        equal_nan=equal_nan,
     )
 
     return True
@@ -2028,6 +2038,7 @@ def gradcheck(
     check_backward_ad: bool = True,
     fast_mode: bool = False,
     masked: bool | None = None,
+    equal_nan: bool = False,
 ) -> bool:
     r"""Check gradients computed via small finite differences against analytical
     gradients wrt tensors in :attr:`inputs` that are of floating point or complex type
@@ -2092,6 +2103,12 @@ def gradcheck(
             is run; otherwise, we fall back to the slow implementation.
         masked (bool, optional): if ``True``, the gradients of unspecified elements of
             sparse tensors are ignored. Defaults to ``False``.
+        equal_nan (bool, optional): if ``True``, two ``NaN`` entries in the same position of
+            the numerical and the analytical Jacobian compare as equal, as in
+            :func:`~torch.allclose`. Useful when the function is only defined on part of the
+            sampled domain, so that both Jacobians are ``NaN`` and agree; without it the
+            check reports a mismatch between two identical ``NaN`` values.
+            Defaults to ``False``.
     Returns:
         ``True`` if all differences satisfy allclose condition
 
@@ -2134,6 +2151,7 @@ def _gradcheck_helper(
     check_backward_ad,
     fast_mode,
     masked,
+    equal_nan,
 ):
     tupled_inputs = _as_tuple(inputs)
     _check_inputs(tupled_inputs)
@@ -2143,7 +2161,9 @@ def _gradcheck_helper(
     _check_outputs(outputs)
 
     gradcheck_fn = functools.partial(
-        _fast_gradcheck if fast_mode else _slow_gradcheck, masked=masked
+        _fast_gradcheck if fast_mode else _slow_gradcheck,
+        masked=masked,
+        equal_nan=equal_nan,
     )
     _gradcheck_real_imag(
         gradcheck_fn,
@@ -2197,6 +2217,7 @@ def gradgradcheck(
     check_rev_over_rev: bool = True,
     fast_mode: bool = False,
     masked: bool = False,
+    equal_nan: bool = False,
 ) -> bool:
     r"""Check gradients of gradients computed via small finite differences
     against analytical gradients wrt tensors in :attr:`inputs` and
@@ -2249,6 +2270,9 @@ def gradgradcheck(
             no longer computes the entire jacobian.
         masked (bool, optional): if True, the gradients of unspecified elements of
             sparse tensors are ignored (default, False).
+        equal_nan (bool, optional): if True, two NaN entries in the same position of the
+            numerical and the analytical Jacobian compare as equal, as in
+            :func:`~torch.allclose` (default, False).
     Returns:
         True if all differences satisfy allclose condition
     """
@@ -2336,4 +2360,5 @@ def gradgradcheck(
         check_forward_ad=check_fwd_over_rev,
         check_backward_ad=check_rev_over_rev,
         masked=masked,
+        equal_nan=equal_nan,
     )

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1798,7 +1798,16 @@ If the test
 
 
 def _run_slow_mode_and_get_error(
-    func, tupled_inputs, outputs, input_idx, output_idx, rtol, atol, eps, is_forward_ad
+    func,
+    tupled_inputs,
+    outputs,
+    input_idx,
+    output_idx,
+    rtol,
+    atol,
+    eps,
+    is_forward_ad,
+    equal_nan=False,
 ):
     # Compute jacobians in slow mode for better error message
     if is_forward_ad:
@@ -1838,7 +1847,9 @@ def _run_slow_mode_and_get_error(
     # Assume jacobians are non-empty and have the same shape
     slow_max_diff = (slow_numerical - slow_analytical).abs().max()
 
-    slow_allclose = torch.allclose(slow_analytical, slow_numerical, rtol, atol)
+    slow_allclose = torch.allclose(
+        slow_analytical, slow_numerical, rtol, atol, equal_nan
+    )
     msg = (
         "\nThe above quantities relating the numerical and analytical jacobians are computed \n"
         "in fast mode. See: https://github.com/pytorch/pytorch/issues/53876 for more background \n"
@@ -1921,7 +1932,16 @@ def _check_analytical_numerical_equal(
                 a, n.to(a.device), rtol, updated_atol, equal_nan
             ):
                 jacobians_str = _run_slow_mode_and_get_error(
-                    func, tupled_inputs, outputs, i, j, rtol, atol, eps, is_forward_ad
+                    func,
+                    tupled_inputs,
+                    outputs,
+                    i,
+                    j,
+                    rtol,
+                    atol,
+                    eps,
+                    is_forward_ad,
+                    equal_nan,
                 )
                 raise GradcheckError(
                     _get_notallclose_msg(


### PR DESCRIPTION
Fixes #76780.

## What

`gradcheck`'s own docstring says "The check between numerical and analytical gradients uses `torch.allclose`", but it never exposed `allclose`'s `equal_nan`. So a function that is only defined on part of the sampled domain produces two **identical, all-NaN** Jacobians and is reported as a mismatch between them:

```python
x = torch.rand(4, dtype=torch.float64, requires_grad=True)   # in [0, 1)
torch.autograd.gradcheck(torch.acosh, (x,))
```
```
GradcheckError: Jacobian mismatch for output 0 with respect to input 0,
numerical:tensor([[nan, nan, nan, nan], ...])
analytical:tensor([[nan, nan, nan, nan], ...])
```

Nothing mismatches there. `acosh` is NaN on `[0, 1)`, both sides agree, and the message sends the reader looking for a gradient bug that does not exist.

## Change

`equal_nan: bool = False` on `gradcheck` and `gradgradcheck`, forwarded to the `torch.allclose` call the comparison already makes. It is threaded through the same `functools.partial` that already carries `masked`, so none of the seven `gradcheck_fn(...)` call sites in `_gradcheck_real_imag` move:

```python
    gradcheck_fn = functools.partial(
        _fast_gradcheck if fast_mode else _slow_gradcheck,
        masked=masked,
        equal_nan=equal_nan,
    )
```

Default is `False`, so existing callers are unaffected. Both the slow and the fast path are covered.

## Scope, stated plainly

`equal_nan=True` fixes the Jacobian comparison, which is the check the issue's traceback names. On the backward path the same `torch.acosh` call then reaches `_test_backward_mul_by_grad_output`, which feeds `grad_output = 0` and requires `grad_input == 0`; a NaN gradient is not zero, so it fails there for a **different and correct** reason. I deliberately did not touch that check: whether gradcheck should relax it for NaN gradients is a semantics question for the autograd owners, not something an `allclose` flag should quietly paper over. The issue asked for "the comparison of NaN", and that is what this changes.

## Verification

Run against the file loaded standalone next to an installed wheel; I cannot build PyTorch on this machine, so CI is the test runner for the in-tree run.

```
BEFORE (main)
  fwd-AD default           -> GradcheckError: Jacobian computed with forward mode mismatch ...
  fwd-AD equal_nan=True    -> TypeError: gradcheck() got an unexpected keyword argument 'equal_nan'

AFTER
  fwd-AD default           -> GradcheckError   (unchanged)
  fwd-AD equal_nan=True    -> True
  fwd-AD fast equal_nan    -> True
  control: wrong jvp with equal_nan=True -> GradcheckError   (still caught)
```

## Test

`test_gradcheck_equal_nan` in `test/test_autograd.py`, over `fast_mode` in `(True, False)`:

- `torch.acosh` on `[0, 1)` raises today and passes with `equal_nan=True`
- a deliberately wrong `jvp` still raises **with** `equal_nan=True`, so the flag cannot hide a real defect
- a correct function passes with the flag both set and unset

Extracted and run against `main`'s `gradcheck.py` and against this one: **error on main (`TypeError: unexpected keyword argument 'equal_nan'`), passes here.**

cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93