### PR TITLE
linear_cross_entropy: replace is_cuda with explicit device capability gates

### DIFF
--- a/torch/nn/modules/linear_cross_entropy.py
+++ b/torch/nn/modules/linear_cross_entropy.py
@@ -3,6 +3,11 @@ from functools import cached_property
 
 import torch
 
+from .linear_cross_entropy_options import (
+    _gemm_accumulates_in_fp32,
+    _mm_supports_out_dtype,
+)
+
 
 __all__ = []
 
@@ -117,7 +122,7 @@ class _ChunkViews:
         ctx = self.ctx
         return (
             ctx.linear_weight
-            if ctx.forward_uses_cuda_out_dtype
+            if ctx.forward_uses_mm_out_dtype
             else ctx.linear_weight_cast
         )
 
@@ -139,15 +144,16 @@ class _ChunkViews:
     @property
     def weight_grad_input(self) -> torch.Tensor:
         ctx = self.ctx
-        if ctx.is_cuda and not ctx.weight_grad_mm_same_dtype:
+        if ctx.mm_has_out_dtype and not ctx.weight_grad_mm_same_dtype:
             return self.input_chunk
         return self.input_chunk_acc
 
     @property
     def logits_upcast(self) -> torch.Tensor:
-        # Non-CUDA mixed-dtype: copy into logits_acc_buf for matching-dtype mm.
+        # Without out_dtype= mm, mixed dtypes need a matching-dtype copy in
+        # logits_acc_buf.
         ctx = self.ctx
-        if ctx.is_cuda or ctx.weight_grad_mm_same_dtype:
+        if ctx.mm_has_out_dtype or ctx.weight_grad_mm_same_dtype:
             return self.logits
         return ctx.logits_acc_buf.narrow(0, 0, self.bchunk_size).copy_(self.logits)
 
@@ -196,7 +202,7 @@ class _ChunkContext:
     num_batches: int
     in_features: int
     num_classes: int
-    is_cuda: bool
+    mm_has_out_dtype: bool
     use_acc_dtype: bool
 
     acc_dtype: torch.dtype
@@ -239,7 +245,7 @@ class _ChunkContext:
     alloc_input_chunk_acc_buf: bool
     alloc_logits_acc_buf: bool
     forward_uses_acc_input: bool
-    forward_uses_cuda_out_dtype: bool
+    forward_uses_mm_out_dtype: bool
     weight_grad_mm_same_dtype: bool
     input_grad_uses_logits_lw: bool
     loop_caches_logits_downcast: bool
@@ -351,7 +357,7 @@ class _ChunkContext:
 
     @cached_property
     def logits_acc_buf(self) -> torch.Tensor:
