### PR TITLE
Loosen fp16 gradient tolerance for special.i1/i1e on XPU

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -680,6 +680,14 @@ inductor_override_kwargs["xpu"] = {
     ("softmax", f16): {"atol": 1e-4, "rtol": 0.02},
     ("_softmax_backward_data", f16): {"atol": 0.008, "rtol": 0.002},
     ("special.log_ndtr", f64): {"atol": 1e-6, "rtol": 1e-5},
+    # fp16 backward: i1e_backward/i1_backward combine i0e/i1e with sgn+reciprocal
+    # in one expression; Inductor fuses the whole thing into a single kernel
+    # (one fp16 rounding at the end) while eager rounds after each sub-op, so
+    # the two accumulate rounding differently. Same fix already applied for
+    # CUDA above; XPU only started exercising this once Half/BFloat16 were
+    # added to i1/i1e's AT_DISPATCH_FLOATING_TYPES_AND2 backward dispatch.
+    ("special.i1", f16): {"grad_atol": 1e-5, "grad_rtol": 1e-2},
+    ("special.i1e", f16): {"grad_atol": 1e-5, "grad_rtol": 1e-2},
     ("std_mean.unbiased", f16): {
         "reference_in_float": True,
         "atol": 5e-5,


### PR DESCRIPTION
Fixes #194147

test_comprehensive_special_i1{,e}_xpu_float16 fails on XPU because Inductor
fuses i1e_backward's gradient formula (`i0e(x) - result * (sgn(x) +
reciprocal(x))`) into a single Triton kernel that accumulates in fp32 and
rounds to fp16 only once at the final store, while eager runs each op (sgn,
reciprocal, add, mul, sub) separately, rounding to fp16 after every step.
Both are numerically valid; they just round differently, producing a
gradient difference (~1.2e-4 absolute / 1.4e-3 relative) that falls just
outside the default fp16 tolerance.

**Kernel-level verification (no kernel code changes needed):**
- `i0e(x)`, `sgn(x)`, `reciprocal(x)` were each computed standalone under
  `torch.compile` (same inductor config as the test) and compared to eager:
  bit-identical in every case. The XPU-native kernels for these ops
  (`aten/src/ATen/native/Math.h`'s `calc_i0e`, dispatched via
  `third_party/torch-xpu-ops`) are correct; nothing there needed to change.
- The divergence only appears once these ops are combined into the single
  backward expression. Dumping the actual generated code
  (`TORCH_LOGS=output_code`) confirms Inductor fuses the whole expression
  into one Triton kernel that loads fp16 inputs, upcasts to fp32, does the
  entire sign/reciprocal/add/mul/sub chain in fp32, and only casts back to
  fp16 once at the final store — a generic Inductor fusion behavior
  unrelated to any XPU-specific kernel code.
- CUDA already carries the identical override for the same reason
  (`inductor_override_kwargs["cuda"]`); XPU only started exercising this
  path now that `special.i1`/`special.i1e`'s OpInfo `backward_dtypes`
  include half/bfloat16 and `i1e_backward`'s `AT_DISPATCH` covers
  Half/BFloat16.

Since eager's per-op fp16 rounding and Inductor's single-fp32-then-round
both round differently but neither is "wrong", the fix is a tolerance
override (matching CUDA's existing values), not a kernel change.

Test: test/inductor/test_torchinductor_opinfo.py::TestInductorOpInfoXPU::test_comprehensive_special_i1_xpu_float16, test/inductor/test_torchinductor_opinfo.py::TestInductorOpInfoXPU::test_comprehensive_special_i1e_xpu_float16

> This PR body and commit message were drafted with AI assistance (GitHub Copilot); numerics were verified by hand against generated Triton kernel source on real XPU hardware.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo