### PR TITLE
Fix remove_identity crash on keyword-form Identity call

### DIFF
--- a/test/inductor/test_fx_fusion.py
+++ b/test/inductor/test_fx_fusion.py
@@ -8,6 +8,7 @@ from torch._inductor.fx_passes.pre_grad import (
     linear_transpose,
     permute_linear_fusion,
     permute_matmul_fusion,
+    remove_identity,
     sink_cat_after_pointwise,
     transpose_linear,
     transpose_matmul,
@@ -45,6 +46,18 @@ def count_call_method(module: torch.fx.GraphModule, target_op: Any) -> int:
 
 
 class TestFxFusion(TestCase):
+    def test_remove_identity_keyword_input(self):
+        module = torch.nn.Identity()
+        graph = torch.fx.Graph()
+        input_node = graph.placeholder("x")
+        identity = graph.call_module("0", args=(), kwargs={"input": input_node})
+        graph.output(identity)
+        graph_module = torch.fx.GraphModule(torch.nn.Sequential(module), graph)
+
+        result = remove_identity(graph_module)
+
+        self.assertEqual(list(result.graph.nodes)[-1].args[0].name, "x")
+
     def test_sink_cat_after_pointwise(self):
         def test_kwarg(x, y):
             return torch.cat([x, y], dim=-1).view(-1).view(128).tanh()

--- a/test/inductor/test_fx_fusion.py
+++ b/test/inductor/test_fx_fusion.py
@@ -15,6 +15,10 @@ from torch._inductor.fx_passes.pre_grad import (
 )
 from torch._inductor.test_case import run_tests, TestCase
 from torch.fx.passes.shape_prop import ShapeProp
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 
 PassFunc = Callable[[torch.fx.GraphModule, Any], torch.fx.GraphModule]
@@ -46,17 +50,25 @@ def count_call_method(module: torch.fx.GraphModule, target_op: Any) -> int:
 
 
 class TestFxFusion(TestCase):
-    def test_remove_identity_keyword_input(self):
-        module = torch.nn.Identity()
-        graph = torch.fx.Graph()
-        input_node = graph.placeholder("x")
-        identity = graph.call_module("0", args=(), kwargs={"input": input_node})
-        graph.output(identity)
-        graph_module = torch.fx.GraphModule(torch.nn.Sequential(module), graph)
+    @parametrize("call_form", ("positional", "keyword"))
+    def test_remove_identity(self, call_form: str):
+        class Module(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.identity = torch.nn.Identity()
 
-        result = remove_identity(graph_module)
+            def forward(self, x):
+                if call_form == "keyword":
+                    return self.identity(input=x).tanh()
+                return self.identity(x).tanh()
 
-        self.assertEqual(list(result.graph.nodes)[-1].args[0].name, "x")
+        module = Module()
+        inputs = [torch.randn(8, 8)]
+        trace_func = chain_passes(torch.fx.symbolic_trace, remove_identity)
+        traced = trace_func(module, inputs)
+
+        self.assertEqual(count_call(traced, "call_module", "identity"), 0)
+        torch.testing.assert_close(module(*inputs), traced(*inputs))
 
     def test_sink_cat_after_pointwise(self):
         def test_kwarg(x, y):
@@ -196,6 +208,9 @@ class TestFxFusion(TestCase):
         self.assertEqual(num_transpose_matmul, 1)
 
         torch.testing.assert_close(module(input), traced(input))
+
+
+instantiate_parametrized_tests(TestFxFusion)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -504,10 +504,13 @@ def remove_identity(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
             for node in list(graph.find_nodes(op="call_module", target=module_name)):
                 if len(node.args) == 1 and not node.kwargs:
                     input_node = node.args[0]
-                elif not node.args and set(node.kwargs) == {"input"}:
+                elif not node.args and tuple(node.kwargs) == ("input",):
                     input_node = node.kwargs["input"]
                 else:
-                    raise AssertionError("expected one input for identity node")
+                    raise AssertionError(
+                        f"expected one input for identity node {node.format_node()}, "
+                        f"got args={node.args}, kwargs={node.kwargs}"
+                    )
                 node.replace_all_uses_with(input_node)
                 graph.erase_node(node)
                 work_done = True

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -502,11 +502,14 @@ def remove_identity(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     for module_name, module in gm.named_modules():
         if type(module) is nn.Identity:
             for node in list(graph.find_nodes(op="call_module", target=module_name)):
-                if len(node.args) != 1:
+                if len(node.args) == 1 and not node.kwargs:
+                    input_node = node.args[0]
+                elif not node.args and set(node.kwargs) == {"input"}:
+                    input_node = node.kwargs["input"]
+                else:
                     raise AssertionError(
-                        f"expected 1 arg for identity node, got {len(node.args)}"
+                        "expected one input for identity node"
                     )
-                input_node = node.args[0]
                 node.replace_all_uses_with(input_node)
                 graph.erase_node(node)
                 work_done = True

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -507,9 +507,7 @@ def remove_identity(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 elif not node.args and set(node.kwargs) == {"input"}:
                     input_node = node.kwargs["input"]
                 else:
-                    raise AssertionError(
-                        "expected one input for identity node"
-                    )
+                    raise AssertionError("expected one input for identity node")
                 node.replace_all_uses_with(input_node)
                 graph.erase_node(node)
                 work_done = True


### PR DESCRIPTION
Fixes #195569.

remove_identity assumed a single positional arg. TorchInductor can also call the module with `input=` as a kwarg, which hit the assert. Handled both forms and added a regression test for the kwarg case.

Debugged and fixed by me, using AI-assisted tooling for parts of the implementation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo