### PR TITLE
[dynamo] Allow partial regional memory budget coverage

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2523,6 +2523,60 @@ cos: aten.cos.default -> PREFER_RECOMPUTE""",
 
         self.assertEqual(budgets, [0.0, 0.0, 0.7, 0.7])
 
+    def test_region_activation_memory_budget_partial_coverage_survives_graph_break(
+        self,
+    ):
+        def fn(x):
+            with torch.autograd.graph.region_activation_memory_budget(
+                0.2, require_full_coverage=False
+            ):
+                x = x.sin()
+                torch._dynamo.graph_break()
+                x = x.cos()
+            return x + 1
+
+        compiled = torch.compile(fn, backend="aot_eager")
+        x = torch.randn(4, requires_grad=True)
+        out = compiled(x)
+        self.assertEqual(out, x.sin().cos() + 1)
+        out.sum().backward()
+
+    def test_region_activation_memory_budget_coverage_continuation_cache(self):
+        graphs = []
+
+        def backend(gm, _):
+            graphs.append(gm)
+            return gm.forward
+
+        def fn(x, require_full_coverage):
+            with torch.autograd.graph.region_activation_memory_budget(
+                0.2, require_full_coverage=require_full_coverage
+            ):
+                x = x.sin()
+                torch._dynamo.graph_break()
+                return x.cos()
+
+        compiled = torch.compile(fn, backend=backend)
+        x = torch.randn(4)
+        for require_full_coverage in (True, False, True):
+            self.assertEqual(compiled(x, require_full_coverage), x.sin().cos())
+
+        annotations = []
+        get_requirement = torch.fx.traceback._get_memory_budget_require_full_coverage
+        for gm in graphs:
+            graph_annotations = []
+            for node in gm.graph.nodes:
+                if node.op not in ("call_function", "call_method"):
+                    continue
+                budget = torch.fx.traceback._get_memory_budget_annotation(node)
+                if budget is not None:
+                    graph_annotations.append((budget, get_requirement(node)))
+            annotations.append(graph_annotations)
+        self.assertEqual(
+            annotations,
+            [[(0.2, True)], [(0.2, True)], [(0.2, False)], [(0.2, False)]],
+        )
+
     def test_region_activation_memory_budget_nested_graph_breaks(self):
         graphs = []
 
@@ -2637,6 +2691,8 @@ cos: aten.cos.default -> PREFER_RECOMPUTE""",
             region_activation_memory_budget(2.0)
         with self.assertRaisesRegex(ValueError, r"\[0, 1\]"):
             region_activation_memory_budget(-0.1)
+        with self.assertRaisesRegex(TypeError, "require_full_coverage.*bool"):
+            region_activation_memory_budget(0.5, require_full_coverage=1)
 
     def test_region_activation_memory_budget_eager_raises(self):
         """Using the context manager outside a torch.compile region is an error."""
@@ -2661,8 +2717,7 @@ cos: aten.cos.default -> PREFER_RECOMPUTE""",
             cfn(x, y).sum().backward()
 
     def test_region_activation_memory_budget_partial_annotation_raises(self):
-        """Annotating only part of a graph is rejected: the budget is applied
-        graph-wide, so it must cover the entire forward."""
+        """The default rejects a context that annotates only part of a graph."""
 
         def fn(x, y):
             with torch.autograd.graph.region_activation_memory_budget(0.3):
@@ -2675,6 +2730,76 @@ cos: aten.cos.default -> PREFER_RECOMPUTE""",
         y = torch.randn(8, 8, requires_grad=True)
         with self.assertRaisesRegex(RuntimeError, "must cover the entire forward"):
             cfn(x, y).sum().backward()
