### PR TITLE
[Feature Refactoring] Generalize inductor wrapper_benchmark memory stats and snapshot collection from CUDA to all accelerators

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch._inductor.async_compile
@@ -14,6 +14,10 @@ from torch._inductor import config
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache, run_and_get_code, run_and_get_kernels
+from torch._inductor.wrapper_benchmark import (
+    collect_memory_snapshot,
+    compiled_module_main,
+)
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import xfailIfSM89
 from torch.testing._internal.common_utils import recover_orig_fp32_precision
@@ -548,6 +552,185 @@ class TestKernelBenchmark(TestCase):
         FileCheck().check(
             f"print_performance(fn, times=times, repeat=repeat, device='{GPU_TYPE}')"
         ).run(src)
+
+
+class TestCompiledModuleMain(TestCase):
+    """Mock-based tests for the compiled_module_main CLI entry; no GPU needed."""
+
+    def _run_main(self, argv, benchmark_fn=None):
+        benchmark_fn = benchmark_fn or (lambda times, repeat: 0.001)
+        with patch("sys.argv", ["compiled_module.py", *argv]):
+            compiled_module_main("test_benchmark", benchmark_fn)
+
+    def _patch_unavailable_acc(self):
+        # Simulate a built-but-unavailable accelerator (e.g. CUDA build, no GPUs):
+        # the compile-time lookup returns a device but the runtime check fails
+        return (
+            patch(
+                "torch._C._accelerator_getAccelerator",
+                return_value=torch.device("cuda"),
+            ),
+            patch("torch.accelerator.is_available", return_value=False),
+        )
+
+    def test_no_accelerator_skips_memory_stats(self):
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=None) as mock_acc,
+            patch("torch.accelerator.reset_peak_memory_stats") as mock_reset,
+            patch("builtins.print") as mock_print,
+        ):
+            self._run_main([])
+            mock_acc.assert_called_once_with(check_available=True)
+            mock_reset.assert_not_called()
+            printed = " ".join(str(c) for c in mock_print.call_args_list)
+            self.assertNotIn("Peak", printed)
+
+    def test_built_but_unavailable_accelerator_skips_memory_stats(self):
+        # CUDA build on a machine with no visible GPUs: check_available=True makes
+        # the real current_accelerator return None, so no misleading
+        # "Peak CUDA memory usage 0.000 MB" output and no snapshot dispatch
+        patch_acc, patch_avail = self._patch_unavailable_acc()
+        with (
+            patch_acc,
+            patch_avail as mock_avail,
+            patch("torch.accelerator.reset_peak_memory_stats") as mock_reset,
+            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
+            patch("builtins.print") as mock_print,
+        ):
+            self._run_main(["--memory-snapshot"])
+            mock_avail.assert_called_once_with()
+            mock_reset.assert_not_called()
+            mock_collect.assert_not_called()
+            printed = " ".join(str(c) for c in mock_print.call_args_list)
+            self.assertNotIn("Peak", printed)
+
+    def test_accelerator_resets_and_reports_peak_memory(self):
+        acc = torch.device("cuda")
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=acc),
+            patch("torch.accelerator.reset_peak_memory_stats") as mock_reset,
+            patch("torch.accelerator.max_memory_allocated", return_value=int(2e6)) as mock_max,
+            patch("builtins.print") as mock_print,
+        ):
+            self._run_main([])
+            mock_reset.assert_called_once_with()
+            mock_max.assert_called_once_with()
+            printed = " ".join(str(c) for c in mock_print.call_args_list)
+            self.assertIn("Peak CUDA memory usage 2.000 MB", printed)
+
+    def test_peak_reset_happens_before_benchmark(self):
+        # reset must be called before the benchmark fn runs, so max_memory_allocated
+        # measures the peak of the benchmark itself
+        acc = torch.device("cuda")
+        order = []
+        reset = MagicMock(side_effect=lambda: order.append("reset"))
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=acc),
+            patch("torch.accelerator.reset_peak_memory_stats", reset),
+            patch("torch.accelerator.max_memory_allocated", return_value=0),
+            patch("builtins.print"),
+        ):
+
+            def benchmark_fn(times, repeat):
+                order.append("benchmark")
+                return 0.001
+
+            self._run_main([], benchmark_fn=benchmark_fn)
+            self.assertEqual(order, ["reset", "benchmark"])
+
+    def test_memory_snapshot_dispatched_when_accelerator_present(self):
+        acc = torch.device("cuda")
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=acc),
+            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
+            patch("torch.accelerator.reset_peak_memory_stats"),
+            patch("torch.accelerator.max_memory_allocated", return_value=0),
+            patch("builtins.print"),
+        ):
+            self._run_main(["--memory-snapshot"])
+            mock_collect.assert_called_once()
+
+    def test_cuda_memory_snapshot_legacy_alias(self):
+        acc = torch.device("cuda")
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=acc),
+            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
+            patch("torch.accelerator.reset_peak_memory_stats"),
+            patch("torch.accelerator.max_memory_allocated", return_value=0),
+            patch("builtins.print"),
+        ):
+            self._run_main(["--cuda-memory-snapshot"])
+            mock_collect.assert_called_once()
+
+    def test_memory_snapshot_not_dispatched_without_accelerator(self):
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=None),
+            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
+            patch("builtins.print"),
+        ):
+            self._run_main(["--memory-snapshot"])
+            mock_collect.assert_not_called()
+
+    def test_collect_memory_snapshot_requires_accelerator(self):
+        with patch("torch.accelerator.current_accelerator", return_value=None):
+            with self.assertRaisesRegex(AssertionError, "No accelerator is available"):
+                collect_memory_snapshot(lambda times, repeat: 0.0)
+
+    def test_collect_memory_snapshot_raises_when_unavailable(self):
+        # built-but-unavailable: snapshot collection must fail fast instead of
+        # hitting a runtime error inside _record_memory_history
+        patch_acc, patch_avail = self._patch_unavailable_acc()
+        with patch_acc, patch_avail:
+            with self.assertRaisesRegex(AssertionError, "No accelerator is available"):
+                collect_memory_snapshot(lambda times, repeat: 0.0)
+
+    def test_collect_memory_snapshot_no_memory_module_skips(self):
+        # e.g. mps has no memory submodule at all; should print and return
+        acc = torch.device("mps")
+        fake_device_mod = MagicMock(spec=[])  # no `memory` attribute
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=acc),
+            patch("torch.get_device_module", return_value=fake_device_mod) as mock_gdm,
+            patch("builtins.print") as mock_print,
+        ):
+            collect_memory_snapshot(lambda times, repeat: 0.0)
+            mock_gdm.assert_called_once_with(acc)
+            printed = " ".join(str(c) for c in mock_print.call_args_list)
+            self.assertIn("not supported on mps", printed)
+
+    def test_collect_memory_snapshot_unsupported_memory_module_skips(self):
+        # device module has `memory` but it lacks _record_memory_history
+        acc = torch.device("mtia")
+        mem_mod = MagicMock(spec=["_dump_snapshot"])
+        fake_device_mod = MagicMock()
+        fake_device_mod.memory = mem_mod
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=acc),
+            patch("torch.get_device_module", return_value=fake_device_mod),
+            patch("builtins.print") as mock_print,
+        ):
+            collect_memory_snapshot(lambda times, repeat: 0.0)
+            mem_mod._dump_snapshot.assert_not_called()
+            printed = " ".join(str(c) for c in mock_print.call_args_list)
+            self.assertIn("not supported on mtia", printed)
+
+    def test_collect_memory_snapshot_supported_device(self):
+        acc = torch.device("cuda")
+        mem_mod = MagicMock(spec=["_record_memory_history", "_dump_snapshot"])
+        fake_device_mod = MagicMock()
+        fake_device_mod.memory = mem_mod
+        benchmark_fn = MagicMock(return_value=0.0)
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=acc),
+            patch("torch.get_device_module", return_value=fake_device_mod),
+            patch("builtins.print"),
+        ):
+            collect_memory_snapshot(benchmark_fn)
+            mem_mod._record_memory_history.assert_any_call(max_entries=100000)
+            mem_mod._record_memory_history.assert_any_call(enabled=None)
+            benchmark_fn.assert_called_once_with(times=10, repeat=1)
+            dumped_path = mem_mod._dump_snapshot.call_args[0][0]
+            self.assertIn("memory_snapshot.pickle", dumped_path)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import torch
 import torch._inductor.async_compile
