### PR TITLE
Translate std::out_of_range to IndexError

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2885,6 +2885,32 @@ TORCH_LIBRARY(test_autograd_function_backed_op, m) {
         with self.assertWarnsRegex(UserWarning, "torch.ger is deprecated"):
             torch._C._dispatch_call_boxed(op, x, y, out=out)
 
+    @scoped_load_inline
+    def test_torch_ops_out_of_range_raises_index_error(self, load_inline):
+        load_inline(
+            name="test_out_of_range_index_error",
+            cpp_sources="""
+#include <torch/extension.h>
+
+#include <stdexcept>
+
+torch::Tensor out_of_range_op(const torch::Tensor& x) {
+  throw std::out_of_range("index 5 is out of bounds");
+}
+
+TORCH_LIBRARY(_test_out_of_range_index_error, m) {
+  m.def("foo(Tensor x) -> Tensor");
+  m.impl("foo", c10::DispatchKey::CPU, TORCH_FN(out_of_range_op));
+}
+""",
+            is_python_module=False,
+            verbose=True,
+        )
+
+        x = torch.ones(2)
+        with self.assertRaisesRegex(IndexError, "index 5 is out of bounds"):
+            torch.ops._test_out_of_range_index_error.foo.default(x)
+
     # Using a non-existent DSO is a quick way to trigger an OSError,
     # which can be used to not break BC.
     def test_load_library(self):

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -2,6 +2,7 @@
 
 #include <exception>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 
@@ -103,6 +104,11 @@ inline void PyErr_SetString(PyObject* type, const std::string& message) {
 
 #define CATCH_ALL_ERRORS(retstmnt)               \
   CATCH_TH_ERRORS(retstmnt)                      \
+  catch (const std::out_of_range& e) {           \
+    auto msg = torch::processErrorMsg(e.what()); \
+    PyErr_SetString(PyExc_IndexError, msg);      \
+    retstmnt;                                    \
+  }                                              \
   catch (const std::exception& e) {              \
     auto msg = torch::processErrorMsg(e.what()); \
     PyErr_SetString(PyExc_RuntimeError, msg);    \


### PR DESCRIPTION
code is from `claude`, text is from me.

----

https://github.com/pytorch/pytorch/pull/193451 [broke TorchCodec](https://github.com/meta-pytorch/torchcodec/pull/1683). The issue is exactly the BC-breaking note acknowledged in https://github.com/pytorch/pytorch/pull/193451:

> BC-breaking note: we make torch.ops.* call go through the same exception and warning translation as the rest of the library. This means that some exception translation that used to be handle by pybind is now handled natively. User-defined pybind exception translation is thus lost here


TorchCodec [throws `std::out_of_range`](https://github.com/meta-pytorch/torchcodec/blob/85a89e2bd9d806381c60564f136fea8047114287/src/torchcodec/_core/StableABICompat.h#L39-L47) and relies on pybind to convert that to an `IndexError`. With https://github.com/pytorch/pytorch/pull/193451, this `IndexError` is now a `RuntimeError`, which [breaks various tests](https://github.com/meta-pytorch/torchcodec/pull/1683) in the TorchCodec CI, as they expect an `IndexError`. These are user-facing exceptions, so it's not something I can transparently handle as implementation detail.



This PR lets `std::out_of_range` propagate to an `IndexError`, preserving the previous behavior before https://github.com/pytorch/pytorch/pull/193451. This is probably not the holistic fix that `torch` really needs, but I'm blocked on TC until this is resolved. I can also submit a revert PR for https://github.com/pytorch/pytorch/pull/193451 if that's the preferred solution.


(I am considering two temporary workarounds in TC: https://github.com/meta-pytorch/torchcodec/pull/1684 which pins the torch nightly, or https://github.com/meta-pytorch/torchcodec/pull/1685 which skip the failing tests - neither are viable long-term workarounds!)