-        # (B, V) scratch for non-CUDA mixed-dtype logits_upcast.
+        # (B, V) scratch for mixed-dtype logits_upcast without out_dtype= mm.
         return _make_empty(
             (self.logits_buf.shape[0], self.num_classes),
             self.acc_dtype,
@@ -362,7 +368,7 @@ class _ChunkContext:
     @cached_property
     def input_grad_acc_buf(self) -> torch.Tensor:
         # (B, F) scratch for input-grad addmm on the buf-and-copy path
-        # (CPU mixed-dtype, MPS).
+        # (mixed dtypes with no out_dtype= mm, or MPS).
         return _make_empty(
             (self.logits_buf.shape[0], self.in_features),
             self.linear_weight_cast_dtype,
@@ -480,10 +486,10 @@ class _ChunkContext:
         dtype = input.dtype
         num_batches, in_features = input.shape
         num_classes, _ = linear_weight.shape
-        # CUDA gates the out_dtype= mm fast path; the non-CUDA path
-        # (CPU, MPS, XPU, ...) routes mixed-dtype mm through explicit
-        # casts until out_dtype= is validated on those backends.
-        is_cuda = device.type == "cuda"
+        # Backends with a validated out_dtype= mm take the fast path; the
+        # rest route mixed-dtype mm through explicit casts.
+        mm_has_out_dtype = _mm_supports_out_dtype(device.type)
+        gemm_fp32_accum = _gemm_accumulates_in_fp32(device.type)
         is_mps = device.type == "mps"
 
         if dtype != acc_dtype and not (
@@ -515,15 +521,16 @@ class _ChunkContext:
             )
 
         # ===== Dispatch flags =====
-        # CUDA + compact uses cuBLAS out_dtype= directly; no cast.
+        # out_dtype= mm under compact writes the wider output directly; no cast.
         needs_linear_weight_cast = use_acc_dtype and (
-            not is_cuda or (compute_input_grad and grad_input_dtype == logits_buf_dtype)
+            not mm_has_out_dtype
+            or (compute_input_grad and grad_input_dtype == logits_buf_dtype)
         )
         linear_weight_cast_dtype = (
             logits_buf_dtype if needs_linear_weight_cast else dtype
         )
         alloc_weight_grad_chunk = compute_linear_weight_grad and not (
-            acc_policy == "compact" and (is_cuda or logits_buf_dtype == dtype)
+            acc_policy == "compact" and (gemm_fp32_accum or logits_buf_dtype == dtype)
         )
         # Per-chunk acc_dtype scratch for grad_linear_bias; same
         # bulk-+-correction precision rationale as
@@ -533,21 +540,24 @@ class _ChunkContext:
         alloc_linear_bias_grad_chunk = compute_linear_bias_grad and use_acc_dtype
         alloc_input_grad_acc_buf = (
             compute_input_grad
-            and not is_cuda
+            and not mm_has_out_dtype
             and (grad_input_dtype != linear_weight_cast_dtype or is_mps)
         )
         alloc_input_chunk_acc_buf = use_acc_dtype and (
-            compute_linear_weight_grad or (not is_cuda and dtype != logits_buf_dtype)
+            compute_linear_weight_grad
+            or (not mm_has_out_dtype and dtype != logits_buf_dtype)
         )
         forward_uses_acc_input = (
-            use_acc_dtype and not is_cuda and dtype != logits_buf_dtype
+            use_acc_dtype and not mm_has_out_dtype and dtype != logits_buf_dtype
         )
-        forward_uses_cuda_out_dtype = is_cuda and use_acc_dtype
+        forward_uses_mm_out_dtype = mm_has_out_dtype and use_acc_dtype
         weight_grad_mm_same_dtype = logits_buf_dtype == acc_dtype
         # Storage-trick fires when logits' dtype differs from the input-
         # grad accumulator dtype.
         input_grad_uses_logits_lw = (
-            is_cuda and compute_input_grad and logits_buf_dtype != grad_input_dtype
+            mm_has_out_dtype
+            and compute_input_grad
+            and logits_buf_dtype != grad_input_dtype
         )
         # Per-iter ``logits.to(linear_weight.dtype)`` shared between the
         # inlined input-grad addmm and the inlined direct weight-grad addmm_.
@@ -557,7 +567,9 @@ class _ChunkContext:
             and logits_buf_dtype != dtype
         )
         alloc_logits_acc_buf = (
-            alloc_weight_grad_chunk and not is_cuda and logits_buf_dtype != acc_dtype
+            alloc_weight_grad_chunk
+            and not mm_has_out_dtype
+            and logits_buf_dtype != acc_dtype
         )
         # Direct weight-grad path: reuse logits_buf storage for the
         # acc_dtype->dtype cast when its bytes/row fits the (B, F) cast.
@@ -586,7 +598,7 @@ class _ChunkContext:
             num_batches=num_batches,
             in_features=in_features,
             num_classes=num_classes,
-            is_cuda=is_cuda,
+            mm_has_out_dtype=mm_has_out_dtype,
             use_acc_dtype=use_acc_dtype,
             acc_dtype=acc_dtype,
             weight_chunk_dtype=weight_chunk_dtype,
@@ -625,7 +637,7 @@ class _ChunkContext:
             alloc_input_chunk_acc_buf=alloc_input_chunk_acc_buf,
             alloc_logits_acc_buf=alloc_logits_acc_buf,
             forward_uses_acc_input=forward_uses_acc_input,
-            forward_uses_cuda_out_dtype=forward_uses_cuda_out_dtype,
+            forward_uses_mm_out_dtype=forward_uses_mm_out_dtype,
             weight_grad_mm_same_dtype=weight_grad_mm_same_dtype,
             input_grad_uses_logits_lw=input_grad_uses_logits_lw,
             loop_caches_logits_downcast=loop_caches_logits_downcast,
@@ -678,7 +690,7 @@ class _ChunkContext:
         )
 
     def mm(self, mat1: torch.Tensor, mat2: torch.Tensor, *, out: torch.Tensor) -> None:
-        # Mismatched dtype: cuBLAS ``out_dtype=`` upcasts inside the matmul.
+        # Mismatched dtype: ``out_dtype=`` upcasts inside the matmul.
         if mat1.dtype == out.dtype:
             torch.mm(mat1, mat2, out=out)
         else:
@@ -824,7 +836,7 @@ def _linear_cross_entropy_batch_chunked_accumulator(
       buffer-reuse decisions behind a single math call.
 
     The function body therefore should not introduce inline
-    ``if ctx.use_acc_dtype`` / ``if ctx.is_cuda`` / etc. branches; new
+    ``if ctx.use_acc_dtype`` / ``if ctx.mm_has_out_dtype`` / etc. branches; new
     policy-aware behaviour belongs in one of the three locations
     above. The two existing inline branches (``if compute_input_grad``,
     ``if compute_linear_weight_grad``, etc.) gate optional outputs,

--- a/torch/nn/modules/linear_cross_entropy_options.py
+++ b/torch/nn/modules/linear_cross_entropy_options.py
@@ -9,6 +9,12 @@ __all__ = ["LinearCrossEntropyOptions"]
 
 _VALID_ACC_POLICIES = ("auto", "accurate", "compact")
 
+# Device types whose capabilities have been validated for the chunked path.
+# Both are opt-in: a device absent from one takes the slower but always-correct
+# route, so adding an entry is additive and never silently wrong.
+_MM_OUT_DTYPE_DEVICES = ("cuda",)
+_FP32_ACCUM_GEMM_DEVICES = ("cuda",)
+
 
 def _auto_acc_policy(device_type: str | None, dtype: torch.dtype) -> str:
     """Resolve the ``acc_policy`` ``"auto"`` sentinel from device and dtype.
@@ -24,6 +30,36 @@ def _auto_acc_policy(device_type: str | None, dtype: torch.dtype) -> str:
     if device_type == "cpu" and dtype in (torch.float16, torch.bfloat16):
         return "accurate"
     return "compact"
+
+
+def _mm_supports_out_dtype(device_type: str) -> bool:
+    """Whether ``mm(out_dtype=)`` is available and validated on this device.
+
+    Lets the chunked path feed mixed-dtype operands straight to ``mm`` instead
+    of staging explicit casts through scratch buffers.
+
+    To add a device: check ``aten::mm.dtype_out`` is registered for it in
+    ``native_functions.yaml``, then compare numerics against the reference path
+    for fp16/bf16 inputs with an fp32 accumulator.
+    """
+    return device_type in _MM_OUT_DTYPE_DEVICES
+
+
+def _gemm_accumulates_in_fp32(device_type: str) -> bool:
+    """Whether a same-dtype ``addmm_`` keeps an fp32 accumulator internally.
+
+    Distinct from :func:`_mm_supports_out_dtype`: this is about the kernel's
+    internal accumulator, not an operator overload, so no registration or
+    device query can answer it. The two gates stay separate by construction --
+    ``out_dtype=`` governs single writes whose destination dtype differs from
+    the operands, while this governs the one path that accumulates every chunk
+    into the same narrow tensor.
+
+    Gates skipping the ``(num_classes, in_features)`` weight-grad scratch under
+    ``acc_policy="compact"``. A wrong ``True`` degrades gradient precision
+    across chunks silently rather than raising, so verify before adding.
+    """
+    return device_type in _FP32_ACCUM_GEMM_DEVICES
 
 
 @dataclasses.dataclass(slots=True, frozen=True)


### PR DESCRIPTION
## Summary

The chunked `linear_cross_entropy` path resolved eleven buffer and dtype
decisions from a single `is_cuda` flag. That flag was correct — CUDA is the only
backend satisfying both properties it stood for — but it bundled two independent
claims under a name that mentions neither:

| Claim | Question | Uses |
|---|---|---|
| `mm(out_dtype=)` support | Can `mm` write a destination whose dtype differs from its operands? | 10 |
| fp32 GEMM accumulator | Does a same-dtype `addmm_` keep an fp32 accumulator internally? | 1 |

Because the two travel together under one device name, a backend cannot answer
them separately, and nothing in the file says what a new device would need to
satisfy. This splits them into two named helpers in
`linear_cross_entropy_options.py`, each backed by its own tuple of validated
device types and a docstring stating what to verify before adding one.

This does not make the path device-generic, and is not meant to: both tuples
still read `("cuda",)`, because that is what has been validated. What changes is
that the device-specificity is stated per capability, in one discoverable place,
with instructions — instead of implied by a vendor name spread across eleven
call sites.

**Behavior is unchanged.** Both tuples keep exactly the membership `is_cuda`
had, so enabling any additional device is a separate change that should land
with its own numerics validation.

## Motivation

This is groundwork for enabling additional devices on the chunked path. Today
the decision of whether a device can use it is spread across eleven `is_cuda`
call sites and encodes two different requirements at once, so there is no single
answer to "what would my backend need to satisfy?" This PR does not enable any
new device; it makes that question answerable before anyone tries.

## Adding a device after this change

Registering a validated device becomes a one-line change in one file:

```diff
-_MM_OUT_DTYPE_DEVICES = ("cuda",)
+_MM_OUT_DTYPE_DEVICES = ("cuda", "xpu")
```

with the docstring on `_mm_supports_out_dtype` stating what to check first: that
`aten::mm.dtype_out` is registered for the device, then numerics against the
reference path for fp16/bf16 input with an fp32 accumulator.

XPU is the obvious next candidate — it registers every `*.dtype_out` overload
this path uses (`_mm_dtype_out_xpu`, `_addmm_dtype_out_xpu`,
`_bmm_out_dtype_xpu`, `_baddbmm_out_dtype_xpu`). Two caveats worth stating
plainly before someone tries it:

- This is one line *for this file*. A device still needs an in-tree change, not
  an out-of-tree registration.
- Adding XPU to the tuple alone will not change behavior by default.
  `LinearCrossEntropyOptions._resolve_auto_acc_dtype` hardcodes CUDA and CPU, so
  on XPU `acc_dtype` never resolves to fp32 under `acc_policy="auto"` and
  `use_acc_dtype` stays `False`. That function needs a matching change for the
  path to become reachable without an explicit `acc_dtype=torch.float32`.

## How to review

1. `linear_cross_entropy_options.py` — the two helpers and their tuples. This is
   the whole design; the rest follows from it.
2. `linear_cross_entropy.py`, `_ChunkContext.build` — the single site where both
   gates are resolved, plus the flags consuming them.
3. Everything else is a mechanical rename (`is_cuda` -> `mm_has_out_dtype`,
   `forward_uses_cuda_out_dtype` -> `forward_uses_mm_out_dtype`) and comment
   rewording from vendor language to capability language.

## Why the two gates are not merged

Both tuples currently read `("cuda",)`, which invites collapsing them. They
should stay separate: `out_dtype=` governs single writes whose destination dtype
differs from the operands, while the accumulator gate governs the one path that
accumulates every chunk into the same narrow tensor
(`grad_linear_weight.addmm_(logits_downcast.T, input_chunk)` — the only
bf16 x bf16 -> bf16 GEMM in the file, and so the only site where a kernel's
internal accumulator is observable). Merging is safe in one direction only:
`out_dtype=` support implies a wide internal accumulator, not the reverse. A
merged gate would prevent a device opting into one without the other.

## Test plan

Reproducible from this branch:

```
python test/test_nn.py -k linear_cross_entropy     # 226 passed, 1 skipped
lintrunner -a --paths-cmd 'git diff --name-only HEAD'
```

The following was verified locally with throwaway scripts that are not part of
this PR, so the numbers are reported rather than reproducible as-is.

Behavior preservation, diffing forward and backward outputs against `main`
across 144 configurations (device x dtype x acc_dtype x acc_policy x reduction x
bias), with `acc_dtype=torch.float32` included so the mixed-precision path is
actually exercised rather than short-circuited by `use_acc_dtype=False`:

- CPU: bit-identical in 54/54 configurations, including all 18 that exercise the
  mixed-precision path.
- CUDA: agreed to within 3.125e-02, which equals the run-to-run nondeterminism
  measured by re-running the identical build three times.

All four combinations of the two gates were forced via monkeypatch and produce
four distinct buffer configurations, confirming orthogonality: the accumulator
gate flips only `alloc_weight_grad_chunk`, and `out_dtype=` flips everything
else. The four agreed with each other to 8.68e-04 relative, roughly a tenth of a
bfloat16 ULP.

Not covered: `alloc_logits_acc_buf` was not reached by any configuration in the
sweep. It is on the `out_dtype=` side and is covered by the orthogonality
argument, but was not exercised directly.

---

This PR was prepared with the assistance of Claude Code. The capability
analysis, the refactor, and the verification above were produced with it and
reviewed by the author.