### PR TITLE
Correct the editable-install mechanism described in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Follow the instructions for [installing PyTorch from source](https://github.com/
 * If you want to have no-op incremental rebuilds (which are fast), see [Make no-op build fast](#make-no-op-build-fast) below.
 
 * When installing with `python -m pip install -e . -v --no-build-isolation` (in contrast to `python -m pip install . -v --no-build-isolation`) Python runtime will use
-  the current local source-tree when importing `torch` package. (This is done by creating [`.egg-link`](https://wiki.python.org/moin/PythonPackagingTerminology#egg-link) file in `site-packages` folder)
+  the current local source-tree when importing `torch` package. (This is done by installing an import hook in the `site-packages` folder that redirects `torch`'s Python modules to the source tree; compiled output is not redirected.)
   This way you do not need to repeatedly install after modifying Python files (`.py`).
   However, you would need to reinstall if you modify Python interface (`.pyi`, `.pyi.in`) or non-Python files (`.cpp`, `.cc`, `.cu`, `.h`, ...).
 


### PR DESCRIPTION
CONTRIBUTING.md said `pip install -e .` redirects `torch` to the source tree "by creating a .egg-link file in site-packages", and linked to the packaging glossary entry for it. That is `setup.py develop`, which we no longer use. Since the scikit-build-core migration the redirect is an import hook and no `.egg-link` is written, so a contributor who goes looking for one finds nothing.

The replacement names no file, because the file differs across the Python versions we support. Through 3.14 the hook is installed by an `import` line in a `.pth`; PEP 829 (Final, 3.15) deprecates those lines and replaces them with a `<name>.start` entry-point file, and scikit-build-core already switches on `sys.version_info >= (3, 15)`. `requires-python` is `>=3.10` with classifiers through 3.15, so both are live for us now.

It says only that compiled output is not redirected, which is what the next sentence about reinstalling after `.pyi`/`.cpp` changes needs. Documenting where each kind of artifact lives is a larger job for a dedicated document.

Test Plan:

Documentation only. The replaced claim was checked against the scikit-build-core release we require (`requirements-build.txt` floors at `scikit-build-core>=1.0`):

```
python3 -m pip download "scikit-build-core>=1.0" --no-deps -d sbc1
python3 -c "
import zipfile, re
z = zipfile.ZipFile('sbc1/scikit_build_core-1.0.3-py3-none-any.whl')
r = z.read('scikit_build_core/resources/_editable_redirect.py').decode()
print([m.group(0) for m in re.finditer(r'.*MetaPathFinder.*', r)])
"
```

which shows `class ScikitBuildRedirectingFinder(importlib.abc.MetaPathFinder)` installed onto `sys.meta_path`, and no `.egg-link` anywhere in the tree.

```
grep -rn "egg-link\|egg_link\|setup.py develop" CONTRIBUTING.md docs/
lintrunner -a CONTRIBUTING.md
```

Authored with the assistance of Claude Code.