### PR TITLE
Add missing typename in IValue tuple SFINAE for clang-15

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -513,11 +513,11 @@ struct TORCH_API IValue final {
 
   template <
       typename... Args,
-      typename = enable_if_ivalue_compatible<Args...>::type>
+      typename = typename enable_if_ivalue_compatible<Args...>::type>
   IValue(const std::tuple<Args...>& t);
   template <
       typename... Args,
-      typename = enable_if_ivalue_compatible<Args...>::type>
+      typename = typename enable_if_ivalue_compatible<Args...>::type>
   IValue(std::tuple<Args...>&& t);
   bool isTuple() const {
     return Tag::Tuple == tag;

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1874,7 +1874,7 @@ Tuple generic_to_tuple_impl(
 template <
     typename... Args,
     typename Indices = std::make_index_sequence<sizeof...(Args)>,
-    typename = IValue::enable_if_ivalue_compatible<Args...>::type>
+    typename = typename IValue::enable_if_ivalue_compatible<Args...>::type>
 std::tuple<Args...> generic_to(const IValue& ivalue, _fake_type<std::tuple<Args...>> /*unused*/) {
   const auto& vals = ivalue.toTupleRef().elements();
   TORCH_CHECK(vals.size() == sizeof...(Args));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195671

Forward fix for D117882908 (pytorch/pytorch#194977), which broke every
arvr/ovrsource build that depends on `xplat/caffe2:ATen_lib_ovrsource`:

```
xplat/caffe2/aten/src/ATen/core/ivalue.h:516:18: error: missing 'typename' prior to
  dependent type name 'enable_if_ivalue_compatible<Args...>::type'
xplat/caffe2/aten/src/ATen/core/ivalue_inl.h:1959:16: error: missing 'typename' prior to
  dependent type name 'IValue::enable_if_ivalue_compatible<Args...>::type'
3 errors generated.
```

That diff factored the tuple-constructor SFINAE into a new alias member:

```
template <typename... Ts>
using enable_if_ivalue_compatible = std::enable_if<...>;   // enable_if, not enable_if_t
```

and uses it as `typename = enable_if_ivalue_compatible<Args...>::type`. Since
the alias expands to `std::enable_if<...>`, `::type` is a dependent name and
needs the `typename` disambiguator.

C++20's P0634R3 ("Down with typename!") makes `typename` optional in exactly
this position -- the default argument of a type template parameter -- which is
why this compiled everywhere the change was tested. This is not a language
version difference: both fbcode and arvr build caffe2 at `-std=gnu++20`. It is
a compiler version difference. fbcode uses clang-21, while `ATen_lib_ovrsource`
under `arvr/mode/platform010/*` pins clang-15 (see the
`x86_64-clang-dev-platform010` platform in
`arvr/tools/build_defs/config/platform/linux/generated.bzl`), and clang did not
implement P0634R3 until 16.

Add the `typename` disambiguator at the three use sites. It is well formed in
every standard from C++11 on, so it is also accepted by the newer compilers
that already build the current form.

The SFINAE predicate itself is left alone. Rewriting
`!disjunction_v<is_lvalue_reference<Args>..., negation<is_constructible<IValue, Args>>...>`
as `conjunction<negation<is_lvalue_reference<Ts>>..., is_constructible<IValue, Ts>...>`
is a correct De Morgan transform and preserves the short-circuit ordering that
keeps `is_constructible<IValue, T>` from being instantiated on reference types.

`xplat/caffe2` is updated to keep it in sync with `fbcode/caffe2`.

This should also go upstream to pytorch/pytorch#194977, since OSS CI will hit
the same error on any clang-15 build.

Differential Revision: [D118389865](https://our.internmc.facebook.com/intern/diff/D118389865/)