### PR TITLE
Accept NumPy dtypes in `torch._numpy.dtype` / `astype`

### DIFF
--- a/test/torch_np/test_dtype.py
+++ b/test/torch_np/test_dtype.py
@@ -65,6 +65,19 @@ class TestConvertDType(TestCase):
         if empty.dtype != tnp.float32:
             raise AssertionError(f"Expected float32, got {empty.dtype}")
 
+    def test_non_numpy_dtype_name_lookalike_raises(self):
+        class float32:
+            pass
+
+        with self.assertRaises(TypeError):
+            tnp.dtype(float32)
+
+        class _Lookalike:
+            name = "float32"
+
+        with self.assertRaises(TypeError):
+            tnp.dtype(_Lookalike())
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/torch_np/test_dtype.py
+++ b/test/torch_np/test_dtype.py
@@ -1,7 +1,5 @@
 # Owner(s): ["module: dynamo"]
 
-from unittest import expectedFailure as xfail
-
 import numpy
 
 import torch._numpy as tnp
@@ -24,22 +22,15 @@ dtype_names = [
 
 np_dtype_params = [
     subtest(("bool", "bool"), name="bool"),
-    subtest(
-        ("bool", numpy.dtype("bool")),
-        name="numpy_dtype('bool')",
-        decorators=[xfail],  # reason="XXX: np.dtype() objects not supported"),
-    ),
+    subtest(("bool", numpy.dtype("bool")), name="numpy_dtype('bool')"),
 ]
 
 
 for name in dtype_names:
     np_dtype_params.append(subtest((name, name), name=repr(name)))
-
+    np_dtype_params.append(subtest((name, getattr(numpy, name)), name=f"numpy_{name}"))
     np_dtype_params.append(
-        subtest((name, getattr(numpy, name)), name=f"numpy_{name}", decorators=[xfail])
-    )  # numpy namespaced dtypes not supported
-    np_dtype_params.append(
-        subtest((name, numpy.dtype(name)), name=f"numpy_{name!r}", decorators=[xfail])
+        subtest((name, numpy.dtype(name)), name=f"numpy_{name!r}")
     )
 
 
@@ -63,6 +54,16 @@ class TestConvertDType(TestCase):
                 raise AssertionError(
                     f"Expected tnp_dtype.name == '{name}', got '{tnp_dtype.name}'"
                 )
+
+    def test_astype_accepts_numpy_dtype(self):
+        x = tnp.arange(4)
+        y = x.astype(tnp.float32)
+        z = x.astype(numpy.float32)
+        if y.dtype != z.dtype:
+            raise AssertionError(f"Expected matching dtypes, got {y.dtype} vs {z.dtype}")
+        empty = tnp.empty((1, 1), dtype=numpy.float32)
+        if empty.dtype != tnp.float32:
+            raise AssertionError(f"Expected float32, got {empty.dtype}")
 
 
 if __name__ == "__main__":

--- a/torch/_numpy/_dtypes.py
+++ b/torch/_numpy/_dtypes.py
@@ -5,6 +5,7 @@ Define the scalar types and supported dtypes and numpy <--> torch dtype mappings
 from __future__ import annotations
 
 import builtins
+import sys
 from typing import TYPE_CHECKING, TypeGuard, TypeVar
 
 import torch
@@ -277,6 +278,19 @@ def sctype_from_torch_dtype(torch_dtype: torch.dtype) -> type[generic]:
     return _torch_dtypes[torch_dtype]
 
 
+def _sctype_from_numpy_arg(arg: object) -> type[generic] | None:
+    np = sys.modules.get("numpy")
+    if np is None:
+        return None
+    # np.float32 / np.bool_ / etc.
+    if isinstance(arg, type) and issubclass(arg, np.generic):
+        return sctype_from_string(arg.__name__)
+    # np.dtype("float32")
+    if isinstance(arg, np.dtype):
+        return sctype_from_string(arg.name)
+    return None
+
+
 # ### DTypes. ###
 
 
@@ -304,17 +318,9 @@ class DType:
         elif hasattr(arg, "dtype") and isinstance(arg.dtype, DType):
             sctype = arg.dtype._scalar_type
         else:
-            # numpy scalar types are classes (np.float32.__name__);
-            # numpy.dtype objects expose .name ("float32").
-            if isinstance(arg, type):
-                name = getattr(arg, "__name__", None)
-            else:
-                name = getattr(arg, "name", None)
-            if isinstance(name, str):
-                try:
-                    sctype = sctype_from_string(name)
-                except TypeError:
-                    sctype = sctype_from_string(arg)
+            numpy_sctype = _sctype_from_numpy_arg(arg)
+            if numpy_sctype is not None:
+                sctype = numpy_sctype
             else:
                 sctype = sctype_from_string(arg)
         self._scalar_type = sctype

--- a/torch/_numpy/_dtypes.py
+++ b/torch/_numpy/_dtypes.py
@@ -301,11 +301,22 @@ class DType:
         # a dtype already?
         elif isinstance(arg, DType):
             sctype = arg._scalar_type
-        # a has a right attribute?
-        elif hasattr(arg, "dtype"):
+        elif hasattr(arg, "dtype") and isinstance(arg.dtype, DType):
             sctype = arg.dtype._scalar_type
         else:
-            sctype = sctype_from_string(arg)
+            # numpy scalar types are classes (np.float32.__name__);
+            # numpy.dtype objects expose .name ("float32").
+            if isinstance(arg, type):
+                name = getattr(arg, "__name__", None)
+            else:
+                name = getattr(arg, "name", None)
+            if isinstance(name, str):
+                try:
+                    sctype = sctype_from_string(name)
+                except TypeError:
+                    sctype = sctype_from_string(arg)
+            else:
+                sctype = sctype_from_string(arg)
         self._scalar_type = sctype
 
     @property


### PR DESCRIPTION
Fixes #139281

`DType` treated any object with a `.dtype` attribute as a `torch._numpy` `DType`. NumPy scalar types such as `np.float32` expose a descriptor there, so `astype(np.float32)` and `empty(..., dtype=np.float32)` raised `AttributeError`. Map NumPy scalar types via `__name__` and `numpy.dtype` objects via `.name`.

The existing xfailed cases in `test/torch_np/test_dtype.py` now run, plus a repro for the original `astype` / `empty` report.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```bash
python test/torch_np/test_dtype.py
```

cc @mruberry @rgommers