### PR TITLE
Fix dtype of torch._refs.nn.functional.alpha_dropout

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -445,6 +445,19 @@ class TestRefs(TestCase):
     def test_inferred_tags(self):
         self.assertEqual(torch.ops.prims.normal.default.tags, (torch.Tag.nondeterministic_seeded, torch.Tag.pt2_compliant_tag))
 
+    # From https://github.com/pytorch/pytorch/issues/195705
+    @dtypes(torch.bfloat16, torch.float16, torch.float32, torch.float64)
+    def test_alpha_dropout_dtype(self, device, dtype):
+        # python_ref_db skips the ref-vs-eager comparisons for dropout because
+        # the mask is redrawn per call, and test_python_ref_meta compares the
+        # ref against itself, so nothing else cross-checks the output dtype.
+        a = make_tensor((8,), device=device, dtype=dtype)
+        for p in (0.0, 0.5, 1.0):
+            actual = refs.nn.functional.alpha_dropout(a, p=p, training=True)
+            self.assertEqual(actual.dtype, dtype)
+        actual = refs.nn.functional.alpha_dropout(a, p=0.5, training=False)
+        self.assertEqual(actual.dtype, dtype)
+
 
 
 instantiate_device_type_tests(TestRefs, globals())

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -136,7 +136,7 @@ def alpha_dropout(
     b = b * (alpha * a) + alpha * a * p
     dropout_mask = a * dropout_mask
 
-    return self * dropout_mask + b
+    return (self * dropout_mask + b).to(self.dtype)
 
 
 def _inplace_wrapper(fn: Callable[_P, _T]) -> Callable[_P, _T]:


### PR DESCRIPTION
I hit the same thing on a different platform, so here is what I measured before writing the patch:

```
_refs.nn.functional.alpha_dropout, torch 2.14.0, macOS arm64, CPU
  bfloat16 -> float32     (divergence)
  float16  -> float32     (divergence)
  float32  -> float32
  float64  -> float64

torch.nn.functional.alpha_dropout (eager), same machine
  all four dtypes: output dtype == input dtype

_refs dropout family
  _refs.dropout        bfloat16/float16 -> preserved
  _refs.alpha_dropout  bfloat16/float16 -> float32   (only one affected)
  feature_alpha_dropout, dropout1d/2d/3d: not in _refs
```

Measurements produced with Claude Code and verified locally.

The reference upcast its output for low-precision inputs. `b` and `dropout_mask` are a bool tensor scaled by Python float scalars, which promotes to float32 under weak scalar type promotion, and the final expression was returned without casting back, so a bfloat16 or float16 input produced a float32 output while the eager op preserves the input dtype. Casting the result to `self.dtype` fixes it and leaves the values untouched; the early returns for `training=False`, `p=0` and `p=1` already returned `self` or `zeros_like(self)` and were unaffected.

Nothing cross-checked this. python_ref_db skips test_python_ref and test_python_ref_torch_fallback for the dropout refs, correctly, because the mask is redrawn per call so ref and eager values are not comparable, and test_python_ref_meta compares the ref against itself, so a dtype divergence from eager is invisible to it. Since the value comparison cannot be enabled, the new test asserts only the output dtype.

Test Plan:

Added `TestRefs::test_alpha_dropout_dtype` in test/test_prims.py:

```
python test/test_prims.py -k test_alpha_dropout_dtype
```

The test body was also checked against an installed 2.14.0 wheel by editing `torch/_refs/nn/functional/__init__.py` in site-packages, since the change is pure Python:

```
# without the fix
p=0.5 training=True  torch.bfloat16 -> torch.float32
p=0.5 training=True  torch.float16  -> torch.float32
# with the fix
all dtype and p combinations return the input dtype
```

Values are unchanged by the cast: over dtype in {bfloat16, float16, float32, float64} and p in {0.1, 0.5, 0.9}, the patched output is bitwise equal to the unpatched expression cast to the input dtype in all 12 cases.

Fixes #195705

Co-authored-with-AI: analysis, patch and test were prepared with Claude Code; I reviewed and verified every claim above on my own machine.