+
+    def test_region_activation_memory_budget_partial_coverage_allowed(self):
+        from unittest.mock import patch
+
+        import torch._functorch.partitioners as partitioners
+
+        budgets = []
+        choose_saved_values_set = partitioners.choose_saved_values_set
+
+        def record_budget(joint_graph, node_info, memory_budget=1):
+            budgets.append(memory_budget)
+            return choose_saved_values_set(
+                joint_graph, node_info, memory_budget=memory_budget
+            )
+
+        def fn(x, y):
+            with torch.autograd.graph.region_activation_memory_budget(
+                0.3, require_full_coverage=False
+            ):
+                a = (torch.mm(x, y) + 1).relu()
+            return (a * 2).relu()
+
+        backend = aot_autograd(
+            fw_compiler=lambda gm, _: gm.forward,
+            bw_compiler=lambda gm, _: gm.forward,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+        with patch.object(partitioners, "choose_saved_values_set", record_budget):
+            cfn = torch.compile(fn, backend=backend, fullgraph=True)
+            x = torch.randn(8, 8, requires_grad=True)
+            y = torch.randn(8, 8, requires_grad=True)
+            cfn(x, y).sum().backward()
+
+        self.assertEqual(budgets, [0.3])
+
+    def test_region_activation_memory_budget_strict_coverage_wins(self):
+        def fn(x):
+            with torch.autograd.graph.region_activation_memory_budget(
+                0.3, require_full_coverage=False
+            ):
+                x = x.sin()
+            with torch.autograd.graph.region_activation_memory_budget(0.3):
+                x = x.cos()
+            return x.tan()
+
+        cfn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        x = torch.randn(8, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "must cover the entire forward"):
+            cfn(x).sum().backward()
+
+    @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
+    def test_region_activation_memory_budget_partial_coverage_invoke_subgraph(self):
+        from torch.compiler import nested_compile_region
+
+        weight = torch.randn(8, 8, requires_grad=True)
+
+        @nested_compile_region
+        def region(x):
+            with torch.autograd.graph.region_activation_memory_budget(
+                0.3, require_full_coverage=False
+            ):
+                return (x @ weight).relu()
+
+        def fn(x):
+            return (region(x) + 1).sum()
+
+        cfn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        x = torch.randn(8, 8, requires_grad=True)
+        cfn(x).backward()
+        self.assertIsNotNone(x.grad)
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3493,6 +3493,38 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 4)
             self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 2)
 
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_region_activation_memory_budget_partial_coverage_graph_break_cache(
+        self,
+    ):
+        def fn(x):
+            with torch.autograd.graph.region_activation_memory_budget(
+                0.3, require_full_coverage=False
+            ):
+                x = (x + 1).relu()
+                torch._dynamo.graph_break()
+                x = (x * 2).relu()
+            return (x + 3).relu()
+
+        with fresh_cache():
+            compiled = torch.compile(fn, backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            compiled = torch.compile(fn, backend="inductor")
+            x = torch.randn(10, 10, requires_grad=True)
+            compiled(x).sum().backward()
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 2)
+
 
 @functorch_config.patch({"bundled_autograd_cache": True})
 class AOTAutogradCacheBundledTests(AOTAutogradCacheTests):
@@ -3621,6 +3653,32 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         low_again = self.gen_cache_key(make_fn(0.2), config)
         self.assertNotEqual(low, high)
         self.assertEqual(low, low_again)
+
+    def test_region_activation_memory_budget_coverage_cache_key(self):
+        def full_coverage(require_full_coverage):
+            def fn(x):
+                with torch.autograd.graph.region_activation_memory_budget(
+                    0.2, require_full_coverage=require_full_coverage
+                ):
+                    return x.sin().cos()
+
+            return fn
+
+        def partial_coverage(x):
+            x = x.sin()
+            with torch.autograd.graph.region_activation_memory_budget(
+                0.2, require_full_coverage=False
+            ):
+                return x.cos()
+
+        config = self.default_config()
+        strict = self.gen_cache_key(full_coverage(True), config)
+        permissive = self.gen_cache_key(full_coverage(False), config)
+        partial = self.gen_cache_key(partial_coverage, config)
+        partial_again = self.gen_cache_key(partial_coverage, config)
+        self.assertNotEqual(strict, permissive)
+        self.assertNotEqual(permissive, partial)
+        self.assertEqual(partial, partial_again)
 
     def test_runtime_only_configs_do_not_change_key(self):
         def fn(x):

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1608,10 +1608,17 @@ class FxTracebackAnnotateVariable(ContextWrappingVariable):
         self, annotation: dict[str, Any], initial_values: Any = None, **kwargs: Any
     ) -> None:
         self.annotation = annotation
