### PR TITLE
Stop excluding clang from the SIMD float reduction specializations

### DIFF
--- a/aten/src/ATen/cpu/vec/functional_base.h
+++ b/aten/src/ATen/cpu/vec/functional_base.h
@@ -52,8 +52,7 @@ struct VecReduceAllSIMD {
   }
 };
 
-#if defined(__GNUC__) && (__GNUC__ > 5) && !defined(_MSC_VER) && \
-    !defined(C10_MOBILE)
+#if defined(__GNUC__) && !defined(_MSC_VER) && !defined(C10_MOBILE)
 #if defined(CPU_CAPABILITY_AVX2)
 template <typename Op>
 struct VecReduceAllSIMD<float, Op> {
@@ -99,8 +98,7 @@ struct VecReduceAllSIMD<float, Op> {
   }
 };
 #endif // defined(CPU_CAPABILITY_AVX512)
-#endif // defined(__GNUC__) && (__GNUC__ > 5) && !defined(_MSC_VER) &&
-       // !defined(C10_MOBILE)
+#endif // defined(__GNUC__) && !defined(_MSC_VER) && !defined(C10_MOBILE)
 
 #if defined(__aarch64__) && !defined(C10_MOBILE) && !defined(__CUDACC__) && \
     !defined(CPU_CAPABILITY_SVE256)


### PR DESCRIPTION
The AVX2/AVX512 float reduction specializations require `__GNUC__ > 5`, but clang reports `__GNUC__` as 4, so clang builds have always used the slow scalar-loop fallback instead. GCC 5 predates every supported toolchain, so the version test is dropped, matching the aarch64 specialization below which has no compiler check at all.

Test plan:

    python test/test_torch.py -k test_sum
    python test/test_reductions.py -k test_sum_vs_numpy

This change was authored with the assistance of an AI coding agent and reviewed before submission.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01