### PR TITLE
[BE] Build all XPU wheels on a single runner

### DIFF
--- a/.ci/manywheel/build.sh
+++ b/.ci/manywheel/build.sh
@@ -21,6 +21,24 @@ case "${GPU_ARCH_TYPE:-BLANK}" in
 
         python3 "${SCRIPTPATH}/build_install_deps.py" "${PYTORCH_ROOT}"
 
+        # Unified manywheel jobs rebuild once per Python ABI on one runner.
+        # Each Python env installs its own `cmake`/`ninja` wheel, so each
+        # iteration would reconfigure with a different CMAKE_COMMAND. CMake bakes
+        # that absolute path into DEPFILE-based custom commands (the
+        # cmake_transform_depfile step of torch-xpu-ops SYCL device objects and
+        # other generated-file steps), so Ninja sees changed commands and
+        # recompiles the whole SYCL/ABI-free backend per Python. Pin the
+        # toolchain cmake/ninja from the first iteration so later ABI iterations
+        # keep identical commands and reuse the existing objects.
+        shared_tools_dir="${RUNNER_TEMP:-/tmp}/pytorch-shared-build-tools"
+        if [[ ! -x "${shared_tools_dir}/cmake" ]]; then
+            mkdir -p "${shared_tools_dir}"
+            ln -sf "$(readlink -f "$(command -v cmake)")" "${shared_tools_dir}/cmake"
+            ln -sf "$(readlink -f "$(command -v ninja)")" "${shared_tools_dir}/ninja"
+        fi
+        PATH="${shared_tools_dir}:${PATH}"
+        export PATH
+
         : "${PYTORCH_FINAL_PACKAGE_DIR:=/artifacts}"
         mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
         RAW_WHEEL_DIR=$(mktemp -d)

--- a/.ci/manywheel/build.sh
+++ b/.ci/manywheel/build.sh
@@ -21,15 +21,9 @@ case "${GPU_ARCH_TYPE:-BLANK}" in
 
         python3 "${SCRIPTPATH}/build_install_deps.py" "${PYTORCH_ROOT}"
 
-        # Unified manywheel jobs rebuild once per Python ABI on one runner.
-        # Each Python env installs its own `cmake`/`ninja` wheel, so each
-        # iteration would reconfigure with a different CMAKE_COMMAND. CMake bakes
-        # that absolute path into DEPFILE-based custom commands (the
-        # cmake_transform_depfile step of torch-xpu-ops SYCL device objects and
-        # other generated-file steps), so Ninja sees changed commands and
-        # recompiles the whole SYCL/ABI-free backend per Python. Pin the
-        # toolchain cmake/ninja from the first iteration so later ABI iterations
-        # keep identical commands and reuse the existing objects.
+        # Keep CMake and Ninja stable across Python ABI iterations. PATH alone is
+        # insufficient because scikit-build-core prefers its importable,
+        # per-environment cmake/ninja packages.
         shared_tools_dir="${RUNNER_TEMP:-/tmp}/pytorch-shared-build-tools"
         if [[ ! -x "${shared_tools_dir}/cmake" ]]; then
             mkdir -p "${shared_tools_dir}"
@@ -37,7 +31,9 @@ case "${GPU_ARCH_TYPE:-BLANK}" in
             ln -sf "$(readlink -f "$(command -v ninja)")" "${shared_tools_dir}/ninja"
         fi
         PATH="${shared_tools_dir}:${PATH}"
-        export PATH
+        CMAKE_EXECUTABLE="$(readlink -f "${shared_tools_dir}/cmake")"
+        CMAKE_ARGS="${CMAKE_ARGS:-} -DCMAKE_MAKE_PROGRAM=$(readlink -f "${shared_tools_dir}/ninja")"
+        export PATH CMAKE_EXECUTABLE CMAKE_ARGS
 
         : "${PYTORCH_FINAL_PACKAGE_DIR:=/artifacts}"
         mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -20,7 +20,7 @@ name: !{{ build_environment }}
     invalidation handles the per-Python ABI bits). Everything else still runs
     on the per-Python matrix below. Add more arch types here as their inline
     build job is wired up. -#}