@@ -14,10 +14,6 @@ from torch._inductor import config
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache, run_and_get_code, run_and_get_kernels
-from torch._inductor.wrapper_benchmark import (
-    collect_memory_snapshot,
-    compiled_module_main,
-)
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import xfailIfSM89
 from torch.testing._internal.common_utils import recover_orig_fp32_precision
@@ -552,185 +548,6 @@ class TestKernelBenchmark(TestCase):
         FileCheck().check(
             f"print_performance(fn, times=times, repeat=repeat, device='{GPU_TYPE}')"
         ).run(src)
-
-
-class TestCompiledModuleMain(TestCase):
-    """Mock-based tests for the compiled_module_main CLI entry; no GPU needed."""
-
-    def _run_main(self, argv, benchmark_fn=None):
-        benchmark_fn = benchmark_fn or (lambda times, repeat: 0.001)
-        with patch("sys.argv", ["compiled_module.py", *argv]):
-            compiled_module_main("test_benchmark", benchmark_fn)
-
-    def _patch_unavailable_acc(self):
-        # Simulate a built-but-unavailable accelerator (e.g. CUDA build, no GPUs):
-        # the compile-time lookup returns a device but the runtime check fails
-        return (
-            patch(
-                "torch._C._accelerator_getAccelerator",
-                return_value=torch.device("cuda"),
-            ),
-            patch("torch.accelerator.is_available", return_value=False),
-        )
-
-    def test_no_accelerator_skips_memory_stats(self):
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=None) as mock_acc,
-            patch("torch.accelerator.reset_peak_memory_stats") as mock_reset,
-            patch("builtins.print") as mock_print,
-        ):
-            self._run_main([])
-            mock_acc.assert_called_once_with(check_available=True)
-            mock_reset.assert_not_called()
-            printed = " ".join(str(c) for c in mock_print.call_args_list)
-            self.assertNotIn("Peak", printed)
-
-    def test_built_but_unavailable_accelerator_skips_memory_stats(self):
-        # CUDA build on a machine with no visible GPUs: check_available=True makes
-        # the real current_accelerator return None, so no misleading
-        # "Peak CUDA memory usage 0.000 MB" output and no snapshot dispatch
-        patch_acc, patch_avail = self._patch_unavailable_acc()
-        with (
-            patch_acc,
-            patch_avail as mock_avail,
-            patch("torch.accelerator.reset_peak_memory_stats") as mock_reset,
-            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
-            patch("builtins.print") as mock_print,
-        ):
-            self._run_main(["--memory-snapshot"])
-            mock_avail.assert_called_once_with()
-            mock_reset.assert_not_called()
-            mock_collect.assert_not_called()
-            printed = " ".join(str(c) for c in mock_print.call_args_list)
-            self.assertNotIn("Peak", printed)
-
-    def test_accelerator_resets_and_reports_peak_memory(self):
-        acc = torch.device("cuda")
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=acc),
-            patch("torch.accelerator.reset_peak_memory_stats") as mock_reset,
-            patch("torch.accelerator.max_memory_allocated", return_value=int(2e6)) as mock_max,
-            patch("builtins.print") as mock_print,
-        ):
-            self._run_main([])
-            mock_reset.assert_called_once_with()
-            mock_max.assert_called_once_with()
-            printed = " ".join(str(c) for c in mock_print.call_args_list)
-            self.assertIn("Peak CUDA memory usage 2.000 MB", printed)
-
-    def test_peak_reset_happens_before_benchmark(self):
-        # reset must be called before the benchmark fn runs, so max_memory_allocated
-        # measures the peak of the benchmark itself
-        acc = torch.device("cuda")
-        order = []
-        reset = MagicMock(side_effect=lambda: order.append("reset"))
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=acc),
-            patch("torch.accelerator.reset_peak_memory_stats", reset),
-            patch("torch.accelerator.max_memory_allocated", return_value=0),
-            patch("builtins.print"),
-        ):
-
-            def benchmark_fn(times, repeat):
-                order.append("benchmark")
-                return 0.001
-
-            self._run_main([], benchmark_fn=benchmark_fn)
-            self.assertEqual(order, ["reset", "benchmark"])
-
-    def test_memory_snapshot_dispatched_when_accelerator_present(self):
-        acc = torch.device("cuda")
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=acc),
-            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
-            patch("torch.accelerator.reset_peak_memory_stats"),
-            patch("torch.accelerator.max_memory_allocated", return_value=0),
-            patch("builtins.print"),
-        ):
-            self._run_main(["--memory-snapshot"])
-            mock_collect.assert_called_once()
-
-    def test_cuda_memory_snapshot_legacy_alias(self):
-        acc = torch.device("cuda")
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=acc),
-            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
-            patch("torch.accelerator.reset_peak_memory_stats"),
-            patch("torch.accelerator.max_memory_allocated", return_value=0),
-            patch("builtins.print"),
-        ):
-            self._run_main(["--cuda-memory-snapshot"])
-            mock_collect.assert_called_once()
-
-    def test_memory_snapshot_not_dispatched_without_accelerator(self):
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=None),
-            patch("torch._inductor.wrapper_benchmark.collect_memory_snapshot") as mock_collect,
-            patch("builtins.print"),
-        ):
-            self._run_main(["--memory-snapshot"])
-            mock_collect.assert_not_called()
-
-    def test_collect_memory_snapshot_requires_accelerator(self):
-        with patch("torch.accelerator.current_accelerator", return_value=None):
-            with self.assertRaisesRegex(AssertionError, "No accelerator is available"):
-                collect_memory_snapshot(lambda times, repeat: 0.0)
-
-    def test_collect_memory_snapshot_raises_when_unavailable(self):
-        # built-but-unavailable: snapshot collection must fail fast instead of
-        # hitting a runtime error inside _record_memory_history
-        patch_acc, patch_avail = self._patch_unavailable_acc()
-        with patch_acc, patch_avail:
-            with self.assertRaisesRegex(AssertionError, "No accelerator is available"):
-                collect_memory_snapshot(lambda times, repeat: 0.0)
-
-    def test_collect_memory_snapshot_no_memory_module_skips(self):
-        # e.g. mps has no memory submodule at all; should print and return
-        acc = torch.device("mps")
-        fake_device_mod = MagicMock(spec=[])  # no `memory` attribute
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=acc),
-            patch("torch.get_device_module", return_value=fake_device_mod) as mock_gdm,
-            patch("builtins.print") as mock_print,
-        ):
-            collect_memory_snapshot(lambda times, repeat: 0.0)
-            mock_gdm.assert_called_once_with(acc)
-            printed = " ".join(str(c) for c in mock_print.call_args_list)
-            self.assertIn("not supported on mps", printed)
-
-    def test_collect_memory_snapshot_unsupported_memory_module_skips(self):
-        # device module has `memory` but it lacks _record_memory_history
-        acc = torch.device("mtia")
-        mem_mod = MagicMock(spec=["_dump_snapshot"])
-        fake_device_mod = MagicMock()
-        fake_device_mod.memory = mem_mod
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=acc),
-            patch("torch.get_device_module", return_value=fake_device_mod),
-            patch("builtins.print") as mock_print,
-        ):
-            collect_memory_snapshot(lambda times, repeat: 0.0)
-            mem_mod._dump_snapshot.assert_not_called()
-            printed = " ".join(str(c) for c in mock_print.call_args_list)
-            self.assertIn("not supported on mtia", printed)
-
-    def test_collect_memory_snapshot_supported_device(self):
-        acc = torch.device("cuda")
-        mem_mod = MagicMock(spec=["_record_memory_history", "_dump_snapshot"])
-        fake_device_mod = MagicMock()
-        fake_device_mod.memory = mem_mod
-        benchmark_fn = MagicMock(return_value=0.0)
-        with (
-            patch("torch.accelerator.current_accelerator", return_value=acc),
-            patch("torch.get_device_module", return_value=fake_device_mod),
-            patch("builtins.print"),
-        ):
-            collect_memory_snapshot(benchmark_fn)
-            mem_mod._record_memory_history.assert_any_call(max_entries=100000)
-            mem_mod._record_memory_history.assert_any_call(enabled=None)
-            benchmark_fn.assert_called_once_with(times=10, repeat=1)
-            dumped_path = mem_mod._dump_snapshot.call_args[0][0]
-            self.assertIn("memory_snapshot.pickle", dumped_path)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_wrapper_benchmark.py
+++ b/test/inductor/test_wrapper_benchmark.py
@@ -1,0 +1,189 @@
+# Owner(s): ["module: inductor"]
+
+import contextlib
+import io
+import sys
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch._inductor.wrapper_benchmark import (
+    collect_memory_snapshot,
+    compiled_module_main,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+class TestCompiledModuleMain(TestCase):
+    def _run_main(self, argv, benchmark_fn=None):
+        benchmark_fn = benchmark_fn or (lambda times, repeat: 0.001)
+        with patch.object(sys, "argv", ["compiled_module.py", *argv]):
+            compiled_module_main("test_benchmark", benchmark_fn)
+
+    def test_no_accelerator_skips_memory_stats(self):
+        benchmark_fn = MagicMock(return_value=0.001)
+        with (
+            patch(
+                "torch.accelerator.current_accelerator", return_value=None
+            ) as mock_acc,
+            patch("torch.accelerator.reset_peak_memory_stats") as mock_reset,
+            patch("torch.accelerator.max_memory_allocated") as mock_max,
+            patch("builtins.print") as mock_print,
+        ):
+            self._run_main([], benchmark_fn)
+
+        mock_acc.assert_called_once_with(check_available=True)
+        mock_reset.assert_not_called()
+        mock_max.assert_not_called()
+        benchmark_fn.assert_called_once_with(times=10, repeat=10)
+        self.assertNotIn("Peak", " ".join(str(c) for c in mock_print.call_args_list))
+
+    def test_accelerator_resets_and_reports_peak_memory(self):
+        events = []
+        benchmark_fn = MagicMock(
+            side_effect=lambda times, repeat: events.append("benchmark") or 0.001
+        )
+        with (
+            patch(
+                "torch.accelerator.current_accelerator",
+                return_value=torch.device("cuda"),
+            ),
+            patch(
+                "torch.accelerator.reset_peak_memory_stats",
+                side_effect=lambda: events.append("reset"),
+            ) as mock_reset,
+            patch(
+                "torch.accelerator.max_memory_allocated",
+                side_effect=lambda: events.append("max") or int(2e6),
+            ) as mock_max,
+            patch("builtins.print") as mock_print,
+        ):
+            self._run_main([], benchmark_fn)
+
+        self.assertEqual(events, ["reset", "benchmark", "max"])
+        mock_reset.assert_called_once_with()
+        mock_max.assert_called_once_with()
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("Peak CUDA memory usage 2.000 MB", printed)
+
+    @parametrize("flag", ["--memory-snapshot", "--cuda-memory-snapshot"])
+    def test_memory_snapshot_flag(self, flag):
+        benchmark_fn = MagicMock(return_value=0.001)
+        with (
+            patch(
+                "torch.accelerator.current_accelerator",
+                return_value=torch.device("cuda"),
+            ),
+            patch(
+                "torch._inductor.wrapper_benchmark.collect_memory_snapshot"
+            ) as mock_collect,
+            patch("torch.accelerator.reset_peak_memory_stats"),
+            patch("torch.accelerator.max_memory_allocated", return_value=0),
+            patch("builtins.print"),
+        ):
+            self._run_main([flag], benchmark_fn)
+
+        mock_collect.assert_called_once_with(benchmark_fn)
+
+    def test_legacy_memory_snapshot_flag_is_hidden(self):
+        output = io.StringIO()
+        with self.assertRaises(SystemExit), contextlib.redirect_stdout(output):
+            self._run_main(["--help"])
+        self.assertIn("--memory-snapshot", output.getvalue())
+        self.assertNotIn("--cuda-memory-snapshot", output.getvalue())
+
+    def test_memory_snapshot_not_dispatched_without_accelerator(self):
+        with (
+            patch("torch.accelerator.current_accelerator", return_value=None),
+            patch(
+                "torch._inductor.wrapper_benchmark.collect_memory_snapshot"
+            ) as mock_collect,
+            patch("builtins.print"),
+        ):
+            self._run_main(["--memory-snapshot"])
+        mock_collect.assert_not_called()
+
+
+class TestCollectMemorySnapshot(TestCase):
+    def test_requires_accelerator(self):
+        with patch("torch.accelerator.current_accelerator", return_value=None):
+            with self.assertRaisesRegex(AssertionError, "No accelerator is available"):
+                collect_memory_snapshot(lambda times, repeat: None)
+
+    def test_unsupported_device_skips(self):
+        device_mod = MagicMock(spec=[])
+        benchmark_fn = MagicMock()
+        with (
+            patch(
+                "torch.accelerator.current_accelerator",
+                return_value=torch.device("mps"),
+            ),
+            patch("torch.get_device_module", return_value=device_mod),
+            patch("builtins.print") as mock_print,
+        ):
+            collect_memory_snapshot(benchmark_fn)
+
+        benchmark_fn.assert_not_called()
+        self.assertIn(
+            "not supported on mps",
+            " ".join(str(c) for c in mock_print.call_args_list),
+        )
+
+    def test_supported_device(self):
+        mem_mod = MagicMock(spec=["_record_memory_history", "_dump_snapshot"])
+        device_mod = MagicMock()
+        device_mod.memory = mem_mod
+        benchmark_fn = MagicMock(return_value=None)
+        with (
+            patch(
+                "torch.accelerator.current_accelerator",
+                return_value=torch.device("cuda"),
+            ),
+            patch("torch.get_device_module", return_value=device_mod),
+            patch("builtins.print"),
+        ):
+            collect_memory_snapshot(benchmark_fn)
+
+        self.assertEqual(mem_mod._record_memory_history.call_count, 2)
+        self.assertEqual(
+            mem_mod._record_memory_history.call_args_list[0].kwargs,
+            {"max_entries": 100000},
+        )
+        mem_mod._record_memory_history.assert_called_with(enabled=None)
+        benchmark_fn.assert_called_once_with(times=10, repeat=1)
+        snapshot_path = mem_mod._dump_snapshot.call_args.args[0]
+        self.assertTrue(snapshot_path.endswith("memory_snapshot.pickle"))
+
+    def test_recording_is_disabled_when_benchmark_fails(self):
+        mem_mod = MagicMock(spec=["_record_memory_history", "_dump_snapshot"])
+        device_mod = MagicMock()
+        device_mod.memory = mem_mod
+        benchmark_fn = MagicMock(side_effect=RuntimeError("benchmark failed"))
+        with (
+            patch(
+                "torch.accelerator.current_accelerator",
+                return_value=torch.device("cuda"),
+            ),
+            patch("torch.get_device_module", return_value=device_mod),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "benchmark failed"):
+                collect_memory_snapshot(benchmark_fn)
+
+        self.assertEqual(mem_mod._record_memory_history.call_count, 2)
+        self.assertEqual(
+            mem_mod._record_memory_history.call_args_list[0].kwargs,
+            {"max_entries": 100000},
+        )
+        mem_mod._record_memory_history.assert_called_with(enabled=None)
+        mem_mod._dump_snapshot.assert_not_called()
+
+
+instantiate_parametrized_tests(TestCompiledModuleMain)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -403,14 +403,27 @@ def ncu_analyzer(
 def collect_memory_snapshot(
     benchmark_compiled_module_fn: BenchmarkCallableType,
 ) -> None:
-    if not torch.cuda.is_available():
-        raise AssertionError("CUDA is not available")
+    # check_available matters: without it we may get a built-but-unavailable
+    # accelerator and the snapshot calls below would fail with a runtime error
+    acc = torch.accelerator.current_accelerator(check_available=True)
+    if acc is None:
+        raise AssertionError("No accelerator is available")
 
-    torch.cuda.memory._record_memory_history(max_entries=100000)
+    # not every device module exposes a memory submodule (e.g. mps) or
+    # implements snapshots; skip gracefully instead of crashing
+    mem_mod = getattr(torch.get_device_module(acc), "memory", None)
+    if mem_mod is None or not (
+        hasattr(mem_mod, "_record_memory_history")
+        and hasattr(mem_mod, "_dump_snapshot")
+    ):
+        print(f"Memory snapshot is not supported on {acc.type}, skipping")
+        return
+
+    mem_mod._record_memory_history(max_entries=100000)
     benchmark_compiled_module_fn(times=10, repeat=1)  # run 10 times
     snapshot_path = f"{tempfile.gettempdir()}/memory_snapshot.pickle"
-    torch.cuda.memory._dump_snapshot(snapshot_path)
-    torch.cuda.memory._record_memory_history(enabled=None)
+    mem_mod._dump_snapshot(snapshot_path)
+    mem_mod._record_memory_history(enabled=None)
     print(f"The collect memory snapshot has been written to {snapshot_path}")
 
 
@@ -445,10 +458,11 @@ def compiled_module_main(
         help="Whether to profile the compiled module",
     )
     parser.add_argument(
+        "--memory-snapshot",
         "--cuda-memory-snapshot",
         action="store_true",
         help="""
-            Whether to collect CUDA memory snapshot. Refer to
+            Whether to collect accelerator memory snapshot. Refer to
             "https://pytorch.org/blog/understanding-gpu-memory-1/
             for details about how to visualize the collected snapshot
         """,
@@ -498,15 +512,19 @@ def compiled_module_main(
         times = args.times
         repeat = args.repeat
 
-        if torch.cuda.is_available():
-            torch.cuda.reset_peak_memory_stats()
+        # check_available: report peak memory only when the accelerator is
+        # actually usable, matching the old torch.cuda.is_available() gating
+        acc = torch.accelerator.current_accelerator(check_available=True)
+        if acc is not None:
+            torch.accelerator.reset_peak_memory_stats()
+
         wall_time_ms = benchmark_compiled_module_fn(times=times, repeat=repeat) * 1000
 
-        if torch.cuda.is_available():
-            peak_mem = torch.cuda.max_memory_allocated()
-            print(f"Peak GPU memory usage {peak_mem / 1e6:.3f} MB")
+        if acc is not None:
+            peak_mem = torch.accelerator.max_memory_allocated()
+            print(f"Peak {acc.type.upper()} memory usage {peak_mem / 1e6:.3f} MB")
 
-        if torch.cuda.is_available() and args.cuda_memory_snapshot:
+        if acc is not None and args.memory_snapshot:
             collect_memory_snapshot(benchmark_compiled_module_fn)
 
         if args.profile:

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -419,11 +419,13 @@ def collect_memory_snapshot(
         print(f"Memory snapshot is not supported on {acc.type}, skipping")
         return
 
-    mem_mod._record_memory_history(max_entries=100000)
-    benchmark_compiled_module_fn(times=10, repeat=1)  # run 10 times
     snapshot_path = f"{tempfile.gettempdir()}/memory_snapshot.pickle"
-    mem_mod._dump_snapshot(snapshot_path)
-    mem_mod._record_memory_history(enabled=None)
+    mem_mod._record_memory_history(max_entries=100000)
+    try:
+        benchmark_compiled_module_fn(times=10, repeat=1)  # run 10 times
+        mem_mod._dump_snapshot(snapshot_path)
+    finally:
+        mem_mod._record_memory_history(enabled=None)
     print(f"The collect memory snapshot has been written to {snapshot_path}")
 
 
@@ -459,13 +461,18 @@ def compiled_module_main(
     )
     parser.add_argument(
         "--memory-snapshot",
-        "--cuda-memory-snapshot",
         action="store_true",
         help="""
             Whether to collect accelerator memory snapshot. Refer to
             "https://pytorch.org/blog/understanding-gpu-memory-1/
             for details about how to visualize the collected snapshot
         """,
+    )
+    parser.add_argument(
+        "--cuda-memory-snapshot",
+        dest="memory_snapshot",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--ncu",


### PR DESCRIPTION
## Summary

- Generalize `torch/_inductor/wrapper_benchmark.py` to report peak memory and collect memory snapshots on any accelerator, not just CUDA.
- `compiled_module_main` resolves the current accelerator once via `torch.accelerator.current_accelerator()` and routes `reset_peak_memory_stats`/`max_memory_allocated` through the device-agnostic `torch.accelerator` APIs; the report now says `Peak {ACC_TYPE} memory usage` instead of hardcoding "GPU".
- `collect_memory_snapshot` dispatches through `torch.get_device_module(acc).memory` with a `hasattr(_record_memory_history)` capability check: CUDA/XPU collect real snapshots, devices without the API (e.g. MPS) print a notice and skip.
- CLI flag `--cuda-memory-snapshot` renamed to `--memory-snapshot`; the old name remains as a hidden alias, so existing scripts keep working.

## Motivation/evidence

- All eight hardcoded call sites (`torch.cuda.is_available` x3, `reset_peak_memory_stats`, `max_memory_allocated`, `memory._record_memory_history`, `_dump_snapshot`, plus the flag name and assert message) silently disabled peak-memory reporting and snapshots on XPU/MPS/MTIA machines.
- `torch.accelerator` already exposes the exact statistics APIs used here (`reset_peak_memory_stats`, `max_memory_allocated` in `torch/accelerator/memory.py`), dispatching to any `c10::DeviceAllocator` (CUDA/XPU/HIP/MPS/HPU/MTIA/PrivateUse1) — no new mechanism needed for the stats path.
- Snapshot APIs have no accelerator-level equivalent yet, so they are dispatched via `torch.get_device_module(acc).memory` with a capability probe, mirroring the `getattr`-guard pattern in `torch/utils/backend_registration.py`.
- `ncu_analyzer` was left untouched: NCU is an NVIDIA-only tool, so hardcoding is correct there.

## Test Plan

- New `test/inductor/test_wrapper_benchmark.py`: 9 CPU-only mock-based cases covering the no-accelerator path (no reset, no Peak output), accelerator path (reset/max called once, output format), reset-before-benchmark ordering, `--memory-snapshot` dispatch, legacy `--cuda-memory-snapshot` alias, snapshot skip on unsupported devices (MPS-style), and full record/dump/disable call sequence with argument checks.
- Verified locally with `python -m py_compile` on both files; argparse aliasing and the `Peak CUDA memory usage 2.000 MB` format string confirmed via stdlib-only scripts (repo checkout not built, so `run_tests()` could not be executed locally).
- On a CUDA machine, also run the existing end-to-end suite `test/inductor/test_kernel_benchmark.py` (it subprocess-executes the emitted `compiled_module_main`) to confirm no regression.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo