### PR TITLE
[aot_autograd] Replay input mutations the way autograd saw them, and dealias marked returns

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -73,6 +73,7 @@ from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.codecache import compiled_fx_graph_hash
 from torch._inductor.custom_graph_pass import CustomPartitionerFn
 from torch._inductor.output_code import MockFXGraphCacheOutput
+from torch._inductor.utils import fresh_cache
 from torch._subclasses.fake_tensor import DynamicOutputShapeException, FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     _FAKE_TENSOR_ID_TO_PROXY_MAP_FOR_EXPORT,
@@ -5263,6 +5264,233 @@ def forward(self, tangents_1):
         loss_list.pop().backward()
 
         self._assert_no_extra_refs(refcount_box)
+
+    @parametrize("backend", ["aot_eager", "inductor"])
+    def test_detach_output_aliasing_intermediate_base(self, backend):
+        # mark_non_differentiable is keyed on TensorImpl, and a backend is free
+        # to lower aten.detach to a no-op -- inductor does -- so y.detach() and
+        # y's intermediate base can be the same object. Marking the detach
+        # output then marks the base, which is a slot the backward requires a
+        # tangent for, and autograd hands it None because
+        # _materialize_non_diff_grads is False. Depending on whether that
+        # backward has any compute this either silently drops the gradient or
+        # dies inside the compiled backward.
+        def f(x):
+            y = torch.sin(x)
+            return y[0:4], y[4:8], y.detach(), x * 3
+
+        def run(fn, x):
+            outs = fn(x)
+            (outs[0].sum() + outs[1].sum() + outs[3].sum()).backward()
+            return (
+                [o.requires_grad for o in outs],
+                [o.grad_fn is not None for o in outs],
+                x.grad,
+                outs[2],
+            )
+
+        x_ref = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        rg_ref, gf_ref, grad_ref, _ = run(f, x_ref)
+        self.assertIsNotNone(grad_ref)
+
+        torch._dynamo.reset()
+        x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        rg, gf, grad, detached = run(torch.compile(f, backend=backend), x)
+        self.assertEqual(rg, rg_ref)
+        self.assertEqual(gf, gf_ref)
+        self.assertEqual(grad, grad_ref)
+        # The detach output must stay a leaf: sparing the base must not be
+        # done by declining to mark the output that aliases it.
+        self.assertFalse(detached.requires_grad)
+        self.assertIsNone(detached.grad_fn)
+
+    def test_detach_output_aliasing_sibling_output(self):
+        # No intermediate base here: h * 1 folds to h and detach() no-ops, so
+        # two OUTPUT slots hold one object and marking the second marks the
+        # first, dropping the only gradient in the model.
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l = torch.nn.Linear(3, 3)
+
+            def forward(self, x):
+                h = torch.relu(self.l(x))
+                return h * 1.0, h.detach()
+
+        torch.manual_seed(0)
+        ref = Net()
+        x_ref = torch.randn(3, requires_grad=True)
+        out_ref = ref(x_ref)
+        out_ref[0].sum().backward()
+
+        torch._dynamo.reset()
+        torch.manual_seed(0)
+        mod = Net()
+        x = torch.randn(3, requires_grad=True)
+        outs = torch.compile(mod, backend="inductor")(x)
+        self.assertEqual(
+            [(o.requires_grad, o.grad_fn is not None) for o in outs],
+            [(o.requires_grad, o.grad_fn is not None) for o in out_ref],
+        )
+        outs[0].sum().backward()
+        self.assertEqual(x.grad, x_ref.grad)
+
+    @parametrize("backend", ["aot_eager", "inductor"])
+    def test_tracked_input_mutation_on_custom_function_view_raises(self, backend):
+        # An input a custom Function returned as-is is a view stamped
+        # IN_CUSTOM_FUNCTION, and eager refuses a tracked in-place write to it.
+        # The epilogue replays a tracked mutation as a tracked copy_, so it
+        # must refuse too, even after the graph was warmed on an ordinary
+        # tensor: nothing guards the caller's CreationMeta.
+        class Identity(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, t):
+                return t
+
+            @staticmethod
+            def backward(ctx, g):
+                return g
+
+        def fn(w, x):
+            w.add_(x)
+            return w * 2
+
+        msg = "is a view and is being modified inplace"
+        base = torch.randn(4, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            fn(Identity.apply(base * 1.0), torch.randn(4))
+
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, backend=backend)
+        compiled(torch.randn(4, requires_grad=True) * 1.0, torch.randn(4))
+        with self.assertRaisesRegex(RuntimeError, msg):
+            compiled(Identity.apply(base * 1.0), torch.randn(4))
+
+    def test_hidden_input_mutation_replayed_onto_custom_function_view(self):
+        # A mutation recorded as hidden from autograd bumped no version counter
+        # in eager, so its replay must not either: the view keeps the custom
+        # Function's backward and its later use passes the view+inplace check.
+        from torch._functorch._aot_autograd.runtime_wrappers import (
+            _replay_input_mutation,
+        )
+
+        class Scale(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, t):
+                return t
+
+            @staticmethod
+            def backward(ctx, g):
+                return g * 3
+
+        base = torch.randn(4, requires_grad=True)
+        w = Scale.apply(base * 1.0)
+        grad_fn, version = w.grad_fn, w._version
+        _replay_input_mutation(w, torch.ones(4))
+        self.assertIs(w.grad_fn, grad_fn)
+        self.assertEqual(w._version, version)
+        self.assertEqual(w.detach(), torch.ones(4))
+        (w * 2).sum().backward()
+        self.assertEqual(base.grad, torch.full((4,), 6.0))
+
+    def test_none_tangent_in_kept_slot_names_the_forward_output(self):
+        # A None in a kept tangent slot otherwise surfaces several frames below
+        # AOTAutograd as inductor's "expected Tensor() for op: input", naming
+        # only a codegen'd variable like tangents_3 -- which is not positional
+        # and cannot be mapped back to a user output by hand. Disabling the
+        # marking dedup puts a None back in the intermediate-base slot.
+        import torch._functorch._aot_autograd.runtime_wrappers as rw
+
+        def f(x):
+            y = torch.sin(x)
+            return y[0:4], y[4:8], y.detach(), x * 3
+
+        torch._dynamo.reset()
+        x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        with patch.object(rw, "_dealias_marked_returns", lambda raw, marked: None):
+            outs = torch.compile(f, backend="inductor")(x)
+            with self.assertRaises(RuntimeError) as cm:
+                outs[3].sum().backward()
+
+        msg = str(cm.exception)
+        self.assertIn("handed a non-Tensor for a tangent it requires", msg)
+        self.assertIn("tangent index         : 1", msg)
+        self.assertIn("received              : None (type NoneType", msg)
+        self.assertIn("IntermediateBaseAOTOutput(base_of=PlainAOTOutput(idx=0))", msg)
+        self.assertIn("that slot holds       : intermediate base 0", msg)
+        self.assertIn("user output index     : 0", msg)
+        self.assertIn("OutputType.alias_of_intermediate_save_as_output", msg)
+        self.assertIn("its requires_grad     : True", msg)
+        self.assertIn("its dtype             : torch.float32", msg)
+        self.assertIn("This slot is case (2) or (3)", msg)
+
+    def test_none_tangent_error_reports_non_differentiable_dtype(self):
+        # An integer output never gets a kept tangent slot from metadata, so the
+        # dtype arm of the explanation is only reachable when the recorded
+        # metadata and the runtime output disagree. Drive it directly.
+        from torch._functorch._aot_autograd.descriptors import (
+            PlainAOTOutput,
+            TangentAOTInput,
+        )
+        from torch._functorch._aot_autograd.runtime_wrappers import (
+            AOTDispatchAutograd,
+            KeptTangentInfo,
+        )
+
+        info = KeptTangentInfo(
+            grad_out_idx=(0, 2),
+            dtype=(torch.float32, torch.int64),
+            num_mutated_inputs=0,
+            num_outputs=3,
+            num_intermediate_bases=0,
+            output_type=("non_alias",) * 3,
+            output_requires_grad=(True, False, True),
+            output_requires_grad_for_backward=(True, False, True),
+        )
+        msg = str(
+            AOTDispatchAutograd._non_tensor_tangent_error(
+                None, 1, TangentAOTInput(PlainAOTOutput(idx=2)), "1/0", "here\n", info
+            )
+        )
+        self.assertIn("user output index     : 2", msg)
+        self.assertIn("its dtype             : torch.int64", msg)
+        self.assertIn("torch.int64 is not a differentiable dtype", msg)
+        self.assertIn("This error occurred in compiled graph [1/0].", msg)
+        self.assertIn("The forward output was created here:\nhere", msg)
+
+    def test_none_tangent_for_a_dropped_slot_still_passes_through(self):
+        # Autograd legitimately hands back None for every returned slot it
+        # treats as non-differentiable: integer and bool outputs, a detached
+        # output, and the TensorAlias-wrapped outputs that alias an input or an
+        # intermediate. Six of the eight slots here arrive None; the prologue
+        # drops all six before any tangent processing, so the check must not
+        # see them. Only x * 3 and the intermediate base behind y[0:4] / y[4:8]
+        # are kept.
+        def f(x, lengths):
+            y = torch.sin(x)
+            return (
+                y[0:4],
+                y[4:8],
+                lengths * 2,
+                lengths > 1,
+                (x * 2).detach(),
+                x[0:2],
+                x * 3,
+            )
+
+        def run(fn, x, lengths):
+            outs = fn(x, lengths)
+            (outs[0].sum() + outs[1].sum() + outs[6].sum()).backward()
+            return x.grad
+
+        torch._dynamo.reset()
+        lengths = torch.arange(4)
+        x_ref = torch.randn(8, requires_grad=True)
+        grad_ref = run(f, x_ref, lengths)
+
+        x = x_ref.detach().clone().requires_grad_(True)
+        grad = run(torch.compile(f, backend="inductor"), x, lengths)
+        self.assertEqual(grad, grad_ref)
 
 
 def extract_graph(fx_g, _, graph_cell):
