### PR TITLE
[dynamo] Preserve activation memory budgets across graph breaks

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2485,6 +2485,79 @@ cos: aten.cos.default -> PREFER_RECOMPUTE""",
         compiled = torch.compile(Model(budget=0.0).cuda(), backend="aot_eager")
         self.assertEqual(get_act_mem(lambda: compiled(x)), 0)
 
+    @torch._dynamo.config.patch(automatic_dynamic_shapes=False)
+    def test_region_activation_memory_budget_survives_graph_break(self):
+        from unittest.mock import patch
+
+        import torch._functorch.partitioners as partitioners
+
+        budgets = []
+        choose_saved_values_set = partitioners.choose_saved_values_set
+
+        def record_budget(joint_graph, node_info, memory_budget=1):
+            budgets.append(memory_budget)
+            return choose_saved_values_set(
+                joint_graph, node_info, memory_budget=memory_budget
+            )
+
+        def fn(x, budget):
+            with torch.autograd.graph.region_activation_memory_budget(budget):
+                x = x.sin()
+                torch._dynamo.graph_break()
+                return x.cos()
+
+        backend = aot_autograd(
+            fw_compiler=lambda gm, _: gm.forward,
+            bw_compiler=lambda gm, _: gm.forward,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+
+        with (
+            patch.object(partitioners, "choose_saved_values_set", record_budget),
+            torch._functorch.config.patch(activation_memory_budget=0.9),
+        ):
+            compiled = torch.compile(fn, backend=backend)
+            for budget in (0.0, 0.7, 0.0):
+                x = torch.randn(4, requires_grad=True)
+                compiled(x, budget).sum().backward()
+
+        self.assertEqual(budgets, [0.0, 0.0, 0.7, 0.7])
+
+    def test_region_activation_memory_budget_nested_graph_breaks(self):
+        graphs = []
+
+        def backend(gm, _):
+            graphs.append(gm)
+            return gm.forward
+
+        def fn(x):
+            with torch.autograd.graph.region_activation_memory_budget(0.2):
+                x = x.sin()
+                torch._dynamo.graph_break()
+                with torch.autograd.graph.region_activation_memory_budget(0.7):
+                    x = x.cos()
+                    torch._dynamo.graph_break()
+                    x = x.tan()
+                torch._dynamo.graph_break()
+                x = x + 1
+            torch._dynamo.graph_break()
+            return x * 2
+
+        compiled = torch.compile(fn, backend=backend)
+        x = torch.randn(4)
+        self.assertEqual(compiled(x), (x.sin().cos().tan() + 1) * 2)
+        self.assertEqual(
+            [
+                [
+                    torch.fx.traceback._get_memory_budget_annotation(node)
+                    for node in gm.graph.nodes
+                    if node.op in ("call_function", "call_method")
+                ]
+                for gm in graphs
+            ],
+            [[0.2], [0.7], [0.7], [0.2], [None]],
+        )
+
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     def test_region_activation_memory_budget_per_region(self):
         """Different graphs (separated by a graph break) can have different

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3606,6 +3606,22 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         c2 = self.gen_cache_key(fn, config)
         self.assertEqual(c1, c2)
 
+    def test_region_activation_memory_budget_cache_key(self):
+        def make_fn(budget):
+            def fn(x):
+                size = x.shape[0]
+                with torch.autograd.graph.region_activation_memory_budget(budget):
+                    return x.sin() + size
+
+            return fn
+
+        config = self.default_config()
+        low = self.gen_cache_key(make_fn(0.2), config)
+        high = self.gen_cache_key(make_fn(0.7), config)
+        low_again = self.gen_cache_key(make_fn(0.2), config)
+        self.assertNotEqual(low, high)
+        self.assertEqual(low, low_again)
+
     def test_runtime_only_configs_do_not_change_key(self):
         def fn(x):
             return x.sin().cos()

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1608,7 +1608,15 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
         self, annotation: dict[str, Any], initial_values: Any = None, **kwargs: Any
     ) -> None:
         self.annotation = annotation