-{%- set unified_arch_types = ['cpu', 'cpu-aarch64', 'cuda', 'cuda-aarch64'] %}
+{%- set unified_arch_types = ['cpu', 'cpu-aarch64', 'cuda', 'cuda-aarch64', 'xpu'] %}
 {%- set unified_build_configs = build_configs | selectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 {%- set matrix_build_configs = build_configs | rejectattr('gpu_arch_type', 'in', unified_arch_types) | list %}
 
@@ -255,7 +255,7 @@ jobs:
   {%- set first = group[0] %}
   {#- Job name: keep cpu/cpu-aarch64 names stable; for cuda, include the
       desired_cuda variant so cu126/cu130/cu132 each get a distinct job. -#}
-  {%- if desired_cuda == 'cpu' %}
+  {%- if desired_cuda == 'cpu' or desired_cuda == arch_type %}
     {%- set job_name = "manywheel-" ~ arch_type ~ "-build" %}
   {%- else %}
     {%- set job_name = "manywheel-" ~ arch_type ~ "-" ~ desired_cuda ~ "-build" %}
@@ -264,17 +264,19 @@ jobs:
       E.g. "manywheel-py3_10-cuda-aarch64-12_6" -> "-cuda-aarch64-12_6". -#}
   {%- set py_dotless = first['python_version'] | replace('.', '_') %}
   {%- set build_name_suffix = first['build_name'] | replace('manywheel-py' ~ py_dotless, '') %}
+  {%- if arch_type != 'xpu' %}
   {%- set _ = unified_upload_groups.append({
         'job_name': job_name,
         'test_name': job_name | replace('-build', '-test'),
         'configs': group}) %}
+  {%- endif %}
 
   !{{ job_name }}:
     name: !{{ job_name }}
     if: !{{ owner_if }}
     needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}]
     runs-on: "!{{ runner_prefix }}!{{ build_runs_on }}"
-    timeout-minutes: !{{ timeout_minutes }}
+    timeout-minutes: !{{ 420 if arch_type == 'xpu' else timeout_minutes }}
     container:
       image: !{{ docker_registry_host }}pytorch/!{{ first['container_image'] }}:!{{ first['container_image_tag_prefix'] }}!{{ docker_image_suffix }}
     env:
@@ -314,7 +316,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -492,7 +494,7 @@ jobs:
   manywheel-test-xpu:
     name: ${{ matrix.build_name }}-test
     if: !{{ owner_if }}
-    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}, manywheel-build]
+    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}, manywheel-xpu-build]
     uses: ./.github/workflows/_binary-test-xpu-linux.yml
     strategy:
       fail-fast: false
@@ -552,7 +554,7 @@ jobs:
 {%- if xpu_configs %}
   {%- set _ = upload_jobs.append({
         'name': 'manywheel-xpu-upload',
-        'needs': ['manywheel-build', 'manywheel-test-xpu'],
+        'needs': ['manywheel-xpu-build', 'manywheel-test-xpu'],
         'configs': xpu_configs}) %}
 {%- endif %}
 {%- for job in upload_jobs %}

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -271,7 +271,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -360,7 +360,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -449,7 +449,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -272,7 +272,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -361,7 +361,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -450,7 +450,7 @@ jobs:
       - name: Build all wheels
         shell: bash
         run: |
