### PR TITLE
Pin pywavelets 1.9.0 for Python 3.14

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -337,9 +337,11 @@ tensorboard==2.18.0 ; python_version >= "3.13"
 #test that import: test_tensorboard
 
 pywavelets==1.4.1 ; python_version < "3.12"
-pywavelets==1.7.0 ; python_version >= "3.12"
+pywavelets==1.7.0 ; python_version >= "3.12" and python_version < "3.14"
+pywavelets==1.9.0 ; python_version >= "3.14"
 #Description: This is a requirement of scikit-image, we need to pin
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
+# 1.7.0 has no cp314 wheel; 1.9.0 ships wheels for 3.14
 #Pinned versions: 1.4.1
 #test that import:
 


### PR DESCRIPTION
*✳️ Assisted by Claude Opus 5*

`pywavelets==1.7.0` publishes no cp314 wheel, so on Python 3.14 pip falls back to a source build. That build fails on Windows: `cwt.template.c` defines `_USE_MATH_DEFINES` *after* including `Python.h`, which has already pulled in `<math.h>`, so the second include hits the include guard and is a no-op — `M_PI` ends up undeclared. Linux is unaffected because `Python.h` sets `_XOPEN_SOURCE`, which makes glibc expose `M_PI` regardless of `_USE_MATH_DEFINES`.

`1.9.0` is the first release with cp314 wheels, and requires `numpy>=1.25,<3` — compatible with the `numpy==2.3.4` already pinned for 3.14 on line 144 of the same file. Below 3.14 nothing changes.

No-op for current CI, where the Windows jobs run Python 3.10 (`_win-build.yml`, `_win-test.yml`); this unblocks downstream Windows + Python 3.14 builds (ROCm/TheRock#7798).