@@ -12985,6 +13213,49 @@ class TestAOTAutogradWithCache(TestAOTAutogradWithDynamo):
         # But also can't be xfailed because it causes undefined behavior for
         # ASAN
         self.skipTest("Skipping because it fails in strict cache mode")
+
+    @torch._functorch.config.patch(
+        {"enable_autograd_cache": True, "strict_autograd_cache": True}
+    )
+    @torch._inductor.config.patch(
+        {"fx_graph_cache": True, "fx_graph_remote_cache": False}
+    )
+    def test_traced_tangent_dtypes_survive_warm_cache(self):
+        def fn(a):
+            return a.sin(), (a * 2).to(torch.float64)
+
+        saved, loaded = [], []
+        orig_save, orig_lookup = AOTAutogradCache.save, AOTAutogradCache._lookup
+
+        def save(key, entry, remote):
+            saved.append(entry.runtime_metadata.traced_tangent_dtypes)
+            orig_save(key, entry, remote)
+
+        def lookup(*args, **kwargs):
+            result = orig_lookup(*args, **kwargs)
+            if result is not None:
+                loaded.append(result[0].runtime_metadata.traced_tangent_dtypes)
+            return result
+
+        def run():
+            torch._dynamo.reset()
+            a = torch.randn(4, requires_grad=True)
+            out = torch.compile(fn, backend="inductor")(a)
+            (out[0].sum() + out[1].sum()).backward()
+
+        with (
+            fresh_cache(),
+            patch.object(AOTAutogradCache, "save", staticmethod(save)),
+            patch.object(AOTAutogradCache, "_lookup", staticmethod(lookup)),
+        ):
+            counters.clear()
+            run()
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+            run()
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+        self.assertEqual(saved, [[torch.float32, torch.float64]])
+        self.assertEqual(loaded, saved)
 
 
 if __name__ == "__main__":

