### PR TITLE
Improve async collective remap error

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -1745,6 +1745,21 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         outputs = torch.empty(global_size, device=self.device)
         correct_outputs = torch.empty(global_size, device=self.device)
         counter = CompileCounter()
+
+        fullgraph_compiled = torch.compile(
+            func, backend=CompileCounter(), fullgraph=True
+        )
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as cm:
+            fullgraph_compiled(inputs, outputs, pg=GroupMember.WORLD)
+        message = str(cm.exception)
+        self.assertIn(
+            "Dynamo can only remap synchronous torch.distributed collectives",
+            message,
+        )
+        self.assertIn("set async_op=False", message)
+        self.assertIn("torch.distributed._functional_collectives", message)
+        self.assertIn("https://github.com/pytorch/pytorch/issues/119890", message)
+
         compiled = torch.compile(func, backend=counter)
         compiled(inputs, outputs, pg=GroupMember.WORLD)
         func(inputs, correct_outputs, pg=GroupMember.WORLD)

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2809,6 +2809,14 @@
     {
       "Gb_type": "async_op=True for distributed collectives",
       "Context": "{self.fn}, args={args}, kwargs={kwargs}",
+      "Explanation": "_ASYNC_OP_REMAP_ERROR",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "async_op=True for distributed collectives",
+      "Context": "{self.fn}, args={args}, kwargs={kwargs}",
       "Explanation": "`torch.compile` doesn't support `async_op=True for {self.fn}",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3142,7 +3142,10 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
         # It's safe to assume args/kwargs from orig_fn map 1:1 to args/kwargs of remapped_fn,
         # since that's the contract for putting a mapping in `traceable_collective_remaps`
         import torch.distributed as dist
-        from torch.distributed._functional_collectives import REDUCE_OP_TO_STR
+        from torch.distributed._functional_collectives import (
+            _ASYNC_OP_REMAP_ERROR,
+            REDUCE_OP_TO_STR,
+        )
 
         # Merge args into kwargs so positional and keyword args
         # can be processed the same way.
@@ -3154,7 +3157,7 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
             unimplemented(
                 gb_type="async_op=True for distributed collectives",
                 context=f"{self.fn}, {args=}, {kwargs=}",
-                explanation=f"`torch.compile` doesn't support `async_op=True for {self.fn}",
+                explanation=_ASYNC_OP_REMAP_ERROR,
                 hints=[
                     *graph_break_hints.SUPPORTABLE,
                 ],

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1801,6 +1801,20 @@ These schemas intentionally match torch.distributed.distributed_c10d.* ops that 
 """
 
 
+_ASYNC_OP_REMAP_ERROR = (
+    "Dynamo can only remap synchronous torch.distributed collectives "
+    "(async_op=False) to functional collectives. If your program does not need "
+    "the Work handle, set async_op=False. Otherwise, rewrite the collective "
+    "with torch.distributed._functional_collectives and synchronize the "
+    "returned tensor with wait_tensor or wait_tensors. Tracking issue: "
+    "https://github.com/pytorch/pytorch/issues/119890"
+)
+
+
+def _raise_async_op_remap_error() -> None:
+    raise AssertionError(_ASYNC_OP_REMAP_ERROR)
+
+
 def all_gather_tensor_inplace(
     output_tensor: torch.Tensor,
     input_tensor: torch.Tensor,
@@ -1810,9 +1824,7 @@ def all_gather_tensor_inplace(
     gather_dim: int = 0,
 ):
     if async_op:
-        raise AssertionError(
-            "Can't remap async version of inplace op to functional collective"
-        )
+        _raise_async_op_remap_error()
 
     group = group or dist.group.WORLD
     if group is None:
@@ -1831,9 +1843,7 @@ def reduce_scatter_tensor_inplace(
     tag: str = "",
 ):
     if async_op:
-        raise AssertionError(
-            "Can't remap async version of inplace op to functional collective"
-        )
+        _raise_async_op_remap_error()
 
     group = group or dist.group.WORLD
     if group is None:
@@ -1862,9 +1872,7 @@ def all_reduce_inplace(
     tag: str = "",
 ):
     if async_op:
-        raise AssertionError(
-            "Can't remap async version of inplace op to functional collective"
-        )
+        _raise_async_op_remap_error()
 
     group = group or dist.group.WORLD
     if group is None:
@@ -1883,9 +1891,7 @@ def all_to_all_inplace(
     tag: str = "",
 ):
     if async_op:
-        raise AssertionError(
-            "Can't remap async version of inplace op to functional collective"
-        )
+        _raise_async_op_remap_error()
 
     group = group or dist.group.WORLD
     if group is None:
@@ -1910,9 +1916,7 @@ def all_gather_inplace(
     tag: str = "",
 ):
     if async_op:
-        raise AssertionError(
-            "Can't remap async version of inplace op to functional collective"
-        )
+        _raise_async_op_remap_error()
     if tensor.dim() != 0 and not all(t.size(0) == tensor.size(0) for t in tensor_list):
         raise AssertionError("Remapping variable size all_gather is not yet supported")
 
@@ -1948,9 +1952,7 @@ def reduce_scatter_inplace(
     tag: str = "",
 ):
     if async_op:
-        raise AssertionError(
-            "Can't remap async version of inplace op to functional collective"
-        )
+        _raise_async_op_remap_error()
     if not all(t.size() == output.size() for t in input_list):
         raise AssertionError(
             "reduce_scatter requires every input_list element to have the same size as output"


### PR DESCRIPTION
Fixes #119890

Updates the Dynamo remap failure for legacy `torch.distributed` collectives called with `async_op=True` so the user-facing message explains:

- only synchronous `async_op=False` legacy collectives are remapped automatically;
- users who do not need a `Work` handle can set `async_op=False`;
- users who do need async semantics should rewrite with `torch.distributed._functional_collectives` and synchronize via `wait_tensor`/`wait_tensors`;
- the current tracking issue for Work-object support.

Also extends the existing async remap graph-break test to assert the guidance appears when compiling with `fullgraph=True`.

Tests:
- `python -m compileall -q torch/distributed/_functional_collectives.py test/distributed/test_inductor_collectives.py`
- `python -m ruff check torch/distributed/_functional_collectives.py test/distributed/test_inductor_collectives.py`

I could not run the focused PyTorch test in this fresh source checkout because importing local `torch` fails before build/generated files exist (`ModuleNotFoundError: No module named 'torch.version'`).


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98