### PR TITLE
[ROCm] Tune MediumRadixSort items_per_thread for sorts of 129-2048 elements

### DIFF
--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -209,20 +209,33 @@ struct MediumRadixSort {
     TORCH_INTERNAL_ASSERT(ceilPowerOf2 <= 4096);
 #ifdef USE_ROCM
     constexpr int default_ipt = 8;
+    // 4 is faster than 8 on both ROCm architectures measured, but only up to
+    // sort_size 2048. Because fixed_size_sort derives block = sort_size /
+    // items_per_thread, halving this doubles the block, and at sort_size 4096
+    // the resulting 1024-thread block regresses on both boxes -- 0.881x on
+    // gfx1250 and 0.931x on gfx950, 0/8 mirrored pairs each. Hence the split
+    // rather than a replaced constant.
+    //
+    // Measured, mirrored-pair A/B, sort_size 1024 / 2048 / 4096:
+    //   gfx950  (MI350X): 1.328x / 1.020x / 0.931x
+    //   gfx1250 (MI450):  1.140x / 1.069x / 0.881x
+    // See operator_benchmark_shortlist_analysis/sort_operators/.
+    constexpr int small_ipt = 4;
 #else
     constexpr int default_ipt = 32;
+    constexpr int small_ipt = 32;
 #endif
     switch (ceilPowerOf2) {
       case 4096:
-        HANDLE_CASE(4096, default_ipt);
+        HANDLE_CASE(4096, default_ipt);   // block 512, unchanged
         break;
       case 2048:
-        HANDLE_CASE(2048, default_ipt);
+        HANDLE_CASE(2048, small_ipt);     // block 256 -> 512, measured
         break;
       case 1024:
       case 512:
       case 256:
-        HANDLE_CASE(1024, default_ipt);
+        HANDLE_CASE(1024, small_ipt);     // block 128 -> 256, measured
         break;
       case 128:
       case 64:

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -209,33 +209,29 @@ struct MediumRadixSort {
     TORCH_INTERNAL_ASSERT(ceilPowerOf2 <= 4096);
 #ifdef USE_ROCM
     constexpr int default_ipt = 8;
-    // 4 is faster than 8 on both ROCm architectures measured, but only up to
-    // sort_size 2048. Because fixed_size_sort derives block = sort_size /
-    // items_per_thread, halving this doubles the block, and at sort_size 4096
-    // the resulting 1024-thread block regresses on both boxes -- 0.881x on
-    // gfx1250 and 0.931x on gfx950, 0/8 mirrored pairs each. Hence the split
-    // rather than a replaced constant.
-    //
-    // Measured, mirrored-pair A/B, sort_size 1024 / 2048 / 4096:
-    //   gfx950  (MI350X): 1.328x / 1.020x / 0.931x
-    //   gfx1250 (MI450):  1.140x / 1.069x / 0.881x
-    // See operator_benchmark_shortlist_analysis/sort_operators/.
+    // fixed_size_sort derives block = sort_size / items_per_thread, so halving
+    // this doubles the block. 4 measures faster than 8 up to sort_size 2048,
+    // but at 4096 the resulting 1024-thread block regresses; hence the split
+    // rather than a replaced constant. ROCm blocks: 4096 -> 512 (unchanged),
+    // 2048 -> 512 (was 256), 1024 -> 256 (was 128).
     constexpr int small_ipt = 4;
 #else
     constexpr int default_ipt = 32;
-    constexpr int small_ipt = 32;
+    // Equal by construction, so every HANDLE_CASE below instantiates the same
+    // templates as before on CUDA.
+    constexpr int small_ipt = default_ipt;
 #endif
     switch (ceilPowerOf2) {
       case 4096:
-        HANDLE_CASE(4096, default_ipt);   // block 512, unchanged
+        HANDLE_CASE(4096, default_ipt);
         break;
       case 2048:
-        HANDLE_CASE(2048, small_ipt);     // block 256 -> 512, measured
+        HANDLE_CASE(2048, small_ipt);
         break;
       case 1024:
       case 512:
       case 256:
-        HANDLE_CASE(1024, small_ipt);     // block 128 -> 256, measured
+        HANDLE_CASE(1024, small_ipt);
         break;
       case 128:
       case 64:


### PR DESCRIPTION
## Summary

`MediumRadixSort` in `aten/src/ATen/native/cuda/Sort.cu` already picks a different
`items_per_thread` on ROCm (8) than on CUDA (32), and that split is well founded — CUDA's 32
measures 2.0-2.3x slower on both ROCm parts. But 8 is not optimal either: 4 is faster at
`sort_size` 1024 and 2048, and slower at 4096. A new `small_ipt` constant routes the smaller
buckets only.

CUDA is unchanged by construction: `small_ipt` is defined as `default_ipt` in the non-ROCm branch,
so all three `HANDLE_CASE` invocations expand to exactly the same template arguments as before and
no new kernel is instantiated.

## Scope — wider than "1024/2048"

`case 1024: case 512: case 256:` all fall through to `HANDLE_CASE(1024, small_ipt)`, so **every
slice from 129 to 2048 elements** changes block size, not just the two sizes benchmarked. On ROCm:

| `ceilPowerOf2` | block before | block after |
|---|---|---|
| 4096 | 512 | 512 (unchanged) |
| 2048 | 256 | 512 |
| 1024 / 512 / 256 | 128 | 256 |

`topk(sorted=True)` with `k` in that range reaches the same path.

## Measurements

Mirrored-pair A/B, alternating arms, median ratios with win counts, GPU pinned via
`HIP_VISIBLE_DEVICES`.

| sort_size | gfx950 | gfx1250 |
|---|---|---|
| 1024 | 1.328x (8/8) | 1.140x (8/8) |
| 2048 | 1.020x (8/8) | 1.069x (8/8) |
| 4096 | 0.931x (0/8) | 0.881x (0/8) |

Absolute at the shortlist shape: gfx950 17.40us -> 13.22us; gfx1250 11.36us -> 10.38us. 16
items/thread costs 10% and 28% respectively.

Because `fixed_size_sort` derives `block = sort_size / items_per_thread`, halving items doubles the
block; at 4096 that is a 1024-thread block, which regresses on both parts. That reversal, not
launch bounds, is the whole reason for the gate.

## Correction: tie ordering does NOT change

An earlier revision of this description said tie ordering among equal keys may change. That is
wrong, and it matters, because `torch.sort(stable=True)` genuinely does reach this code —
`Sort.cpp:88` forwards `stable` verbatim into `sortKeyValueInplace`, `Sort.h:9-11` gates only on
`size(dim) <= 4096`, `stable` is consulted only to suppress the bitonic kernel at n <= 32, and
`_torch_docs.py:10454` documents `stable` as a guarantee. If the claim were true this PR would be
a documented-guarantee break.

It is not true. rocPRIM's block radix sort is documented stable
(`rocprim/block/block_radix_sort.hpp:66-72`), and `BLOCK_LOAD_TRANSPOSE` gives a blocked
arrangement where thread *t* holds slice elements `[t*ipt, (t+1)*ipt)`, so an element's stability
rank is its global slice index regardless of how `sort_size` splits into
`block_size x items_per_thread`. Index output is bit-identical. (Consistent with this,
`test_stable_sort` asserts exact indices on all-tie input at n=200 and n=2000 — both inside the
changed buckets.)

## Correction: shared memory reasoning

An earlier revision said `BlockRadixSort` sizes temp storage from `block_size * items_per_thread`,
which is `sort_size` and therefore unchanged. That is not what the code does: `storage_type_` is a
union, and the `match` rank variant allocates as a function of `BLOCK_THREADS` alone — it doubles
at both changed cases (2056 -> 4112 bytes at 1024; 4112 -> 8224 at 2048).

The union total is nonetheless unchanged, for a different reason: `BlockLoad`/`BlockStore` with
`TRANSPOSE` hardcode `block_padding_hint::avoid_conflicts` and contribute
`sizeof(T) * sort_size * 33/32`, which dominates, and the value type is always `int64_t`.
Compiling the five exact instantiations with `hipcc --offload-arch=gfx942` and `gfx1100` gives
8448 B, 16896 B and 33792 B — byte-identical before and after on both wavefront widths, far below
the 64 KB LDS limit. The conclusion holds; the original reasoning did not.

## Known open items

1. **256 and 512 are unmeasured.** They change (see Scope) but appear in no benchmark. They are
   also the buckets least likely to benefit: at `keySliceSize = 200` the block already computes
   1024 padded slots for 200 real elements, so doubling the thread count doubles the per-slice
   footprint while useful work is unchanged. `should_use_small_sort` has no batch term, so the
   common "large batch of short rows" shape — `(1_000_000, 200)` — is governed entirely by this
   bucket.

2. **Arch coverage.** Only gfx950 and gfx1250 were measured, and **gfx1250 is in no shipping
   wheel** (`.ci/docker/manywheel/build.sh:81`). The production CDNA parts gfx90a and gfx942 —
   which are what the constant being partially reverted here (#147657) was tuned for — have no
   data. PR CI covers only `gfx90a;gfx942;gfx950;gfx1100`, so a regression on gfx908/gfx1030/gfx12xx
   would not surface. Doubling the block also tightens the per-thread register budget under
   `C10_LAUNCH_BOUNDS_1`: 8 wave64s must co-reside at block 512 versus 2 at block 128, and gfx908's
   256-VGPR arch file behaves differently from the unified 512-VGPR file. Halving
   `items_per_thread` halves the local arrays so this likely nets out, but it is unmeasured where
   it matters. `at::detail::getCUDAHooks().isGPUArch({...})` is the in-tree pattern for scoping
   this (see `CUDALoops.cuh:337`, `int4mm.cu:144-148`).

3. **Two new kernel instantiations, no test.** `radixSortKVInPlace<..., 512, 4, ...>` and
   `<..., 256, 4, ...>` have never been compiled or run, across every dtype in the dispatch. Sizes
   256 and 512 have no `torch.sort` coverage at all; the sort OpInfo produces sorted-dim sizes of
   only 5 and 8000, and its keys are `randperm`-derived so ties never occur.

## Test plan

- [ ] Rebuild for ROCm and CUDA.
- [ ] Verify dispatched template args either side of the gate.
- [ ] `python test/test_sort_and_select.py` on gfx950 and gfx942.
- [ ] Re-run sort/argsort timings; sweep `keySliceSize` 129, 256, 512, 1024, 2048, 4096 with a
      large batch dimension (open item 1).
- [ ] Test descending, a non-float32 dtype, and index permutation with repeated keys.
- [ ] Confirm on gfx942 / gfx90a, or arch-gate per open item 2.
- [ ] Extend `sample_inputs_sort` with a mid-size sample so `sort`, `argsort` and `msort` all gain
      coverage in the changed window.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang
@naromero77amd @pragupta @jerrymannil @xinyazhang

> This PR was prepared with the assistance of an AI coding assistant. I have read and understand
> the change and take responsibility for it.