### PR TITLE
[ROCm] Tune DilatedMaxPool3d block size for narrow outputs

### DIFF
--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -143,8 +143,23 @@ void max_pool3d_with_indices_out_frame(
   bool channels_last)
 {
   int offsetZ = 0;
+  // The 32-wide x dimension is a CUDA warp assumption, and any output narrower
+  // than 32 leaves most of each x row idle. 16x16 keeps the same 256 threads
+  // while wasting one lane per row instead of seventeen, and is faster on both
+  // ROCm architectures at narrow outputs -- but it *loses* once the output is
+  // 32 or wider, where 32x8 stops wasting anything. Hence the gate rather than
+  // a replaced constant.
+  //
+  // Measured, mirrored-pair A/B, output widths 8 / 15 / 32 / 64:
+  //   gfx950  (MI350X): 1.196x / 1.131x / 0.930x / 0.996x
+  //   gfx1250 (MI450):  1.218x / 1.049x / 0.861x / 0.968x
+  // See operator_benchmark_shortlist_analysis/maxpool_operators/.
   int threadX = 32;
   int threadY = 8;
+  if (owidth < 32) {
+    threadX = 16;
+    threadY = 16;
+  }
   int threadZ = 1;
   int stepZ = 65535;
   if (channels_last) {

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -143,17 +143,11 @@ void max_pool3d_with_indices_out_frame(
   bool channels_last)
 {
   int offsetZ = 0;
-  // The 32-wide x dimension is a CUDA warp assumption, and any output narrower
-  // than 32 leaves most of each x row idle. 16x16 keeps the same 256 threads
-  // while wasting one lane per row instead of seventeen, and is faster on both
-  // ROCm architectures at narrow outputs -- but it *loses* once the output is
-  // 32 or wider, where 32x8 stops wasting anything. Hence the gate rather than
-  // a replaced constant.
-  //
-  // Measured, mirrored-pair A/B, output widths 8 / 15 / 32 / 64:
-  //   gfx950  (MI350X): 1.196x / 1.131x / 0.930x / 0.996x
-  //   gfx1250 (MI450):  1.218x / 1.049x / 0.861x / 0.968x
-  // See operator_benchmark_shortlist_analysis/maxpool_operators/.
+  // The 32-wide x dimension assumes a 32-lane warp, so an output narrower than
+  // 32 leaves most of each x row idle. 16x16 keeps the same 256 threads and
+  // doubles the output rows a warp covers, which measures faster at narrow
+  // outputs but loses once the output is 32 or wider. Hence the gate rather
+  // than a replaced constant.
   int threadX = 32;
   int threadY = 8;
   if (owidth < 32) {


### PR DESCRIPTION
## Summary

`max_pool3d_with_indices_out_frame` launches a fixed `32x8` block. The 32-wide x dimension assumes
a 32-lane warp, so any output narrower than 32 leaves most of each x row idle. A `16x16` block
keeps the same 256 threads and doubles the number of output rows a warp covers, which measures
faster at narrow outputs on both ROCm parts tested — but loses once the output is 32 or wider,
where `32x8` wastes nothing. Hence a gate rather than a replaced constant.

## Measurements

Mirrored-pair A/B, `totalZ = 112`.

| output width | gfx950 (MI350X) | gfx1250 |
|---|---|---|
| 8 | 1.196x | 1.218x |
| 15 | 1.131x | 1.049x |
| 32 | 0.930x | 0.861x |
| 64 | 0.996x | 0.968x |

Correctness is unaffected: the guard at the top of the kernel fully bounds every load and store,
so no block shape can read or write out of range.

## Known open items

These are the reasons this is still a draft. The first is blocking.

1. **The change is not ROCm-gated, despite the `[ROCm]` title.** `DilatedMaxPool3d.cu` contains
   **zero** occurrences of `USE_ROCM`, so this alters launch geometry for every NVIDIA CUDA build
   too, and there is no NVIDIA measurement anywhere in this PR. On CUDA the mechanism is
   materially different: 32-wide x is *exactly* one warp, giving one coalesced output segment per
   warp; at `blockDim.x = 16` a warp straddles two output rows, producing two disjoint segments
   `owidth` apart for both the store and the input gather.

   Fix: wrap in `#if defined(USE_ROCM)`. In-tree precedent in the same directory —
   `EmbeddingBag.cu:290-295` forks the *identical* `dim3(32, 8)` into `dim3(64, 4)` on ROCm only,
   and the sibling `DilatedMaxPool2d.cu:31-39` already gates `CUDA_MAX_THREADS` /
   `BLOCK_STRIDE_FWD` on `#ifdef USE_ROCM`. A 3-D pooling tuning that is not gated is a mismatch
   against its own 2-D counterpart.

2. **The gate is wider than the mechanism justifies.** Lane index is
   `threadIdx.x + threadIdx.y * blockDim.x`, and the guard is what masks work. Once
   `owidth > 16`, `ceil_div(owidth, 16)` makes `gridDim.x = 2` and averaged lane utilization
   becomes *identical* to `32x8`, while the store and gather still split into two segments. So for
   `owidth` in `[17, 31]` the change is all coalescing cost and no occupancy benefit, by this PR's
   own model. The same algebra on wave64 gives `owidth/32` for both configs, so this is
   architecture-independent — and it explains the measured 0.930x / 0.861x at width 32 as the tail
   of a band beginning at 17, not a cliff at 32.

   The sweep is 8 / 15 / 32 / 64, so nothing in `[16, 31]` was measured and `< 32` was never
   tested as the boundary. `owidth <= 16` is the value the mechanism supports.

3. **The backward launcher is left divergent.** `max_pool3d_with_indices_backward_out_frame` has
   the same `threadX = 32; threadY = 8;`, the same `ceil_div(owidth, block.x)` grid, and the *same
   guard* — so the idle-lane argument transfers verbatim. Its scatter access pattern affects the
   magnitude of any win, not the sign of the lane-utilization argument. One operator should not
   carry two launch policies for no recorded reason; if both are tuned, the choice belongs in a
   single file-local helper so they cannot drift.

4. **`channels_last_3d` gets no benefit.** The `if (channels_last)` block unconditionally
   overwrites `threadX`/`threadY`/`threadZ` after the new gate, so that path is unaffected — and
   it is the only 3-D max-pool path with real device test coverage today.

5. **`gridDim.y` halves.** It goes from `ceil_div(oheight, 8)` to `ceil_div(oheight, 16)`, halving
   total blocks whenever `oheight > 8`. All measurements were at `totalZ = 112` (224+ blocks),
   where this is invisible; an unbatched single-channel input with `oheight = 16` drops from 8
   blocks to 4 on a 100+ CU device.

6. **Coverage in the affected band is essentially nil.** `test_max_pool3d_ndhwc`
   (`test/nn/test_pooling.py:1455`) tops out at output width 9; the `max_pool3d` OpInfo yields
   output widths 1-3; `ModuleInfo(MaxPool3d)` yields 2-3. The only test landing in `[16, 31]` is
   `test_pool3d_large_size_int64` (owidth 20), gated `@largeTensorTest("18GB")` and not run in CI.
   3-D index correctness is explicitly skipped — `_test_maxpool_indices` guards its
   `expected_indices` assertions with `if num_dim != 3:`.

## Correction to an earlier version of this description

A previous revision claimed that reshaping the block "changes the order in which candidate maxima
are compared within a window." That is wrong. The entire pooling-window reduction runs
sequentially inside a **single thread**, accumulating into a thread-local `max`. Block geometry
changes only which thread owns an output element, never the intra-window comparison order.
`max_abs_err = 0` is therefore a tautology here rather than evidence — it would hold for any legal
block shape — and the tie-breaking test plan built on that premise was testing nothing. The one
place order-dependence genuinely exists is the backward's `gpuAtomicAddNoReturn`, which this PR
does not touch.

## Test plan

- [ ] Rebuild for ROCm and for CUDA.
- [ ] `python test/nn/test_pooling.py -k max_pool3d` and `-k maxpool3d`.
- [ ] Sweep output widths 8, 15, 16, 17, 20, 24, 28, 31, 32, 64 on gfx950 and gfx1250 to settle
      open item 2 and pick the boundary from data.
- [ ] Include a low-`totalZ` shape (batch=1, channels=1) for open item 5.
- [ ] If left ungated, measure on an NVIDIA part before merge.
- [ ] Confirm on gfx942 or gfx90a.
- [ ] Add width parametrization covering 15/16/17/31/32 across `contiguous_format` and
      `channels_last_3d`, asserting indices as well as values.

cc @jeffdaily @jithunnair-amd @hongxiayang @pruthvistony @naromero77amd @jataylo @pragupta

> This PR was prepared with the assistance of an AI coding assistant. I have read and understand
> the change and take responsibility for it.