### PR TITLE
Generate a causal mask when MHA `is_causal=True` and `need_weights=True`

### DIFF
--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -970,6 +970,48 @@ class TestMultiheadAttentionNNDeviceType(NNTestCase):
         self.assertEqual(out_auto, out_sdpa)
         self.assertIsNone(w_sdpa)
 
+    def test_multihead_attention_is_causal_need_weights_static_k_len(self, device):
+        # static_k sequence length can differ from key.shape[0]; the implicit
+        # causal mask must be built from the final k length, not the original key.
+        embed_dim = 8
+        num_heads = 2
+        head_dim = embed_dim // num_heads
+        tgt_len, key_len, static_len, bsz = 4, 3, 5, 2
+        mha = nn.MultiheadAttention(embed_dim, num_heads, device=device)
+        q = torch.randn(tgt_len, bsz, embed_dim, device=device)
+        key = torch.randn(key_len, bsz, embed_dim, device=device)
+        value = torch.randn(key_len, bsz, embed_dim, device=device)
+        static_k = torch.randn(bsz * num_heads, static_len, head_dim, device=device)
+        static_v = torch.randn(bsz * num_heads, static_len, head_dim, device=device)
+
+        out, w = torch.nn.functional.multi_head_attention_forward(
+            q,
+            key,
+            value,
+            embed_dim,
+            num_heads,
+            mha.in_proj_weight,
+            mha.in_proj_bias,
+            mha.bias_k,
+            mha.bias_v,
+            mha.add_zero_attn,
+            mha.dropout,
+            mha.out_proj.weight,
+            mha.out_proj.bias,
+            training=False,
+            need_weights=True,
+            static_k=static_k,
+            static_v=static_v,
+            is_causal=True,
+        )
+        self.assertEqual(out.shape, (tgt_len, bsz, embed_dim))
+        self.assertEqual(w.shape, (bsz, tgt_len, static_len))
+        future = torch.triu(
+            torch.ones(tgt_len, static_len, dtype=torch.bool, device=device),
+            diagonal=1,
+        )
+        self.assertEqual(w[:, future], torch.zeros_like(w[:, future]))
+
     @dtypes(torch.double)
     @torch.no_grad()
     def test_multihead_attn_in_proj_bias_none(self, device, dtype):

--- a/test/nn/test_multihead_attention.py
+++ b/test/nn/test_multihead_attention.py
@@ -951,6 +951,25 @@ class TestMultiheadAttentionNNDeviceType(NNTestCase):
         pad_mask[..., 0] = True
         encoder(x, mask=None, src_key_padding_mask=pad_mask)
 
+    def test_multihead_attention_is_causal_need_weights(self, device):
+        embed_dim = 8
+        num_heads = 2
+        sl, bs = 4, 3
+        mha = nn.MultiheadAttention(embed_dim, num_heads, device=device)
+        q = torch.randn(sl, bs, embed_dim, device=device)
+        causal_mask = nn.Transformer.generate_square_subsequent_mask(
+            sl, device=device, dtype=q.dtype
+        )
+
+        out_auto, w_auto = mha(q, q, q, is_causal=True, need_weights=True)
+        out_mask, w_mask = mha(q, q, q, attn_mask=causal_mask, need_weights=True)
+        self.assertEqual(out_auto, out_mask)
+        self.assertEqual(w_auto, w_mask)
+
+        out_sdpa, w_sdpa = mha(q, q, q, is_causal=True, need_weights=False)
+        self.assertEqual(out_auto, out_sdpa)
+        self.assertIsNone(w_sdpa)
+
     @dtypes(torch.double)
     @torch.no_grad()
     def test_multihead_attn_in_proj_bias_none(self, device, dtype):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6846,15 +6846,13 @@ def multi_head_attention_forward(
         target_type=query.dtype,
     )
 
-    if is_causal and attn_mask is None:
-        # SDPA can take the is_causal hint directly. The need_weights and
-        # key_padding_mask paths merge into an explicit attn_mask, so
-        # materialize a causal mask for those.
-        if need_weights or key_padding_mask is not None:
-            attn_mask = torch.triu(
-                query.new_ones((tgt_len, src_len), dtype=torch.bool),
-                diagonal=1,
-            )
+    # SDPA can take the is_causal hint directly. The need_weights and
+    # key_padding_mask paths merge into an explicit attn_mask; defer
+    # creating it until after static_k / add_zero_attn so src_len is final.
+    # Save the flag now: is_causal is later set to False when a kpm is present.
+    need_implicit_causal_mask = (
+        is_causal and attn_mask is None and (need_weights or key_padding_mask is not None)
+    )
 
     if is_causal and key_padding_mask is None and not need_weights:
         # when we have a kpm or need weights, we need attn_mask
@@ -7038,6 +7036,21 @@ def multi_head_attention_forward(
 
     # update source sequence length after adjustments
     src_len = k.size(1)
+
+    if need_implicit_causal_mask:
+        attn_mask = torch.triu(
+            query.new_ones((tgt_len, src_len), dtype=torch.bool),
+            diagonal=1,
+        )
+        attn_mask = _canonical_mask(
+            mask=attn_mask,
+            mask_name="attn_mask",
+            other_type=None,
+            other_name="",
+            target_type=query.dtype,
+            check_other=False,
+        )
+        attn_mask = attn_mask.unsqueeze(0)  # match the existing 2D -> (1, L, S) path
 
     # merge key padding and attention masks
     if key_padding_mask is not None:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6847,11 +6847,14 @@ def multi_head_attention_forward(
     )
 
     if is_causal and attn_mask is None:
-        raise RuntimeError(
-            "Need attn_mask if specifying the is_causal hint. "
-            "You may use the Transformer module method "
-            "`generate_square_subsequent_mask` to create this mask."
-        )
+        # SDPA can take the is_causal hint directly. The need_weights and
+        # key_padding_mask paths merge into an explicit attn_mask, so
+        # materialize a causal mask for those.
+        if need_weights or key_padding_mask is not None:
+            attn_mask = torch.triu(
+                query.new_ones((tgt_len, src_len), dtype=torch.bool),
+                diagonal=1,
+            )
 
     if is_causal and key_padding_mask is None and not need_weights:
         # when we have a kpm or need weights, we need attn_mask
@@ -7062,9 +7065,6 @@ def multi_head_attention_forward(
     if need_weights:
         _B, _Nt, E = q.shape
         q_scaled = q * math.sqrt(1.0 / float(E))
-
-        if is_causal and attn_mask is None:
-            raise AssertionError("FIXME: is_causal not implemented for need_weights")
 
         if attn_mask is not None:
             attn_output_weights = torch.baddbmm(


### PR DESCRIPTION
Fixes #172338

`multi_head_attention_forward` required an explicit `attn_mask` whenever `is_causal=True`, and the `need_weights` path still had a FIXME `AssertionError`. Build the upper-triangular mask when weights or a key padding mask force the explicit-mask path, and leave `attn_mask` None so SDPA can use the `is_causal` hint when neither is present.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```bash
python test/nn/test_multihead_attention.py TestMultiheadAttentionNNDeviceTypeCPU.test_multihead_attention_is_causal_need_weights_cpu
```