--- a/test/functorch/test_codegen_mutation_epilogue.py
+++ b/test/functorch/test_codegen_mutation_epilogue.py
@@ -4,9 +4,10 @@
 Tests for codegen'ing the mutation epilogue in _create_runtime_wrapper.
 
 The codegen'd mutation epilogue emits one of as_strided_(), copy_(),
-or detach().copy_() per mutated input, with the branch resolved at codegen
-time from each input's mutation metadata (mutates_metadata, mutates_data,
-is_leaf).
+detach().copy_() or _replay_input_mutation() per mutated input, with the
+branch resolved at codegen time from each input's mutation metadata
+(mutates_metadata, mutates_data, is_leaf, mutations_hidden_from_autograd,
+mutations_under_no_grad_or_inference_mode).
 
 Tests that exercise data-only mutations use torch.compile (dynamo handles
 metadata mutations in-graph, so only data mutations reach the epilogue).
@@ -20,8 +21,10 @@ trace_structured.
 
 import logging
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import torch
+import torch._functorch._aot_autograd.collect_metadata_analysis as collect_metadata_analysis
 import torch._functorch.config
 from functorch.compile import nop
 from torch._functorch.aot_autograd import aot_function
@@ -61,8 +64,9 @@ class TestCodegenMutationEpilogue(TestCase):
 
     def test_single_data_mutation(self):
         """
-        Single input data mutation via mul_. Codegen should emit a direct
-        copy_() for this input.
+        Single input data mutation via mul_, visible to autograd. Codegen
+        should emit a tracked copy_() for this input; only a mutation recorded
+        as hidden from autograd goes through _replay_input_mutation().
         """
         with self._capture_codegen_source("mutation_epilogue") as captured:
 
@@ -86,11 +90,86 @@ class TestCodegenMutationEpilogue(TestCase):
             1,
             "Expected mutation_epilogue codegen artifact to be emitted",
         )
-        self.assertIn("copy_", captured[0])
+        self.assertIn("orig_inputs[0].copy_(updated_inputs[0])", captured[0])
+        self.assertNotIn("_replay_input_mutation", captured[0])
+
+    @skipIfTorchDynamo(
+        "aot_function uses FX tracing which conflicts with dynamo wrapping"
+    )
+    def test_hidden_data_mutation(self):
+        """
+        Data mutation recorded as hidden from autograd (only a triton kernel
+        write produces one, so the flag is patched in). Codegen should emit
+        _replay_input_mutation(), which writes under no_grad with the version
+        counter preserved, instead of a tracked copy_(). Uses aot_function
+        directly because torch.compile keeps hidden mutations in the graph.
+        """
+        with (
+            self._capture_codegen_source("mutation_epilogue") as captured,
+            patch.object(
+                collect_metadata_analysis,
+                "are_all_mutations_hidden_from_autograd",
+                lambda t: True,
+            ),
+        ):
+
+            def f(a):
+                a.mul_(2)
+                return a + 1
+
+            a = torch.randn(4, requires_grad=True).add(0)
+            a_ref = a.detach().clone()
+            grad_fn, version = a.grad_fn, a._version
+            out = aot_function(f, nop)(a)
+
+        self.assertEqual(a.detach(), a_ref * 2)
+        self.assertEqual(out, a_ref * 2 + 1)
+        self.assertIs(a.grad_fn, grad_fn)
+        self.assertEqual(a._version, version)
+
+        self.assertEqual(len(captured), 1)
+        self.assertIn(
+            "_replay_input_mutation(orig_inputs[0], updated_inputs[0])", captured[0]
+        )
+        self.assertNotIn(".copy_(", captured[0])
+
+    @skipIfTorchDynamo(
+        "aot_function uses FX tracing which conflicts with dynamo wrapping"
+    )
+    def test_non_leaf_mutation_under_no_grad(self):
+        """
+        Non-leaf tensor mutated under no_grad. Codegen should emit copy_()
+        under no_grad, which bumps the version counter like eager did but
+        leaves the tensor's grad_fn alone. Uses aot_function directly because
+        torch.compile keeps no_grad mutations in the graph.
+        """
+        with self._capture_codegen_source("mutation_epilogue") as captured:
+
+            def f(a):
+                with torch.no_grad():
+                    a.mul_(2)
+                return a + 1
+
+            a = torch.randn(4, requires_grad=True).add(0)
+            a_ref = a.detach().clone()
+            grad_fn, version = a.grad_fn, a._version
+            out = aot_function(f, nop)(a)
+
+        self.assertEqual(a.detach(), a_ref * 2)
+        self.assertEqual(out, a_ref * 2 + 1)
+        self.assertIs(a.grad_fn, grad_fn)
+        self.assertEqual(a._version, version + 1)
+
+        self.assertEqual(len(captured), 1)
+        self.assertIn(
+            "with torch.no_grad(): orig_inputs[0].copy_(updated_inputs[0])",
+            captured[0],
+        )
+        self.assertNotIn("_replay_input_mutation", captured[0])
 
     def test_multiple_data_mutations(self):
         """
-        Multiple inputs mutated. Codegen should emit a copy_() per mutated
+        Multiple inputs mutated. Codegen should emit one copy_() per mutated
         input, with non-mutated inputs skipped entirely.
         """
         with self._capture_codegen_source("mutation_epilogue") as captured:
