### PR TITLE
Fix UnboundLocalError in find_free_port when socket creation fails

### DIFF
--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Fix for Issue #191395

### Problem
When `socket.socket()` raises an `OSError`, the variable `s` is never assigned, but `s.close()` is unconditionally called in the except block. This causes an `UnboundLocalError` that masks the actual socket error.

### Solution
Initialize `s = None` before the try block and only call `s.close()` if `s` was successfully created.

### Testing
The issue author provided a reproduction script:
```python
from unittest.mock import patch
from torch.distributed.elastic.rendezvous.etcd_server import find_free_port

with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 0))]),      patch("socket.socket", side_effect=OSError("socket failed")):
    find_free_port()
```

Before the fix, this raises `UnboundLocalError`. After the fix, it properly continues to try remaining addresses.

cc @d4l3k @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh