### PR TITLE
[Testcase Refactoring] Label test_c10d_functional_native classes and migrate TestWithNCCL to device-type instantiation

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -21,13 +21,17 @@ from torch.distributed._functional_collectives import (
     reduce_scatter_single_coalesced,
 )
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
-from torch.testing._internal.common_device_type import e4m3_type
+from torch.testing._internal.common_device_type import (
+    e4m3_type,
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_distributed import (
     DistributedTestBase,
     requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
+    HardwareClassification,
     IS_LINUX,
     run_tests,
     TEST_WITH_TORCHINDUCTOR,
@@ -62,6 +66,8 @@ if not dist.is_available():
 
 @requires_accelerator_dist_backend()
 class TestWithNCCL(DistributedTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
@@ -72,14 +78,14 @@ class TestWithNCCL(DistributedTestBase):
 
     @property
     def device(self) -> torch.device:
-        return torch.device(self.rank)
+        return torch.device(self.device_type, self.rank)
 
     def _init_process_group(self) -> None:
         self.create_pg(self.device.type)
         torch._C._distributed_c10d._register_process_group("default", dist.group.WORLD)
 
     @skip_if_lt_x_gpu(2)
-    def test_all_reduce_single(self) -> None:
+    def test_all_reduce_single(self, device) -> None:
         self._init_process_group()
 
         input = torch.full((10, 10), float(self.rank), device=self.device)
@@ -111,7 +117,7 @@ class TestWithNCCL(DistributedTestBase):
             raise AssertionError("Expected output.completed to be True after access")
 
     @skip_if_lt_x_gpu(2)
-    def test_all_reduce_single_(self) -> None:
+    def test_all_reduce_single_(self, device) -> None:
         self._init_process_group()
 
         input = torch.full((10, 10), float(self.rank), device=self.device)
@@ -128,7 +134,7 @@ class TestWithNCCL(DistributedTestBase):
             raise AssertionError(f"Expected output to equal {expect}")
 
     @skip_if_lt_x_gpu(2)
-    def test_all_reduce_coalesced(self) -> None:
+    def test_all_reduce_coalesced(self, device) -> None:
         self._init_process_group()
 
         inputs = [
@@ -166,7 +172,7 @@ class TestWithNCCL(DistributedTestBase):
                 )
 
     @skip_if_lt_x_gpu(2)
-    def test_all_reduce_coalesced_(self) -> None:
+    def test_all_reduce_coalesced_(self, device) -> None:
         self._init_process_group()
 
         inputs = [
@@ -187,7 +193,7 @@ class TestWithNCCL(DistributedTestBase):
                 raise AssertionError(f"Expected output to equal {expected}")
 
     @skip_if_lt_x_gpu(2)
-    def test_all_gather_into_tensor_single(self) -> None:
+    def test_all_gather_into_tensor_single(self, device) -> None:
         self._init_process_group()
 
         input = torch.full((10, 10), float(self.rank), device=self.device)
@@ -239,7 +245,7 @@ class TestWithNCCL(DistributedTestBase):
 
     # https://github.com/pytorch/pytorch/issues/133421
     @skip_if_lt_x_gpu(2)
-    def test_functional_collectives_inference_mode(self) -> None:
+    def test_functional_collectives_inference_mode(self, device) -> None:
         self._init_process_group()
 
         with torch.inference_mode():
@@ -260,7 +266,7 @@ class TestWithNCCL(DistributedTestBase):
             )
 
     @skip_if_lt_x_gpu(2)
-    def test_functional_collectives_batched(self) -> None:
+    def test_functional_collectives_batched(self, device) -> None:
         self._init_process_group()
 
         def f(x):
@@ -291,7 +297,7 @@ class TestWithNCCL(DistributedTestBase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
     # https://github.com/pytorch/pytorch/issues/126338
-    def test_inductor_dtypeview_memory_leak(self):
+    def test_inductor_dtypeview_memory_leak(self, device):
         self._init_process_group()
 
         def func(arg: torch.Tensor) -> torch.Tensor:
@@ -329,7 +335,7 @@ class TestWithNCCL(DistributedTestBase):
             )
 
     @skip_if_lt_x_gpu(2)
-    def test_all_gather_into_tensor_coalesced(self) -> None:
+    def test_all_gather_into_tensor_coalesced(self, device) -> None:
         self._init_process_group()
 
         inputs = [
@@ -371,7 +377,7 @@ class TestWithNCCL(DistributedTestBase):
                 )
 
     @skip_if_lt_x_gpu(2)
-    def test_reduce_scatter_tensor_single(self) -> None:
+    def test_reduce_scatter_tensor_single(self, device) -> None:
         self._init_process_group()
 
         input = torch.tensor(self.ranks, device=self.device)
@@ -402,7 +408,7 @@ class TestWithNCCL(DistributedTestBase):
             raise AssertionError("Expected output.completed to be True after access")
 
     @skip_if_lt_x_gpu(2)
-    def test_reduce_scatter_tensor_out(self) -> None:
+    def test_reduce_scatter_tensor_out(self, device) -> None:
         self._init_process_group()
 
         input = torch.tensor(self.ranks, device=self.device)
@@ -419,7 +425,7 @@ class TestWithNCCL(DistributedTestBase):
             raise AssertionError(f"Expected out to equal {self.rank}")
 
     @skip_if_lt_x_gpu(2)
-    def test_reduce_scatter_tensor_coalesced(self) -> None:
+    def test_reduce_scatter_tensor_coalesced(self, device) -> None:
         self._init_process_group()
 
         inputs = [torch.tensor(self.ranks, device=self.device) * i for i in range(10)]
@@ -454,7 +460,7 @@ class TestWithNCCL(DistributedTestBase):
                 )
 
     @skip_if_lt_x_gpu(2)
-    def test_all_to_all_single(self) -> None:
+    def test_all_to_all_single(self, device) -> None:
         self._init_process_group()
         torch.accelerator.set_device_index(self.rank)
 
@@ -495,7 +501,7 @@ class TestWithNCCL(DistributedTestBase):
             raise AssertionError("Expected output.completed to be True after access")
 
     @skip_if_lt_x_gpu(2)
-    def test_broadcast(self) -> None:
+    def test_broadcast(self, device) -> None:
         self._init_process_group()
 
         input = torch.full((10, 10), float(self.rank), device=self.device)
@@ -527,7 +533,7 @@ class TestWithNCCL(DistributedTestBase):
             raise AssertionError("Expected output.completed to be True after access")
 
     @skip_if_lt_x_gpu(2)
-    def test_wait_tensor(self) -> None:
+    def test_wait_tensor(self, device) -> None:
         self._init_process_group()
 
         input = torch.full((10, 10), float(self.rank), device=self.device)
@@ -543,7 +549,7 @@ class TestWithNCCL(DistributedTestBase):
         self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
 
     @skip_if_lt_x_gpu(2)
-    def test_unwaited(self) -> None:
+    def test_unwaited(self, device) -> None:
         # Verify that the process can terminate gracefully
         # even with unwaited tensors
         self._init_process_group()
@@ -560,7 +566,7 @@ class TestWithNCCL(DistributedTestBase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
     @fresh_cache()
-    def test_threading(self):
+    def test_threading(self, device):
         self._init_process_group()
         device = self.device
 
@@ -605,7 +611,7 @@ class TestWithNCCL(DistributedTestBase):
     )
     @skip_if_lt_x_gpu(2)
     @fresh_cache()
-    def test_fixed_striding(self):
+    def test_fixed_striding(self, device):
         self._init_process_group()
 
         def scale(t):
@@ -746,6 +752,8 @@ class CrossThreadWaitTest(TestCase):
     than where the collective was initiated.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_wait_tensor_cross_thread(self) -> None:
         """
         Test that wait_tensor works when called from a different thread
@@ -823,6 +831,8 @@ class PyWorkTest(TestCase):
     aren't getting prematurely freed.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_wait_tensor(self) -> None:
         wait_called = False
 
@@ -889,6 +899,8 @@ class ProcessGroupArgTest(TestCase):
     (not just string group names) via the Any-typed group argument.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         dummy_init_pg()
@@ -926,6 +938,8 @@ class ProcessGroupArgTest(TestCase):
 
 
 class ProcessGroupOpaqueTypeRegistrationTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_process_group_is_registered_on_distributed_import(self) -> None:
         from torch._library.opaque_object import (
             get_member_type,
@@ -954,6 +968,8 @@ def find_buffer_assignments(code):
 
 
 class CompileTestCPU(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def setUp(self):
         super().setUp()
 
@@ -1003,12 +1019,12 @@ class CompileTestCPU(TestCase):
         AOTIRunnerUtil.run(func, (arg,))
         torch.cpu.synchronize()
 
-    def test_inductor_all_reduce_cpu(self):
+    def test_inductor_all_reduce_cpu(self, device):
         self._test_inductor_all_reduce_cpu(cpp_wrapper=False)
         self._test_inductor_all_reduce_cpu(cpp_wrapper=True)
 
     @fresh_cache()
-    def test_inductor_all_reduce_coalesced_cpu(self):
+    def test_inductor_all_reduce_coalesced_cpu(self, device):
         def func(args: list[torch.Tensor]) -> list[torch.Tensor]:
             return funcol.all_reduce_coalesced([arg + 42 for arg in args], "avg", "0")
 
@@ -1029,6 +1045,8 @@ class CompileTestCPU(TestCase):
 
 
 class CompileTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
 
@@ -1570,6 +1588,8 @@ class ACTCompileTest(TestCase):
     mismatch at runtime because autograd produces plain-tensor tangents.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_act_compile_backward_tangent_mismatch(self):
         """
         When a bare AsyncCollectiveTensor (ACT) enters a torch.compiled
@@ -1715,6 +1735,11 @@ class ACTCompileTest(TestCase):
         self.assertEqual(r3, elem * 2)
         self.assertEqual(cnt.frame_count, 2)
 
+
+instantiate_device_type_tests(
+    TestWithNCCL, globals(), allow_xpu=True, except_for=("cpu",)
+)
+instantiate_device_type_tests(CompileTestCPU, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Label every test class in `test_c10d_functional_native.py` with `HardwareClassification`, and migrate `TestWithNCCL` from a single current-accelerator device to per-device-variant instantiation via `instantiate_device_type_tests`.

## Changes
- **`TestWithNCCL` → `ACCELERATOR` + `instantiate_device_type_tests(except_for=("cpu",), allow_xpu=True)`**: the class name dates from when NCCL was the only accelerator backend, but the test body verifies functional-collective correctness on whatever accelerator is present — the `device` property already resolved the CURRENT accelerator via `torch.device(self.rank)` (int construction), not a hard-coded CUDA device. A `device` parameter is added to all 18 test methods; the property now builds `torch.device(self.device_type, self.rank)` from the per-variant class attribute, so the 22 `self.device` consumers and `create_pg(self.device.type)` are unchanged.
  - `except_for=("cpu",)` rather than a platform-resolved `only_for` list (as in `test_functional_api.py`): the class needs "any accelerator", so a blacklist avoids re-enumating device names and stays open to future backends.
- **Five mechanism-only classes → `GENERIC`**: `CrossThreadWaitTest`, `PyWorkTest`, `ProcessGroupArgTest`, `ProcessGroupOpaqueTypeRegistrationTest` (dummy-PG lifetime/registration mechanics) and `ACTCompileTest` (AsyncCollectiveTensor compile-type checks on CPU tensors).
- **`CompileTestCPU` → `CPU` + `instantiate_device_type_tests(only_for="cpu")`** with a `device` param on both tests (inductor CPU codegen assertions).
- **`CompileTest` → `ACCELERATOR`, label only (no mechanism migration)**: all 16 tests are gated `@skipIf(not HAS_GPU)` where `HAS_GPU` is the inductor-side definition (cuda/xpu/mtia + Triton) that excludes PrivateUse1 — instantiating would only generate all-skip variants. Generalizing the gate requires an inductor-side change (separate, orthogonal). Label-only ACCELERATOR without instantiation has landed precedents (`test_dataloader.py` `TestDictDataLoaderDevice`, `test_functional_autograd_benchmark.py`).

## Motivation
An unclassified `TestCase` is silently dropped under `--hw-classification` filtering. `TestWithNCCL` resolves a single current-accelerator device and therefore cannot generate per-backend variants; instantiation makes the collection dimension device-variant-based (CUDA/XPU/PrivateUse1 each run the suite).

Device-property equivalence, scoped: on single-accelerator machines (all CI today), `torch.device(self.rank)` and `torch.device(self.device_type, self.rank)` construct the same device. On machines where PrivateUse1 coexists with CUDA/XPU, the old int form always resolved to PrivateUse1 regardless of variant (a CUDA variant would silently run on the PrivateUse1 device), while the new form addresses the variant's own device — a deliberate behavior improvement, not just equivalence.

## Test Plan
- Verified on an 8-card out-of-tree accelerator backend, with two infra prerequisites applied locally (they are NOT in this PR): the `requires_accelerator_dist_backend()` hccl mapping (`"hccl": TEST_HPU or PrivateUse1`) and `DistributedTestBase.backend()` device-to-backend resolution (npu → hccl rather than the gloo fallback). On the pristine upstream baseline the NPU variant is class-level skipped and the backend resolves to gloo.
  - All 15 non-capability-gated `TestWithNCCL` methods pass on the accelerator variant over HCCL (13 eager + 2 compile), the five GENERIC classes pass, and variants generate correctly (`TestWithNCCLPRIVATEUSE1`, `CompileTestCPUCPU`).
- The 3 capability-gated methods (`2× HAS_GPU`, `1× PLATFORM_SUPPORTS_FP8`) keep their gates; their first post-migration execution is the nightly inductor distributed job (the PR-triggered workflow runs on CPU-only runners). Residual risk is mechanical: device injection is signature-driven and all three decorators preserve signatures via `functools.wraps`, the same injection path as the 15 verified methods.
- Note on CPU-only CI counting: `except_for=("cpu",)` means `TestWithNCCL` reports 0 collected tests (instead of N skips) on machines with no accelerator — no coverage is lost; the accelerator variants are what carry it.
- `lintrunner` reports no lint issues.

## Notes
- `@skip_if_lt_x_gpu(2)` is kept unchanged; its device-agnostic rewrite already landed in main (`common_distributed.py` now checks `torch.accelerator.*`).
- `HAS_GPU` (inductor_utils) excludes PrivateUse1 backends — generalizing `CompileTest` needs an inductor-side extension, tracked separately.
- Pre-existing (not addressed here): `DistributedTestBase.create_pg` uses `torch.accelerator.current_accelerator()` rather than the variant device type for `set_default_device`/`set_device_index` in the nccl/xccl branches — on PrivateUse1+CUDA coexistence machines the CUDA variant would still configure the PrivateUse1 device.
- This is part of the test case refactoring initiative tracked in #185590.
