### PR TITLE
Add distributed transport benchmark

### DIFF
--- a/benchmarks/distributed/transport/README.md
+++ b/benchmarks/distributed/transport/README.md
@@ -1,0 +1,110 @@
+# Transport benchmark
+
+Install the optional backend package matching the operation:
+
+```bash
+uv pip install "ibverbs[gpunetio-triton]"
+uv pip install "ucxx-cu12==0.51.1"  # use ucxx-cu13 with CUDA 13
+```
+
+GPUNetIO needs `doca-sdk-gpunetio`, `doca-sdk-gpunetio-devel`, and ibverbs
+bitcode ABI 2 or newer. The measurements below used rdma4py commit `22cf83d`;
+until that change is released, install its `ibverbs/` package from a checkout.
+Build and cache its device bitcode once:
+
+```bash
+python -c "from ibverbs.gpunetio import build_bitcode; print(build_bitcode(arch='sm_90'))"
+```
+
+Run one rank per host with `torchrun`. `--options` accepts one backend option
+object per rank. `--interfaces` records physical byte counters and rejects
+throughput below 80% of link rate by default.
+
+```bash
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True torchrun \
+  --nnodes=2 --nproc-per-node=1 --node-rank="$NODE_RANK" \
+  --master-addr="$MASTER_ADDR" --master-port=29500 \
+  benchmarks/distributed/transport/benchmark.py \
+  --backend ibverbs --interfaces "$INTERFACE" \
+  --options="{\"hca\":\"$HCA\",\"num_qps\":4}"
+```
+
+Use `--device cpu --backend tcp` for frontend-NIC testing. Set each rank's
+`host` in `--options` to the address of the interface under test.
+
+Add `--cuda-graph` to capture one write and one read and benchmark graph
+replay. The `ibverbs` backend also needs `"cuda_graph":true` in each rank's
+options to select GPUNetIO.
+
+## UCXX transports
+
+Force TCP so same-host tests do not silently use shared memory:
+
+```bash
+UCX_TLS=tcp,cuda_copy UCX_NET_DEVICES=eth0 \
+UCX_SOCKADDR_TLS_PRIORITY=tcp UCX_PROTO_INFO=y torchrun \
+  --nnodes=2 --nproc-per-node=1 --node-rank="$NODE_RANK" \
+  --master-addr="$MASTER_ADDR" --master-port=29500 \
+  benchmarks/distributed/transport/benchmark.py \
+  --backend ucxx --interfaces "$INTERFACE" \
+  --options="{\"host\":\"$LOCAL_IPV4\"}"
+```
+
+The `ucxx-cu12` and `ucxx-cu13` wheels bundle UCX without verbs. To use RC,
+provide UCX 1.19 or newer built with CUDA, verbs, and RDMA-CM, then run:
+
+```bash
+RAPIDS_LIBUCX_PREFER_SYSTEM_LIBRARY=true \
+UCX_TLS=rc,cuda_copy UCX_NET_DEVICES=mlx5_0:1 \
+UCX_SOCKADDR_TLS_PRIORITY=tcp UCX_PROTO_INFO=y torchrun \
+  --nnodes=2 --nproc-per-node=1 --node-rank="$NODE_RANK" \
+  --master-addr="$MASTER_ADDR" --master-port=29500 \
+  benchmarks/distributed/transport/benchmark.py \
+  --backend ucxx --interfaces "$INTERFACE" \
+  --options="{\"host\":\"$LOCAL_IPV4\"}"
+```
+
+Omit `cuda_copy` for CPU-only runs. `UCX_PROTO_INFO=y` reports the selected
+data path.
+
+## Benchmark report
+
+Measured 2026-09-01 on one host with two H100 GPUs and two directly attached
+400 Gb/s ConnectX-7 ports (`GPU0/mlx5_0/beth3` and
+`GPU1/mlx5_3/beth4`). The environment used DOCA 3.4.0112, Triton 3.8.0,
+ibverbs 0.1.0 at `22cf83d`, UCXX-cu12 0.51.1, and CUDA 12.8. Results are
+medians for 64 MiB transfers.
+
+| Backend | Mode | Write | Read | Result |
+|---|---|---:|---:|---|
+| rdma4py | host-posted, 4 QPs | 381.4 Gb/s | 381.0 Gb/s | 95% application rate |
+| rdma4py GPUNetIO | eager, 4 QPs | 368.7 Gb/s | 370.2 Gb/s | 92% application rate |
+| rdma4py GPUNetIO | CUDA graph, 4 QPs | 381.5 Gb/s | 382.7 Gb/s | 95% application rate |
+| TCP | CPU, 16 flows, loopback | 224.2 Gb/s | 249.6 Gb/s | host-only |
+| TCP | CUDA staging, 16 flows, loopback | 13.3 Gb/s | 13.2 Gb/s | host-only |
+| UCXX TCP | CPU, forced TCP loopback | 45.4 Gb/s | 41.3 Gb/s | host-only |
+| UCXX TCP | CUDA, forced TCP loopback | 3.6 Gb/s | 3.6 Gb/s | host-only |
+
+The graph run's directional NIC counters measured 384.0/387.8 Gb/s. A
+604-completion-per-QP graph test crossed the 256-entry CQ twice without a hang;
+at 1 MiB it reached 174.9/179.0 Gb/s and wire throughput matched payload
+throughput.
+
+Physical TCP and UCXX-RC bandwidth were not measurable on this single host:
+its data interfaces expose only IPv6 while UCXX 0.51 creates an IPv4 listener,
+and local addresses route through the host instead of the NIC. System UCX with
+the verbs plugins exposed `rc_verbs`; GPU RC additionally needs a combined
+CUDA+verbs UCX build. The torchcomms RDMA extension was unavailable.
+
+The exact same-host report commands were:
+
+```bash
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True .venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend ibverbs --device cuda --sizes 67108864 --warmup 5 --iterations 20 --interfaces beth3,beth4 --options='[{"hca":"mlx5_0","num_qps":4},{"hca":"mlx5_3","num_qps":4}]'
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True .venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend ibverbs --device cuda --sizes 67108864 --warmup 5 --iterations 20 --interfaces beth3,beth4 --options='[{"hca":"mlx5_0","num_qps":4,"cuda_graph":true},{"hca":"mlx5_3","num_qps":4,"cuda_graph":true}]'
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True .venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend ibverbs --device cuda --sizes 67108864 --warmup 5 --iterations 20 --cuda-graph --interfaces beth3,beth4 --options='[{"hca":"mlx5_0","num_qps":4,"cuda_graph":true},{"hca":"mlx5_3","num_qps":4,"cuda_graph":true}]'
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True .venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend ibverbs --device cuda --sizes 1048576 --warmup 2 --iterations 300 --cuda-graph --minimum-line-rate 0 --interfaces beth3,beth4 --options='[{"hca":"mlx5_0","num_qps":4,"cuda_graph":true},{"hca":"mlx5_3","num_qps":4,"cuda_graph":true}]'
+.venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend tcp --device cpu --sizes 67108864 --warmup 2 --iterations 10 --minimum-line-rate 0 --options='{"host":"127.0.0.1","num_flows":16}'
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True .venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend tcp --device cuda --sizes 67108864 --warmup 1 --iterations 3 --minimum-line-rate 0 --options='{"host":"127.0.0.1","num_flows":16}'
+UCX_TLS=tcp UCX_SOCKADDR_TLS_PRIORITY=tcp .venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend ucxx --device cpu --sizes 67108864 --warmup 2 --iterations 10 --minimum-line-rate 0 --options='{"host":"127.0.0.1"}'
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True UCX_TLS=tcp,cuda_copy UCX_SOCKADDR_TLS_PRIORITY=tcp .venv/bin/torchrun --standalone --nproc-per-node=2 benchmarks/distributed/transport/benchmark.py --backend ucxx --device cuda --sizes 67108864 --warmup 2 --iterations 10 --minimum-line-rate 0 --options='{"host":"127.0.0.1"}'
+```

