### PR TITLE
Fix fbcode import of triton_constexpr_configs in inductor test

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -54,7 +54,7 @@ from torch.utils._triton import has_triton_package
 
 
 try:
-    from triton_constexpr_configs import (
+    from .triton_constexpr_configs import (
         tl as TritonLanguageShadowConfig,
         UserDefinedAttrsLikeConfig,
         UserDefinedPydanticLikeConfig,
@@ -66,7 +66,7 @@ try:
         UserDefinedTritonKernelNonInitConfig,
     )
 except ImportError:
-    from test.inductor.triton_constexpr_configs import (
+    from triton_constexpr_configs import (
         tl as TritonLanguageShadowConfig,
         UserDefinedAttrsLikeConfig,
         UserDefinedPydanticLikeConfig,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195663

Forward fix for D117882973 (pytorch/pytorch#189692), which broke
`fbcode//caffe2/test/inductor:codegen_triton` at listing time.

That diff added a new helper module `triton_constexpr_configs.py` next to
`test_codegen_triton.py` and imported it with two OSS-only fallbacks:

```
try:
    from triton_constexpr_configs import ...          # test/inductor on sys.path
except ImportError:
    from test.inductor.triton_constexpr_configs import ...   # pytorch repo root on sys.path
```

The file itself is packaged fine internally -- `:inductor_test_lib` uses
`srcs = glob(["*.py"])`, so no BUCK change is needed -- but inside the PAR it
resolves under the fbcode base module as
`caffe2.test.inductor.triton_constexpr_configs`. Neither branch matches, so
both raised `ModuleNotFoundError` and the whole module failed to import,
taking down all 22 tests in the suite, not just the new ones:

```
ModuleNotFoundError: No module named 'triton_constexpr_configs'
During handling of the above exception, another exception occurred:
ModuleNotFoundError: No module named 'test.inductor'
```

Switch to the relative-first pattern already used elsewhere in this directory
(`test_codecache.py`, `test_ck_backend.py`). The relative import resolves
against whatever package the test module actually lives in, so it covers all
three run modes: the fbcode PAR (`caffe2.test.inductor`), OSS pytest from the
repo root (`test.inductor`), and `python test/inductor/test_codegen_triton.py`
(no package, falls through to the bare import).

This also matters beyond the import statement itself. The new
`get_importable_constexpr_types` emits `from {type.__module__} import ...`
into the generated Triton kernel source, so the helper module has to be
reachable under its real package name for
`test_user_defined_triton_kernel_non_builtin_constexpr` to compile and run.

`xplat/caffe2` is updated to keep it in sync with `fbcode/caffe2`.

Differential Revision: [D118378564](https://our.internmc.facebook.com/intern/diff/D118378564/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo