### PR TITLE
Skip index_add bfloat16 atomic-add inductor tests on XPU

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2828,6 +2828,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         not SM90OrLater and not TEST_WITH_ROCM,
         "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",
     )
+    @skipIfXpu(msg="XPU does not support bfloat16 atomic add; index_add falls back")
     def test_index_add_bfloat16_dim0(self):
         def f(x, y):
             return torch.index_select(x, 0, y)
@@ -2884,6 +2885,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         not SM90OrLater and not TEST_WITH_ROCM,
         "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",
     )
+    @skipIfXpu(msg="XPU does not support bfloat16 atomic add; index_add falls back")
     def test_index_add_bfloat16_direct(self):
         def f(x, idx, src):
             return torch.index_add(x, -1, idx, src, alpha=0.5)
@@ -2908,6 +2910,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         not SM90OrLater and not TEST_WITH_ROCM,
         "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",
     )
+    @skipIfXpu(msg="XPU does not support bfloat16 atomic add; index_add falls back")
     def test_index_add_bfloat16_scalar_index(self):
         def f(x, idx, src):
             return torch.index_add(x, 1, idx, src)


### PR DESCRIPTION
To solve https://github.com/pytorch/pytorch/issues/195559, https://github.com/pytorch/pytorch/issues/195560 and https://github.com/pytorch/pytorch/issues/195561

This PR is to skip `test_index_add_bfloat16_{dim0,direct,scalar_index}` which assert that the inductor lowering emits tl.atomic_add for bfloat16 index_add. On XPU, bfloat16 atomic-add is disabled due to known issue https://github.com/pytorch/pytorch/issues/170756, so inductor falls back to the aten op and never emits tl.atomic_add, making the FileCheck fail.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo