### PR TITLE
[Feature Refactoring] Generalize jit validate_map_location to all device types

### DIFF
--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -9,11 +9,13 @@ from typing import NamedTuple, Optional
 
 import torch
 from torch import Tensor
+from torch.jit._serialization import validate_map_location
 from torch.testing._internal.common_cuda import SM120OrLater
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     raise_on_run_directly,
     skipIfTorchDynamo,
+    TEST_CUDA,
     TemporaryFileName,
 )
 
@@ -608,6 +610,77 @@ class TestSaveLoad(JitTestCase):
         self.assertTrue(m_loaded_params["bar.weight"].is_cpu)
         self.assertTrue(m_params["bar.bias"].is_cpu)
         self.assertTrue(m_loaded_params["bar.bias"].is_cpu)
+
+    def test_validate_map_location_fast_path(self):
+        # None and cpu targets skip device validation and return unchanged.
+        self.assertIsNone(validate_map_location(None))
+        self.assertEqual(validate_map_location("cpu"), torch.device("cpu"))
+        self.assertEqual(
+            validate_map_location(torch.device("cpu:0")), torch.device("cpu:0")
+        )
+
+    def test_validate_map_location_meta_passthrough(self):
+        # Devices without a registered torch.<type> module (e.g. meta) keep
+        # the previous pass-through behavior: no availability/index checks.
+        self.assertFalse(hasattr(torch, "meta"))
+        dev = torch.device("meta")
+        self.assertEqual(validate_map_location(dev), dev)
+        self.assertEqual(validate_map_location("meta"), torch.device("meta"))
+
+    def test_validate_map_location_invalid_type(self):
+        with self.assertRaisesRegex(ValueError, "map_location should be either None"):
+            validate_map_location(123)
+
+    def test_validate_map_location_non_cuda_device_validation(self):
+        # Verify the generalized validation path (the core of this change)
+        # is taken for non-cuda device types: attach a fake module for a
+        # valid but usually-unregistered device type and confirm
+        # _validate_device raises on both the is_available and
+        # device_count checks.
+        backend = "hpu"
+        had_module = hasattr(torch, backend)
+        orig_module = getattr(torch, backend, None)
+
+        class UnavailableModule:
+            @staticmethod
+            def is_available():
+                return False
+
+            @staticmethod
+            def device_count():
+                return 0
+
+        class AvailableModule:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def device_count():
+                return 0
+
+        try:
+            setattr(torch, backend, UnavailableModule)
+            with self.assertRaisesRegex(RuntimeError, "is_available"):
+                validate_map_location(torch.device(f"{backend}:0"))
+
+            setattr(torch, backend, AvailableModule)
+            with self.assertRaisesRegex(RuntimeError, "device_count"):
+                validate_map_location(torch.device(f"{backend}:5"))
+        finally:
+            if had_module:
+                setattr(torch, backend, orig_module)
+            else:
+                delattr(torch, backend)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_validate_map_location_cuda_invalid_index(self):
+        # Regression guard for the previously cuda-only path, now routed
+        # through the generic _validate_device: an out-of-range cuda index
+        # must raise RuntimeError.
+        invalid_idx = torch.cuda.device_count()
+        with self.assertRaisesRegex(RuntimeError, "device_count"):
+            validate_map_location(torch.device(f"cuda:{invalid_idx}"))
 
     def test_save_load_with_saved_traced_inputs(self):
         """

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 from pathlib import Path
 from typing import NamedTuple, Optional
+from unittest.mock import patch
 
 import torch
 from torch import Tensor
@@ -15,8 +16,8 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     raise_on_run_directly,
     skipIfTorchDynamo,
-    TEST_CUDA,
     TemporaryFileName,
+    TEST_CUDA,
 )
 
 
@@ -619,13 +620,14 @@ class TestSaveLoad(JitTestCase):
             validate_map_location(torch.device("cpu:0")), torch.device("cpu:0")
         )
 
-    def test_validate_map_location_meta_passthrough(self):
-        # Devices without a registered torch.<type> module (e.g. meta) keep
-        # the previous pass-through behavior: no availability/index checks.
-        self.assertFalse(hasattr(torch, "meta"))
+    def test_validate_map_location_unregistered_device_module_passthrough(self):
+        # Preserve the existing pass-through behavior when torch.<device>
+        # does not provide a module that can validate availability and indices.
         dev = torch.device("meta")
-        self.assertEqual(validate_map_location(dev), dev)
-        self.assertEqual(validate_map_location("meta"), torch.device("meta"))
+        with patch("torch.jit._serialization._validate_device") as mock_validate:
+            self.assertEqual(validate_map_location(dev), dev)
+            self.assertEqual(validate_map_location("meta"), dev)
+        mock_validate.assert_not_called()
 
     def test_validate_map_location_invalid_type(self):
         with self.assertRaisesRegex(ValueError, "map_location should be either None"):

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -17,7 +17,7 @@ import torch
 from torch._jit_internal import _get_model_id
 from torch._utils_internal import log_torchscript_usage
 from torch.jit._recursive import wrap_cpp_module
-from torch.serialization import validate_cuda_device
+from torch.serialization import _validate_device
 
 
 def save(m, f, _extra_files=None) -> None:
@@ -222,8 +222,12 @@ def validate_map_location(map_location=None):
             "but got type: " + str(type(map_location))
         )
 
-    if str(map_location).startswith("cuda"):
-        validate_cuda_device(map_location)
+    if (
+        map_location is not None
+        and map_location.type != "cpu"
+        and hasattr(torch, map_location.type)
+    ):
+        _validate_device(map_location, map_location.type)
 
     return map_location
 


### PR DESCRIPTION
## Summary
- Generalize `validate_map_location` in `torch/jit/_serialization.py` to validate any device type instead of hardcoding `cuda`, via the device-agnostic `torch.serialization._validate_device`.
- Fast path: `None` and `cpu` return immediately without validation.
- Devices without a `torch.<type>` module (e.g. `meta`) keep pass-through behavior, same as before.

## Motivation / evidence
- Old code string-matched the `"cuda"` prefix and called `validate_cuda_device`, so `map_location` targeting other accelerators (`xpu`, `mps`, `mtia`, renamed `privateuse1` backends, ...) silently skipped availability and index checks, surfacing later as opaque deserialization errors.
- `_validate_device` already implements generic `is_available`/`device_count` checks; `privateuse1` needs no special-casing since `device.type` reports the registered backend name.

## Test Plan
- `python -m py_compile torch/jit/_serialization.py`
- Mock-based path checks: `None`, `cpu`, `cpu:0`, `cuda:1`, `xpu`, `mps:0`, `meta` pass-through, and invalid type raising `ValueError`. (Repo not built locally, so jit/serialization suites were not run.)