@@ -118,7 +197,8 @@ class TestCodegenMutationEpilogue(TestCase):
             1,
             "Expected mutation_epilogue codegen artifact to be emitted",
         )
-        self.assertIn("copy_", captured[0])
+        self.assertEqual(captured[0].count(".copy_("), 2)
+        self.assertNotIn("_replay_input_mutation", captured[0])
 
     def test_leaf_mutation_under_no_grad(self):
         """

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -8,11 +8,12 @@ This module defines runtime wrappers, which, based on previous analysis attempts
 
 import collections
 import contextlib
-import threading
 import copy
 import functools
 import itertools
+import logging
 import pprint
+import threading
 import typing
 import warnings
 import weakref
@@ -125,6 +126,7 @@ def _unwrap_tensor_subclasses_no_symints(
 
 zip = strict_zip
 
+log = logging.getLogger(__name__)
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
 
 
@@ -231,6 +233,26 @@ def _unwrap_tensoralias(x: TensorAlias) -> torch.Tensor:
 
 def _identity(x: Any) -> Any:
     return x
+
+
+def _replay_input_mutation(orig: torch.Tensor, updated: torch.Tensor) -> None:
+    """Write back an input mutation that was hidden from autograd.
+
+    Emitted only for an input whose InputAliasInfo records
+    mutations_hidden_from_autograd; a tracked mutation is written back with a
+    plain copy_, so a target that refuses in-place edits (a view stamped
+    IN_CUSTOM_FUNCTION) raises exactly as in eager. Whether an eager write
+    bumps the version counter is decided by the ADInplaceOrView layer (aten
+    codegen, or the fallback torch.library.custom_op installs), so a write
+    recorded hidden bypassed that layer and is replayed under no_grad with the
+    version counter preserved, as apply_in_graph_mutations does in-graph.
+    """
+    if orig.is_inference():
+        with torch.no_grad():
+            orig.copy_(updated)
+        return
+    with torch.no_grad(), torch.autograd._unsafe_preserve_version_counter(orig):
+        orig.copy_(updated)
 
 
 class AliasOfInputHandler:
@@ -795,7 +817,13 @@ class _RuntimeForwardEpilogue:
                             "Mutations on inputs with user-specified streams are not yet supported. "
                             "See: https://github.com/pytorch/pytorch/issues/172522"
                         )
-                    original_inpt.copy_(updated_inpt)
+                    if meta.mutations_hidden_from_autograd:
+                        _replay_input_mutation(original_inpt, updated_inpt)
+                    elif meta.mutations_under_no_grad_or_inference_mode:
+                        with torch.no_grad():
+                            original_inpt.copy_(updated_inpt)
+                    else:
+                        original_inpt.copy_(updated_inpt)
 
     def _replay_output_aliases(
         self, orig_inputs: dict[int, Tensor], fw_outs: list[Any]
@@ -1084,7 +1112,11 @@ def _create_runtime_wrapper(
             args="orig_inputs, updated_inputs",
             artifact_name="mutation_epilogue",
         )
-        buf.bind(torch=torch, _unwrap_tensoralias=_unwrap_tensoralias)
+        buf.bind(
+            torch=torch,
+            _unwrap_tensoralias=_unwrap_tensoralias,
+            _replay_input_mutation=_replay_input_mutation,
+        )
         wrote_body = False
         with buf.indent():
             for i, inpt_idx in enumerate(runtime_metadata.mutated_inp_runtime_indices):
@@ -1139,6 +1171,10 @@ def _create_runtime_wrapper(
                                 "See: https://github.com/pytorch/pytorch/issues/172522",
                             )
                             buf.writeline(f"raise RuntimeError({msg_name})")
+                        elif meta.mutations_hidden_from_autograd:
+                            buf.writeline(f"_replay_input_mutation({oi}, {ui})")
+                        elif meta.mutations_under_no_grad_or_inference_mode:
+                            buf.writeline(f"with torch.no_grad(): {oi}.copy_({ui})")
                         else:
                             buf.writeline(f"{oi}.copy_({ui})")
             if not wrote_body:
@@ -2692,6 +2728,37 @@ class _AutogradSavedState:
         ctx.opaque_objects = opaque_object_outs
 
 
+def _dealias_marked_returns(raw_returns: list[Any], marked: frozenset[int]) -> None:
+    """Give each slot about to be marked non-differentiable its own TensorImpl.
+
+    mark_non_differentiable is keyed on TensorImpl, so marking one slot marks
+    EVERY returned slot holding that same object, and with
+    ctx._materialize_non_diff_grads = False a slot marked this way is handed a
+    None instead of zeros. Backends are free to return one object in two slots
+    -- inductor lowers aten.detach to a no-op, and h*1 / h+0 fold away -- so
+    `return h * 1, h.detach()` marks the differentiable output too and drops
+    the gradient, and `return y[:2], y[2:], y.detach()` marks y's intermediate
+    base, which the backward requires a tangent for.
+
+    Substituting an alias is only correct because the slot is one we are about
+    to declare non-differentiable anyway; slots that stay differentiable keep
+    their identity.
+    """
+    # Runs on every forward and almost never fires: index the marked slots
+    # (usually one or two) by identity and probe the unmarked Tensor slots.
+    marked_positions: dict[int, list[int]] = {}
+    for i in marked:
+        x = raw_returns[i]
+        if isinstance(x, Tensor):
+            marked_positions.setdefault(id(x), []).append(i)
+    if not marked_positions:
+        return
+    for j, o in enumerate(raw_returns):
+        if j not in marked and isinstance(o, Tensor):
+            for i in marked_positions.pop(id(o), ()):
+                raw_returns[i] = raw_returns[i].detach()
+
+
 @dataclass
 class _AutogradForwardEpilogue:
     metadata: ViewAndMutationMeta
@@ -2756,12 +2823,13 @@ class _AutogradForwardEpilogue:
             if x.mutation_type == MutationType.MUTATED_OUT_GRAPH
         ] + self.metadata.output_info
 
-        fw_outs_not_requiring_grad = [
-            x
+        non_diff_indices = [
+            i
             for (i, x) in enumerate(raw_returns_not_including_intermediate_bases)
             if isinstance(x, torch.Tensor) and not raw_returns_meta[i].requires_grad
         ]
-        ctx.mark_non_differentiable(*fw_outs_not_requiring_grad)
+        _dealias_marked_returns(raw_returns, frozenset(non_diff_indices))
+        ctx.mark_non_differentiable(*(raw_returns[i] for i in non_diff_indices))
         ctx._materialize_non_diff_grads = False
         _snapshot_external_objects(ctx)
 
@@ -2988,6 +3056,30 @@ class _AutogradBackwardCompiler:
                 )
 
 
+class KeptTangentInfo(typing.NamedTuple):
+    """Compile-time description of the tangent slots the backward prologue keeps.
+
+    One of these is built per backward prologue and passed (as a single shared
+    object, not per element) to process_runtime_tangent, which reads it only when
+    a kept slot arrives holding something other than a Tensor. Everything here is
+    metadata that is gone by the time the backward runs: output_info is not
+    reachable from the runtime tangent, and traced_tangents (hence the dtypes)
+    are dropped by ViewAndMutationMeta.make_runtime_safe.
+    """
+
+    # kept tangent j -> its index among the autograd.Function's returned slots
+    grad_out_idx: tuple[int, ...]
+    # kept tangent j -> dtype of the forward output / mutated input behind it
+    dtype: tuple[torch.dtype | None, ...]
+    num_mutated_inputs: int
+    num_outputs: int
+    num_intermediate_bases: int
+    # parallel to fw_metadata.output_info, indexed by user forward output
+    output_type: tuple[str, ...]
+    output_requires_grad: tuple[bool, ...]
+    output_requires_grad_for_backward: tuple[bool, ...]
+
+
 def _codegen_backward_prologue(
     fw_metadata: ViewAndMutationMeta,
     maybe_subclass_meta: SubclassMeta | None,
@@ -3034,6 +3126,28 @@ def _codegen_backward_prologue(
         + list(range(intermediate_start, expected_grad_outs))
     )
     num_flat_bw_args_with_grads = len(all_surviving)
+
+    tangent_dtypes = fw_metadata.traced_tangent_dtypes or []
+    if len(tangent_dtypes) != num_flat_bw_args_with_grads:
+        log.warning(
+            "traced_tangent_dtypes has %d entries but the backward prologue keeps "
+            "%d tangent slots; not reporting tangent dtypes",
+            len(tangent_dtypes),
+            num_flat_bw_args_with_grads,
+        )
+        tangent_dtypes = [None] * num_flat_bw_args_with_grads
+    kept_tangent_info = KeptTangentInfo(
+        grad_out_idx=tuple(all_surviving),
+        dtype=tuple(tangent_dtypes),
+        num_mutated_inputs=num_mutated_runtime_inps,
+        num_outputs=num_outputs,
+        num_intermediate_bases=num_intermediate_bases,
+        output_type=tuple(i.output_type.name for i in fw_metadata.output_info),
+        output_requires_grad=tuple(i.requires_grad for i in fw_metadata.output_info),
+        output_requires_grad_for_backward=tuple(
+            i.requires_grad_for_backward for i in fw_metadata.output_info
+        ),
+    )
 
     buf = PySourceBuilder(
         "_backward_prologue",
@@ -3107,6 +3221,7 @@ def _codegen_backward_prologue(
             _tangent_descs_=fw_metadata.traced_tangents_descs,
             _compile_id_=fw_metadata.compile_id_str,
             _stack_traces_=fw_metadata.tangent_source_stack_traces or (),
+            _kept_tangent_info_=kept_tangent_info,
         )
 
         if has_subclass:
@@ -3124,7 +3239,8 @@ def _codegen_backward_prologue(
             buf.writeline(
                 "_fpt = list(_chain_("
                 "_process_tangent_(t, m, idx, desc, _compile_id_, "
-                "_stack_traces_[idx] if _stack_traces_ else None)[1] "
+                "_stack_traces_[idx] if _stack_traces_ else None, "
+                "_kept_tangent_info_)[1] "
                 "for idx, (t, m, desc) in enumerate("
                 "zip(_tangents, _tangent_metas_, _tangent_descs_))))"
             )
@@ -3143,7 +3259,8 @@ def _codegen_backward_prologue(
                 buf.writeline(
                     "all_args[_i] = _process_tangent_(all_args[_i], "
                     "_tangent_metas_[j], j, _tangent_descs_[j], _compile_id_, "
-                    "_stack_traces_[j] if _stack_traces_ else None)[0]"
+                    "_stack_traces_[j] if _stack_traces_ else None, "
+                    "_kept_tangent_info_)[0]"
                 )
 
         if has_mutations_in_bw:
@@ -3424,7 +3541,12 @@ class _AOTDispatchAutogradFunctionFactory:
             args="raw_returns",
             artifact_name="compiled_fn_wrapper",
         )
-        buf.bind(TensorAlias=TensorAlias, torch=torch, Tensor=Tensor)
+        buf.bind(
+            TensorAlias=TensorAlias,
+            torch=torch,
+            Tensor=Tensor,
+            _dealias_marked_returns=_dealias_marked_returns,
+        )
 
         with buf.indent():
             for i, idx in enumerate(fw_metadata.mutated_inp_runtime_indices):
@@ -3460,6 +3582,11 @@ class _AOTDispatchAutogradFunctionFactory:
                 ):
                     _non_diff_indices.append(i)
             if _non_diff_indices:
+                # See _dealias_marked_returns: marking is keyed on TensorImpl,
+                # so a slot sharing an object with another returned slot marks
+                # that one too.
+                marked = buf.bind_value("_marked", frozenset(_non_diff_indices))
+                buf.writeline(f"_dealias_marked_returns(raw_returns, {marked})")
                 checks = " + ".join(
                     f"([raw_returns[{i}]] if isinstance(raw_returns[{i}], Tensor) else [])"
                     for i in _non_diff_indices
@@ -3733,6 +3860,140 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
             )
 
     @staticmethod
+    def _non_tensor_tangent_error(
+        x: Any,
+        tangent_idx: int,
+        tangent_desc: Any | None,
+        compile_id_str: str | None,
+        tangent_stack_trace: str | None,
+        kept_tangent_info: "KeptTangentInfo | None",
+    ) -> RuntimeError:
+        """Explain a kept tangent slot that arrived as a non-Tensor (in practice None).
+
+        Autograd hands a compiled backward None for a returned slot only when it
+        recorded no gradient metadata for it, and AOTAutograd's forward epilogue sets
+        ctx._materialize_non_diff_grads = False so nothing zero-fills it. Naming the
+        forward output behind the slot is the whole point: inductor reports this
+        several frames lower as "TypeError: expected Tensor()" against a codegen'd
+        name like tangents_3, which is not positional and cannot be mapped back to a
+        user output by hand.
+        """
+        from .descriptors import (
+            IntermediateBaseAOTOutput,
+            PlainAOTOutput,
+            TangentAOTInput,
+        )
+
+        # The descriptor names the user output behind the slot, including through an
+        # intermediate base (which is not itself a user output).
+        out_idx: int | None = None
+        via_base = False
+        if isinstance(tangent_desc, TangentAOTInput):
+            out = tangent_desc.output
+            if isinstance(out, IntermediateBaseAOTOutput):
+                via_base = True
+                out = out.base_of
+            if isinstance(out, PlainAOTOutput):
+                out_idx = out.idx
+
+        lines = [
+            f"  tangent index         : {tangent_idx}",
+            f"  received              : {x!r:.200} (type {type(x).__name__}, expected a Tensor)",
+            f"  tangent descriptor    : {tangent_desc!r}",
+        ]
+        if isinstance(tangent_desc, TangentAOTInput):
+            lines.append(f"  descriptor expression : {tangent_desc.expr()}")
+
+        dtype: torch.dtype | None = None
+        if kept_tangent_info is not None and tangent_idx < len(
+            kept_tangent_info.grad_out_idx
+        ):
+            info = kept_tangent_info
+            dtype = info.dtype[tangent_idx]
+            grad_out_idx = info.grad_out_idx[tangent_idx]
+            total = (
+                info.num_mutated_inputs + info.num_outputs + info.num_intermediate_bases
+            )
+            if grad_out_idx < info.num_mutated_inputs:
+                what = "the updated value of a mutated forward input"
+            elif grad_out_idx < info.num_mutated_inputs + info.num_outputs:
+                what = f"user forward output {grad_out_idx - info.num_mutated_inputs}"
+            else:
+                nth = grad_out_idx - info.num_mutated_inputs - info.num_outputs
+                # An intermediate base is not a user output: AOTAutograd appends
+                # the base of several aliasing outputs as an extra return.
+                what = f"intermediate base {nth} (not a user output)"
+            lines.append(
+                f"  grad_output slot      : {grad_out_idx} of {total} slots returned "
+                "by the compiled autograd.Function"
+            )
+            lines.append(f"  that slot holds       : {what}")
+            if out_idx is not None and out_idx < len(info.output_type):
+                lines.append(
+                    f"  user output index     : {out_idx}"
+                    + (" (the output this intermediate base backs)" if via_base else "")
+                )
+                lines.append(
+                    f"  its OutputType        : OutputType.{info.output_type[out_idx]}"
+                )
+                lines.append(
+                    f"  its requires_grad     : {info.output_requires_grad[out_idx]} "
+                    f"(requires_grad_for_backward="
+                    f"{info.output_requires_grad_for_backward[out_idx]})"
+                )
+            if dtype is not None:
+                lines.append(f"  its dtype             : {dtype}")
+        elif out_idx is not None:
+            lines.append(f"  user output index     : {out_idx}")
+
+        marked_reason = """(2) or (3), since the dtype above is differentiable.
+AOTAutograd marks every returned slot whose recorded requires_grad is False, and
+marking is keyed on TensorImpl, so a backend returning the SAME tensor object in
+two returned slots marks both -- inductor lowers aten.detach to a no-op and
+folds h * 1 / h + 0 away, which is how one object ends up in two slots."""
+        if dtype is None:
+            reason = "any of (1), (2) or (3): no dtype was recorded for this slot."
+        elif not (dtype.is_floating_point or dtype.is_complex):
+            reason = f"""(1).
+{dtype} is not a differentiable dtype, so autograd never recorded gradient
+metadata for this output, yet AOTAutograd recorded that same output as needing a
+tangent."""
+        else:
+            reason = marked_reason
+
+        graph_hint = (
+            f"\nThis error occurred in compiled graph [{compile_id_str}]."
+            if compile_id_str is not None
+            else ""
+        )
+        stack_hint = (
+            f"\nThe forward output was created here:\n{tangent_stack_trace}"
+            if tangent_stack_trace is not None
+            else ""
+        )
+        body = "\n".join(lines)
+        return RuntimeError(
+            f"""
+The compiled backward was handed a non-Tensor for a tangent it requires.
+
+{body}
+
+Autograd hands back None rather than a zero tangent only for a returned slot it
+recorded no gradient metadata for, which is exactly three cases: (1) the output
+has a non-differentiable dtype, (2) the output was marked via
+ctx.mark_non_differentiable, or (3) the forward returned a non-Tensor in that
+slot. AOTAutograd's forward epilogue sets ctx._materialize_non_diff_grads =
+False, so nothing fills the slot back in.
+
+This slot is case {reason}
+
+The backward requires this tangent, so none of the three is something your model
+can ask for: this is a bug in AOTAutograd or in the backend. Please report it
+with this message.
+{graph_hint}{stack_hint}"""
+        )
+
+    @staticmethod
     def process_runtime_tangent(
         x: Any,
         meta: PlainTensorMeta | SubclassCreationMeta,
@@ -3740,8 +4001,23 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
         tangent_desc: Any | None = None,
         compile_id_str: str | None = None,
         tangent_stack_trace: str | None = None,
+        kept_tangent_info: "KeptTangentInfo | None" = None,
     ) -> tuple[Any, list[Any]]:
         if not isinstance(x, torch.Tensor):
+            # Every top-level call comes from the backward prologue, which only
+            # iterates the slots it kept (all_surviving), so a non-Tensor here is
+            # always a tangent the backward graph is about to be handed. Slots the
+            # prologue drops never reach this function, and the recursive call for a
+            # subclass's attrs passes no tangent_idx.
+            if tangent_idx is not None:
+                raise AOTDispatchAutograd._non_tensor_tangent_error(
+                    x,
+                    tangent_idx,
+                    tangent_desc,
+                    compile_id_str,
+                    tangent_stack_trace,
+                    kept_tangent_info,
+                )
             return x, [x]
 
         if is_fake_tensor(x):

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -505,6 +505,14 @@ class ViewAndMutationMeta:
     # This list is generated after calling make_runtime_safe().
     traced_tangent_metas: list[Any] | None = None
 
+    # Same length/order as traced_tangents, also captured by make_runtime_safe()
+    # before the fake traced_tangents are dropped. Diagnostic only: the backward
+    # prologue reports the dtype of the forward output behind a tangent slot when
+    # that slot arrives as None, which is the one fact that separates "autograd
+    # refused to differentiate this dtype" from "something marked this output
+    # non-differentiable".
+    traced_tangent_dtypes: list[torch.dtype | None] | None = None
+
     num_symints_saved_for_bw: int | None = None
 
     # See Note [Activations with no version counter checks in eager]
@@ -757,6 +765,10 @@ class ViewAndMutationMeta:
                 return None
 
         self.traced_tangent_metas = [extract_metadata(t) for t in self.traced_tangents]
+        self.traced_tangent_dtypes = [
+            t.dtype if isinstance(t, torch.Tensor) else None
+            for t in self.traced_tangents
+        ]
         # Clear traced tangents at runtime
         self.traced_tangents = []
         for inp_meta in self.subclass_inp_meta:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195352
* #195351
* __->__ #195664
* #195350
* #195349
* #195348
* #195347
* #195346

AOTAutograd's runtime wrapper had two places where the recorded metadata was
right and the runtime did something else with it.

mark_non_differentiable is keyed on TensorImpl, and the forward epilogue pairs
it with ctx._materialize_non_diff_grads = False, so marking one returned slot
marks every slot holding that same object, and each is then handed None
rather than zeros. Backends share one object across slots freely -- inductor
lowers aten.detach to a no-op, and h * 1 folds away -- so `return y[0:4],
y[4:8], y.detach()` marks the intermediate base the backward needs a tangent
for, and `return h * 1.0, h.detach()` marks the only differentiable output.
The recorded metadata is not at fault, the runtime identity collision is, so a
slot about to be marked that shares its object with a slot staying
differentiable is detached first and gets its own TensorImpl; one that collides
with nothing keeps its identity. Sparing the aliasing slot instead, by
declining to mark it, would leave the detach output with a grad_fn. The marked
index set is bound as a codegen-time constant so the per-call cost is one
identity scan over the Tensor slots.

The mutation epilogue wrote every functionalized input mutation back as a
tracked copy_. That is right for a mutation autograd saw, and wrong for one it
did not. Functionalization records a write as mutations_hidden_from_autograd
only when the op calls mark_mutation_hidden_from_autograd, which today is the
triton kernel HOP alone: such a write bypasses the ADInplaceOrView layer that
decides whether an eager in-place op bumps the version counter, so it left no
trace on the tensor in eager, and replaying it as a tracked copy_ both
rewrites the tensor's grad_fn and, when the target is an input a custom
autograd.Function returned as-is (an identity view stamped
IN_CUSTOM_FUNCTION), raises where eager did not. The epilogue now follows the
recorded metadata, exactly as apply_in_graph_mutations already does for
in-graph mutations: a hidden mutation is written under no_grad with the
version counter preserved, a mutation recorded under no_grad or inference
mode is written under no_grad, and everything else stays a tracked copy_.
That split now applies to leaf inputs too; previously a requires-grad leaf
always took the detach().copy_() path, which bumps a version counter a hidden
write never bumped. A tracked requires-grad leaf keeps detach().copy_(): a tracked write reaches
such a leaf through a detached view or through .data, and both take that
path, so a .data write that eager never counted still bumps the version once
under compile, exactly as it did before this change.
A Tensor(a!) op registered through torch.library with a
CompositeExplicitAutograd impl and no ADInplaceOrView kernel, writing through
.data, is recorded as a tracked mutation, so compiled code raises on a
restricted view where eager does not; that is what main did before this
stack, and teaching functionalization to record such ops as hidden is a
separate change. Deciding from the target's CreationMeta instead was rejected
because nothing guards it and it would let a tracked mutation silently
succeed on a view eager refuses. The reference _apply_input_mutations
implementation follows the same rule as the codegen'd epilogue. Both also check
for a mutated input bound to a stream index before the leaf branch rather than
after it, so that write is refused wherever it appears, and a mutation of an
inference tensor is replayed without the version-counter guard, which inference
tensors do not carry.

Diagnostic only: a kept tangent slot arriving as None now raises from
process_runtime_tangent, naming the forward output behind the slot, which of
the returned slots it is, and its recorded dtype, rather than surfacing several
frames lower as inductor's "expected Tensor()" against a codegen'd name like
tangents_3, which is not positional and cannot be mapped back to a user output
by hand. That needs the tangent dtypes, which make_runtime_safe dropped along
with the fake tangents, so ViewAndMutationMeta records them; a length mismatch
against the kept slots is logged rather than silently treated as unknown.

These changes run for every torch.compile and are not gated on precompile,
which is why they are their own commit rather than part of the precompile
stack's own PRs; nothing later in the stack calls into them directly.

Test Plan:

```
python test/functorch/test_aotdispatch.py
python test/functorch/test_codegen_mutation_epilogue.py
```

The two aliasing tests compare requires_grad, grad_fn and the gradient against
uncompiled eager over aot_eager and inductor, and the intermediate-base one
also asserts the detach output stays a leaf so the rejected fix cannot pass
it. The mutation tests split three ways. End to end,
test_tracked_input_mutation_on_custom_function_view_raises warms the compiled
function on an ordinary tensor and then calls it with the restricted view,
asserting the tracked write raises exactly as eager does on aot_eager and
inductor. test_hidden_input_mutation_replayed_onto_custom_function_view calls
the _replay_input_mutation helper directly on such a view and asserts the
grad_fn, the version counter and the custom backward all survive. The codegen
tests in test_codegen_mutation_epilogue.py assert the emitted epilogue is
copy_, a no_grad copy_, detach().copy_() or _replay_input_mutation according
to the recorded metadata, including a hidden and a no_grad mutation of a
requires-grad leaf, with the hidden flag patched in since only the triton
kernel HOP sets it. Three more cover the None-tangent path, and a warm-cache
test asserts the recorded tangent dtypes survive an AOTAutogradCache reload.

Authored with the assistance of an AI coding agent.