-          # shellcheck disable=SC1091
+          # shellcheck disable=SC1090,SC1091
           source "${BINARY_ENV_FILE}"
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
@@ -496,6 +496,95 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_4/*
 
+  manywheel-xpu-build:
+    name: manywheel-xpu-build
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
+    timeout-minutes: 420
+    container:
+      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:xpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+    env:
+      PYTORCH_ROOT: ${{ github.workspace }}
+      PACKAGE_TYPE: manywheel
+      DESIRED_CUDA: xpu
+      GPU_ARCH_VERSION: ""
+      GPU_ARCH_TYPE: xpu
+      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:xpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
+      SKIP_ALL_TESTS: 1
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
+      BUILD_NAME_PREFIX: "manywheel-py"
+      BUILD_NAME_SUFFIX: "-xpu"
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
+    steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Full fetch on tag pushes so the release tag is visible to
+          # `git describe --tags --exact`; nightlies stay shallow for speed.
+          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
+          fetch-tags: ${{ github.ref_type == 'tag' }}
+          submodules: recursive
+          show-progress: false
+      - name: Populate binary env
+        shell: bash
+        run: |
+          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
+          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
+          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
+          bash .ci/pytorch/binary_populate_env.sh
+      - name: Build all wheels
+        shell: bash
+        run: |
+          # shellcheck disable=SC1090,SC1091
+          source "${BINARY_ENV_FILE}"
+          bash .ci/manywheel/build_all.sh
+      # One artifact per built Python -- names must match what the test/upload
+      # matrix below downloads.
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_10-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_11-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_12-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_13-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_14t-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-xpu/*
+      - uses: actions/upload-artifact@v4.4.0
+        with:
+          name: manywheel-py3_15t-xpu
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-xpu/*
+
   manywheel-build:
     name: ${{ matrix.build_name }}-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
@@ -523,15 +612,6 @@ jobs:
             build_name: "manywheel-py3_10-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.10"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_10-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.11"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -550,15 +630,6 @@ jobs:
             build_name: "manywheel-py3_11-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.11"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_11-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.12"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -577,15 +648,6 @@ jobs:
             build_name: "manywheel-py3_12-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.12"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_12-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.13"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -604,15 +666,6 @@ jobs:
             build_name: "manywheel-py3_13-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.13"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_13-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -631,15 +684,6 @@ jobs:
             build_name: "manywheel-py3_14-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.14"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14t"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -658,15 +702,6 @@ jobs:
             build_name: "manywheel-py3_14t-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.14t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_14t-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -685,15 +720,6 @@ jobs:
             build_name: "manywheel-py3_15-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.15"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15t"
             desired_cuda: "rocm7.14"
             gpu_arch_version: "7.14"
@@ -712,15 +738,6 @@ jobs:
             build_name: "manywheel-py3_15t-rocm10_0"
             timeout_minutes: 420
             pytorch_extra_install_requirements: "rocm[libraries,device-all]==10.0.*"
-          - desired_python: "3.15t"
-            desired_cuda: "xpu"
-            gpu_arch_version: ""
-            gpu_arch_type: "xpu"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "xpu"
-            build_name: "manywheel-py3_15t-xpu"
-            timeout_minutes: 280
-            pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.1.0 | intel-cmplr-lib-ur==2026.1.0 | intel-cmplr-lic-rt==2026.1.0 | intel-sycl-rt==2026.1.0 | oneccl-devel==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.1.1; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.1; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.1.0 | onemkl-sycl-blas==2026.1.0 | onemkl-sycl-dft==2026.1.0 | onemkl-sycl-lapack==2026.1.0 | onemkl-sycl-rng==2026.1.0 | onemkl-sycl-sparse==2026.1.0 | dpcpp-cpp-rt==2026.1.0 | intel-opencl-rt==2026.1.0 | mkl==2026.1.0 | intel-openmp==2026.1.0 | tbb==2023.1.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==1.0.1 | pyzes==0.1.2; platform_system == 'Linux' and platform_machine == 'x86_64'"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -1247,7 +1264,7 @@ jobs:
   manywheel-test-xpu:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag, manywheel-build]
+    needs: [get-label-type, get-docker-tag, manywheel-xpu-build]
     uses: ./.github/workflows/_binary-test-xpu-linux.yml
     strategy:
       fail-fast: false
@@ -1795,7 +1812,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [get-docker-tag, manywheel-build, manywheel-test-xpu]
+    needs: [get-docker-tag, manywheel-xpu-build, manywheel-test-xpu]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1269,6 +1269,11 @@ if(USE_XPU)
   if(DEFINED Python3_INCLUDE_DIRS)
     list(REMOVE_ITEM TORCH_XPU_OPS_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
   endif()
+  # Some Python-derived include paths (for example NumPy/site-packages entries)
+  # can still arrive through transitive include sets and vary per CPython ABI.
+  # Strip them so FindSYCL custom-command scripts stay stable across iterations.
+  list(FILTER TORCH_XPU_OPS_INCLUDE_DIRS EXCLUDE REGEX "(^|/)site-packages(/|$)")
+  list(FILTER TORCH_XPU_OPS_INCLUDE_DIRS EXCLUDE REGEX "(^|/)python[0-9.]+(/|$)")
   # Pass the target as a dependency so that ATen headers generation
   # could be followed by torch-xpu-ops build.
   # 1. Sources in torch-xpu-ops depend on generated ATen headers.

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1231,18 +1231,29 @@ if(USE_XPU)
     endif()
   endif()
   execute_process(
-    COMMAND git fetch --quiet
+    COMMAND git rev-parse HEAD
     WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-    RESULT_VARIABLE _exitcode)
+    OUTPUT_VARIABLE TORCH_XPU_OPS_CURRENT_COMMIT
+    RESULT_VARIABLE _exitcode
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(NOT _exitcode EQUAL 0)
-    message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
+    set(TORCH_XPU_OPS_CURRENT_COMMIT "")
   endif()
-  execute_process(
-    COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
-    WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
-    RESULT_VARIABLE _exitcode)
-  if(NOT _exitcode EQUAL 0)
-    message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
+  if(NOT TORCH_XPU_OPS_CURRENT_COMMIT STREQUAL TORCH_XPU_OPS_COMMIT)
+    execute_process(
+      COMMAND git fetch --quiet
+      WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+      RESULT_VARIABLE _exitcode)
+    if(NOT _exitcode EQUAL 0)
+      message(FATAL_ERROR "Fail to fetch ${TORCH_XPU_OPS_REPO_URL}")
+    endif()
+    execute_process(
+      COMMAND git checkout --quiet ${TORCH_XPU_OPS_COMMIT}
+      WORKING_DIRECTORY ${TORCH_XPU_OPS_DIR}
+      RESULT_VARIABLE _exitcode)
+    if(NOT _exitcode EQUAL 0)
+      message(FATAL_ERROR "Fail to checkout ${TORCH_XPU_OPS_REPO_URL} to ${TORCH_XPU_OPS_COMMIT}")
+    endif()
   endif()
 
   set(TORCH_XPU_OPS_INCLUDE_DIRS

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1250,6 +1250,14 @@ if(USE_XPU)
       ${TORCH_SRC_DIR}/csrc/api/include
       ${Caffe2_CPU_INCLUDE}
       ${Caffe2_XPU_INCLUDE})
+  # Keep torch-xpu-ops compile flags Python-ABI-agnostic so unified manywheel
+  # jobs can reuse SYCL/C++ objects across per-Python wheel iterations.
+  if(DEFINED Python_INCLUDE_DIRS)
+    list(REMOVE_ITEM TORCH_XPU_OPS_INCLUDE_DIRS ${Python_INCLUDE_DIRS})
+  endif()
+  if(DEFINED Python3_INCLUDE_DIRS)
+    list(REMOVE_ITEM TORCH_XPU_OPS_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
+  endif()
   # Pass the target as a dependency so that ATen headers generation
   # could be followed by torch-xpu-ops build.
   # 1. Sources in torch-xpu-ops depend on generated ATen headers.

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -45,38 +45,54 @@ IF(NOT MKLDNN_FOUND)
                            Detected system '${CMAKE_SYSTEM_NAME}' is not supported.")
     endif()
 
-    set(DNNL_MAKE_COMMAND "cmake" "--build" ".")
-    include(ProcessorCount)
-    ProcessorCount(proc_cnt)
-    if((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
-      list(APPEND DNNL_MAKE_COMMAND "-j" "$ENV{MAX_JOBS}")
-      if(CMAKE_GENERATOR MATCHES "Make|Ninja")
-        list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
-      endif()
+    if(XPU_MKLDNN_DIR_PREFIX)
+      set(_xpu_mkldnn_prefix "${XPU_MKLDNN_DIR_PREFIX}")
+    else()
+      set(_xpu_mkldnn_prefix "${CMAKE_CURRENT_BINARY_DIR}/xpu_mkldnn_proj-prefix")
     endif()
-    ExternalProject_Add(xpu_mkldnn_proj
-      GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.12.3
-      PREFIX ${XPU_MKLDNN_DIR_PREFIX}
-      BUILD_IN_SOURCE 0
-      CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
-      -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
-      -DDNNL_GPU_RUNTIME=SYCL
-      -DDNNL_CPU_RUNTIME=NONE
-      -DDNNL_BUILD_TESTS=OFF
-      -DDNNL_BUILD_EXAMPLES=OFF
-      -DONEDNN_BUILD_GRAPH=ON
-      -DDNNL_LIBRARY_TYPE=STATIC
-      -DDNNL_DPCPP_HOST_COMPILER=${DNNL_HOST_COMPILER} # Use global cxx compiler as host compiler
-      -G ${CMAKE_GENERATOR} # Align Generator to Torch
-      BUILD_COMMAND ${DNNL_MAKE_COMMAND}
-      BUILD_BYPRODUCTS "xpu_mkldnn_proj-prefix/src/xpu_mkldnn_proj-build/src/${DNNL_LIB_NAME}"
-      INSTALL_COMMAND ""
-    )
+    set(_xpu_mkldnn_src_dir "${_xpu_mkldnn_prefix}/src/xpu_mkldnn_proj")
+    set(_xpu_mkldnn_build_dir "${_xpu_mkldnn_prefix}/src/xpu_mkldnn_proj-build")
+    set(_xpu_mkldnn_lib "${_xpu_mkldnn_build_dir}/src/${DNNL_LIB_NAME}")
 
-    ExternalProject_Get_Property(xpu_mkldnn_proj SOURCE_DIR BINARY_DIR)
-    set(XPU_MKLDNN_LIBRARIES ${BINARY_DIR}/src/${DNNL_LIB_NAME})
-    set(XPU_MKLDNN_INCLUDE ${SOURCE_DIR}/include ${BINARY_DIR}/include)
+    if(EXISTS "${_xpu_mkldnn_lib}" AND IS_DIRECTORY "${_xpu_mkldnn_src_dir}/include")
+      message(STATUS "Reusing existing oneDNN XPU build: ${_xpu_mkldnn_lib}")
+      add_custom_target(xpu_mkldnn_proj)
+      set(XPU_MKLDNN_LIBRARIES "${_xpu_mkldnn_lib}")
+      set(XPU_MKLDNN_INCLUDE "${_xpu_mkldnn_src_dir}/include" "${_xpu_mkldnn_build_dir}/include")
+    else()
+      set(DNNL_MAKE_COMMAND "cmake" "--build" ".")
+      include(ProcessorCount)
+      ProcessorCount(proc_cnt)
+      if((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
+        list(APPEND DNNL_MAKE_COMMAND "-j" "$ENV{MAX_JOBS}")
+        if(CMAKE_GENERATOR MATCHES "Make|Ninja")
+          list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
+        endif()
+      endif()
+      ExternalProject_Add(xpu_mkldnn_proj
+        GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
+        GIT_TAG v3.12.3
+        PREFIX ${XPU_MKLDNN_DIR_PREFIX}
+        BUILD_IN_SOURCE 0
+        CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
+        -DDNNL_GPU_RUNTIME=SYCL
+        -DDNNL_CPU_RUNTIME=NONE
+        -DDNNL_BUILD_TESTS=OFF
+        -DDNNL_BUILD_EXAMPLES=OFF
+        -DONEDNN_BUILD_GRAPH=ON
+        -DDNNL_LIBRARY_TYPE=STATIC
+        -DDNNL_DPCPP_HOST_COMPILER=${DNNL_HOST_COMPILER}
+        -G ${CMAKE_GENERATOR}
+        BUILD_COMMAND ${DNNL_MAKE_COMMAND}
+        BUILD_BYPRODUCTS "${_xpu_mkldnn_build_dir}/src/${DNNL_LIB_NAME}"
+        INSTALL_COMMAND ""
+      )
+
+      ExternalProject_Get_Property(xpu_mkldnn_proj SOURCE_DIR BINARY_DIR)
+      set(XPU_MKLDNN_LIBRARIES ${BINARY_DIR}/src/${DNNL_LIB_NAME})
+      set(XPU_MKLDNN_INCLUDE ${SOURCE_DIR}/include ${BINARY_DIR}/include)
+    endif()
     # This target would be further linked to libtorch_xpu.so.
     # The libtorch_xpu.so would contain Conv&GEMM operators that depend on
     # oneDNN primitive implementations inside libdnnl.a.


### PR DESCRIPTION
Take over #188136.

Builds all Linux XPU manywheel variants in one job, reusing ABI-independent C++/SYCL artifacts across Python versions while rebuilding Python-bound artifacts per interpreter.

## Before vs after

Comparing the eight XPU matrix builds from [#195438 run 33729050328](https://github.com/pytorch/pytorch/actions/runs/33729050328) with the unified build from [this PR, run 34123506914](https://github.com/pytorch/pytorch/actions/runs/34123506914):

### Linux XPU build runner-minutes

| Before (per-Python matrix, 8 jobs) | After (1 unified job) | Delta |
|---|---:|---:|
| 8 x ~78m = **623m** ([matrix jobs](https://github.com/pytorch/pytorch/actions/runs/33729050328)) | **139m** ([unified job](https://github.com/pytorch/pytorch/actions/runs/34123506914/job/101746866663)) | **-78%** |

This saves approximately **484 runner-minutes per XPU manywheel build**.

### Per-Python build breakdown

- First Python (cp310): **~74m** from a clean build.
- Following seven Pythons (cp311 through cp315t): **~7m each** on average.
- The unified job produced all eight XPU wheel artifacts successfully.

The first build establishes the shared XPU backend. Subsequent interpreters reuse the SYCL kernel objects and device link, rebuilding only Python-ABI-bound components.

### Fix for SYCL reuse

The earlier PATH-only tool pin did not prevent scikit-build-core from selecting the importable CMake/Ninja packages in each Python environment. The final implementation explicitly sets `CMAKE_EXECUTABLE` and passes the shared Ninja path through `CMAKE_ARGS`, keeping CMake's generated SYCL depfile commands stable across the loop.

Local Python 3.10 then Python 3.11 XPU builds confirmed **zero SYCL object recompilations** and **zero XPU device relinks** on the second build.

> AI-assisted drafting; CI measurements and implementation reviewed by the PR author.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal