### PR TITLE
Answer every device predicate on ExpandedWeight, not just is_cuda

### DIFF
--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -32,6 +32,7 @@ from torch.testing._internal.common_nn import (
 )
 from torch.testing._internal.common_utils import (
     freeze_rng_state,
+    HardwareClassification,
     make_tensor,
     parametrize,
     run_tests,
@@ -46,6 +47,8 @@ class TestContext:
 
 
 class TestExpandedWeightHelperFunction(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_forward_helper(self, device):
         input = torch.randn(3, 4, device=device)
         weight = torch.randn(5, 4, device=device)
@@ -232,21 +235,35 @@ class TestExpandedWeightHelperFunction(TestCase):
         weight = torch.randn(3, 4, device=device, requires_grad=True)
         expanded = ExpandedWeight(weight, 5, loss_reduction="sum")
 
+        # Whichever device this class was instantiated for is the one that has
+        # to work, so a new backend is covered without an entry here.
         device_type = torch.device(device).type
-        for name in sorted(
-            {f"is_{device_type}", "is_cpu", "is_cuda", "is_xpu", "is_mps", "is_mtia"}
-        ):
-            self.assertEqual(getattr(expanded, name), getattr(weight, name), msg=name)
         self.assertTrue(getattr(expanded, f"is_{device_type}"))
 
-        # Only device predicates are answered; everything else still raises, so
-        # this does not quietly turn ExpandedWeight into a general proxy.
+        # No is_* property may answer differently from the weight it wraps.
+        # Collected from Tensor rather than listed, for the same reason.
+        getset = type(torch._C.TensorBase.is_cuda)
+        for name in sorted(dir(torch._C.TensorBase)):
+            if not name.startswith("is_") or not isinstance(
+                getattr(torch._C.TensorBase, name), getset
+            ):
+                continue
+            try:
+                answer = getattr(expanded, name)
+            except RuntimeError:
+                continue  # not forwarded; the block below pins which those are
+            self.assertEqual(answer, getattr(weight, name), msg=name)
+
+        # These are not device types, so they must still raise -- this list does
+        # not grow when a backend is added.
         for name in ("is_sparse", "is_nested", "is_leaf", "is_quantized"):
             with self.assertRaisesRegex(RuntimeError, "cannot handle function"):
                 getattr(expanded, name)
 
 
 class TestExpandedWeightFunctional(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _compare_ew_and_for_loop_per_sample_grads(self, op, sample_input, reduction):
         input = sample_input.input
         args = sample_input.args
@@ -643,6 +660,8 @@ class TestExpandedWeightFunctional(TestCase):
 
 
 class TestExpandedWeightModule(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _do_test(
         self,
         module,

--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -223,6 +223,28 @@ class TestExpandedWeightHelperFunction(TestCase):
         res = sum_over_all_but_batch_and_last_n(input, 4)
         self.assertEqual(res, input)
 
+    def test_device_predicates_match_the_wrapped_weight(self, device):
+        # Tensor.is_<device> is a property, and property access on a subclass is
+        # routed through __torch_function__, so each predicate has to be answered
+        # there or it raises. Only is_cuda used to be, which left every other
+        # backend -- including the is_<name> a PrivateUse1 backend generates --
+        # raising on an attribute a plain tensor answers.
+        weight = torch.randn(3, 4, device=device, requires_grad=True)
+        expanded = ExpandedWeight(weight, 5, loss_reduction="sum")
+
+        device_type = torch.device(device).type
+        for name in sorted(
+            {f"is_{device_type}", "is_cpu", "is_cuda", "is_xpu", "is_mps", "is_mtia"}
+        ):
+            self.assertEqual(getattr(expanded, name), getattr(weight, name), msg=name)
+        self.assertTrue(getattr(expanded, f"is_{device_type}"))
+
+        # Only device predicates are answered; everything else still raises, so
+        # this does not quietly turn ExpandedWeight into a general proxy.
+        for name in ("is_sparse", "is_nested", "is_leaf", "is_quantized"):
+            with self.assertRaisesRegex(RuntimeError, "cannot handle function"):
+                getattr(expanded, name)
+
 
 class TestExpandedWeightFunctional(TestCase):
     def _compare_ew_and_for_loop_per_sample_grads(self, op, sample_input, reduction):

--- a/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import functools
+import warnings
 from collections.abc import Callable
 from contextlib import contextmanager
 
@@ -23,7 +24,12 @@ def _is_device_predicate(name: str) -> bool:
     if not name.startswith("is_"):
         return False
     try:
-        torch.device(name[3:])
+        # Deliberately probing, so a name that parses only with a deprecation
+        # warning (``mkldnn``) must not surface one to the caller. Runs at most
+        # once per name thanks to the cache.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            torch.device(name[3:])
     except RuntimeError:
         return False
     return True

--- a/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
+++ b/torch/nn/utils/_expanded_weights/expanded_weights_impl.py
@@ -10,6 +10,37 @@ from torch.utils._pytree import tree_map_only
 
 HANDLED_FUNCTIONS: dict[Callable, torch.autograd.Function] = {}
 
+
+@functools.lru_cache
+def _is_device_predicate(name: str) -> bool:
+    """Whether ``name`` is one of ``Tensor``'s ``is_<device type>`` properties.
+
+    Ask the device-type parser instead of listing backends: this has to cover
+    ``is_cuda``, ``is_xpu``, ``is_mps``, ``is_mtia`` and whatever a PrivateUse1
+    backend registers, and the answer must not need editing when one is added.
+    Cached because it sits on attribute access and the answer never changes.
+    """
+    if not name.startswith("is_"):
+        return False
+    try:
+        torch.device(name[3:])
+    except RuntimeError:
+        return False
+    return True
+
+
+def _property_name(func) -> str | None:
+    """Name of the property ``func`` gets, or None if ``func`` is not a getter."""
+    if getattr(func, "__name__", None) != "__get__":
+        return None
+    prop = getattr(func, "__self__", None)
+    # C getsets carry the name directly; a Python property carries it on fget,
+    # which is how a PrivateUse1 backend's generated is_<name> arrives.
+    return getattr(prop, "__name__", None) or getattr(
+        getattr(prop, "fget", None), "__name__", None
+    )
+
+
 aten = torch._ops.ops.aten
 # __torch_function__ runs before the pydispatcher so we need to manually use the same
 # decompositions indexed by their torch equivalent
@@ -127,6 +158,13 @@ class ExpandedWeight(torch.Tensor):
     def __torch_function__(cls, func, _, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
+        # Property access on a tensor subclass is routed here, so every
+        # Tensor.is_<device> predicate lands in this method and hits the raise at
+        # the bottom unless it is answered. Answer them from the wrapped weight,
+        # which is where the explicit property overrides below already point.
+        prop_name = _property_name(func)
+        if prop_name is not None and _is_device_predicate(prop_name):
+            return getattr(args[0].orig_weight, prop_name)
         if func in expanded_weights_rnn_decomps:
             # in aten, choosing the input or data variants is done by parsing logic. This mimics some of that
             decomp_opts = expanded_weights_rnn_decomps[func]
@@ -168,10 +206,6 @@ class ExpandedWeight(torch.Tensor):
     @property
     def device(self):  # type: ignore[override]
         return self.orig_weight.device
-
-    @property
-    def is_cuda(self):  # type: ignore[override]
-        return self.orig_weight.is_cuda
 
     def data_ptr(self):
         return self.orig_weight.data_ptr()


### PR DESCRIPTION

Related to this RFC: #194355

### Summary

`Tensor.is_<device>` is a getset property, and property access on a tensor
subclass routes through `__torch_function__`, which `ExpandedWeight` raises from
for anything it does not recognise. Only `is_cuda` was recognised, via a
hand-written property, so every other device predicate failed on an attribute a
plain tensor answers:

    >>> ew = ExpandedWeight(torch.randn(3, 4, requires_grad=True), 5, "sum")
    >>> ew.is_cuda
    False
    >>> ew.is_xpu
    RuntimeError: Expanded Weights encountered but cannot handle function __get__

Same for `is_mps`, `is_mtia`, `is_cpu`, `is_meta`, and the `is_<name>` a
PrivateUse1 backend generates -- that last one because
`_generate_tensor_methods_for_privateuse1_backend` routes its property through
`handle_torch_function` for subclasses.

The getter is now answered generically rather than one property per backend. The
name is recovered from the descriptor (C getsets carry it directly; a Python
property carries it on `fget`, which is how the generated PrivateUse1 predicate
arrives) and counts as a device predicate when `torch.device(name[3:])` parses --
the same probe `_register_device_module` uses. The `is_cuda` property is removed,
so there is one path and CUDA is not a special case.

### Blast radius

A name is forwarded when `torch.device(name[3:])` parses, so `is_sparse`,
`is_nested`, `is_leaf`, `is_quantized` and the rest are untouched and still raise
-- the test asserts that, so this does not become a general property proxy and
`grad`, `grad_fn` and `requires_grad` do not move. `is_inference` and `is_pinned`
are method descriptors rather than getsets, so they never took this path.

The one accepted name that is not strictly a device predicate is `is_mkldnn`, a
layout query -- `torch.device("mkldnn")` still parses, with a deprecation warning.
Forwarding it returns the wrapped weight's answer, and the cached probe can emit
that warning at most once.

### Test plan

New test `test_device_predicates_match_the_wrapped_weight` in
`TestExpandedWeightHelperFunction`, which the file already runs through
`instantiate_device_type_tests`. It compares every device predicate against the
wrapped weight, so it needs no per-backend branch and no entry per backend.

    CPU     helper 9 / module 87 / functional 94                        OK
    CUDA    helper 8 -> 9, module 123 -> 123, functional 89 -> 89       OK, before and after
    NPU     TestExpandedWeightHelperFunctionPRIVATEUSE1, Ran 9 tests    OK
    lintrunner                                                         ok No lint issues.

On the T4, `is_cuda` is unchanged at `True` -- worth checking, since it is the one
predicate whose implementation moved, from a direct property to
`__torch_function__`. On the NPU (`torch_npu`, PrivateUse1) `is_npu` returns
`True`, not merely non-raising: that is the property
`_generate_tensor_methods_for_privateuse1_backend` synthesises, which reaches
`__torch_function__` via `handle_torch_function`, so it is the only path a real
out-of-tree backend takes through the `fget` branch of the name lookup. And
`TestExpandedWeightHelperFunctionPRIVATEUSE1` exists with no entry in the test file
at all.

`is_sparse`, `is_nested`, `is_leaf` and `is_quantized` still raise on both boxes,
and the test asserts that. Restoring the `is_cuda` property and dropping the
generic handling makes the new test fail, so it is not vacuous.
