### PR TITLE
[2/2][Test] Separate the cuDNN varlen attention tests into their own CUDA class

### DIFF
--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -915,24 +915,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
         )
 
     @skipIfRocm
-    @setSdpaBackendsToDefaultFinally
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
-    @parametrize("window_size", [(-1, -1), (-1, 0), [-1, 0]])
-    @parametrize("_should_use_cudnn", [True])
-    def test_cudnn_attention_varlen(
-        self, device, dtype, window_size, _should_use_cudnn
-    ):
-        self._test_varlen_vs_sdpa(
-            device,
-            dtype,
-            scale=None,
-            window_size=window_size,
-            backend="fa2",
-            enable_gqa=False,
-            _should_use_cudnn=_should_use_cudnn,
-        )
-
-    @skipIfRocm
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
@@ -1317,146 +1299,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
         # The real output matches the query's layout, like Flash and the fake.
         self.assertEqual(eager.stride(), q.stride())
         self.assertEqual(compiled, eager)
-
-    @skipIfRocm
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
-    )
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
-    @parametrize("compile", [False, True])
-    def test_sdpa_kernel_backend_selection(self, device, dtype, compile):
-        """Honor forced backends and preserve the forward choice for backward."""
-        torch.manual_seed(42)
-        seq_len = 256
-        num_heads, head_dim = 4, 64
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-        tensors = [
-            torch.randn(seq_len, num_heads, head_dim, device=device, dtype=dtype)
-            for _ in range(3)
-        ]
-        grad_out = torch.randn_like(tensors[0])
-        _check_cudnn_varlen_supported(device)
-
-        for backend, backward_backend in (
-            (SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION),
-            (SDPBackend.CUDNN_ATTENTION, SDPBackend.FLASH_ATTENTION),
-        ):
-            with (
-                patch.object(
-                    torch.ops.aten,
-                    "_cudnn_attention_forward",
-                    wraps=torch.ops.aten._cudnn_attention_forward,
-                ) as cudnn_forward,
-                patch.object(
-                    torch.ops.aten,
-                    "_cudnn_attention_backward",
-                    wraps=torch.ops.aten._cudnn_attention_backward,
-                ) as cudnn_backward,
-            ):
-                q, k, v = [
-                    tensor.detach().clone().requires_grad_() for tensor in tensors
-                ]
-                if compile:
-                    # SDP enablement is captured when the graph is traced.
-                    torch._dynamo.reset()
-                attn = (
-                    torch.compile(varlen_attn, backend="eager", fullgraph=True)
-                    if compile
-                    else varlen_attn
-                )
-                with sdpa_kernel(backend):
-                    out = attn(
-                        q,
-                        k,
-                        v,
-                        cu_seq,
-                        cu_seq,
-                        seq_len,
-                        seq_len,
-                        window_size=(-1, 0),
-                    )
-                with sdpa_kernel(backward_backend):
-                    torch.autograd.grad(out, (q, k, v), grad_out)
-                expected_calls = int(backend == SDPBackend.CUDNN_ATTENTION)
-                self.assertEqual(cudnn_forward.call_count, expected_calls)
-                self.assertEqual(cudnn_backward.call_count, expected_calls)
-
-    @parametrize("compile", [False, True])
-    def test_sdpa_kernel_backend_priority(self, device, compile):
-        q, k, v, cu_seq = _make_causal_varlen_inputs(device)
-        args = (q, k, v, cu_seq, cu_seq, q.size(0), [-1, 0])
-
-        with patch.object(varlen_attention, "_should_use_cudnn", return_value=True):
-            for backend_order in (
-                [SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION],
-                [SDPBackend.CUDNN_ATTENTION, SDPBackend.FLASH_ATTENTION],
-            ):
-                with sdpa_kernel(backend_order, set_priority=True):
-                    if compile:
-                        torch._dynamo.reset()
-                        get_priority = torch.compile(
-                            lambda x: x + varlen_attention._get_sdp_priority_order()[0],
-                            backend="eager",
-                            fullgraph=True,
-                        )
-                        priority = get_priority(torch.zeros((), device=device)).item()
-                        self.assertEqual(priority, backend_order[0].value)
-                    backend = varlen_attention._select_backend(*args)
-                self.assertEqual(backend, backend_order[0].value)
-            self.assertEqual(
-                varlen_attention._select_backend(*args),
-                SDPBackend.CUDNN_ATTENTION.value,
-            )
-
-    @skipIfRocm
-    def test_cudnn_backend_constraint_errors(self, device):
-        """Name the cuDNN constraints that rejected a forced cuDNN selection."""
-        # Backend selection happens before dispatch, so this needs no cuDNN.
-        seq_len = 256
-        q = torch.randn(seq_len, 4, 64, device=device, dtype=torch.bfloat16)
-        k = torch.randn_like(q)
-        v = torch.randn_like(q)
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-
-        short_seq = torch.tensor([0, 128], device=device, dtype=torch.int32)
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            with self.assertRaises(RuntimeError) as error:
-                varlen_attn(
-                    q[:128],
-                    k[:128],
-                    v[:128],
-                    short_seq,
-                    short_seq,
-                    128,
-                    128,
-                    num_splits=1,
-                )
-        self.assertIn("max_q must", str(error.exception))
-        self.assertIn("num_splits", str(error.exception))
-
-        with (
-            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
-            self.assertRaisesRegex(RuntimeError, "same cu_seq tensor"),
-        ):
-            varlen_attn(
-                q,
-                k,
-                v,
-                cu_seq,
-                cu_seq.clone(),
-                seq_len,
-                seq_len,
-                window_size=(-1, 0),
-            )
-
-        # cuDNN is a valid varlen_attn backend, but varlen_attn_out is flash-only.
-        with (
-            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
-            self.assertRaisesRegex(RuntimeError, "only supports.*FLASH_ATTENTION"),
-        ):
-            varlen_attn_out(
-                torch.empty_like(q), q, k, v, cu_seq, cu_seq, seq_len, seq_len
-            )
 
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179968")
     @unittest.skipIf(
@@ -2384,8 +2226,173 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
             self.assertEqual(out_buf, out)
 
 
+class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
+    # cuDNN is the only varlen backend with dedicated aten ops
+    # (_cudnn_attention_forward/_backward) and it is only ever selected for a
+    # CUDA query, so these tests cannot be shared with other backends.
+
+    @skipIfRocm
+    @setSdpaBackendsToDefaultFinally
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @parametrize("window_size", [(-1, -1), (-1, 0), [-1, 0]])
+    @parametrize("_should_use_cudnn", [True])
+    def test_cudnn_attention_varlen(
+        self, device, dtype, window_size, _should_use_cudnn
+    ):
+        self._test_varlen_vs_sdpa(
+            device,
+            dtype,
+            scale=None,
+            window_size=window_size,
+            backend="fa2",
+            enable_gqa=False,
+            _should_use_cudnn=_should_use_cudnn,
+        )
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @parametrize("compile", [False, True])
+    def test_sdpa_kernel_backend_selection(self, device, dtype, compile):
+        """Honor forced backends and preserve the forward choice for backward."""
+        torch.manual_seed(42)
+        seq_len = 256
+        num_heads, head_dim = 4, 64
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+        tensors = [
+            torch.randn(seq_len, num_heads, head_dim, device=device, dtype=dtype)
+            for _ in range(3)
+        ]
+        grad_out = torch.randn_like(tensors[0])
+        _check_cudnn_varlen_supported(device)
+
+        for backend, backward_backend in (
+            (SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION),
+            (SDPBackend.CUDNN_ATTENTION, SDPBackend.FLASH_ATTENTION),
+        ):
+            with (
+                patch.object(
+                    torch.ops.aten,
+                    "_cudnn_attention_forward",
+                    wraps=torch.ops.aten._cudnn_attention_forward,
+                ) as cudnn_forward,
+                patch.object(
+                    torch.ops.aten,
+                    "_cudnn_attention_backward",
+                    wraps=torch.ops.aten._cudnn_attention_backward,
+                ) as cudnn_backward,
+            ):
+                q, k, v = [
+                    tensor.detach().clone().requires_grad_() for tensor in tensors
+                ]
+                if compile:
+                    # SDP enablement is captured when the graph is traced.
+                    torch._dynamo.reset()
+                attn = (
+                    torch.compile(varlen_attn, backend="eager", fullgraph=True)
+                    if compile
+                    else varlen_attn
+                )
+                with sdpa_kernel(backend):
+                    out = attn(
+                        q,
+                        k,
+                        v,
+                        cu_seq,
+                        cu_seq,
+                        seq_len,
+                        seq_len,
+                        window_size=(-1, 0),
+                    )
+                with sdpa_kernel(backward_backend):
+                    torch.autograd.grad(out, (q, k, v), grad_out)
+                expected_calls = int(backend == SDPBackend.CUDNN_ATTENTION)
+                self.assertEqual(cudnn_forward.call_count, expected_calls)
+                self.assertEqual(cudnn_backward.call_count, expected_calls)
+
+    @parametrize("compile", [False, True])
+    def test_sdpa_kernel_backend_priority(self, device, compile):
+        q, k, v, cu_seq = _make_causal_varlen_inputs(device)
+        args = (q, k, v, cu_seq, cu_seq, q.size(0), [-1, 0])
+
+        with patch.object(varlen_attention, "_should_use_cudnn", return_value=True):
+            for backend_order in (
+                [SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION],
+                [SDPBackend.CUDNN_ATTENTION, SDPBackend.FLASH_ATTENTION],
+            ):
+                with sdpa_kernel(backend_order, set_priority=True):
+                    if compile:
+                        torch._dynamo.reset()
+                        get_priority = torch.compile(
+                            lambda x: x + varlen_attention._get_sdp_priority_order()[0],
+                            backend="eager",
+                            fullgraph=True,
+                        )
+                        priority = get_priority(torch.zeros((), device=device)).item()
+                        self.assertEqual(priority, backend_order[0].value)
+                    backend = varlen_attention._select_backend(*args)
+                self.assertEqual(backend, backend_order[0].value)
+            self.assertEqual(
+                varlen_attention._select_backend(*args),
+                SDPBackend.CUDNN_ATTENTION.value,
+            )
+
+    @skipIfRocm
+    def test_cudnn_backend_constraint_errors(self, device):
+        """Name the cuDNN constraints that rejected a forced cuDNN selection."""
+        # Backend selection happens before dispatch, so this needs no cuDNN.
+        seq_len = 256
+        q = torch.randn(seq_len, 4, 64, device=device, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        short_seq = torch.tensor([0, 128], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaises(RuntimeError) as error:
+                varlen_attn(
+                    q[:128],
+                    k[:128],
+                    v[:128],
+                    short_seq,
+                    short_seq,
+                    128,
+                    128,
+                    num_splits=1,
+                )
+        self.assertIn("max_q must", str(error.exception))
+        self.assertIn("num_splits", str(error.exception))
+
+        with (
+            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
+            self.assertRaisesRegex(RuntimeError, "same cu_seq tensor"),
+        ):
+            varlen_attn(
+                q,
+                k,
+                v,
+                cu_seq,
+                cu_seq.clone(),
+                seq_len,
+                seq_len,
+                window_size=(-1, 0),
+            )
+
+        # cuDNN is a valid varlen_attn backend, but varlen_attn_out is flash-only.
+        with (
+            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
+            self.assertRaisesRegex(RuntimeError, "only supports.*FLASH_ATTENTION"),
+        ):
+            varlen_attn_out(
+                torch.empty_like(q), q, k, v, cu_seq, cu_seq, seq_len, seq_len
+            )
+
+
 instantiate_device_type_tests(TestVarlenAttentionDevice, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestVarlenAttention, globals(), only_for=("cuda",))
+instantiate_device_type_tests(TestVarlenAttentionCuDNN, globals(), only_for=("cuda",))
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -943,200 +943,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
         torch.autograd.grad(out.sum(), (q, k, v))
 
     @skipIfRocm
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
-    )
-    def test_cudnn_causal_varlen_requires_shared_cu_seq(self, device):
-        _check_cudnn_varlen_supported(device)
-        seq_len = 256
-        q = torch.randn(
-            seq_len,
-            4,
-            64,
-            device=device,
-            dtype=torch.bfloat16,
-            requires_grad=True,
-        )
-        k = torch.randn_like(q, requires_grad=True)
-        v = torch.randn_like(q, requires_grad=True)
-        cu_seq_q = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-        cu_seq_k = cu_seq_q.clone()
-
-        with (
-            _use_cudnn_varlen(True, device),
-            patch.object(
-                torch.ops.aten,
-                "_cudnn_attention_forward",
-                wraps=torch.ops.aten._cudnn_attention_forward,
-            ) as cudnn_forward,
-            patch.object(
-                torch.ops.aten,
-                "_cudnn_attention_backward",
-                wraps=torch.ops.aten._cudnn_attention_backward,
-            ) as cudnn_backward,
-        ):
-            out = varlen_attn(
-                q,
-                k,
-                v,
-                cu_seq_q,
-                cu_seq_k,
-                seq_len,
-                seq_len,
-                window_size=(-1, 0),
-            )
-            torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
-
-        self.assertEqual(cudnn_forward.call_count, 0)
-        self.assertEqual(cudnn_backward.call_count, 0)
-
-    @skipIfRocm
-    @parametrize("different_kv_stride", [False, True])
-    def test_cudnn_varlen_shared_cu_seq(self, device, different_kv_stride):
-        """Reusing shared Q/K metadata preserves forward and backward results."""
-        _check_cudnn_varlen_supported(device)
-        torch.manual_seed(42)
-        total, num_heads, head_dim = 512, 4, 64
-        q = torch.randn(
-            total, num_heads, head_dim, device=device, dtype=torch.bfloat16
-        ).requires_grad_()
-
-        def make_kv():
-            shape = (total, num_heads, head_dim + 8) if different_kv_stride else q.shape
-            tensor = torch.randn(shape, device=device, dtype=torch.bfloat16)
-            return tensor[..., :head_dim].requires_grad_()
-
-        k, v = make_kv(), make_kv()
-        cu_seq = torch.tensor([0, 192, total], device=device, dtype=torch.int32)
-        grad_out = torch.randn_like(q)
-
-        def run(cu_seq_k):
-            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-                out = varlen_attn(q, k, v, cu_seq, cu_seq_k, 320, 320)
-                return (out, *torch.autograd.grad(out, (q, k, v), grad_out))
-
-        expected = run(cu_seq.clone())
-        actual = run(cu_seq)
-        self.assertEqual(actual, expected)
-
-    @skipIfRocm
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
-    @parametrize("different_kv_stride", [False, True])
-    def test_cudnn_varlen_cumulative_sequence_lengths(
-        self, device, dtype, different_kv_stride
-    ):
-        """Direct cumulative lengths match the legacy per-sequence path."""
-        _check_cudnn_varlen_supported(device)
-        torch.manual_seed(42)
-        total, num_heads, head_dim = 512, 4, 64
-        q = torch.randn(
-            total, num_heads, head_dim, device=device, dtype=dtype
-        ).requires_grad_()
-
-        def make_kv():
-            shape = (total, num_heads, head_dim + 8) if different_kv_stride else q.shape
-            tensor = torch.randn(shape, device=device, dtype=dtype)
-            return tensor[..., :head_dim].requires_grad_()
-
-        k, v = make_kv(), make_kv()
-        cu_seq_q = torch.tensor([-1, 0, 192, total], device=device, dtype=torch.int32)[
-            1:
-        ]
-        cu_seq_k = torch.tensor([-1, 0, 256, total], device=device, dtype=torch.int32)[
-            1:
-        ]
-        self.assertNotEqual(cu_seq_q.data_ptr() % 16, 0)
-        self.assertNotEqual(cu_seq_k.data_ptr() % 16, 0)
-
-        def run(seqused_k):
-            with torch.no_grad(), sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-                return varlen_attn(
-                    q,
-                    k,
-                    v,
-                    cu_seq_q,
-                    cu_seq_k,
-                    320,
-                    256,
-                    seqused_k=seqused_k,
-                    return_aux=AuxRequest(lse=True),
-                )
-
-        direct = run(None)
-        legacy = run(torch.diff(cu_seq_k))
-        direct_again = run(None)
-        self.assertEqual(direct, legacy)
-        self.assertEqual(direct_again, direct)
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            out = varlen_attn(q, k, v, cu_seq_q, cu_seq_k, 320, 256)
-            grads = torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
-        for grad in grads:
-            self.assertTrue(torch.isfinite(grad).all())
-
-    @skipIfRocm
-    @parametrize("tensor_idx", [0, 1, 2])
-    def test_cudnn_varlen_unaligned_input_raises(self, device, tensor_idx):
-        """Reject varlen inputs whose row strides are not 16-byte aligned.
-
-        cuDNN's varlen kernels silently produce wrong results (forward) or
-        fault (backward) on such layouts.
-        """
-        _check_cudnn_varlen_supported(device)
-        seq_len, num_heads, head_dim = 256, 2, 8
-
-        def make(unaligned):
-            if unaligned:
-                # Row stride (head_dim + 3) * 2 bytes is not 16-byte aligned.
-                storage = torch.randn(
-                    seq_len, num_heads, head_dim + 3, device=device, dtype=torch.float16
-                )
-                return storage[..., :head_dim]
-            return torch.randn(
-                seq_len, num_heads, head_dim, device=device, dtype=torch.float16
-            )
-
-        q, k, v = (make(i == tensor_idx) for i in range(3))
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            with self.assertRaisesRegex(RuntimeError, "16-byte-aligned"):
-                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-
-    @skipIfRocm
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
-    )
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
-    def test_cudnn_varlen_unaligned_grad_out(self, device, dtype):
-        """Unaligned grad_output row strides are contiguified, not crashed on."""
-        _check_cudnn_varlen_supported(device)
-        torch.manual_seed(42)
-        seq_len, num_heads, head_dim = 256, 2, 8
-        tensors = [
-            torch.randn(
-                seq_len, num_heads, head_dim, device=device, dtype=dtype
-            ).requires_grad_()
-            for _ in range(3)
-        ]
-        q, k, v = tensors
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-
-        def grads(grad_out, use_cudnn):
-            with _use_cudnn_varlen(use_cudnn, device):
-                out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-                return torch.autograd.grad(out, tensors, grad_out)
-
-        # Row stride (head_dim + 3) * itemsize is not 16-byte aligned.
-        storage = torch.randn(
-            seq_len, num_heads, head_dim + 3, device=device, dtype=dtype
-        )
-        unaligned = storage[..., :head_dim]
-        self.assertNotEqual(unaligned.stride(-2) * unaligned.element_size() % 16, 0)
-        expected = grads(unaligned.clone(), use_cudnn=False)
-        actual = grads(unaligned, use_cudnn=True)
-        for got, want in zip(actual, expected):
-            self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
-
-    @skipIfRocm
     @unittest.skipUnless(SM100OrLater, "large varlen head dimensions require SM100")
     @parametrize(
         "qk_dim,value_dim,requires_backward,supported",
@@ -1207,21 +1013,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
                     self.assertEqual(
                         grad.float(), expected_grad.float(), atol=2e-2, rtol=2e-2
                     )
-
-    @skipIfRocm
-    def test_cudnn_varlen_key_head_dim_mismatch_raises(self, device):
-        """A mismatched key head dim must raise instead of overreading K."""
-        _check_cudnn_varlen_supported(device)
-        seq_len, num_heads = 256, 2
-        q = torch.randn(seq_len, num_heads, 64, device=device, dtype=torch.bfloat16)
-        k = torch.randn(seq_len, num_heads, 32, device=device, dtype=torch.bfloat16)
-        v = torch.randn(seq_len, num_heads, 64, device=device, dtype=torch.bfloat16)
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            with self.assertRaisesRegex(
-                RuntimeError, "key head dimension to match query"
-            ):
-                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
 
     @skipIfRocm
     def test_cudnn_varlen_empty_batch(self, device):
@@ -2248,6 +2039,215 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
             enable_gqa=False,
             _should_use_cudnn=_should_use_cudnn,
         )
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
+    def test_cudnn_causal_varlen_requires_shared_cu_seq(self, device):
+        _check_cudnn_varlen_supported(device)
+        seq_len = 256
+        q = torch.randn(
+            seq_len,
+            4,
+            64,
+            device=device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        k = torch.randn_like(q, requires_grad=True)
+        v = torch.randn_like(q, requires_grad=True)
+        cu_seq_q = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+        cu_seq_k = cu_seq_q.clone()
+
+        with (
+            _use_cudnn_varlen(True, device),
+            patch.object(
+                torch.ops.aten,
+                "_cudnn_attention_forward",
+                wraps=torch.ops.aten._cudnn_attention_forward,
+            ) as cudnn_forward,
+            patch.object(
+                torch.ops.aten,
+                "_cudnn_attention_backward",
+                wraps=torch.ops.aten._cudnn_attention_backward,
+            ) as cudnn_backward,
+        ):
+            out = varlen_attn(
+                q,
+                k,
+                v,
+                cu_seq_q,
+                cu_seq_k,
+                seq_len,
+                seq_len,
+                window_size=(-1, 0),
+            )
+            torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
+
+        self.assertEqual(cudnn_forward.call_count, 0)
+        self.assertEqual(cudnn_backward.call_count, 0)
+
+    @skipIfRocm
+    @parametrize("different_kv_stride", [False, True])
+    def test_cudnn_varlen_shared_cu_seq(self, device, different_kv_stride):
+        """Reusing shared Q/K metadata preserves forward and backward results."""
+        _check_cudnn_varlen_supported(device)
+        torch.manual_seed(42)
+        total, num_heads, head_dim = 512, 4, 64
+        q = torch.randn(
+            total, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_()
+
+        def make_kv():
+            shape = (total, num_heads, head_dim + 8) if different_kv_stride else q.shape
+            tensor = torch.randn(shape, device=device, dtype=torch.bfloat16)
+            return tensor[..., :head_dim].requires_grad_()
+
+        k, v = make_kv(), make_kv()
+        cu_seq = torch.tensor([0, 192, total], device=device, dtype=torch.int32)
+        grad_out = torch.randn_like(q)
+
+        def run(cu_seq_k):
+            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                out = varlen_attn(q, k, v, cu_seq, cu_seq_k, 320, 320)
+                return (out, *torch.autograd.grad(out, (q, k, v), grad_out))
+
+        expected = run(cu_seq.clone())
+        actual = run(cu_seq)
+        self.assertEqual(actual, expected)
+
+    @skipIfRocm
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @parametrize("different_kv_stride", [False, True])
+    def test_cudnn_varlen_cumulative_sequence_lengths(
+        self, device, dtype, different_kv_stride
+    ):
+        """Direct cumulative lengths match the legacy per-sequence path."""
+        _check_cudnn_varlen_supported(device)
+        torch.manual_seed(42)
+        total, num_heads, head_dim = 512, 4, 64
+        q = torch.randn(
+            total, num_heads, head_dim, device=device, dtype=dtype
+        ).requires_grad_()
+
+        def make_kv():
+            shape = (total, num_heads, head_dim + 8) if different_kv_stride else q.shape
+            tensor = torch.randn(shape, device=device, dtype=dtype)
+            return tensor[..., :head_dim].requires_grad_()
+
+        k, v = make_kv(), make_kv()
+        cu_seq_q = torch.tensor([-1, 0, 192, total], device=device, dtype=torch.int32)[
+            1:
+        ]
+        cu_seq_k = torch.tensor([-1, 0, 256, total], device=device, dtype=torch.int32)[
+            1:
+        ]
+        self.assertNotEqual(cu_seq_q.data_ptr() % 16, 0)
+        self.assertNotEqual(cu_seq_k.data_ptr() % 16, 0)
+
+        def run(seqused_k):
+            with torch.no_grad(), sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                return varlen_attn(
+                    q,
+                    k,
+                    v,
+                    cu_seq_q,
+                    cu_seq_k,
+                    320,
+                    256,
+                    seqused_k=seqused_k,
+                    return_aux=AuxRequest(lse=True),
+                )
+
+        direct = run(None)
+        legacy = run(torch.diff(cu_seq_k))
+        direct_again = run(None)
+        self.assertEqual(direct, legacy)
+        self.assertEqual(direct_again, direct)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out = varlen_attn(q, k, v, cu_seq_q, cu_seq_k, 320, 256)
+            grads = torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
+        for grad in grads:
+            self.assertTrue(torch.isfinite(grad).all())
+
+    @skipIfRocm
+    @parametrize("tensor_idx", [0, 1, 2])
+    def test_cudnn_varlen_unaligned_input_raises(self, device, tensor_idx):
+        """Reject varlen inputs whose row strides are not 16-byte aligned.
+
+        cuDNN's varlen kernels silently produce wrong results (forward) or
+        fault (backward) on such layouts.
+        """
+        _check_cudnn_varlen_supported(device)
+        seq_len, num_heads, head_dim = 256, 2, 8
+
+        def make(unaligned):
+            if unaligned:
+                # Row stride (head_dim + 3) * 2 bytes is not 16-byte aligned.
+                storage = torch.randn(
+                    seq_len, num_heads, head_dim + 3, device=device, dtype=torch.float16
+                )
+                return storage[..., :head_dim]
+            return torch.randn(
+                seq_len, num_heads, head_dim, device=device, dtype=torch.float16
+            )
+
+        q, k, v = (make(i == tensor_idx) for i in range(3))
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaisesRegex(RuntimeError, "16-byte-aligned"):
+                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_cudnn_varlen_unaligned_grad_out(self, device, dtype):
+        """Unaligned grad_output row strides are contiguified, not crashed on."""
+        _check_cudnn_varlen_supported(device)
+        torch.manual_seed(42)
+        seq_len, num_heads, head_dim = 256, 2, 8
+        tensors = [
+            torch.randn(
+                seq_len, num_heads, head_dim, device=device, dtype=dtype
+            ).requires_grad_()
+            for _ in range(3)
+        ]
+        q, k, v = tensors
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        def grads(grad_out, use_cudnn):
+            with _use_cudnn_varlen(use_cudnn, device):
+                out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+                return torch.autograd.grad(out, tensors, grad_out)
+
+        # Row stride (head_dim + 3) * itemsize is not 16-byte aligned.
+        storage = torch.randn(
+            seq_len, num_heads, head_dim + 3, device=device, dtype=dtype
+        )
+        unaligned = storage[..., :head_dim]
+        self.assertNotEqual(unaligned.stride(-2) * unaligned.element_size() % 16, 0)
+        expected = grads(unaligned.clone(), use_cudnn=False)
+        actual = grads(unaligned, use_cudnn=True)
+        for got, want in zip(actual, expected):
+            self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
+
+    @skipIfRocm
+    def test_cudnn_varlen_key_head_dim_mismatch_raises(self, device):
+        """A mismatched key head dim must raise instead of overreading K."""
+        _check_cudnn_varlen_supported(device)
+        seq_len, num_heads = 256, 2
+        q = torch.randn(seq_len, num_heads, 64, device=device, dtype=torch.bfloat16)
+        k = torch.randn(seq_len, num_heads, 32, device=device, dtype=torch.bfloat16)
+        v = torch.randn(seq_len, num_heads, 64, device=device, dtype=torch.bfloat16)
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaisesRegex(
+                RuntimeError, "key head dimension to match query"
+            ):
+                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
 
     @skipIfRocm
     @unittest.skipIf(

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -363,7 +363,9 @@ def create_variable_length_batch(
 
 class TestVarlenAttentionDevice(NNTestCase):
     # varlen_attn validates the scale and resolves a backend before dispatching
-    # any kernel, so these checks hold on every device.
+    # any kernel, so these checks hold on every device. GENERIC rather than
+    # ACCELERATOR because CPU runs them too.
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize("scale", [0.0, -0.125, float("nan")])
     def test_varlen_invalid_scale(self, device, scale):

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -2377,7 +2377,7 @@ class TestVarlenAttention(NNTestCase):
             self.assertEqual(out_buf, out)
 
 
-instantiate_device_type_tests(TestVarlenAttentionDevice, globals())
+instantiate_device_type_tests(TestVarlenAttentionDevice, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestVarlenAttention, globals(), only_for=("cuda",))
 
 if __name__ == "__main__":

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -943,126 +943,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
         torch.autograd.grad(out.sum(), (q, k, v))
 
     @skipIfRocm
-    @unittest.skipUnless(SM100OrLater, "large varlen head dimensions require SM100")
-    @parametrize(
-        "qk_dim,value_dim,requires_backward,supported",
-        [
-            (192, 128, False, True),
-            (192, 192, False, True),
-            (256, 128, False, True),
-            (256, 256, False, True),
-            (128, 256, False, False),
-            (192, 128, True, True),
-            (192, 192, True, False),
-            (256, 128, True, False),
-            (256, 256, True, False),
-        ],
-    )
-    def test_cudnn_varlen_large_head_dims(
-        self, device, qk_dim, value_dim, requires_backward, supported
-    ):
-        """Select only large head-dimension combinations supported by cuDNN."""
-        _check_cudnn_varlen_supported(device)
-        cudnn_version = torch.backends.cudnn.version() or 0
-        required_version = 91900 if requires_backward else 92400
-        is_supported = supported and cudnn_version >= required_version
-        torch.manual_seed(42)
-        seq_len, num_heads = 256, 2
-        q = torch.randn(
-            seq_len, num_heads, qk_dim, device=device, dtype=torch.bfloat16
-        ).requires_grad_(requires_backward)
-        k = torch.randn_like(q, requires_grad=requires_backward)
-        v = torch.randn(
-            seq_len, num_heads, value_dim, device=device, dtype=torch.bfloat16
-        ).requires_grad_(requires_backward)
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-
-        q_ref, k_ref, v_ref = (
-            tensor.detach().double().requires_grad_(requires_backward)
-            for tensor in (q, k, v)
-        )
-        scores = torch.einsum("thd,shd->hts", q_ref, k_ref) / math.sqrt(qk_dim)
-        expected = torch.einsum("hts,shd->thd", scores.softmax(-1), v_ref)
-
-        if not is_supported:
-            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-                with self.assertRaisesRegex(
-                    RuntimeError, "unsupported for cuDNN varlen"
-                ):
-                    varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-                if requires_backward and cudnn_version >= 92400:
-                    with torch.no_grad():
-                        out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-                    self.assertEqual(
-                        out.float(), expected.float(), atol=2e-2, rtol=2e-2
-                    )
-            return
-
-        grad_out = torch.randn_like(v)
-        if requires_backward:
-            expected_grads = torch.autograd.grad(
-                expected, (q_ref, k_ref, v_ref), grad_out.double()
-            )
-
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-            self.assertEqual(out.float(), expected.float(), atol=2e-2, rtol=2e-2)
-            if requires_backward:
-                grads = torch.autograd.grad(out, (q, k, v), grad_out)
-                for grad, expected_grad in zip(grads, expected_grads):
-                    self.assertEqual(
-                        grad.float(), expected_grad.float(), atol=2e-2, rtol=2e-2
-                    )
-
-    @skipIfRocm
-    def test_cudnn_varlen_empty_batch(self, device):
-        """Zero-token batches return well-formed empties, matching Flash."""
-        _check_cudnn_varlen_supported(device)
-        num_heads, head_dim = 2, 64
-        q = torch.randn(0, num_heads, head_dim, device=device, dtype=torch.bfloat16)
-        k, v = torch.randn_like(q), torch.randn_like(q)
-        cu_seq = torch.tensor([0, 0], device=device, dtype=torch.int32)
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            out, lse = varlen_attn(
-                q, k, v, cu_seq, cu_seq, 256, 256, return_aux=AuxRequest(lse=True)
-            )
-        self.assertEqual(out.shape, torch.Size([0, num_heads, head_dim]))
-        self.assertEqual(lse.shape, torch.Size([num_heads, 0]))
-
-    @skipIfRocm
-    def test_cudnn_varlen_empty_kv(self, device):
-        """Empty KV returns constant outputs and zero gradients."""
-        _check_cudnn_varlen_supported(device)
-        num_heads, head_dim = 2, 64
-        q = torch.randn(
-            256, num_heads, head_dim, device=device, dtype=torch.bfloat16
-        ).requires_grad_()
-        k = torch.randn(
-            0, num_heads, head_dim, device=device, dtype=torch.bfloat16
-        ).requires_grad_()
-        v = torch.randn_like(k, requires_grad=True)
-        cu_seq_q = torch.tensor([0, 256], device=device, dtype=torch.int32)
-        cu_seq_k = torch.tensor([0, 0], device=device, dtype=torch.int32)
-
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            out, lse = varlen_attn(
-                q,
-                k,
-                v,
-                cu_seq_q,
-                cu_seq_k,
-                256,
-                0,
-                return_aux=AuxRequest(lse=True),
-            )
-            grads = torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
-
-        self.assertEqual(out, torch.zeros_like(out))
-        self.assertEqual(lse, torch.full_like(lse, -torch.inf))
-        for grad in grads:
-            self.assertEqual(grad, torch.zeros_like(grad))
-
-    @skipIfRocm
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
@@ -1655,55 +1535,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
 
     @skipIfRocm
     @parametrize("dtype", [torch.bfloat16, torch.float16])
-    def test_cudnn_varlen_lse(self, device, dtype):
-        """cuDNN returns log-sum-exp in (num_heads, total_q) layout."""
-        torch.manual_seed(42)
-        num_heads, head_dim = 4, 64
-        q_lens, kv_lens = [192, 256, 192], [256, 300, 192]
-        q_seqs = [
-            torch.randn(n, num_heads, head_dim, device=device, dtype=dtype)
-            for n in q_lens
-        ]
-        k_seqs = [
-            torch.randn(n, num_heads, head_dim, device=device, dtype=dtype)
-            for n in kv_lens
-        ]
-        q, cu_seq_q, max_q = pack_sequences(q_seqs, device)
-        k, cu_seq_k, max_k = pack_sequences(k_seqs, device)
-
-        cudnn_forward = patch.object(
-            torch.ops.aten,
-            "_cudnn_attention_forward",
-            wraps=torch.ops.aten._cudnn_attention_forward,
-        )
-        with (
-            _use_cudnn_varlen(True, device),
-            cudnn_forward as spy,
-            torch.no_grad(),
-        ):
-            _, lse = varlen_attn(
-                q,
-                k,
-                torch.randn_like(k),
-                cu_seq_q,
-                cu_seq_k,
-                max_q,
-                max_k,
-                return_aux=AuxRequest(lse=True),
-            )
-
-        self.assertEqual(spy.call_count, 1, "expected the cuDNN backend to be used")
-        self.assertEqual(lse.shape, (num_heads, q.size(0)))
-        scale = 1.0 / math.sqrt(head_dim)
-        expected = torch.empty_like(lse)
-        for i, k_i in enumerate(k_seqs):
-            lo, hi = int(cu_seq_q[i]), int(cu_seq_q[i + 1])
-            scores = torch.einsum("qhd,khd->hqk", q[lo:hi].float(), k_i.float())
-            expected[:, lo:hi] = (scores * scale).logsumexp(-1)
-        self.assertEqual(lse, expected, atol=2e-2, rtol=2e-2)
-
-    @skipIfRocm
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
     def test_cudnn_varlen_cached_graph_grad_out_layout(self, device, dtype):
         """Key cached backward graphs by grad_output layout."""
         torch.manual_seed(42)
@@ -2235,6 +2066,78 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
             self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
 
     @skipIfRocm
+    @unittest.skipUnless(SM100OrLater, "large varlen head dimensions require SM100")
+    @parametrize(
+        "qk_dim,value_dim,requires_backward,supported",
+        [
+            (192, 128, False, True),
+            (192, 192, False, True),
+            (256, 128, False, True),
+            (256, 256, False, True),
+            (128, 256, False, False),
+            (192, 128, True, True),
+            (192, 192, True, False),
+            (256, 128, True, False),
+            (256, 256, True, False),
+        ],
+    )
+    def test_cudnn_varlen_large_head_dims(
+        self, device, qk_dim, value_dim, requires_backward, supported
+    ):
+        """Select only large head-dimension combinations supported by cuDNN."""
+        _check_cudnn_varlen_supported(device)
+        cudnn_version = torch.backends.cudnn.version() or 0
+        required_version = 91900 if requires_backward else 92400
+        is_supported = supported and cudnn_version >= required_version
+        torch.manual_seed(42)
+        seq_len, num_heads = 256, 2
+        q = torch.randn(
+            seq_len, num_heads, qk_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_(requires_backward)
+        k = torch.randn_like(q, requires_grad=requires_backward)
+        v = torch.randn(
+            seq_len, num_heads, value_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_(requires_backward)
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        q_ref, k_ref, v_ref = (
+            tensor.detach().double().requires_grad_(requires_backward)
+            for tensor in (q, k, v)
+        )
+        scores = torch.einsum("thd,shd->hts", q_ref, k_ref) / math.sqrt(qk_dim)
+        expected = torch.einsum("hts,shd->thd", scores.softmax(-1), v_ref)
+
+        if not is_supported:
+            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                with self.assertRaisesRegex(
+                    RuntimeError, "unsupported for cuDNN varlen"
+                ):
+                    varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+                if requires_backward and cudnn_version >= 92400:
+                    with torch.no_grad():
+                        out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+                    self.assertEqual(
+                        out.float(), expected.float(), atol=2e-2, rtol=2e-2
+                    )
+            return
+
+        grad_out = torch.randn_like(v)
+        if requires_backward:
+            expected_grads = torch.autograd.grad(
+                expected, (q_ref, k_ref, v_ref), grad_out.double()
+            )
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+            self.assertEqual(out.float(), expected.float(), atol=2e-2, rtol=2e-2)
+            if requires_backward:
+                grads = torch.autograd.grad(out, (q, k, v), grad_out)
+                for grad, expected_grad in zip(grads, expected_grads):
+                    self.assertEqual(
+                        grad.float(), expected_grad.float(), atol=2e-2, rtol=2e-2
+                    )
+
+    @skipIfRocm
     def test_cudnn_varlen_key_head_dim_mismatch_raises(self, device):
         """A mismatched key head dim must raise instead of overreading K."""
         _check_cudnn_varlen_supported(device)
@@ -2248,6 +2151,54 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
                 RuntimeError, "key head dimension to match query"
             ):
                 varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+    @skipIfRocm
+    def test_cudnn_varlen_empty_batch(self, device):
+        """Zero-token batches return well-formed empties, matching Flash."""
+        _check_cudnn_varlen_supported(device)
+        num_heads, head_dim = 2, 64
+        q = torch.randn(0, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+        k, v = torch.randn_like(q), torch.randn_like(q)
+        cu_seq = torch.tensor([0, 0], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out, lse = varlen_attn(
+                q, k, v, cu_seq, cu_seq, 256, 256, return_aux=AuxRequest(lse=True)
+            )
+        self.assertEqual(out.shape, torch.Size([0, num_heads, head_dim]))
+        self.assertEqual(lse.shape, torch.Size([num_heads, 0]))
+
+    @skipIfRocm
+    def test_cudnn_varlen_empty_kv(self, device):
+        """Empty KV returns constant outputs and zero gradients."""
+        _check_cudnn_varlen_supported(device)
+        num_heads, head_dim = 2, 64
+        q = torch.randn(
+            256, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_()
+        k = torch.randn(
+            0, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_()
+        v = torch.randn_like(k, requires_grad=True)
+        cu_seq_q = torch.tensor([0, 256], device=device, dtype=torch.int32)
+        cu_seq_k = torch.tensor([0, 0], device=device, dtype=torch.int32)
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out, lse = varlen_attn(
+                q,
+                k,
+                v,
+                cu_seq_q,
+                cu_seq_k,
+                256,
+                0,
+                return_aux=AuxRequest(lse=True),
+            )
+            grads = torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
+
+        self.assertEqual(out, torch.zeros_like(out))
+        self.assertEqual(lse, torch.full_like(lse, -torch.inf))
+        for grad in grads:
+            self.assertEqual(grad, torch.zeros_like(grad))
 
     @skipIfRocm
     @unittest.skipIf(
@@ -2388,6 +2339,55 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
             varlen_attn_out(
                 torch.empty_like(q), q, k, v, cu_seq, cu_seq, seq_len, seq_len
             )
+
+    @skipIfRocm
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_cudnn_varlen_lse(self, device, dtype):
+        """cuDNN returns log-sum-exp in (num_heads, total_q) layout."""
+        torch.manual_seed(42)
+        num_heads, head_dim = 4, 64
+        q_lens, kv_lens = [192, 256, 192], [256, 300, 192]
+        q_seqs = [
+            torch.randn(n, num_heads, head_dim, device=device, dtype=dtype)
+            for n in q_lens
+        ]
+        k_seqs = [
+            torch.randn(n, num_heads, head_dim, device=device, dtype=dtype)
+            for n in kv_lens
+        ]
+        q, cu_seq_q, max_q = pack_sequences(q_seqs, device)
+        k, cu_seq_k, max_k = pack_sequences(k_seqs, device)
+
+        cudnn_forward = patch.object(
+            torch.ops.aten,
+            "_cudnn_attention_forward",
+            wraps=torch.ops.aten._cudnn_attention_forward,
+        )
+        with (
+            _use_cudnn_varlen(True, device),
+            cudnn_forward as spy,
+            torch.no_grad(),
+        ):
+            _, lse = varlen_attn(
+                q,
+                k,
+                torch.randn_like(k),
+                cu_seq_q,
+                cu_seq_k,
+                max_q,
+                max_k,
+                return_aux=AuxRequest(lse=True),
+            )
+
+        self.assertEqual(spy.call_count, 1, "expected the cuDNN backend to be used")
+        self.assertEqual(lse.shape, (num_heads, q.size(0)))
+        scale = 1.0 / math.sqrt(head_dim)
+        expected = torch.empty_like(lse)
+        for i, k_i in enumerate(k_seqs):
+            lo, hi = int(cu_seq_q[i]), int(cu_seq_q[i + 1])
+            scores = torch.einsum("qhd,khd->hqk", q[lo:hi].float(), k_i.float())
+            expected[:, lo:hi] = (scores * scale).logsumexp(-1)
+        self.assertEqual(lse, expected, atol=2e-2, rtol=2e-2)
 
 
 instantiate_device_type_tests(TestVarlenAttentionDevice, globals(), allow_xpu=True)

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -617,15 +617,16 @@ class _VarlenVsSdpaMixin:
 
 
 class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
-    # NOTE: This class is currently CUDA-specific, although a significant portion of its
-    # functionality can be shared by other backends. Separating the common logic from
-    # CUDA-specific logic would require a substantial refactoring, so this is deferred
-    # for now.
-    # The planned refactoring is to introduce a Capability mechanism, allowing each backend
-    # to report its supported Flash Attention implementations (FA2/FA3/FA4) and determine
-    # whether to enable them accordingly. The cuDNN-related logic will also be separated
-    # from the current class and kept CUDA-specific, ultimately resulting in a generic
-    # Accelerator class and a CUDA-specific class.
+    # NOTE: These tests exercise the flash backends, which every accelerator can in
+    # principle provide, but they stay CUDA-specific for now: the backend matrix is
+    # spelled in terms of FA2/FA3/FA4 and SM capabilities, and only CUDA has a varlen
+    # flash kernel behind aten::_flash_attention_forward. Reclassifying this as
+    # ACCELERATOR needs the planned Capability mechanism, through which each backend
+    # reports the flash implementations it supports.
+    # test_varlen_lse_is_not_differentiable and test_batch_invariance also parametrize
+    # over cuDNN: they compare flash against cuDNN rather than being cuDNN-specific, so
+    # they stay here while both classes are CUDA-only. That parameter has to be split
+    # off before this class can go ACCELERATOR.
     hw_classification = HardwareClassification.CUDA
 
     @unittest.skipIf(
@@ -1466,6 +1467,7 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
     # cuDNN is the only varlen backend with dedicated aten ops
     # (_cudnn_attention_forward/_backward) and it is only ever selected for a
     # CUDA query, so these tests cannot be shared with other backends.
+    hw_classification = HardwareClassification.CUDA
 
     @skipIfRocm
     @setSdpaBackendsToDefaultFinally

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -411,17 +411,9 @@ class TestVarlenAttentionDevice(NNTestCase):
             )
 
 
-class TestVarlenAttention(NNTestCase):
-    # NOTE: This class is currently CUDA-specific, although a significant portion of its
-    # functionality can be shared by other backends. Separating the common logic from
-    # CUDA-specific logic would require a substantial refactoring, so this is deferred
-    # for now.
-    # The planned refactoring is to introduce a Capability mechanism, allowing each backend
-    # to report its supported Flash Attention implementations (FA2/FA3/FA4) and determine
-    # whether to enable them accordingly. The cuDNN-related logic will also be separated
-    # from the current class and kept CUDA-specific, ultimately resulting in a generic
-    # Accelerator class and a CUDA-specific class.
-    hw_classification = HardwareClassification.CUDA
+class _VarlenVsSdpaMixin:
+    # Shared by the flash and the cuDNN test class, which cannot inherit from
+    # each other: each would then run the other's tests.
 
     def _test_varlen_vs_sdpa(
         self,
@@ -622,6 +614,19 @@ class TestVarlenAttention(NNTestCase):
             )
 
             start_idx = end_idx
+
+
+class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
+    # NOTE: This class is currently CUDA-specific, although a significant portion of its
+    # functionality can be shared by other backends. Separating the common logic from
+    # CUDA-specific logic would require a substantial refactoring, so this is deferred
+    # for now.
+    # The planned refactoring is to introduce a Capability mechanism, allowing each backend
+    # to report its supported Flash Attention implementations (FA2/FA3/FA4) and determine
+    # whether to enable them accordingly. The cuDNN-related logic will also be separated
+    # from the current class and kept CUDA-specific, ultimately resulting in a generic
+    # Accelerator class and a CUDA-specific class.
+    hw_classification = HardwareClassification.CUDA
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -942,35 +942,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
         self.assertFalse(lse.requires_grad)
         torch.autograd.grad(out.sum(), (q, k, v))
 
-    @skipIfRocm
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
-    )
-    def test_cudnn_varlen_compile_noncontiguous_query(self, device):
-        """The real and fake ops preserve the query's dimension order."""
-        _check_cudnn_varlen_supported(device)
-        torch.manual_seed(42)
-        seq_len, num_heads, head_dim = 256, 4, 64
-
-        def make():
-            # Head-major storage: strides (head_dim, seq_len * head_dim, 1).
-            return torch.randn(
-                num_heads, seq_len, head_dim, device=device, dtype=torch.bfloat16
-            ).permute(1, 0, 2)
-
-        q, k, v = make(), make(), make()
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-
-        def fn(q, k, v):
-            return varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            eager = fn(q, k, v)
-            compiled = torch.compile(fn, fullgraph=True)(q, k, v)
-        # The real output matches the query's layout, like Flash and the fake.
-        self.assertEqual(eager.stride(), q.stride())
-        self.assertEqual(compiled, eager)
-
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179968")
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
@@ -1440,142 +1411,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
                 )
             self.assertTrue(torch.equal(paged_num_splits, ref_num_splits))
 
-    @skipIfRocm
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
-    def test_cudnn_varlen_cached_graph_grad_out_layout(self, device, dtype):
-        """Key cached backward graphs by grad_output layout."""
-        torch.manual_seed(42)
-        num_heads, head_dim = 4, 64
-        q_lens = [192, 256]
-        total, max_len = sum(q_lens), max(q_lens)
-        cu_seq_q = torch.tensor([0, q_lens[0], total], device=device, dtype=torch.int32)
-        tensors = [
-            torch.randn(
-                total, num_heads, head_dim, device=device, dtype=dtype
-            ).requires_grad_()
-            for _ in range(3)
-        ]
-        q, k, v = tensors
-
-        def grads(grad_out, use_cudnn):
-            with _use_cudnn_varlen(use_cudnn, device):
-                out = varlen_attn(q, k, v, cu_seq_q, cu_seq_q, max_len, max_len)
-                return torch.autograd.grad(out, tensors, grad_out)
-
-        contiguous = torch.randn(total, num_heads, head_dim, device=device, dtype=dtype)
-        # Same shape and innermost stride 1, but a wider row stride.
-        padded = torch.randn(
-            total, num_heads, head_dim * 2, device=device, dtype=dtype
-        )[..., :head_dim]
-        self.assertEqual(padded.stride(-1), 1)
-        self.assertNotEqual(padded.stride(-2), contiguous.stride(-2))
-        expanded = torch.randn(
-            total, num_heads, 1, device=device, dtype=dtype
-        ).expand_as(contiguous)
-        self.assertEqual(expanded.stride(-1), 0)
-        storage = torch.empty(contiguous.numel() + 1, device=device, dtype=dtype)
-        misaligned = torch.as_strided(
-            storage, contiguous.shape, contiguous.stride(), storage_offset=1
-        )
-        misaligned.copy_(contiguous)
-        self.assertEqual(misaligned.stride(), contiguous.stride())
-        self.assertNotEqual(misaligned.data_ptr() % 16, 0)
-
-        cudnn_backward = patch.object(
-            torch.ops.aten,
-            "_cudnn_attention_backward",
-            wraps=torch.ops.aten._cudnn_attention_backward,
-        )
-        # Prime the cache before exercising alternate strides and alignment.
-        with cudnn_backward as spy:
-            for grad_out in (contiguous, padded, expanded, misaligned):
-                expected = grads(grad_out.clone(), use_cudnn=False)
-                actual = grads(grad_out, use_cudnn=True)
-                for got, want in zip(actual, expected):
-                    self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
-        self.assertEqual(spy.call_count, 4, "expected the cuDNN backend to be used")
-
-    @skipIfRocm
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
-    def test_cudnn_varlen_cached_graph_aux_layouts(self, device, dtype):
-        """Key cached backward graphs by output and LSE layouts."""
-        _check_cudnn_varlen_supported(device)
-        torch.manual_seed(42)
-        total, num_heads, head_dim, max_len = 384, 4, 64, 192
-        cu_seq = torch.tensor([0, max_len, total], device=device, dtype=torch.int32)
-        q, k, v = (
-            torch.randn(total, num_heads, head_dim, device=device, dtype=dtype)
-            for _ in range(3)
-        )
-        grad_out = torch.randn_like(q)
-
-        with torch.no_grad():
-            result = torch.ops.aten._cudnn_attention_forward(
-                q,
-                k,
-                v,
-                None,
-                cu_seq,
-                cu_seq,
-                max_len,
-                max_len,
-                True,
-                0.0,
-                False,
-                False,
-            )
-        out, lse, seed, offset = result[0], result[1], result[6], result[7]
-
-        def backward(output, output_grad, stats):
-            return torch.ops.aten._cudnn_attention_backward(
-                output_grad,
-                q,
-                k,
-                v,
-                output,
-                stats,
-                seed,
-                offset,
-                None,
-                cu_seq,
-                cu_seq,
-                max_len,
-                max_len,
-                0.0,
-                False,
-            )
-
-        # Prime the cache with contiguous auxiliary tensors.
-        expected = backward(out, grad_out, lse)
-        out_permuted = (
-            torch.empty(num_heads, total, head_dim, device=device, dtype=dtype)
-            .permute(1, 0, 2)
-            .copy_(out)
-        )
-        grad_permuted = (
-            torch.empty(num_heads, total, head_dim, device=device, dtype=dtype)
-            .permute(1, 0, 2)
-            .copy_(grad_out)
-        )
-        out_padded = torch.empty(
-            total, num_heads, 2 * head_dim, device=device, dtype=dtype
-        )[..., :head_dim]
-        out_padded.copy_(out)
-        lse_padded = torch.empty(num_heads, 2 * total, device=device, dtype=lse.dtype)[
-            :, :total
-        ]
-        lse_padded.copy_(lse)
-
-        cases = [
-            (out_permuted, grad_permuted, lse),
-            (out_padded, grad_out, lse),
-            (out, grad_out, lse_padded),
-        ]
-        for output, output_grad, stats in cases:
-            actual = backward(output, output_grad, stats)
-            for got, want in zip(actual, expected):
-                self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
-
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
@@ -1983,6 +1818,35 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
+    def test_cudnn_varlen_compile_noncontiguous_query(self, device):
+        """The real and fake ops preserve the query's dimension order."""
+        _check_cudnn_varlen_supported(device)
+        torch.manual_seed(42)
+        seq_len, num_heads, head_dim = 256, 4, 64
+
+        def make():
+            # Head-major storage: strides (head_dim, seq_len * head_dim, 1).
+            return torch.randn(
+                num_heads, seq_len, head_dim, device=device, dtype=torch.bfloat16
+            ).permute(1, 0, 2)
+
+        q, k, v = make(), make(), make()
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        def fn(q, k, v):
+            return varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            eager = fn(q, k, v)
+            compiled = torch.compile(fn, fullgraph=True)(q, k, v)
+        # The real output matches the query's layout, like Flash and the fake.
+        self.assertEqual(eager.stride(), q.stride())
+        self.assertEqual(compiled, eager)
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
     @parametrize("dtype", [torch.bfloat16, torch.float16])
     @parametrize("compile", [False, True])
     def test_sdpa_kernel_backend_selection(self, device, dtype, compile):
@@ -2260,6 +2124,142 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
             scores = torch.einsum("qhd,khd->hqk", q[lo:hi].float(), k_i.float())
             expected[:, lo:hi] = (scores * scale).logsumexp(-1)
         self.assertEqual(lse, expected, atol=2e-2, rtol=2e-2)
+
+    @skipIfRocm
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_cudnn_varlen_cached_graph_grad_out_layout(self, device, dtype):
+        """Key cached backward graphs by grad_output layout."""
+        torch.manual_seed(42)
+        num_heads, head_dim = 4, 64
+        q_lens = [192, 256]
+        total, max_len = sum(q_lens), max(q_lens)
+        cu_seq_q = torch.tensor([0, q_lens[0], total], device=device, dtype=torch.int32)
+        tensors = [
+            torch.randn(
+                total, num_heads, head_dim, device=device, dtype=dtype
+            ).requires_grad_()
+            for _ in range(3)
+        ]
+        q, k, v = tensors
+
+        def grads(grad_out, use_cudnn):
+            with _use_cudnn_varlen(use_cudnn, device):
+                out = varlen_attn(q, k, v, cu_seq_q, cu_seq_q, max_len, max_len)
+                return torch.autograd.grad(out, tensors, grad_out)
+
+        contiguous = torch.randn(total, num_heads, head_dim, device=device, dtype=dtype)
+        # Same shape and innermost stride 1, but a wider row stride.
+        padded = torch.randn(
+            total, num_heads, head_dim * 2, device=device, dtype=dtype
+        )[..., :head_dim]
+        self.assertEqual(padded.stride(-1), 1)
+        self.assertNotEqual(padded.stride(-2), contiguous.stride(-2))
+        expanded = torch.randn(
+            total, num_heads, 1, device=device, dtype=dtype
+        ).expand_as(contiguous)
+        self.assertEqual(expanded.stride(-1), 0)
+        storage = torch.empty(contiguous.numel() + 1, device=device, dtype=dtype)
+        misaligned = torch.as_strided(
+            storage, contiguous.shape, contiguous.stride(), storage_offset=1
+        )
+        misaligned.copy_(contiguous)
+        self.assertEqual(misaligned.stride(), contiguous.stride())
+        self.assertNotEqual(misaligned.data_ptr() % 16, 0)
+
+        cudnn_backward = patch.object(
+            torch.ops.aten,
+            "_cudnn_attention_backward",
+            wraps=torch.ops.aten._cudnn_attention_backward,
+        )
+        # Prime the cache before exercising alternate strides and alignment.
+        with cudnn_backward as spy:
+            for grad_out in (contiguous, padded, expanded, misaligned):
+                expected = grads(grad_out.clone(), use_cudnn=False)
+                actual = grads(grad_out, use_cudnn=True)
+                for got, want in zip(actual, expected):
+                    self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
+        self.assertEqual(spy.call_count, 4, "expected the cuDNN backend to be used")
+
+    @skipIfRocm
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_cudnn_varlen_cached_graph_aux_layouts(self, device, dtype):
+        """Key cached backward graphs by output and LSE layouts."""
+        _check_cudnn_varlen_supported(device)
+        torch.manual_seed(42)
+        total, num_heads, head_dim, max_len = 384, 4, 64, 192
+        cu_seq = torch.tensor([0, max_len, total], device=device, dtype=torch.int32)
+        q, k, v = (
+            torch.randn(total, num_heads, head_dim, device=device, dtype=dtype)
+            for _ in range(3)
+        )
+        grad_out = torch.randn_like(q)
+
+        with torch.no_grad():
+            result = torch.ops.aten._cudnn_attention_forward(
+                q,
+                k,
+                v,
+                None,
+                cu_seq,
+                cu_seq,
+                max_len,
+                max_len,
+                True,
+                0.0,
+                False,
+                False,
+            )
+        out, lse, seed, offset = result[0], result[1], result[6], result[7]
+
+        def backward(output, output_grad, stats):
+            return torch.ops.aten._cudnn_attention_backward(
+                output_grad,
+                q,
+                k,
+                v,
+                output,
+                stats,
+                seed,
+                offset,
+                None,
+                cu_seq,
+                cu_seq,
+                max_len,
+                max_len,
+                0.0,
+                False,
+            )
+
+        # Prime the cache with contiguous auxiliary tensors.
+        expected = backward(out, grad_out, lse)
+        out_permuted = (
+            torch.empty(num_heads, total, head_dim, device=device, dtype=dtype)
+            .permute(1, 0, 2)
+            .copy_(out)
+        )
+        grad_permuted = (
+            torch.empty(num_heads, total, head_dim, device=device, dtype=dtype)
+            .permute(1, 0, 2)
+            .copy_(grad_out)
+        )
+        out_padded = torch.empty(
+            total, num_heads, 2 * head_dim, device=device, dtype=dtype
+        )[..., :head_dim]
+        out_padded.copy_(out)
+        lse_padded = torch.empty(num_heads, 2 * total, device=device, dtype=lse.dtype)[
+            :, :total
+        ]
+        lse_padded.copy_(lse)
+
+        cases = [
+            (out_permuted, grad_permuted, lse),
+            (out_padded, grad_out, lse),
+            (out, grad_out, lse_padded),
+        ]
+        for output, output_grad, stats in cases:
+            actual = backward(output, output_grad, stats)
+            for got, want in zip(actual, expected):
+                self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
 
     @skipIfRocm
     def test_cudnn_kv_cache_validation(self, device):

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1442,99 +1442,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
 
     @skipIfRocm
     @parametrize("dtype", [torch.bfloat16, torch.float16])
-    @parametrize(
-        "paged,page_size,strided_table",
-        [
-            (False, 64, False),
-            (True, 32, False),
-            (True, 64, False),
-            (True, 128, True),
-            (True, 256, False),
-        ],
-    )
-    def test_cudnn_kv_cache(self, device, dtype, paged, page_size, strided_table):
-        """Test cuDNN seqused_k with packed and paged KV caches."""
-        torch.manual_seed(42)
-        actual_kv_lens = [200, 128, 7, 300]
-        batch_size = len(actual_kv_lens)
-        num_heads, head_dim = 8, 64
-        q_seqs = [
-            torch.randn(n, num_heads, head_dim, device=device, dtype=dtype)
-            for n in [192, 256, 192, 129]
-        ]
-        q_packed, cu_seq_q, max_q = pack_sequences(q_seqs, device)
-
-        pages_per_seq = math.ceil(max(actual_kv_lens) / page_size)
-        cache_size = pages_per_seq * page_size
-        if paged:
-            total_pages = batch_size * pages_per_seq
-            k_cache = torch.randn(
-                total_pages, page_size, num_heads, head_dim, device=device, dtype=dtype
-            )
-            v_cache = torch.randn_like(k_cache)
-            block_table = torch.randperm(
-                total_pages, device=device, dtype=torch.int32
-            ).view(batch_size, pages_per_seq)
-            if strided_table:
-                padded_table = torch.empty(
-                    batch_size, pages_per_seq + 1, device=device, dtype=torch.int32
-                )
-                padded_table[:, :pages_per_seq].copy_(block_table)
-                block_table = padded_table[:, :pages_per_seq]
-            k_logical = gather_paged_cache(k_cache, block_table)
-            v_logical = gather_paged_cache(v_cache, block_table)
-            cu_seq_k = None
-        else:
-            k_logical = torch.randn(
-                batch_size, cache_size, num_heads, head_dim, device=device, dtype=dtype
-            )
-            v_logical = torch.randn_like(k_logical)
-            k_cache, v_cache = k_logical.flatten(0, 1), v_logical.flatten(0, 1)
-            block_table = None
-            cu_seq_k = torch.arange(
-                0,
-                (batch_size + 1) * cache_size,
-                cache_size,
-                device=device,
-                dtype=torch.int32,
-            )
-
-        seqused_k = torch.tensor(actual_kv_lens, device=device, dtype=torch.int32)
-        cudnn_forward = patch.object(
-            torch.ops.aten,
-            "_cudnn_attention_forward",
-            wraps=torch.ops.aten._cudnn_attention_forward,
-        )
-        with (
-            _use_cudnn_varlen(True, device),
-            cudnn_forward as spy,
-            torch.no_grad(),
-        ):
-            output = varlen_attn(
-                q_packed,
-                k_cache,
-                v_cache,
-                cu_seq_q,
-                cu_seq_k,
-                max_q,
-                cache_size,
-                seqused_k=seqused_k,
-                block_table=block_table,
-            )
-        self.assertEqual(spy.call_count, 1, "expected the cuDNN backend to be used")
-
-        scale = 1.0 / math.sqrt(head_dim)
-        expected = torch.empty_like(q_packed)
-        for i, kv_len in enumerate(actual_kv_lens):
-            lo, hi = int(cu_seq_q[i]), int(cu_seq_q[i + 1])
-            q_i = q_packed[lo:hi].float()
-            k_i, v_i = k_logical[i, :kv_len].float(), v_logical[i, :kv_len].float()
-            attn = (torch.einsum("qhd,khd->hqk", q_i, k_i) * scale).softmax(-1)
-            expected[lo:hi] = torch.einsum("hqk,khd->qhd", attn, v_i).to(dtype)
-        self.assertEqual(output.float(), expected.float(), atol=2e-2, rtol=2e-2)
-
-    @skipIfRocm
-    @parametrize("dtype", [torch.bfloat16, torch.float16])
     def test_cudnn_varlen_cached_graph_grad_out_layout(self, device, dtype):
         """Key cached backward graphs by grad_output layout."""
         torch.manual_seed(42)
@@ -1668,134 +1575,6 @@ class TestVarlenAttention(_VarlenVsSdpaMixin, NNTestCase):
             actual = backward(output, output_grad, stats)
             for got, want in zip(actual, expected):
                 self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
-
-    @skipIfRocm
-    def test_cudnn_kv_cache_validation(self, device):
-        """Validate cuDNN KV-cache metadata and inference-only inputs."""
-        dtype = torch.bfloat16
-        batch_size, num_heads, head_dim, page_size = 2, 8, 64, 64
-        pages_per_seq = 4
-        cache_size = pages_per_seq * page_size
-
-        q = torch.randn(2 * 192, num_heads, head_dim, device=device, dtype=dtype)
-        cu_seq_q = torch.tensor([0, 192, 384], device=device, dtype=torch.int32)
-        k = torch.randn(
-            batch_size * pages_per_seq,
-            page_size,
-            num_heads,
-            head_dim,
-            device=device,
-            dtype=dtype,
-        )
-        v = torch.randn_like(k)
-        block_table = torch.arange(
-            batch_size * pages_per_seq, device=device, dtype=torch.int32
-        ).view(batch_size, pages_per_seq)
-        seqused_k = torch.tensor([200, 128], device=device, dtype=torch.int32)
-
-        def run(query=q, key=k, value=v, **overrides):
-            kwargs = dict(seqused_k=seqused_k, block_table=block_table)
-            kwargs.update(overrides)
-            with _use_cudnn_varlen(True, device), torch.no_grad():
-                return varlen_attn(
-                    query, key, value, cu_seq_q, None, 192, cache_size, **kwargs
-                )
-
-        bad_inputs = [
-            ("seqused_k must have shape", {"seqused_k": seqused_k[:1]}),
-            ("seqused_k must be on the same", {"seqused_k": seqused_k.cpu()}),
-            ("seqused_k must have dtype int32", {"seqused_k": seqused_k.long()}),
-            ("block_table must have shape", {"block_table": block_table[:1]}),
-            ("block_table must have dtype int32", {"block_table": block_table.long()}),
-            ("block_table must be on the same", {"block_table": block_table.cpu()}),
-        ]
-        for message, override in bad_inputs:
-            with self.subTest(message=message):
-                with self.assertRaisesRegex(RuntimeError, message):
-                    run(**override)
-
-        value_head_dim = 32
-        v_narrow = torch.randn(
-            *v.shape[:-1], value_head_dim, device=device, dtype=dtype
-        )
-        output = run(value=v_narrow)
-        self.assertEqual(output.shape, (q.size(0), num_heads, value_head_dim))
-
-        k_logical = gather_paged_cache(k, block_table)
-        v_logical = gather_paged_cache(v_narrow, block_table)
-        expected = torch.empty_like(output)
-        scale = 1.0 / math.sqrt(head_dim)
-        for i, kv_len in enumerate((200, 128)):
-            lo, hi = int(cu_seq_q[i]), int(cu_seq_q[i + 1])
-            q_i = q[lo:hi].float()
-            k_i = k_logical[i, :kv_len].float()
-            v_i = v_logical[i, :kv_len].float()
-            attn = (torch.einsum("qhd,khd->hqk", q_i, k_i) * scale).softmax(-1)
-            expected[lo:hi] = torch.einsum("hqk,khd->qhd", attn, v_i).to(dtype)
-        self.assertEqual(output.float(), expected.float(), atol=2e-2, rtol=2e-2)
-
-        with self.assertRaisesRegex(RuntimeError, "head dimension must match query"):
-            run(key=k[..., :32])
-
-        mismatched_values = [
-            ("page count", v[:-1]),
-            ("page size", v[:, :-1]),
-            ("number of heads", v[:, :, :-1]),
-        ]
-        for axis, bad_value in mismatched_values:
-            with self.subTest(axis=axis):
-                with self.assertRaisesRegex(RuntimeError, "matching page count"):
-                    run(value=bad_value)
-
-        with self.assertRaisesRegex(RuntimeError, "same dtype"):
-            run(key=k.half(), value=v.half())
-
-        aten_kwargs = dict(
-            query=q,
-            key=k,
-            value=v,
-            attn_bias=None,
-            cum_seq_q=cu_seq_q,
-            cum_seq_k=None,
-            max_q=192,
-            max_k=cache_size,
-            compute_log_sumexp=True,
-            dropout_p=0.0,
-            is_causal=False,
-            return_debug_mask=False,
-            seqused_k=seqused_k,
-            block_table=block_table,
-        )
-        with self.assertRaisesRegex(RuntimeError, "only supports float16"):
-            torch.ops.aten._cudnn_attention_forward(
-                **(aten_kwargs | {"query": q.float()})
-            )
-
-        storage = torch.empty(k.numel() + 1, device=device, dtype=dtype)
-        misaligned_k = torch.as_strided(storage, k.shape, k.stride(), storage_offset=1)
-        misaligned_k.copy_(k)
-        with self.assertRaisesRegex(RuntimeError, "16-byte-aligned"):
-            run(key=misaligned_k)
-
-        # Exercise both the custom-op and direct-aten autograd guards.
-        q_grad = q.clone().requires_grad_()
-        with _use_cudnn_varlen(True, device):
-            with self.assertRaisesRegex(RuntimeError, "inference-only parameter"):
-                varlen_attn(
-                    q_grad,
-                    k,
-                    v,
-                    cu_seq_q,
-                    None,
-                    192,
-                    cache_size,
-                    seqused_k=seqused_k,
-                    block_table=block_table,
-                )
-        with self.assertRaisesRegex(
-            RuntimeError, "seqused_k and block_table are inference-only"
-        ):
-            torch.ops.aten._cudnn_attention_forward(**(aten_kwargs | {"query": q_grad}))
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
@@ -2342,6 +2121,99 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
 
     @skipIfRocm
     @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @parametrize(
+        "paged,page_size,strided_table",
+        [
+            (False, 64, False),
+            (True, 32, False),
+            (True, 64, False),
+            (True, 128, True),
+            (True, 256, False),
+        ],
+    )
+    def test_cudnn_kv_cache(self, device, dtype, paged, page_size, strided_table):
+        """Test cuDNN seqused_k with packed and paged KV caches."""
+        torch.manual_seed(42)
+        actual_kv_lens = [200, 128, 7, 300]
+        batch_size = len(actual_kv_lens)
+        num_heads, head_dim = 8, 64
+        q_seqs = [
+            torch.randn(n, num_heads, head_dim, device=device, dtype=dtype)
+            for n in [192, 256, 192, 129]
+        ]
+        q_packed, cu_seq_q, max_q = pack_sequences(q_seqs, device)
+
+        pages_per_seq = math.ceil(max(actual_kv_lens) / page_size)
+        cache_size = pages_per_seq * page_size
+        if paged:
+            total_pages = batch_size * pages_per_seq
+            k_cache = torch.randn(
+                total_pages, page_size, num_heads, head_dim, device=device, dtype=dtype
+            )
+            v_cache = torch.randn_like(k_cache)
+            block_table = torch.randperm(
+                total_pages, device=device, dtype=torch.int32
+            ).view(batch_size, pages_per_seq)
+            if strided_table:
+                padded_table = torch.empty(
+                    batch_size, pages_per_seq + 1, device=device, dtype=torch.int32
+                )
+                padded_table[:, :pages_per_seq].copy_(block_table)
+                block_table = padded_table[:, :pages_per_seq]
+            k_logical = gather_paged_cache(k_cache, block_table)
+            v_logical = gather_paged_cache(v_cache, block_table)
+            cu_seq_k = None
+        else:
+            k_logical = torch.randn(
+                batch_size, cache_size, num_heads, head_dim, device=device, dtype=dtype
+            )
+            v_logical = torch.randn_like(k_logical)
+            k_cache, v_cache = k_logical.flatten(0, 1), v_logical.flatten(0, 1)
+            block_table = None
+            cu_seq_k = torch.arange(
+                0,
+                (batch_size + 1) * cache_size,
+                cache_size,
+                device=device,
+                dtype=torch.int32,
+            )
+
+        seqused_k = torch.tensor(actual_kv_lens, device=device, dtype=torch.int32)
+        cudnn_forward = patch.object(
+            torch.ops.aten,
+            "_cudnn_attention_forward",
+            wraps=torch.ops.aten._cudnn_attention_forward,
+        )
+        with (
+            _use_cudnn_varlen(True, device),
+            cudnn_forward as spy,
+            torch.no_grad(),
+        ):
+            output = varlen_attn(
+                q_packed,
+                k_cache,
+                v_cache,
+                cu_seq_q,
+                cu_seq_k,
+                max_q,
+                cache_size,
+                seqused_k=seqused_k,
+                block_table=block_table,
+            )
+        self.assertEqual(spy.call_count, 1, "expected the cuDNN backend to be used")
+
+        scale = 1.0 / math.sqrt(head_dim)
+        expected = torch.empty_like(q_packed)
+        for i, kv_len in enumerate(actual_kv_lens):
+            lo, hi = int(cu_seq_q[i]), int(cu_seq_q[i + 1])
+            q_i = q_packed[lo:hi].float()
+            k_i, v_i = k_logical[i, :kv_len].float(), v_logical[i, :kv_len].float()
+            attn = (torch.einsum("qhd,khd->hqk", q_i, k_i) * scale).softmax(-1)
+            expected[lo:hi] = torch.einsum("hqk,khd->qhd", attn, v_i).to(dtype)
+        self.assertEqual(output.float(), expected.float(), atol=2e-2, rtol=2e-2)
+
+    @skipIfRocm
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
     def test_cudnn_varlen_lse(self, device, dtype):
         """cuDNN returns log-sum-exp in (num_heads, total_q) layout."""
         torch.manual_seed(42)
@@ -2388,6 +2260,134 @@ class TestVarlenAttentionCuDNN(_VarlenVsSdpaMixin, NNTestCase):
             scores = torch.einsum("qhd,khd->hqk", q[lo:hi].float(), k_i.float())
             expected[:, lo:hi] = (scores * scale).logsumexp(-1)
         self.assertEqual(lse, expected, atol=2e-2, rtol=2e-2)
+
+    @skipIfRocm
+    def test_cudnn_kv_cache_validation(self, device):
+        """Validate cuDNN KV-cache metadata and inference-only inputs."""
+        dtype = torch.bfloat16
+        batch_size, num_heads, head_dim, page_size = 2, 8, 64, 64
+        pages_per_seq = 4
+        cache_size = pages_per_seq * page_size
+
+        q = torch.randn(2 * 192, num_heads, head_dim, device=device, dtype=dtype)
+        cu_seq_q = torch.tensor([0, 192, 384], device=device, dtype=torch.int32)
+        k = torch.randn(
+            batch_size * pages_per_seq,
+            page_size,
+            num_heads,
+            head_dim,
+            device=device,
+            dtype=dtype,
+        )
+        v = torch.randn_like(k)
+        block_table = torch.arange(
+            batch_size * pages_per_seq, device=device, dtype=torch.int32
+        ).view(batch_size, pages_per_seq)
+        seqused_k = torch.tensor([200, 128], device=device, dtype=torch.int32)
+
+        def run(query=q, key=k, value=v, **overrides):
+            kwargs = dict(seqused_k=seqused_k, block_table=block_table)
+            kwargs.update(overrides)
+            with _use_cudnn_varlen(True, device), torch.no_grad():
+                return varlen_attn(
+                    query, key, value, cu_seq_q, None, 192, cache_size, **kwargs
+                )
+
+        bad_inputs = [
+            ("seqused_k must have shape", {"seqused_k": seqused_k[:1]}),
+            ("seqused_k must be on the same", {"seqused_k": seqused_k.cpu()}),
+            ("seqused_k must have dtype int32", {"seqused_k": seqused_k.long()}),
+            ("block_table must have shape", {"block_table": block_table[:1]}),
+            ("block_table must have dtype int32", {"block_table": block_table.long()}),
+            ("block_table must be on the same", {"block_table": block_table.cpu()}),
+        ]
+        for message, override in bad_inputs:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    run(**override)
+
+        value_head_dim = 32
+        v_narrow = torch.randn(
+            *v.shape[:-1], value_head_dim, device=device, dtype=dtype
+        )
+        output = run(value=v_narrow)
+        self.assertEqual(output.shape, (q.size(0), num_heads, value_head_dim))
+
+        k_logical = gather_paged_cache(k, block_table)
+        v_logical = gather_paged_cache(v_narrow, block_table)
+        expected = torch.empty_like(output)
+        scale = 1.0 / math.sqrt(head_dim)
+        for i, kv_len in enumerate((200, 128)):
+            lo, hi = int(cu_seq_q[i]), int(cu_seq_q[i + 1])
+            q_i = q[lo:hi].float()
+            k_i = k_logical[i, :kv_len].float()
+            v_i = v_logical[i, :kv_len].float()
+            attn = (torch.einsum("qhd,khd->hqk", q_i, k_i) * scale).softmax(-1)
+            expected[lo:hi] = torch.einsum("hqk,khd->qhd", attn, v_i).to(dtype)
+        self.assertEqual(output.float(), expected.float(), atol=2e-2, rtol=2e-2)
+
+        with self.assertRaisesRegex(RuntimeError, "head dimension must match query"):
+            run(key=k[..., :32])
+
+        mismatched_values = [
+            ("page count", v[:-1]),
+            ("page size", v[:, :-1]),
+            ("number of heads", v[:, :, :-1]),
+        ]
+        for axis, bad_value in mismatched_values:
+            with self.subTest(axis=axis):
+                with self.assertRaisesRegex(RuntimeError, "matching page count"):
+                    run(value=bad_value)
+
+        with self.assertRaisesRegex(RuntimeError, "same dtype"):
+            run(key=k.half(), value=v.half())
+
+        aten_kwargs = dict(
+            query=q,
+            key=k,
+            value=v,
+            attn_bias=None,
+            cum_seq_q=cu_seq_q,
+            cum_seq_k=None,
+            max_q=192,
+            max_k=cache_size,
+            compute_log_sumexp=True,
+            dropout_p=0.0,
+            is_causal=False,
+            return_debug_mask=False,
+            seqused_k=seqused_k,
+            block_table=block_table,
+        )
+        with self.assertRaisesRegex(RuntimeError, "only supports float16"):
+            torch.ops.aten._cudnn_attention_forward(
+                **(aten_kwargs | {"query": q.float()})
+            )
+
+        storage = torch.empty(k.numel() + 1, device=device, dtype=dtype)
+        misaligned_k = torch.as_strided(storage, k.shape, k.stride(), storage_offset=1)
+        misaligned_k.copy_(k)
+        with self.assertRaisesRegex(RuntimeError, "16-byte-aligned"):
+            run(key=misaligned_k)
+
+        # Exercise both the custom-op and direct-aten autograd guards.
+        q_grad = q.clone().requires_grad_()
+        with _use_cudnn_varlen(True, device):
+            with self.assertRaisesRegex(RuntimeError, "inference-only parameter"):
+                varlen_attn(
+                    q_grad,
+                    k,
+                    v,
+                    cu_seq_q,
+                    None,
+                    192,
+                    cache_size,
+                    seqused_k=seqused_k,
+                    block_table=block_table,
+                )
+        with self.assertRaisesRegex(
+            RuntimeError, "seqused_k and block_table are inference-only"
+        ):
+            torch.ops.aten._cudnn_attention_forward(**(aten_kwargs | {"query": q_grad}))
 
 
 instantiate_device_type_tests(TestVarlenAttentionDevice, globals(), allow_xpu=True)

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -386,48 +386,13 @@ class TestVarlenAttentionDevice(NNTestCase):
                 scale=scale,
             )
 
-    @skipIfRocm
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
-    )
     def test_sdpa_kernel_backend_errors(self, device):
-        """Report forced-backend constraints instead of silently falling back."""
+        """Report an unusable backend selection instead of silently falling back."""
         seq_len = 256
         q = torch.randn(seq_len, 4, 64, device=device, dtype=torch.bfloat16)
         k = torch.randn_like(q)
         v = torch.randn_like(q)
         cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-
-        short_seq = torch.tensor([0, 128], device=device, dtype=torch.int32)
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            with self.assertRaises(RuntimeError) as error:
-                varlen_attn(
-                    q[:128],
-                    k[:128],
-                    v[:128],
-                    short_seq,
-                    short_seq,
-                    128,
-                    128,
-                    num_splits=1,
-                )
-        self.assertIn("max_q must", str(error.exception))
-        self.assertIn("num_splits", str(error.exception))
-
-        with (
-            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
-            self.assertRaisesRegex(RuntimeError, "same cu_seq tensor"),
-        ):
-            varlen_attn(
-                q,
-                k,
-                v,
-                cu_seq,
-                cu_seq.clone(),
-                seq_len,
-                seq_len,
-                window_size=(-1, 0),
-            )
 
         with (
             sdpa_kernel(SDPBackend.MATH),
@@ -436,7 +401,7 @@ class TestVarlenAttentionDevice(NNTestCase):
             varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
 
         with (
-            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
+            sdpa_kernel(SDPBackend.MATH),
             self.assertRaisesRegex(RuntimeError, "only supports.*FLASH_ATTENTION"),
         ):
             varlen_attn_out(
@@ -1434,6 +1399,56 @@ class TestVarlenAttention(NNTestCase):
             self.assertEqual(
                 varlen_attention._select_backend(*args),
                 SDPBackend.CUDNN_ATTENTION.value,
+            )
+
+    @skipIfRocm
+    def test_cudnn_backend_constraint_errors(self, device):
+        """Name the cuDNN constraints that rejected a forced cuDNN selection."""
+        # Backend selection happens before dispatch, so this needs no cuDNN.
+        seq_len = 256
+        q = torch.randn(seq_len, 4, 64, device=device, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        short_seq = torch.tensor([0, 128], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaises(RuntimeError) as error:
+                varlen_attn(
+                    q[:128],
+                    k[:128],
+                    v[:128],
+                    short_seq,
+                    short_seq,
+                    128,
+                    128,
+                    num_splits=1,
+                )
+        self.assertIn("max_q must", str(error.exception))
+        self.assertIn("num_splits", str(error.exception))
+
+        with (
+            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
+            self.assertRaisesRegex(RuntimeError, "same cu_seq tensor"),
+        ):
+            varlen_attn(
+                q,
+                k,
+                v,
+                cu_seq,
+                cu_seq.clone(),
+                seq_len,
+                seq_len,
+                window_size=(-1, 0),
+            )
+
+        # cuDNN is a valid varlen_attn backend, but varlen_attn_out is flash-only.
+        with (
+            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
+            self.assertRaisesRegex(RuntimeError, "only supports.*FLASH_ATTENTION"),
+        ):
+            varlen_attn_out(
+                torch.empty_like(q), q, k, v, cu_seq, cu_seq, seq_len, seq_len
             )
 
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179968")

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -361,6 +361,89 @@ def create_variable_length_batch(
     }
 
 
+class TestVarlenAttentionDevice(NNTestCase):
+    # varlen_attn validates the scale and resolves a backend before dispatching
+    # any kernel, so these checks hold on every device.
+
+    @parametrize("scale", [0.0, -0.125, float("nan")])
+    def test_varlen_invalid_scale(self, device, scale):
+        q, k, v, cu_seq = _make_causal_varlen_inputs(device)
+        seq_len = q.size(0)
+
+        with self.assertRaisesRegex(ValueError, "scale must be greater than 0"):
+            varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len, scale=scale)
+
+        with self.assertRaisesRegex(ValueError, "scale must be greater than 0"):
+            varlen_attn_out(
+                torch.empty_like(q),
+                q,
+                k,
+                v,
+                cu_seq,
+                cu_seq,
+                seq_len,
+                seq_len,
+                scale=scale,
+            )
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
+    def test_sdpa_kernel_backend_errors(self, device):
+        """Report forced-backend constraints instead of silently falling back."""
+        seq_len = 256
+        q = torch.randn(seq_len, 4, 64, device=device, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        short_seq = torch.tensor([0, 128], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaises(RuntimeError) as error:
+                varlen_attn(
+                    q[:128],
+                    k[:128],
+                    v[:128],
+                    short_seq,
+                    short_seq,
+                    128,
+                    128,
+                    num_splits=1,
+                )
+        self.assertIn("max_q must", str(error.exception))
+        self.assertIn("num_splits", str(error.exception))
+
+        with (
+            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
+            self.assertRaisesRegex(RuntimeError, "same cu_seq tensor"),
+        ):
+            varlen_attn(
+                q,
+                k,
+                v,
+                cu_seq,
+                cu_seq.clone(),
+                seq_len,
+                seq_len,
+                window_size=(-1, 0),
+            )
+
+        with (
+            sdpa_kernel(SDPBackend.MATH),
+            self.assertRaisesRegex(RuntimeError, "No viable backend"),
+        ):
+            varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+        with (
+            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
+            self.assertRaisesRegex(RuntimeError, "only supports.*FLASH_ATTENTION"),
+        ):
+            varlen_attn_out(
+                torch.empty_like(q), q, k, v, cu_seq, cu_seq, seq_len, seq_len
+            )
+
+
 class TestVarlenAttention(NNTestCase):
     # NOTE: This class is currently CUDA-specific, although a significant portion of its
     # functionality can be shared by other backends. Separating the common logic from
@@ -877,27 +960,6 @@ class TestVarlenAttention(NNTestCase):
             _should_use_cudnn=_should_use_cudnn,
         )
 
-    @parametrize("scale", [0.0, -0.125, float("nan")])
-    def test_varlen_invalid_scale(self, device, scale):
-        q, k, v, cu_seq = _make_causal_varlen_inputs(device)
-        seq_len = q.size(0)
-
-        with self.assertRaisesRegex(ValueError, "scale must be greater than 0"):
-            varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len, scale=scale)
-
-        with self.assertRaisesRegex(ValueError, "scale must be greater than 0"):
-            varlen_attn_out(
-                torch.empty_like(q),
-                q,
-                k,
-                v,
-                cu_seq,
-                cu_seq,
-                seq_len,
-                seq_len,
-                scale=scale,
-            )
-
     @skipIfRocm
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
@@ -1372,63 +1434,6 @@ class TestVarlenAttention(NNTestCase):
             self.assertEqual(
                 varlen_attention._select_backend(*args),
                 SDPBackend.CUDNN_ATTENTION.value,
-            )
-
-    @skipIfRocm
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
-    )
-    def test_sdpa_kernel_backend_errors(self, device):
-        """Report forced-backend constraints instead of silently falling back."""
-        seq_len = 256
-        q = torch.randn(seq_len, 4, 64, device=device, dtype=torch.bfloat16)
-        k = torch.randn_like(q)
-        v = torch.randn_like(q)
-        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
-
-        short_seq = torch.tensor([0, 128], device=device, dtype=torch.int32)
-        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            with self.assertRaises(RuntimeError) as error:
-                varlen_attn(
-                    q[:128],
-                    k[:128],
-                    v[:128],
-                    short_seq,
-                    short_seq,
-                    128,
-                    128,
-                    num_splits=1,
-                )
-        self.assertIn("max_q must", str(error.exception))
-        self.assertIn("num_splits", str(error.exception))
-
-        with (
-            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
-            self.assertRaisesRegex(RuntimeError, "same cu_seq tensor"),
-        ):
-            varlen_attn(
-                q,
-                k,
-                v,
-                cu_seq,
-                cu_seq.clone(),
-                seq_len,
-                seq_len,
-                window_size=(-1, 0),
-            )
-
-        with (
-            sdpa_kernel(SDPBackend.MATH),
-            self.assertRaisesRegex(RuntimeError, "No viable backend"),
-        ):
-            varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-
-        with (
-            sdpa_kernel(SDPBackend.CUDNN_ATTENTION),
-            self.assertRaisesRegex(RuntimeError, "only supports.*FLASH_ATTENTION"),
-        ):
-            varlen_attn_out(
-                torch.empty_like(q), q, k, v, cu_seq, cu_seq, seq_len, seq_len
             )
 
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179968")
@@ -2357,6 +2362,7 @@ class TestVarlenAttention(NNTestCase):
             self.assertEqual(out_buf, out)
 
 
+instantiate_device_type_tests(TestVarlenAttentionDevice, globals())
 instantiate_device_type_tests(TestVarlenAttention, globals(), only_for=("cuda",))
 
 if __name__ == "__main__":


### PR DESCRIPTION
cuDNN is the part of `test_varlen_attention.py` that can never become device-generic: it is the only varlen backend with dedicated aten ops (`_cudnn_attention_forward`/`_backward`) and it is only ever selected for a CUDA query. Separating it is the prerequisite for `TestVarlenAttention` becoming `ACCELERATOR` once the flash backends are reported through a capability mechanism.

- Move the 19 cuDNN tests into a new `TestVarlenAttentionCuDNN` class, instantiated `only_for=("cuda",)` exactly as before.
- `TestVarlenAttention` keeps the 9 flash tests, and its NOTE now records what is actually left blocking an accelerator-generic class.
- The varlen-vs-sdpa comparison helper becomes a mixin, since both CUDA classes need it.
- No test changes behaviour and none gains or loses a device: the moved tests change only the class name in their IDs. Review the diff as a reordering.

The file ends up as:

| class | classification | instantiation | tests |
|---|---|---|---|
| `TestVarlenAttentionDevice` | `GENERIC` | `allow_xpu=True` | 2 pre-dispatch checks (unchanged here) |
| `TestVarlenAttention` | `CUDA` | `only_for=("cuda",)` | 9 flash tests |
| `TestVarlenAttentionCuDNN` | `CUDA` | `only_for=("cuda",)` | 19 cuDNN tests |

Until #195455 merges, the diff shown here includes its commits as well.

### Test plan

```
python test/test_varlen_attention.py                              # 8 passed (4 cpu, 4 xpu)
python test/test_varlen_attention.py --hw-classification GENERIC  # total=8, passed=8
lintrunner -a test/test_varlen_attention.py
```

Run on an Intel GPU box, where both CUDA classes collect nothing, so the moves were verified mechanically rather than by running the moved tests; CI is the check.

---

This is a stack of PRs with the goal of separating `test_varlen_attention.py` by backend:
- https://github.com/pytorch/pytorch/pull/195455
- -> https://github.com/pytorch/pytorch/pull/195717

Authored with the assistance of Claude Code (Opus 5).
