### PR TITLE
Enhance OpenMP library discovery logic

### DIFF
--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -307,24 +307,22 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       unset(_omp_clang_lib)
     endif()
 
-    if (NOT OpenMP_libomp_LIBRARY)
-      find_library(OpenMP_libomp_LIBRARY
-        NAMES omp gomp iomp5
-        HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
-        DOC "libomp location for OpenMP"
-      )
-      mark_as_advanced(OpenMP_libomp_LIBRARY)
-    endif()
-
     # Use OpenMP_PREFIX if defined
-    if (NOT OpenMP_libomp_LIBRARY AND NOT "${OpenMP_PREFIX}" STREQUAL "")
+    if (NOT "${OpenMP_PREFIX}" STREQUAL "")
       find_library(OpenMP_libomp_LIBRARY
         NAMES omp gomp iomp5
         HINTS "${OpenMP_PREFIX}/lib"
         DOC "libomp location for OpenMP"
+        NO_DEFAULT_PATH
       )
-      mark_as_advanced(OpenMP_libomp_LIBRARY)
     endif()
+
+    find_library(OpenMP_libomp_LIBRARY
+      NAMES omp gomp iomp5 NAMES_PER_DIR
+      HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
+      DOC "libomp location for OpenMP"
+    )
+    mark_as_advanced(OpenMP_libomp_LIBRARY)
 
     if(OpenMP_libomp_LIBRARY MATCHES "iomp5")
       set(OpenMP_libiomp5_LIBRARY "${MKL_OPENMP_LIBRARY}" CACHE STRING "libiomp5 location for OpenMP")


### PR DESCRIPTION
If `OpenMP_PREFIX` is explicitly set it should be used first.

Otherwise it should search each link directory for libomp, libgomp, libiomp5 to pick up the first of those 3 that is found and avoiding "lower-priority" ones being used.

For example GCC including libgomp.so may be installed to some software folder.
With the current logic it will search all folders for `libomp.so` which may pick up an incompatible system library.
With `NAMES_PER_DIR` it will find the `libgomp.so` in the compilers folder as that will be searched before the system folder.

Note that the explicit check for the library being found can be omitted as the value is cached and not searched again by CMake if already found.