--- a/benchmarks/distributed/transport/benchmark.py
+++ b/benchmarks/distributed/transport/benchmark.py
@@ -1,0 +1,297 @@
+"""Measure a transport between two torchrun ranks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+from torch.distributed._transport import new_transport
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _parse_sizes(value: str) -> list[int]:
+    sizes = [int(size) for size in value.split(",")]
+    if not sizes or any(size <= 0 for size in sizes):
+        raise argparse.ArgumentTypeError("sizes must be positive")
+    return sizes
+
+
+def _device(args: argparse.Namespace) -> torch.device:
+    if args.device == "cuda":
+        return torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    return torch.device(args.device)
+
+
+def _sync(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _line_rate_gbps(interface: str | None) -> float | None:
+    if interface is None:
+        return None
+    try:
+        return int(Path(f"/sys/class/net/{interface}/speed").read_text()) / 1000
+    except (OSError, ValueError):
+        return None
+
+
+def _interface(args: argparse.Namespace) -> str | None:
+    if args.interfaces is None:
+        return None
+    interfaces = args.interfaces.split(",")
+    if len(interfaces) not in (1, 2):
+        raise ValueError("interfaces must name one interface or one per rank")
+    rank = int(os.environ["RANK"])
+    return interfaces[min(rank, len(interfaces) - 1)]
+
+
+def _rdma_wire_bytes(interface: str) -> tuple[int, int] | None:
+    devices = list(Path(f"/sys/class/net/{interface}/device/infiniband").glob("*"))
+    if len(devices) != 1:
+        return None
+    counters = devices[0] / "ports/1/counters"
+    try:
+        return (
+            int((counters / "port_xmit_data").read_text()) * 4,
+            int((counters / "port_rcv_data").read_text()) * 4,
+        )
+    except (OSError, ValueError):
+        return None
+
+
+def _wire_bytes(interface: str | None, backend: str) -> tuple[int, int] | None:
+    if interface is None:
+        return None
+    if backend == "ibverbs" and (counters := _rdma_wire_bytes(interface)) is not None:
+        return counters
+    root = Path(f"/sys/class/net/{interface}/statistics")
+    try:
+        return int((root / "tx_bytes").read_text()), int(
+            (root / "rx_bytes").read_text()
+        )
+    except (OSError, ValueError):
+        return None
+
+
+def _wire_rate(
+    before: tuple[int, int] | None,
+    after: tuple[int, int] | None,
+    seconds: float,
+) -> dict[str, float] | None:
+    if before is None or after is None:
+        return None
+    return {
+        "tx_gbps": (after[0] - before[0]) * 8 / seconds / 1e9,
+        "rx_gbps": (after[1] - before[1]) * 8 / seconds / 1e9,
+    }
+
+
+def _exchange(value: Any) -> Any:
+    values = [None, None]
+    dist.all_gather_object(values, value)
+    return values[1 - dist.get_rank()]
+
+
+def run(args: argparse.Namespace) -> list[dict[str, Any]]:
+    dist.init_process_group("gloo")
+    if dist.get_world_size() != 2:
+        raise RuntimeError("transport benchmark requires exactly two ranks")
+    rank = dist.get_rank()
+    device = _device(args)
+    if args.cuda_graph and device.type != "cuda":
+        raise ValueError("--cuda-graph requires --device cuda")
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+    options = json.loads(args.options)
+    if isinstance(options, list):
+        if len(options) != 2:
+            raise ValueError("rank-specific options must contain two objects")
+        options = options[rank]
+    if not isinstance(options, dict):
+        raise ValueError("options must be an object or a two-element list")
+    interface = _interface(args)
+    transport = new_transport(args.backend, device, **options)
+    results = []
+    try:
+        peer_url = _exchange(transport.bind())
+        if transport.connect(peer_url) != 0:
+            raise RuntimeError("transport connection failed")
+        for size in args.sizes:
+            source = torch.full((size,), rank + 1, dtype=torch.uint8, device=device)
+            destination = torch.zeros_like(source)
+            read_target = torch.zeros_like(source)
+            source_memory = transport.register_memory(source)
+            destination_memory = transport.register_memory(destination)
+            read_memory = transport.register_memory(read_target)
+            peer_source = _exchange(source_memory.to_remote_buffer())
+            peer_destination = _exchange(destination_memory.to_remote_buffer())
+            _sync(device)
+            source_view = source_memory.to_view()
+            read_view = read_memory.to_mutable_view()
+
+            def write() -> None:
+                if transport.write(source_view, peer_destination) != 0:
+                    raise RuntimeError("write failed")
+
+            def read() -> None:
+                if transport.read(read_view, peer_source) != 0:
+                    raise RuntimeError("read failed")
+
+            for _ in range(args.warmup):
+                if rank == 0:
+                    write()
+                    read()
+            _sync(device)
+            write_op: Callable[[], None] = write
+            read_op: Callable[[], None] = read
+            if rank == 0 and args.cuda_graph:
+                write_graph = torch.cuda.CUDAGraph()
+                read_graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(write_graph):
+                    write()
+                with torch.cuda.graph(read_graph):
+                    read()
+                write_op = write_graph.replay
+                read_op = read_graph.replay
+                _sync(device)
+            source.fill_(rank + 3)
+            destination.zero_()
+            read_target.zero_()
+            _sync(device)
+            dist.barrier()
+            write_wire_before = _wire_bytes(interface, args.backend)
+            write_start = time.perf_counter_ns()
+            write_samples = []
+            read_samples = []
+            if rank == 0:
+                for _ in range(args.iterations):
+                    start = time.perf_counter_ns()
+                    write_op()
+                    _sync(device)
+                    write_samples.append(time.perf_counter_ns() - start)
+            dist.barrier()
+            write_seconds = (time.perf_counter_ns() - write_start) / 1e9
+            write_wire = _wire_rate(
+                write_wire_before,
+                _wire_bytes(interface, args.backend),
+                write_seconds,
+            )
+            peer_write_wire = _exchange(write_wire)
+
+            read_wire_before = _wire_bytes(interface, args.backend)
+            read_start = time.perf_counter_ns()
+            if rank == 0:
+                for _ in range(args.iterations):
+                    start = time.perf_counter_ns()
+                    read_op()
+                    _sync(device)
+                    read_samples.append(time.perf_counter_ns() - start)
+            dist.barrier()
+            read_seconds = (time.perf_counter_ns() - read_start) / 1e9
+            read_wire = _wire_rate(
+                read_wire_before,
+                _wire_bytes(interface, args.backend),
+                read_seconds,
+            )
+            peer_read_wire = _exchange(read_wire)
+            _sync(device)
+            if rank == 1:
+                torch.testing.assert_close(destination, torch.full_like(destination, 3))
+            if rank == 0:
+                torch.testing.assert_close(read_target, torch.full_like(read_target, 4))
+                write_seconds = statistics.median(write_samples) / 1e9
+                read_seconds = statistics.median(read_samples) / 1e9
+                results.append(
+                    {
+                        "size_bytes": size,
+                        "write_latency_us": write_seconds * 1e6,
+                        "write_bandwidth_gbps": size * 8 / write_seconds / 1e9,
+                        "read_latency_us": read_seconds * 1e6,
+                        "read_bandwidth_gbps": size * 8 / read_seconds / 1e9,
+                        "write_local_wire": write_wire,
+                        "write_peer_wire": peer_write_wire,
+                        "read_local_wire": read_wire,
+                        "read_peer_wire": peer_read_wire,
+                    }
+                )
+    finally:
+        transport.close()
+        dist.destroy_process_group()
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", required=True)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument(
+        "--interfaces", help="network interface, or a comma-separated pair"
+    )
+    parser.add_argument(
+        "--options",
+        default="{}",
+        help="backend options as JSON, optionally one object per rank",
+    )
+    parser.add_argument(
+        "--sizes",
+        type=_parse_sizes,
+        default=_parse_sizes("8,4096,1048576,67108864"),
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--cuda-graph", action="store_true")
+    parser.add_argument("--minimum-line-rate", type=float, default=0.8)
+    args = parser.parse_args()
+    if args.warmup < 0 or args.iterations <= 0:
+        parser.error("warmup must be nonnegative and iterations must be positive")
+    if not 0 <= args.minimum_line_rate <= 1:
+        parser.error("minimum-line-rate must be between zero and one")
+    return args
+
+
+if __name__ == "__main__":
+    parsed = parse_args()
+    measurements = run(parsed)
+    if int(os.environ["RANK"]) == 0:
+        output = {
+            "backend": parsed.backend,
+            "interfaces": parsed.interfaces,
+            "line_rate_gbps": _line_rate_gbps(_interface(parsed)),
+            "results": measurements,
+        }
+        print(json.dumps(output, indent=2))
+        if output["line_rate_gbps"] is not None and parsed.minimum_line_rate:
+            rates = []
+            for result in measurements:
+                write_local = result["write_local_wire"]
+                write_peer = result["write_peer_wire"]
+                read_local = result["read_local_wire"]
+                read_peer = result["read_peer_wire"]
+                if None in (write_local, write_peer, read_local, read_peer):
+                    raise RuntimeError("physical NIC counters are unavailable")
+                rates.append(
+                    min(
+                        result["write_bandwidth_gbps"],
+                        result["read_bandwidth_gbps"],
+                        write_local["tx_gbps"],
+                        write_peer["rx_gbps"],
+                        read_local["rx_gbps"],
+                        read_peer["tx_gbps"],
+                    )
+                )
+            achieved = max(rates)
+            if achieved < parsed.minimum_line_rate * output["line_rate_gbps"]:
+                raise RuntimeError(
+                    f"{achieved:.1f} Gb/s is below {parsed.minimum_line_rate:.0%} of line rate"
+                )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #197148
* #195648
* __->__ #195647
* #195646
* #195645
* #195644
* #197032
* #195643

User request: "can you add async support via Work objects to the transport API? amend commits and push"

> Authored with an AI assistant.
>
> Measure transport latency, payload throughput, and directional NIC counters, validating transferred data and checking line rate. Document backend setup and physical measurements.
>
> Test plan:
>
> ```bash
> uv run --no-sync spin quicklint -- -a --skip CLANGTIDY
> uv run --no-sync python benchmarks/distributed/transport/benchmark.py --help
> ```
>
> Benchmark CLI passed; distributed execution is exercised by the benchmark update above this PR.