-        budget = annotation.get(torch.fx.traceback.MEMORY_BUDGET_ANNOTATION_KEY)
-        target_values = (
-            (budget,) if len(annotation) == 1 and type(budget) is float else ()
+        budget_key = torch.fx.traceback.MEMORY_BUDGET_ANNOTATION_KEY
+        coverage_key = torch.fx.traceback.MEMORY_BUDGET_REQUIRE_FULL_COVERAGE_KEY
+        budget = annotation.get(budget_key)
+        require_full_coverage = annotation.get(coverage_key, True)
+        is_memory_budget = (
+            budget_key in annotation
+            and set(annotation).issubset({budget_key, coverage_key})
+            and type(budget) is float
+            and type(require_full_coverage) is bool
         )
+        target_values = (budget, require_full_coverage) if is_memory_budget else ()
         super().__init__(
             target_values=target_values,
             initial_values=initial_values,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -800,18 +800,28 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             torch.fx.traceback._dynamo_region_activation_memory_budget,
             torch.fx.traceback._dynamo_region_activation_memory_budget.__wrapped__,  # type: ignore[attr-defined]
         ):
-            if len(args) != 1 or kwargs:
+            if len(args) not in (1, 2) or kwargs:
                 raise AssertionError(
                     "_dynamo_region_activation_memory_budget expects "
-                    "one positional argument"
+                    "one or two positional arguments"
                 )
             budget = guard_if_dyn(args[0])
             if type(budget) is not float:
                 raise AssertionError(
                     f"expected a float budget, got {type(budget).__name__}"
                 )
+            require_full_coverage = guard_if_dyn(args[1]) if len(args) == 2 else True
+            if type(require_full_coverage) is not bool:
+                raise AssertionError(
+                    "expected require_full_coverage to be a bool, got "
+                    f"{type(require_full_coverage).__name__}"
+                )
+            coverage_key = torch.fx.traceback.MEMORY_BUDGET_REQUIRE_FULL_COVERAGE_KEY
             return FxTracebackAnnotateVariable(
-                {torch.fx.traceback.MEMORY_BUDGET_ANNOTATION_KEY: budget},
+                {
+                    torch.fx.traceback.MEMORY_BUDGET_ANNOTATION_KEY: budget,
+                    coverage_key: require_full_coverage,
+                },
                 source=self.source,
             )
         elif inspect.isclass(self.value) and issubclass(self.value, torch.Stream):

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -65,7 +65,10 @@ from torch.compiler._cache import (
 )
 from torch.fx.experimental.symbolic_shapes import guarding_hint_or_throw
 from torch.fx.node import Node
-from torch.fx.traceback import _get_memory_budget_annotation
+from torch.fx.traceback import (
+    _get_memory_budget_annotation,
+    _get_memory_budget_require_full_coverage,
+)
 from torch.utils._triton import has_triton_package
 
 from .aot_autograd_result import (
@@ -522,9 +525,15 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
 
         # node.meta is stripped by GraphModule.__reduce__, so preserve the
-        # location and value of every budget annotation in the cache key.
+        # location, value, and coverage requirement of every budget annotation
+        # in the cache key.
         self.region_activation_memory_budget_annotations = tuple(
-            (module_name, node_index, budget)
+            (
+                module_name,
+                node_index,
+                budget,
+                _get_memory_budget_require_full_coverage(node),
+            )
             for module_name, module in gm.named_modules()
             if isinstance(module, torch.fx.GraphModule)
             for node_index, node in enumerate(module.graph.nodes)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -60,7 +60,10 @@ from torch.fx.experimental.symbolic_shapes import (
     statically_known_true,
 )
 from torch.fx.passes import graph_drawer
-from torch.fx.traceback import _get_memory_budget_annotation
+from torch.fx.traceback import (
+    _get_memory_budget_annotation,
+    _get_memory_budget_require_full_coverage,
+)
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
 
@@ -4268,23 +4271,24 @@ def min_cut_rematerialization_partition(
             break
 
     # The partitioner applies a single budget per joint graph, so all annotated
-    # nodes must agree and the annotation must cover every forward op; otherwise
-    # the caller mixed budgets or annotated only part of a graph (across a graph
-    # break each graph is resolved independently). Collect both in one pass.
+    # nodes must agree. By default the annotation must cover every forward op;
+    # require_full_coverage=False permits partial coverage and applies the budget
+    # to the entire graph. Collect the budget, coverage requirement, and any
+    # unannotated forward ops in one pass.
     region_budgets: OrderedSet[float] = OrderedSet()
+    requires_full_coverage = False
     unannotated_fw_ops: list[fx.Node] = []
     for node in joint_graph.nodes:
         budget = _get_memory_budget_annotation(node)
         if budget is not None:
             region_budgets.add(budget)
+            requires_full_coverage |= _get_memory_budget_require_full_coverage(node)
         elif node.op == "call_function" and node_info.is_required_fw(node):
             unannotated_fw_ops.append(node)
 
-    # A budget must consistently cover the entire forward, including HOP bodies.
-    # Recurse into nested subgraph modules: collect their budgets (for the
-    # agreement check) and flag any unannotated call_function (for coverage). In
-    # a consistent graph every node in every body carries the budget, so an
-    # unannotated body op means the budget did not cover that HOP.
+    # Budget agreement and optional full-coverage checks include HOP bodies.
+    # Recurse into nested subgraph modules to collect their budgets and any
+    # unannotated call_function nodes.
     all_budgets: OrderedSet[float] = OrderedSet(region_budgets)
     for _, sub in joint_module.named_modules():
         if isinstance(sub, fx.GraphModule) and sub.graph is not joint_graph:
@@ -4292,6 +4296,9 @@ def min_cut_rematerialization_partition(
                 b = _get_memory_budget_annotation(node)
                 if b is not None:
                     all_budgets.add(b)
+                    requires_full_coverage |= _get_memory_budget_require_full_coverage(
+                        node
+                    )
                 elif node.op == "call_function":
                     unannotated_fw_ops.append(node)
     if len(all_budgets) > 1:
@@ -4303,14 +4310,14 @@ def min_cut_rematerialization_partition(
         )
 
     if all_budgets:
-        if unannotated_fw_ops:
+        if requires_full_coverage and unannotated_fw_ops:
             raise RuntimeError(
                 f"torch.autograd.graph.region_activation_memory_budget: must "
                 f"cover the entire forward of a graph (including HOP bodies), but "
                 f"{len(unannotated_fw_ops)} forward op(s) are unannotated. Wrap "
-                f"the whole forward in a single region; use a graph break to scope "
-                f"different budgets to different graphs. Note that a graph break "
-                f"inside the annotated region can also cause unannotated ops here. "
+                f"the whole forward in a single region, or set "
+                f"require_full_coverage=False to apply the budget to the entire "
+                f"compiled region. "
                 f"Unannotated ops: {[n.name for n in unannotated_fw_ops]}."
             )
         memory_budget = next(iter(all_budgets))

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -540,9 +540,13 @@ class node_creation_hook:
 
 def region_activation_memory_budget(
     budget: float,
+    *,
+    require_full_coverage: bool = True,
 ) -> contextlib.AbstractContextManager[None]:
-    r"""Context-manager that sets the activation memory budget for the region of
-    a compiled forward traced under it.
+    r"""region_activation_memory_budget(budget, *, require_full_coverage=True)
+
+    Set the activation memory budget for the region of a compiled forward traced
+    under this context manager.
 
     .. warning::
         This is a prototype feature and is subject to change.
@@ -559,19 +563,26 @@ def region_activation_memory_budget(
     for the annotated region.
 
     .. note::
-        Today the partitioner only supports a single budget per compiled graph,
-        so the annotation must cover every forward op in the graph (a partial
-        annotation is rejected rather than silently applied graph-wide), and all
-        annotated nodes must agree on the budget. To use different budgets for
-        different parts of a model, separate them with a graph break (e.g.
-        ``torch._dynamo.graph_break()``) so each part becomes its own graph. The
-        context remains active across graph breaks within the region.
+        Today the partitioner only supports a single budget per compiled region,
+        so all budget contexts within that region must agree. By default, the
+        context must cover every forward operation compiled with it. Set
+        ``require_full_coverage=False`` to permit operations outside the context;
+        the budget then applies to the entire compiled region. To use different
+        budgets for different parts of a model, separate them with a graph break
+        (e.g. ``torch._dynamo.graph_break()``). The context remains active across
+        graph breaks within the region. If multiple contexts select the same
+        budget, any context that requires full coverage makes the compiled region
+        require full coverage.
 
     This only has an effect under :func:`torch.compile`; using it outside of a
     compiled region raises a ``RuntimeError``.
 
     Args:
         budget (float): Activation memory budget ratio in ``[0, 1]``.
+        require_full_coverage (bool, optional): If ``True``, require the context
+          to cover every forward operation compiled with it. If ``False``, permit
+          operations outside the context and apply the budget to the entire
+          compiled region. Default: ``True``.
 
     Example::
 
@@ -591,6 +602,12 @@ def region_activation_memory_budget(
             f"torch.autograd.graph.region_activation_memory_budget: must be in "
             f"[0, 1], got {budget}"
         )
+    if not isinstance(require_full_coverage, bool):
+        raise TypeError(
+            "torch.autograd.graph.region_activation_memory_budget: expects "
+            f"require_full_coverage to be a bool, got "
+            f"{type(require_full_coverage).__name__}"
+        )
     # The budget only takes effect when read back by the partitioner during
     # compilation. Dynamo folds torch.compiler.is_compiling() to True while
     # tracing this (inlined) call, so this guard only fires in eager mode.
@@ -599,7 +616,9 @@ def region_activation_memory_budget(
             "torch.autograd.graph.region_activation_memory_budget can only be "
             "used inside a torch.compile region; it has no effect in eager mode."
         )
-    return fx_traceback._dynamo_region_activation_memory_budget(float(budget))
+    return fx_traceback._dynamo_region_activation_memory_budget(
+        float(budget), require_full_coverage
+    )
 
 
 def set_warn_on_accumulate_grad_stream_mismatch(enabled: bool) -> None:

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -368,12 +368,22 @@ def annotate(annotation_dict: dict[str, Any]) -> Iterator[None]:
 # writer and the reader below so the partitioner / AOTAutograd cache read it the
 # same way.
 MEMORY_BUDGET_ANNOTATION_KEY = "_region_activation_memory_budget"
+MEMORY_BUDGET_REQUIRE_FULL_COVERAGE_KEY = (
+    "_region_activation_memory_budget_require_full_coverage"
+)
 
 
 @contextmanager
-def _dynamo_region_activation_memory_budget(budget: float) -> Iterator[None]:
+def _dynamo_region_activation_memory_budget(
+    budget: float, require_full_coverage: bool = True
+) -> Iterator[None]:
     with (
-        annotate({MEMORY_BUDGET_ANNOTATION_KEY: budget}),
+        annotate(
+            {
+                MEMORY_BUDGET_ANNOTATION_KEY: budget,
+                MEMORY_BUDGET_REQUIRE_FULL_COVERAGE_KEY: require_full_coverage,
+            }
+        ),
         preserve_node_meta(),
     ):
         yield
@@ -390,6 +400,13 @@ def _get_memory_budget_annotation(node: Node) -> float | None:
     if not isinstance(custom, dict):
         return None
     return custom.get(MEMORY_BUDGET_ANNOTATION_KEY)
+
+
+def _get_memory_budget_require_full_coverage(node: Node) -> bool:
+    custom = node.meta.get("custom")
+    if not isinstance(custom, dict):
+        return True
+    return custom.get(MEMORY_BUDGET_REQUIRE_FULL_COVERAGE_KEY) is not False
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #195667

region_activation_memory_budget currently rejects a compiled graph when any
forward operation is outside the context. This is a useful safety default, but
it prevents callers from selecting a graph-wide partitioner budget using a
lexically smaller region.

Add a keyword-only require_full_coverage option that preserves the strict
behavior by default. When disabled, unannotated forward operations are allowed
and the selected budget applies to the entire compiled region. If policies are
mixed within a graph, strict coverage wins.

Carry the policy through Dynamo continuation reconstruction and specialization,
and include it with each annotation location in the AOTAutograd cache key. The
latter is necessary because GraphModule serialization strips node metadata and
strict and permissive compilations must not alias.

Test Plan:

```bash
python -c 'import runpy,sys; old="/data/users/jw3468/a/pytorch/agent_space/autograd_consumption_wt"; new="/data/users/jw3468/a/pytorch/agent_space/full_coverage_test_wt"; finder=next(x for x in sys.meta_path if type(x).__name__=="ScikitBuildRedirectingFinder"); finder.known_source_files={k:v.replace(old,new) for k,v in finder.known_source_files.items()}; finder.submodule_search_locations={k:{p.replace(old,new) for p in ps} for k,ps in finder.submodule_search_locations.items()}; sys.argv=[new+"/test/dynamo/test_activation_checkpointing.py","-k","region_activation_memory_budget"]; runpy.run_path(sys.argv[0],run_name="__main__")'
python -c 'import runpy,sys; old="/data/users/jw3468/a/pytorch/agent_space/autograd_consumption_wt"; new="/data/users/jw3468/a/pytorch/agent_space/full_coverage_test_wt"; finder=next(x for x in sys.meta_path if type(x).__name__=="ScikitBuildRedirectingFinder"); finder.known_source_files={k:v.replace(old,new) for k,v in finder.known_source_files.items()}; finder.submodule_search_locations={k:{p.replace(old,new) for p in ps} for k,ps in finder.submodule_search_locations.items()}; sys.argv=[new+"/test/dynamo/test_aot_autograd_cache.py","AOTAutogradCacheTests.test_region_activation_memory_budget_causes_cache_miss","AOTAutogradCacheTests.test_region_activation_memory_budget_graph_break_cache","AOTAutogradCacheTests.test_region_activation_memory_budget_partial_coverage_graph_break_cache","AOTAutogradCacheBundledTests.test_region_activation_memory_budget_partial_coverage_graph_break_cache","AOTAutogradCachePicklerTests.test_region_activation_memory_budget_cache_key","AOTAutogradCachePicklerTests.test_region_activation_memory_budget_coverage_cache_key"]; runpy.run_path(sys.argv[0],run_name="__main__")'
python -c 'import runpy,sys; old="/data/users/jw3468/a/pytorch/agent_space/autograd_consumption_wt"; new="/data/users/jw3468/a/pytorch/agent_space/full_coverage_test_wt"; finder=next(x for x in sys.meta_path if type(x).__name__=="ScikitBuildRedirectingFinder"); finder.known_source_files={k:v.replace(old,new) for k,v in finder.known_source_files.items()}; finder.submodule_search_locations={k:{p.replace(old,new) for p in ps} for k,ps in finder.submodule_search_locations.items()}; sys.argv=[new+"/test/dynamo/test_fx_annotate.py","AnnotateTests.test_graph_break"]; runpy.run_path(sys.argv[0],run_name="__main__")'
spin lint test/dynamo/test_activation_checkpointing.py test/dynamo/test_aot_autograd_cache.py torch/_dynamo/variables/ctx_manager.py torch/_dynamo/variables/torch.py torch/_functorch/_aot_autograd/autograd_cache.py torch/_functorch/partitioners.py torch/autograd/graph.py torch/fx/traceback.py
lintrunner -a
```

Authored with assistance from an AI coding assistant.