### PR TITLE
Fix the misspelled CUDA_LIMIT_GPU_ARCHITECUTRE, and the clamp it was hiding

### DIFF
--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
@@ -41,7 +41,6 @@ if(CUDA_VERSION VERSION_GREATER "10.5")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "8.0")
 
   if(CUDA_VERSION VERSION_LESS "11.1")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "8.0")
     list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.0+PTX")
   endif()
 endif()
@@ -49,10 +48,8 @@ endif()
 if(NOT CUDA_VERSION VERSION_LESS "11.1")
   list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.6")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "8.6")
-  set(CUDA_LIMIT_GPU_ARCHITECUTRE "8.6")
 
   if(CUDA_VERSION VERSION_LESS "11.8")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "8.9")
     list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.6+PTX")
   endif()
 endif()
@@ -98,6 +95,14 @@ if(CUDA_VERSION VERSION_GREATER_EQUAL "13.4")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "10.7")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "10.7a")
 endif()
+
+# Newest arch this toolkit can compile for, used below to clamp autodetection.
+# Numeric max, not file order: arch numbers are not monotonic per CUDA release
+# (e.g. Rubin's 10.7 is below Blackwell's 12.0).
+set(_cuda_plain_archs ${CUDA_ALL_GPU_ARCHITECTURES})
+list(FILTER _cuda_plain_archs INCLUDE REGEX "^[0-9]+\\.[0-9]+$")
+list(SORT _cuda_plain_archs COMPARE NATURAL)
+list(GET _cuda_plain_archs -1 CUDA_LIMIT_GPU_ARCHITECTURE)
 
 ################################################################################################
 # A function for automatic detection of GPUs installed  (if autodetection is enabled)
@@ -157,10 +162,9 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
     set(CUDA_GPU_DETECT_OUTPUT_FILTERED "")
     separate_arguments(CUDA_GPU_DETECT_OUTPUT)
     foreach(ITEM IN ITEMS ${CUDA_GPU_DETECT_OUTPUT})
-        if(CUDA_LIMIT_GPU_ARCHITECTURE AND (ITEM VERSION_GREATER CUDA_LIMIT_GPU_ARCHITECTURE OR
-                                            ITEM VERSION_EQUAL CUDA_LIMIT_GPU_ARCHITECTURE))
-        list(GET CUDA_COMMON_GPU_ARCHITECTURES -1 NEWITEM)
-        string(APPEND CUDA_GPU_DETECT_OUTPUT_FILTERED " ${NEWITEM}")
+      if(CUDA_LIMIT_GPU_ARCHITECTURE AND ITEM VERSION_GREATER CUDA_LIMIT_GPU_ARCHITECTURE)
+        # Too new for SASS; fall back to the newest known arch's PTX for JIT.
+        string(APPEND CUDA_GPU_DETECT_OUTPUT_FILTERED " ${CUDA_LIMIT_GPU_ARCHITECTURE}+PTX")
       else()
         string(APPEND CUDA_GPU_DETECT_OUTPUT_FILTERED " ${ITEM}")
       endif()


### PR DESCRIPTION
`select_compute_arch.cmake` sets `CUDA_LIMIT_GPU_ARCHITECUTRE` (transposed letters) for CUDA 11.1+, while `CUDA_DETECT_INSTALLED_GPUS` reads the correctly-spelled `CUDA_LIMIT_GPU_ARCHITECTURE`, which is only set below CUDA 11.8. So since CUDA 11.8 the autodetection clamp has been dead: whatever the GPU probe reports passes through to nvcc unchanged.

Just fixing the spelling would make things worse: the misspelled value is a hardcoded `"8.6"` nobody has revised since CUDA 11.1, so a corrected spelling would clamp every Hopper/Blackwell GPU autodetection finds, and the value it clamped to was itself stale. Instead, the limit is now derived from `CUDA_ALL_GPU_ARCHITECTURES` (already version-gated per release) by taking its numeric maximum, and the clamp emits `<newest known>+PTX` so the driver can JIT for newer devices. This also fixes a boundary bug: the old filter clamped values *equal* to the limit too, when only *greater* needs it.

Test plan: drove the version-gated list building and filter for CUDA 11.0/11.4/12.6/13.0/13.4 via `cmake -P`, getting limits of 8.0/8.6/9.0/12.0/12.0 -- each clamping only architectures above it, versus an empty (no-op) limit for every version at or above 11.8 before this change.

This change was authored with the assistance of an AI coding agent and reviewed before submission.