-        super().__init__(target_values=(), initial_values=initial_values, **kwargs)
+        budget = annotation.get(torch.fx.traceback.MEMORY_BUDGET_ANNOTATION_KEY)
+        target_values = (
+            (budget,) if len(annotation) == 1 and type(budget) is float else ()
+        )
+        super().__init__(
+            target_values=target_values,
+            initial_values=initial_values,
+            **kwargs,
+        )
 
     def enter(
         self, tx: "InstructionTranslatorBase", *args: VariableTracker
@@ -1626,12 +1634,16 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
         return "torch.fx.traceback"
 
     def fn_name(self) -> str:
+        if self.target_values:
+            return "_dynamo_region_activation_memory_budget"
         return "annotate"
 
     def python_type(self) -> type:
         return contextlib._GeneratorContextManager
 
     def reconstruct_type(self, codegen: "PyCodegen") -> None:
+        if self.target_values:
+            return super().reconstruct_type(codegen)
         unimplemented(
             gb_type="torch.fx.traceback.annotate escaped from compiled region",
             context=str(self),

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -185,6 +185,8 @@ supported_ctx_manager_classes = dict.fromkeys(
         torch.cuda.use_mem_pool.__wrapped__,  # type: ignore[attr-defined]
         torch.fx.traceback.annotate,
         torch.fx.traceback.annotate.__wrapped__,  # type: ignore[attr-defined]
+        torch.fx.traceback._dynamo_region_activation_memory_budget,
+        torch.fx.traceback._dynamo_region_activation_memory_budget.__wrapped__,  # type: ignore[attr-defined]
         # We'll let Dynamo inline into the contextlib part of these context
         # manager instances, all the way till it invokes the wrapped function
         # itself (at which point we wrap it back to special context manager
@@ -793,6 +795,24 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
                 )
             return FxTracebackAnnotateVariable(
                 args[0].as_python_constant(), source=self.source
+            )
+        elif self.value in (
+            torch.fx.traceback._dynamo_region_activation_memory_budget,
+            torch.fx.traceback._dynamo_region_activation_memory_budget.__wrapped__,  # type: ignore[attr-defined]
+        ):
+            if len(args) != 1 or kwargs:
+                raise AssertionError(
+                    "_dynamo_region_activation_memory_budget expects "
+                    "one positional argument"
+                )
+            budget = guard_if_dyn(args[0])
+            if type(budget) is not float:
+                raise AssertionError(
+                    f"expected a float budget, got {type(budget).__name__}"
+                )
+            return FxTracebackAnnotateVariable(
+                {torch.fx.traceback.MEMORY_BUDGET_ANNOTATION_KEY: budget},
+                source=self.source,
             )
         elif inspect.isclass(self.value) and issubclass(self.value, torch.Stream):
             from torch._dynamo.variables.builder import wrap_fx_proxy_cls

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -521,16 +521,14 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         )
         self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
 
-        # region_activation_memory_budget is graph-wide (the partitioner enforces
-        # a single value across the graph) and propagates to every node, so the
-        # cache key only needs the value off the first node. node.meta is stripped
-        # by GraphModule.__reduce__, so without recording it here a budget change
-        # would not invalidate the cache.
-        first_node = next(iter(gm.graph.nodes), None)
-        self.region_activation_memory_budget: float | None = (
-            _get_memory_budget_annotation(first_node)
-            if first_node is not None
-            else None
+        # node.meta is stripped by GraphModule.__reduce__, so preserve the
+        # location and value of every budget annotation in the cache key.
+        self.region_activation_memory_budget_annotations = tuple(
+            (module_name, node_index, budget)
+            for module_name, module in gm.named_modules()
+            if isinstance(module, torch.fx.GraphModule)
+            for node_index, node in enumerate(module.graph.nodes)
+            if (budget := _get_memory_budget_annotation(node)) is not None
         )
 
         # Note: We use the live config module, not self.autograd_config (the

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -564,7 +564,8 @@ def region_activation_memory_budget(
         annotation is rejected rather than silently applied graph-wide), and all
         annotated nodes must agree on the budget. To use different budgets for
         different parts of a model, separate them with a graph break (e.g.
-        ``torch._dynamo.graph_break()``) so each part becomes its own graph.
+        ``torch._dynamo.graph_break()``) so each part becomes its own graph. The
+        context remains active across graph breaks within the region.
 
     This only has an effect under :func:`torch.compile`; using it outside of a
     compiled region raises a ``RuntimeError``.
@@ -598,9 +599,7 @@ def region_activation_memory_budget(
             "torch.autograd.graph.region_activation_memory_budget can only be "
             "used inside a torch.compile region; it has no effect in eager mode."
         )
-    return fx_traceback.annotate(
-        {fx_traceback.MEMORY_BUDGET_ANNOTATION_KEY: float(budget)}
-    )
+    return fx_traceback._dynamo_region_activation_memory_budget(float(budget))
 
 
 def set_warn_on_accumulate_grad_stream_mismatch(enabled: bool) -> None:

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -370,6 +370,15 @@ def annotate(annotation_dict: dict[str, Any]) -> Iterator[None]:
 MEMORY_BUDGET_ANNOTATION_KEY = "_region_activation_memory_budget"
 
 
+@contextmanager
+def _dynamo_region_activation_memory_budget(budget: float) -> Iterator[None]:
+    with (
+        annotate({MEMORY_BUDGET_ANNOTATION_KEY: budget}),
+        preserve_node_meta(),
+    ):
+        yield
+
+
 def _get_memory_budget_annotation(node: Node) -> float | None:
     """
     Read the ``region_activation_memory_budget`` annotation off an FX node,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

region_activation_memory_budget uses fx.traceback annotations, but Dynamo
previously refused to reconstruct the annotation context after a graph break.
Consequently, operations traced by a resumed frame lost their regional budget.

Special-case the reserved singleton float budget annotation in
FxTracebackAnnotateVariable. Keep the float in the context's target values so
continuation caching distinguishes budgets, and reconstruct a small private
context factory that reuses fx.traceback.annotate and preserve_node_meta.
Arbitrary FX annotations remain unsupported across graph breaks.

Also record every budget annotation in the AOTAutograd cache key instead of
reading only the first node, which may legitimately precede the annotated
region. This narrow lexical solution avoids the module-identity and subtree
coverage limitations of inferring budgets from nn_module_stack.

Test Plan:

```bash
python -c "import runpy,sys; old='/data/users/jw3468/a/pytorch/agent_space/autograd_consumption_wt'; new='/data/users/jw3468/a/pytorch/agent_space/budget_float_wt'; f=[x for x in sys.meta_path if type(x).__name__=='ScikitBuildRedirectingFinder'][0]; f.known_source_files={k:v.replace(old,new) for k,v in f.known_source_files.items()}; f.submodule_search_locations={k:{p.replace(old,new) for p in paths} for k,paths in f.submodule_search_locations.items()}; sys.argv=['test/dynamo/test_activation_checkpointing.py','-k','region_activation_memory_budget']; runpy.run_path('test/dynamo/test_activation_checkpointing.py', run_name='__main__')"
python -c "import runpy,sys; old='/data/users/jw3468/a/pytorch/agent_space/autograd_consumption_wt'; new='/data/users/jw3468/a/pytorch/agent_space/budget_float_wt'; f=[x for x in sys.meta_path if type(x).__name__=='ScikitBuildRedirectingFinder'][0]; f.known_source_files={k:v.replace(old,new) for k,v in f.known_source_files.items()}; f.submodule_search_locations={k:{p.replace(old,new) for p in paths} for k,paths in f.submodule_search_locations.items()}; sys.argv=['test/dynamo/test_aot_autograd_cache.py','AOTAutogradCacheTests.test_region_activation_memory_budget_causes_cache_miss','AOTAutogradCacheTests.test_region_activation_memory_budget_graph_break_cache','AOTAutogradCachePicklerTests.test_region_activation_memory_budget_cache_key']; runpy.run_path('test/dynamo/test_aot_autograd_cache.py', run_name='__main__')"
python -c "import runpy,sys; old='/data/users/jw3468/a/pytorch/agent_space/autograd_consumption_wt'; new='/data/users/jw3468/a/pytorch/agent_space/budget_float_wt'; f=[x for x in sys.meta_path if type(x).__name__=='ScikitBuildRedirectingFinder'][0]; f.known_source_files={k:v.replace(old,new) for k,v in f.known_source_files.items()}; f.submodule_search_locations={k:{p.replace(old,new) for p in paths} for k,paths in f.submodule_search_locations.items()}; sys.argv=['test/dynamo/test_fx_annotate.py','AnnotateTests.test_graph_break']; runpy.run_path('test/dynamo/test_fx_annotate.py', run_name='__main__')"
spin lint test/dynamo/test_activation_checkpointing.py test/dynamo/test_aot_autograd_cache.py torch/_dynamo/variables/ctx_manager.py torch/_dynamo/variables/torch.py torch/_functorch/_aot_autograd/autograd_cache.py torch/autograd/graph.py torch/fx/traceback.py
```

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98