### PR TITLE
[ROCm] Tune cat elements-per-thread based on output size

### DIFF
--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -55,8 +55,26 @@ template<typename T>
 inline std::tuple<dim3, dim3> getCatGridRocm(unsigned int max_elements_per_tensor,
   ptrdiff_t nTensors) {
   constexpr unsigned int threads_per_block = 256;
-  constexpr unsigned int elements_per_thread = 8;
   constexpr unsigned int max_tb_per_sm = 32;
+
+  // 4 elements per thread beats the historical 8 at small output sizes -- 1.385x
+  // on gfx1250 and 1.109x on gfx950 at 524288 total output elements, 8/8
+  // mirrored pairs each -- but the two architectures disagree above ~2M: gfx1250
+  // regresses 7-8% from 4.2M upward while gfx950 stays neutral or wins. The
+  // threshold is therefore the intersection of the two win regions, which costs
+  // gfx1250 nothing. Above the num_sm*max_tb_per_sm grid cap the choice makes no
+  // difference at all: both values issue an identical launch.
+  // See operator_benchmark_shortlist_analysis/cat_stack_operators/.
+  constexpr unsigned int small_output_elements_per_thread = 4;
+  constexpr unsigned int large_output_elements_per_thread = 8;
+  constexpr uint64_t small_output_threshold = 2ull * 1024 * 1024;
+
+  const uint64_t total_output_elements =
+      static_cast<uint64_t>(max_elements_per_tensor) * static_cast<uint64_t>(nTensors);
+  const unsigned int elements_per_thread =
+      total_output_elements <= small_output_threshold
+          ? small_output_elements_per_thread
+          : large_output_elements_per_thread;
 
   unsigned int max_threads = ceil_div(max_elements_per_tensor, elements_per_thread);
   unsigned int thread_blocks = ceil_div(max_threads, threads_per_block);

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -57,14 +57,10 @@ inline std::tuple<dim3, dim3> getCatGridRocm(unsigned int max_elements_per_tenso
   constexpr unsigned int threads_per_block = 256;
   constexpr unsigned int max_tb_per_sm = 32;
 
-  // 4 elements per thread beats the historical 8 at small output sizes -- 1.385x
-  // on gfx1250 and 1.109x on gfx950 at 524288 total output elements, 8/8
-  // mirrored pairs each -- but the two architectures disagree above ~2M: gfx1250
-  // regresses 7-8% from 4.2M upward while gfx950 stays neutral or wins. The
-  // threshold is therefore the intersection of the two win regions, which costs
-  // gfx1250 nothing. Above the num_sm*max_tb_per_sm grid cap the choice makes no
-  // difference at all: both values issue an identical launch.
-  // See operator_benchmark_shortlist_analysis/cat_stack_operators/.
+  // 4 elements per thread measures faster than the historical 8 at small output
+  // sizes, but the two ROCm architectures measured disagree above ~2M elements,
+  // where gfx1250 regresses. The threshold is the intersection of the two win
+  // regions.
   constexpr unsigned int small_output_elements_per_thread = 4;
   constexpr unsigned int large_output_elements_per_thread = 8;
   constexpr uint64_t small_output_threshold = 2ull * 1024 * 1024;


### PR DESCRIPTION
## Summary

`getCatGridRocm` in `aten/src/ATen/native/cuda/Shape.cu` used a hardcoded 8 elements per thread.
Halving it to 4 doubles the grid and measures faster at small output sizes on both ROCm parts
tested. Because the two architectures diverge at larger sizes, the new value is gated on output
size rather than replacing the constant outright.

CUDA builds are unaffected: `getCatGridRocm` is only reachable under `#ifdef USE_ROCM`
(`Shape.cu:446`).

## Measurements

Standalone HIP reproducer, mirrored-pair A/B, equal-sized input tensors.

| total output elements | gfx1250 | gfx950 |
|---|---|---|
| 524,288 | 1.385x (8/8) | 1.109x (8/8) |
| >= 4.2M | 0.92-0.93x | neutral or better |

16 elements per thread is about 31% slower and was not pursued. Output is bit-identical in all
cases — the change is launch geometry only.

## The change

Replaces the constant with `small_output_elements_per_thread = 4`,
`large_output_elements_per_thread = 8`, and a `small_output_threshold` of 2Mi elements, selecting
between them from a 64-bit product to avoid overflow.

## Known open items

These are the reasons this is still a draft. The first is a correctness problem with the gate,
not a tuning question.

1. **The gate input is not the total output size.** It computes
   `max_elements_per_tensor * nTensors`, where `max_elements_per_tensor` (`Shape.cu:379`, updated
   `:438`) is a running *maximum* of `numel()` and `nTensors` is `batchCounter` (`:385-388`), the
   count in the current batch. `max * count == sum` only when all inputs are equal-sized;
   otherwise it is a strict overestimate, so the gate can only ever select 8 where the criterion
   wants 4, never the reverse.

   `torch.cat([t_2000000] + [t_1] * 100)` has a true total of 2,000,100 elements (wants 4), but
   the gate computes `2,000,000 * 101 = 202,000,000` — 96x the real value — and selects 8. It also
   counts 100 grid rows that immediately hit `if (tid >= nElements) return;` (`Shape.cu:212`) as
   though they were full-size output.

   Note the benchmark above uses equal-sized tensors, which is the one regime where the formula is
   exact. **The gate has only been validated where it cannot be wrong.**

   Fix: `parallel_cat` already takes `const Tensor &out` (`Shape.cu:324`), so `out.numel()` is the
   exact output count, loop-invariant and free. Passing it in fixes open item 2 at the same time.

2. **The gate is evaluated per batch.** `CAT_ARRAY_BATCH_SIZE` is 128 (`Shape.cu:28`) and the
   batch loop at `:384` calls `getCatGridRocm` once per iteration, so one logical `cat` can issue
   different geometry for different batches. `torch.cat([t] * 129)` with 1M-element tensors gives
   `ept = 8` for the first 128 and `ept = 4` for the tail — and the tail lands in the region where
   4 is the *regressing* choice on gfx1250. Launch geometry ends up depending on
   `len(inputs) % 128`, which is invisible to the user.

3. **Arch coverage.** The justification is a two-arch disagreement, but the change is selected by
   a bare `#ifdef USE_ROCM`, so it also lands on gfx90a (MI200) and gfx942 (MI300X) unmeasured.
   The grid clamp is `num_sm`-dependent (304 vs 256 vs 104), so the two measured parts are not
   representative. `MemoryAccess.cuh:193-201` — in a header this file already includes — is the
   in-tree precedent for gating a ROCm perf tweak on a specific arch with an explicit
   "do not extend without re-benchmarking" note.

4. **The threshold is in elements but the dtype is discarded.** `template<typename T>`
   (`Shape.cu:54`) is never used in the body, unlike `getCatGridContig` (`:83-84`) which uses
   `sizeof(T)`. This kernel is bandwidth-bound, so 2Mi elements is 2 MiB for `uint8` and 32 MiB
   for `complex128` — a 32x range across the dispatched type set.

5. **No test can distinguish the branches.** `elements_per_thread` is used once, feeding
   `ceil_div`; it is not a template argument and never reaches a kernel, and both ROCm-reachable
   kernels are grid-stride loops guarded by `tid >= nElements`. Results are bit-identical for any
   `grid.x >= 1`. So this is a benchmarking obligation rather than a unit-test one — and
   `test_cat_multi_batch` (`test/test_tensor_creation_ops.py:1213-1227`), the only test crossing
   the batch boundary, yields `grid.x = 1` under both old and new code in its first case and takes
   the same branch every batch in its second.

## Test plan

- [ ] Rebuild for ROCm.
- [ ] `python -m pt.cat_test --device=cuda --tag-filter all` (the invocation PR #118685 used when
      introducing `getCatGridRocm` and the original constant), reporting `manyinputs` and `long`.
- [ ] Repeat on gfx950, gfx1250, and at least one of gfx90a / gfx942.
- [ ] `python test/test_tensor_creation_ops.py -k cat` and `python test/test_shape_ops.py`.
- [ ] Ragged multi-batch equality check vs CPU reference (one large + many tiny; >128 inputs of
      mixed size) to cover open items 1 and 2.
- [ ] Profile grid dims either side of the threshold to confirm the gate fires where intended.

cc @jeffdaily @jithunnair-amd @hongxiayang @pruthvistony @naromero77amd @jataylo @pragupta

> This PR was prepared with the assistance of an AI coding assistant. I have read and understand
> the change and take responsibility for it.