### PR TITLE
[dtensor] Preserve zero-size ops during graph capture

### DIFF
--- a/test/distributed/tensor/test_placement_types.py
+++ b/test/distributed/tensor/test_placement_types.py
@@ -7,6 +7,7 @@ import sympy
 import torch
 from torch._subclasses import FakeTensorMode
 from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor._collective_utils import pad_tensor, unpad_tensor
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._ops.utils import is_tensor_shardable
 from torch.distributed.tensor.placement_types import (
@@ -17,6 +18,7 @@ from torch.distributed.tensor.placement_types import (
     Replicate,
     Shard,
 )
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import (
     free_symbols,
     free_unbacked_symbols,
@@ -29,6 +31,66 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 # Basic functionality test for Placement types.
 class PlacementTypesTestCase(TestCase):
+    def test_zero_pad_and_unpad_eager_identity(self):
+        tensor = torch.randn(2, 8)
+
+        self.assertIs(pad_tensor(tensor, 0, 0), tensor)
+        self.assertIs(unpad_tensor(tensor, 0, 0), tensor)
+
+    def test_zero_pad_and_unpad_are_recorded_by_make_fx(self):
+        def pad_and_unpad(tensor):
+            return unpad_tensor(pad_tensor(tensor, 0, 0), 0, 0)
+
+        graph = make_fx(pad_and_unpad)(torch.randn(2, 8)).graph
+        call_targets = [
+            node.target for node in graph.nodes if node.op == "call_function"
+        ]
+
+        self.assertEqual(
+            call_targets,
+            [
+                torch.ops.aten.constant_pad_nd.default,
+                torch.ops.aten.slice.Tensor,
+            ],
+        )
+
+    def test_zero_pad_and_unpad_match_positive_size_torch_compile_graphs(self):
+        def capture_ops(fn):
+            graphs = []
+
+            def backend(graph_module, example_inputs):
+                graphs.append(graph_module)
+                return graph_module.forward
+
+            torch.compile(fn, backend=backend, fullgraph=True)(torch.randn(2, 8))
+            self.assertEqual(len(graphs), 1)
+            return [
+                (node.op, node.target)
+                for node in graphs[0].graph.nodes
+                if node.op not in ("placeholder", "output")
+            ]
+
+        def zero_pad(tensor):
+            return pad_tensor(tensor, 0, 0)
+
+        def positive_pad(tensor):
+            return pad_tensor(tensor, 0, 1)
+
+        def zero_unpad(tensor):
+            return unpad_tensor(tensor, 0, 0)
+
+        def positive_unpad(tensor):
+            return unpad_tensor(tensor, 0, 1)
+
+        pad_ops = capture_ops(zero_pad)
+        unpad_ops = capture_ops(zero_unpad)
+        self.assertEqual(pad_ops, capture_ops(positive_pad))
+        self.assertEqual(unpad_ops, capture_ops(positive_unpad))
+        self.assertEqual(len(pad_ops), 1)
+        self.assertEqual(pad_ops[0][0], "call_function")
+        self.assertEqual(pad_ops[0][1].__name__, "pad")
+        self.assertEqual(unpad_ops, [("call_method", "narrow")])
+
     def test_type_identification(self):
         shard = Shard(3)
         strided_shard = _StridedShard(dim=3, split_factor=7)

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -25,6 +25,7 @@ from torch.distributed.distributed_c10d import (
     scatter,
     Work,
 )
+from torch.fx.experimental.proxy_tensor import get_proxy_mode
 from torch.fx.experimental.symbolic_shapes import guard_or_false
 from torch.types import IntLikeType
 
@@ -236,22 +237,20 @@ def mesh_broadcast(
     return broadcast(tensor, group=dim_group, async_op=async_op, group_src=group_src)
 
 
+def _can_skip_zero_size_op(size: IntLikeType) -> bool:
+    # Captured graphs must retain zero-size ops so all ranks have the same structure.
+    if isinstance(size, int):
+        return size == 0 and not (
+            torch.compiler.is_dynamo_compiling() or get_proxy_mode() is not None
+        )
+    return not _are_we_tracing() and guard_or_false(size == 0)
+
+
 @maybe_run_for_local_tensor
 def pad_tensor(
     tensor: torch.Tensor, pad_dim: int, pad_size: IntLikeType
 ) -> torch.Tensor:
-    # During tracing, always emit the pad op even when pad_size=0 so all
-    # ranks produce identical FX graph structure (SPMD).
-    # In eager with concrete pad_size=0, guard_or_false returns True and we
-    # skip the no-op pad. Check _are_we_tracing() first to avoid
-    # guard_or_false creating a guard that concretizes symbolic pad sizes
-    # during make_fx tracing.
-    if isinstance(pad_size, int):
-        # Fast path: avoids _are_we_tracing() which is costly at compile
-        # time due to multiple C++ dispatch mode checks.
-        if pad_size == 0:
-            return tensor
-    elif not _are_we_tracing() and guard_or_false(pad_size == 0):
+    if _can_skip_zero_size_op(pad_size):
         return tensor
     if _are_we_tracing():
         from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
@@ -270,18 +269,7 @@ def pad_tensor(
 def unpad_tensor(
     tensor: torch.Tensor, pad_dim: int, pad_size: IntLikeType
 ) -> torch.Tensor:
-    # During tracing, always emit the narrow op even when pad_size=0 so all
-    # ranks produce identical FX graph structure (SPMD).
-    # In eager with concrete pad_size=0, guard_or_false returns True and we
-    # skip the no-op narrow. Check _are_we_tracing() first to avoid
-    # guard_or_false creating a guard that concretizes symbolic pad sizes
-    # during make_fx tracing.
-    if isinstance(pad_size, int):
-        # Fast path: avoids _are_we_tracing() which is costly at compile
-        # time due to multiple C++ dispatch mode checks.
-        if pad_size == 0:
-            return tensor
-    elif not _are_we_tracing() and guard_or_false(pad_size == 0):
+    if _can_skip_zero_size_op(pad_size):
         return tensor
     return tensor.narrow(
         pad_dim,


### PR DESCRIPTION
Concrete zero-sized padding took the eager identity fast path before checking for graph capture, so ranks with uneven shards could record different graph topologies.

Centralize the eager skip decision while keeping concrete integers off the broader tracing check. Use Dynamo and ProxyTensor capture predicates so an unrelated compiler session in another thread does not change eager behavior.

Test Plan:

```
python test/distributed/tensor/test_placement_types.py -v
python test/distributed/tensor/test_dtensor_compile.py TestDTensorCompile.test_pad_tensor_no_guard_on_symbolic_pad_size -v
```

Authored with assistance from an AI coding assistant.