### PR TITLE
Strict pyrefly checking: type the torchfuzz files that suppressed all errors

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -345,3 +345,73 @@ bad-param-name-override = false
 unannotated-return = true
 unannotated-parameter = true
 unannotated-attribute = true
+
+[[sub-config]]
+matches = "tools/experimental/torchfuzz/codegen.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "tools/experimental/torchfuzz/cuda/_codegen.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "tools/experimental/torchfuzz/fuzzer.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "tools/experimental/torchfuzz/ops_fuzzer.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "tools/experimental/torchfuzz/tensor_descriptor.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "tools/experimental/torchfuzz/tensor_fuzzer.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true
+
+[[sub-config]]
+matches = "tools/experimental/torchfuzz/visualize_graph.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true

--- a/tools/experimental/torchfuzz/codegen.py
+++ b/tools/experimental/torchfuzz/codegen.py
@@ -1,13 +1,14 @@
-# mypy: ignore-errors
 import hashlib
 import importlib
 import os
 import random
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import cast, Protocol, TypeAlias
 
 import torch
 
+from torchfuzz.checks import Check
 from torchfuzz.operators import get_operator
 from torchfuzz.ops_fuzzer import OperationGraph
 from torchfuzz.tensor_descriptor import format_tensor_descriptor
@@ -15,6 +16,14 @@ from torchfuzz.tensor_fuzzer import ScalarSpec, Spec, TensorSpec
 
 
 _DEFAULT_DEVICE_MODULE = "torchfuzz.cuda"
+
+# Operations handed to the args/constants codegen hooks: (varname, spec) and
+# (varname, literal, spec) respectively. These are spelled as aliases because
+# list and dict are invariant, so FuzzTemplate and every override must use the
+# identical type or the override is rejected.
+ArgOperations: TypeAlias = list[tuple[str, Spec]]
+ConstantOperations: TypeAlias = list[tuple[str, str, Spec]]
+SpecDistribution: TypeAlias = dict[str, float | bool]
 
 
 @dataclass
@@ -46,11 +55,14 @@ class DeviceInfo:
 
 
 class FuzzTemplate:
-    def __init__(self, supported_ops, check):
+    supported_ops: list[str]
+    check: Check
+
+    def __init__(self, supported_ops: list[str], check: Check) -> None:
         self.supported_ops = supported_ops
         self.check = check
 
-    def supported_dtypes(self):
+    def supported_dtypes(self) -> list[torch.dtype]:
         """Return list of supported dtypes for this template."""
         return [
             torch.float32,
@@ -64,7 +76,7 @@ class FuzzTemplate:
             torch.bool,
         ]
 
-    def spec_distribution(self):
+    def spec_distribution(self) -> SpecDistribution:
         """
         Define the distribution for generating random Specs.
 
@@ -82,7 +94,7 @@ class FuzzTemplate:
             "allow_scalars": True,
         }
 
-    def fuzz_spec_custom(self):
+    def fuzz_spec_custom(self) -> Spec:
         """
         Generate a random Spec based on this template's distribution preferences.
 
@@ -117,7 +129,7 @@ class FuzzTemplate:
             else:
                 return self._generate_scalar_spec(dtype)
 
-    def _generate_tensor_spec(self, dtype):
+    def _generate_tensor_spec(self, dtype: torch.dtype) -> TensorSpec:
         """Generate a TensorSpec with the given dtype."""
         from torchfuzz.tensor_fuzzer import (
             fuzz_tensor_size,
@@ -129,25 +141,25 @@ class FuzzTemplate:
         stride = fuzz_valid_stride(size)
         return TensorSpec(size=size, stride=stride, dtype=dtype)
 
-    def _generate_scalar_spec(self, dtype):
+    def _generate_scalar_spec(self, dtype: torch.dtype) -> ScalarSpec:
         """Generate a ScalarSpec with the given dtype."""
         from torchfuzz.tensor_fuzzer import ScalarSpec
 
         return ScalarSpec(dtype=dtype)
 
-    def imports_codegen(self):
+    def imports_codegen(self) -> list[str]:
         """Return import lines emitted at the top of the generated file."""
         return []
 
-    def flags_codegen(self):
+    def flags_codegen(self) -> list[str]:
         """Return flag/setup lines emitted at the top of the generated file."""
         return []
 
-    def setseed_codegen(self, seed: int):
+    def setseed_codegen(self, seed: int) -> list[str]:
         """Return lines emitted to set the random seed."""
         return [f"torch.manual_seed({seed})", ""]
 
-    def epilogue_codegen(self):
+    def epilogue_codegen(self) -> list[str]:
         """Return lines emitted at the very end of the generated file."""
         return []
 
@@ -195,7 +207,11 @@ class FuzzTemplate:
         """
         return f"{output_name} = {tensor_creation_expr}"
 
-    def args_codegen(self, arg_operations, constant_operations=None):
+    def args_codegen(
+        self,
+        arg_operations: ArgOperations,
+        constant_operations: ConstantOperations | None = None,
+    ) -> list[str]:
         """Generate argument creation code for default template.
 
         ``constant_operations`` is only consulted by templates that opt in via
@@ -296,7 +312,17 @@ class FuzzTemplate:
 # ---------------------------------------------------------------------------
 
 
-_TEMPLATE_REGISTRY: dict[str, type[FuzzTemplate]] | None = None
+# Registered templates are FuzzTemplate subclasses whose __init__ takes no
+# arguments (they pass supported_ops/check to super()), so the registry values
+# are zero-argument factories rather than plain ``type[FuzzTemplate]``.
+class DevicePlugin(Protocol):
+    """The contract a ``TORCHFUZZ_DEVICE_MODULE`` plugin module must satisfy."""
+
+    def register_codegen(self) -> dict[str, Callable[[], FuzzTemplate]]: ...
+    def get_device_info(self) -> DeviceInfo: ...
+
+
+_TEMPLATE_REGISTRY: dict[str, Callable[[], FuzzTemplate]] | None = None
 _DEVICE_INFO: DeviceInfo | None = None
 
 
@@ -314,32 +340,44 @@ def initialize_codegen() -> None:
     if _TEMPLATE_REGISTRY is not None:
         return
     module_name = os.environ.get("TORCHFUZZ_DEVICE_MODULE", _DEFAULT_DEVICE_MODULE)
-    plugin = importlib.import_module(module_name)
+    # import_module returns a bare ModuleType, so every attribute on it is
+    # unchecked; assert the plugin contract instead.
+    plugin = cast("DevicePlugin", importlib.import_module(module_name))
     _TEMPLATE_REGISTRY = plugin.register_codegen()
     _DEVICE_INFO = plugin.get_device_info()
 
 
+def _template_registry() -> dict[str, Callable[[], FuzzTemplate]]:
+    """Return the registry, loading the device plugin on first use."""
+    initialize_codegen()
+    registry = _TEMPLATE_REGISTRY
+    if registry is None:
+        raise RuntimeError("device plugin did not populate the template registry")
+    return registry
+
+
 def get_template_names() -> list[str]:
     """Return the list of template names registered by the active plugin."""
-    initialize_codegen()
-    return list(_TEMPLATE_REGISTRY.keys())
+    return list(_template_registry().keys())
 
 
 def make_template(name: str) -> FuzzTemplate:
     """Instantiate the FuzzTemplate registered under ``name``."""
-    initialize_codegen()
-    if name not in _TEMPLATE_REGISTRY:
+    registry = _template_registry()
+    if name not in registry:
         raise KeyError(
-            f"Unknown template '{name}'; available templates: "
-            f"{sorted(_TEMPLATE_REGISTRY.keys())}"
+            f"Unknown template '{name}'; available templates: {sorted(registry.keys())}"
         )
-    return _TEMPLATE_REGISTRY[name]()
+    return registry[name]()
 
 
 def get_device_info() -> DeviceInfo:
     """Return the active plugin's :class:`DeviceInfo`."""
     initialize_codegen()
-    return _DEVICE_INFO
+    device_info = _DEVICE_INFO
+    if device_info is None:
+        raise RuntimeError("device plugin did not provide DeviceInfo")
+    return device_info
 
 
 def convert_graph_to_python_code(
@@ -450,7 +488,7 @@ def convert_graph_to_python_code(
     final_var_name, _ = node_variables[root_node_id]
 
     # Generate function signature based on discovered arg and constant operations
-    param_names = []
+    param_names: list[str] = []
     if arg_operations:
         param_names.extend([f"arg_{i}" for i in range(len(arg_operations))])
     if constant_as_global and constant_operations:
@@ -487,7 +525,7 @@ def convert_graph_to_python_code(
     code_lines.extend(arg_code_lines)
 
     # Generate the final execution with both normal and compiled versions
-    param_values = []
+    param_values: list[str] = []
     if arg_operations:
         param_values.extend([f"arg_{i}" for i in range(len(arg_operations))])
     if constant_as_global and constant_operations:
@@ -516,10 +554,10 @@ def convert_graph_to_python_code(
 
 def generate_simple_operation_code(
     output_var: str,
-    input_vars: list,
+    input_vars: list[str],
     op_name: str,
-    output_spec,
-) -> list:
+    output_spec: Spec,
+) -> list[str]:
     """
     Generate code lines for executing a single operation using class-based operators.
 

--- a/tools/experimental/torchfuzz/cuda/_codegen.py
+++ b/tools/experimental/torchfuzz/cuda/_codegen.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 """FuzzTemplate subclasses provided by the CUDA device plugin.
 
 These templates are returned by ``torchfuzz.cuda.register_codegen()`` and
@@ -13,13 +12,18 @@ import random
 
 import torch
 
-from torchfuzz.codegen import FuzzTemplate
+from torchfuzz.codegen import (
+    ArgOperations,
+    ConstantOperations,
+    FuzzTemplate,
+    SpecDistribution,
+)
 from torchfuzz.ops_fuzzer import OperationGraph
 from torchfuzz.tensor_fuzzer import ScalarSpec, TensorSpec
 
 
 class DefaultFuzzTemplate(FuzzTemplate):
-    def __init__(self):
+    def __init__(self) -> None:
         from torchfuzz.cuda._checks import EagerVsFullGraphDynamicCompileCheck
 
         super().__init__(
@@ -76,7 +80,7 @@ class DefaultFuzzTemplate(FuzzTemplate):
             check=EagerVsFullGraphDynamicCompileCheck(),
         )
 
-    def spec_distribution(self):
+    def spec_distribution(self) -> SpecDistribution:
         """Default template: tensor-only (no scalars)."""
         return {
             "tensor_prob": 1.0,
@@ -85,23 +89,23 @@ class DefaultFuzzTemplate(FuzzTemplate):
             "allow_scalars": False,
         }
 
-    def imports_codegen(self):
+    def imports_codegen(self) -> list[str]:
         return [
             "import torch",
         ]
 
-    def flags_codegen(self):
+    def flags_codegen(self) -> list[str]:
         return [
             "torch.set_default_device('cuda')",
             "torch._dynamo.config.capture_scalar_outputs = True",
         ]
 
-    def epilogue_codegen(self):
+    def epilogue_codegen(self) -> list[str]:
         return []
 
 
 class DTensorFuzzTemplate(FuzzTemplate):
-    def __init__(self):
+    def __init__(self) -> None:
         from torchfuzz.cuda._checks import EagerVsFullGraphDynamicCompileCheck
 
         super().__init__(
@@ -118,7 +122,7 @@ class DTensorFuzzTemplate(FuzzTemplate):
             check=EagerVsFullGraphDynamicCompileCheck(),
         )
 
-    def supported_dtypes(self):
+    def supported_dtypes(self) -> list[torch.dtype]:
         """Return list of DTensor-compatible dtypes (no complex types)."""
         return [
             torch.float32,
@@ -132,7 +136,7 @@ class DTensorFuzzTemplate(FuzzTemplate):
             torch.bool,
         ]
 
-    def spec_distribution(self):
+    def spec_distribution(self) -> SpecDistribution:
         """DTensor template: tensor-only (no scalars)."""
         return {
             "tensor_prob": 1.0,
@@ -141,7 +145,7 @@ class DTensorFuzzTemplate(FuzzTemplate):
             "allow_scalars": False,
         }
 
-    def imports_codegen(self):
+    def imports_codegen(self) -> list[str]:
         return [
             "import torch",
             "from torch.distributed.tensor.placement_types import Replicate, Shard",
@@ -149,14 +153,18 @@ class DTensorFuzzTemplate(FuzzTemplate):
             "from torch.distributed.tensor import DTensor",
         ]
 
-    def flags_codegen(self):
+    def flags_codegen(self) -> list[str]:
         return [
             "torch._dynamo.config.capture_scalar_outputs = True",
             "torch._dynamo.config.capture_dynamic_output_shape_ops = True",
             "torch._inductor.config.emulate_precision_casts = True",
         ]
 
-    def args_codegen(self, arg_operations, constant_operations=None):
+    def args_codegen(
+        self,
+        arg_operations: ArgOperations,
+        constant_operations: ConstantOperations | None = None,
+    ) -> list[str]:
         """Generate DTensor argument creation code with proper mesh setup."""
         code_lines = []
 
@@ -237,7 +245,7 @@ class DTensorFuzzTemplate(FuzzTemplate):
 
         return code_lines
 
-    def epilogue_codegen(self):
+    def epilogue_codegen(self) -> list[str]:
         return ["torch.distributed.destroy_process_group()"]
 
     def return_codegen(self, final_var_name: str) -> list[str]:
@@ -260,7 +268,7 @@ class DTensorFuzzTemplate(FuzzTemplate):
 
 
 class UnbackedFuzzTemplate(FuzzTemplate):
-    def __init__(self):
+    def __init__(self) -> None:
         from torchfuzz.cuda._checks import EagerVsFullGraphDynamicCompileCheck
 
         super().__init__(
@@ -308,7 +316,7 @@ class UnbackedFuzzTemplate(FuzzTemplate):
             check=EagerVsFullGraphDynamicCompileCheck(),
         )
 
-    def supported_dtypes(self):
+    def supported_dtypes(self) -> list[torch.dtype]:
         """Return list of dtypes good for data-dependent operations."""
         # Focus on dtypes that work well with data-dependent ops and arithmetic
         # Exclude bool since arithmetic operations don't work with boolean tensors
@@ -319,7 +327,7 @@ class UnbackedFuzzTemplate(FuzzTemplate):
             torch.int64,
         ]
 
-    def spec_distribution(self):
+    def spec_distribution(self) -> SpecDistribution:
         """Unbacked template: 50% tensors, 50% scalars."""
         return {
             "tensor_prob": 0.5,
@@ -328,19 +336,19 @@ class UnbackedFuzzTemplate(FuzzTemplate):
             "allow_scalars": True,
         }
 
-    def imports_codegen(self):
+    def imports_codegen(self) -> list[str]:
         return [
             "import torch",
         ]
 
-    def flags_codegen(self):
+    def flags_codegen(self) -> list[str]:
         return [
             "torch.set_default_device('cuda')",
             "torch._dynamo.config.capture_scalar_outputs = True",
             "torch._dynamo.config.capture_dynamic_output_shape_ops = True",
         ]
 
-    def epilogue_codegen(self):
+    def epilogue_codegen(self) -> list[str]:
         return []
 
 
@@ -352,7 +360,7 @@ class StreamFuzzTemplate(DefaultFuzzTemplate):
     synchronization between dependent operations on different streams.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         from torchfuzz.cuda._checks import (
             EagerVsFullGraphDynamicCompileWithBackwardCheck,
@@ -360,18 +368,22 @@ class StreamFuzzTemplate(DefaultFuzzTemplate):
 
         self.check = EagerVsFullGraphDynamicCompileWithBackwardCheck()
 
-    def imports_codegen(self):
+    def imports_codegen(self) -> list[str]:
         return [
             "import torch",
         ]
 
-    def flags_codegen(self):
+    def flags_codegen(self) -> list[str]:
         return [
             "torch.set_default_device('cuda')",
             "torch._dynamo.config.capture_scalar_outputs = True",
         ]
 
-    def args_codegen(self, arg_operations, constant_operations=None):
+    def args_codegen(
+        self,
+        arg_operations: ArgOperations,
+        constant_operations: ConstantOperations | None = None,
+    ) -> list[str]:
         """Generate args with requires_grad=True on float tensors.
 
         This ensures the backward pass traces through stream-wrapped operations,
@@ -408,8 +420,8 @@ class StreamFuzzTemplate(DefaultFuzzTemplate):
         topo_order = graph.get_topological_order()
 
         # Identify leaf vs non-leaf node ids
-        leaf_ids = set()
-        non_leaf_ids = []
+        leaf_ids: set[str] = set()
+        non_leaf_ids: list[str] = []
         for nid in topo_order:
             node = graph.nodes[nid]
             if (
@@ -528,7 +540,7 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
     using fixed (Replicate(), Replicate()) for all tensors.
     """
 
-    def fuzz_spec_custom(self):
+    def fuzz_spec_custom(self) -> TensorSpec:
         """Generate tensor specs with minimum 1 dimension for proper DTensor sharding."""
         from torchfuzz.tensor_fuzzer import fuzz_valid_stride
 
@@ -543,7 +555,7 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
 
         return TensorSpec(size=size, stride=stride, dtype=dtype)
 
-    def imports_codegen(self):
+    def imports_codegen(self) -> list[str]:
         """Add Partial to imports."""
         base_imports = super().imports_codegen()
         # Update the placement imports to include Partial
@@ -564,7 +576,7 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
         """Constants are materialized in args_codegen for this template."""
         return f"# {output_name} is created globally"
 
-    def _generate_random_placement(self, tensor_size):
+    def _generate_random_placement(self, tensor_size: tuple[int, ...]) -> str:
         """Generate random placement tuple (Replicate, Shard, or Partial)."""
         placements = []
         for _ in range(2):  # 2D mesh
@@ -578,7 +590,11 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
                 placements.append("Partial()" if placement_type == 2 else "Replicate()")
         return f"({', '.join(placements)})"
 
-    def args_codegen(self, arg_operations, constant_operations=None):
+    def args_codegen(
+        self,
+        arg_operations: ArgOperations,
+        constant_operations: ConstantOperations | None = None,
+    ) -> list[str]:
         """Generate args with randomized placements using dist_tensor API."""
 
         code_lines = []

--- a/tools/experimental/torchfuzz/fuzzer.py
+++ b/tools/experimental/torchfuzz/fuzzer.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 import logging
 import multiprocessing as mp
 import os
@@ -275,7 +274,7 @@ def fuzz_and_execute(
         sys.exit(1)
 
 
-def main():
+def main() -> None:
     import argparse
 
     # Initialize the device plugin once up front so argparse choices reflect the
@@ -285,14 +284,20 @@ def main():
     default_template = "default" if "default" in template_names else template_names[0]
 
     try:
+        # pyrefly: ignore[missing-import]  # sibling module, only importable when this dir is on sys.path
         from multi_process_fuzzer import run_multi_process_fuzzer, run_until_failure
     except ImportError:
         # If importing as a module fails, import from the same directory
         import os
+
+        # NB: latent bug - `import sys` here shadows the module-level `sys` with a
+        # local binding, so the `sys.exit(...)` calls below raise NameError when the
+        # `try` import succeeds. Left as-is; fixing it needs a test first.
         import sys
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         sys.path.insert(0, current_dir)
+        # pyrefly: ignore[missing-import]  # sibling module, resolved via the sys.path insert above
         from multi_process_fuzzer import run_multi_process_fuzzer, run_until_failure
 
     # Set up command-line argument parsing
@@ -387,6 +392,7 @@ def main():
             print(
                 "❌ Error: --generate-only cannot be used with --stop-at-first-failure"
             )
+            # pyrefly: ignore[unbound-name]  # latent bug: `sys` is local to main() via the except-branch import
             sys.exit(1)
         # Multi-seed mode requires a '?' so generated files don't collide.
         if args.start is not None or args.count is not None:

--- a/tools/experimental/torchfuzz/ops_fuzzer.py
+++ b/tools/experimental/torchfuzz/ops_fuzzer.py
@@ -1,11 +1,9 @@
-# mypy: ignore-errors
-
 import random
 from dataclasses import dataclass
 
 import torch
 
-from torchfuzz.operators import get_operator, list_operators
+from torchfuzz.operators import get_operator, list_operators, Operator
 from torchfuzz.tensor_fuzzer import (
     fuzz_tensor_size,
     fuzz_torch_tensor_type,
@@ -18,10 +16,10 @@ from torchfuzz.tensor_fuzzer import (
 
 
 # Cache operators at module level to avoid repeated calls to list_operators()
-_CACHED_OPERATORS = None
+_CACHED_OPERATORS: dict[str, Operator] | None = None
 
 
-def _get_cached_operators():
+def _get_cached_operators() -> dict[str, Operator]:
     """Get cached operators, initializing if necessary."""
     global _CACHED_OPERATORS
     if _CACHED_OPERATORS is None:
@@ -31,7 +29,7 @@ def _get_cached_operators():
 
 def _get_template_filtered_operators(
     template: str = "default", supported_ops: list[str] | None = None
-):
+) -> dict[str, Operator]:
     """Get operators filtered by template's supported_ops, with user override.
 
     If supported_ops is provided, it takes precedence and is used to filter the
@@ -55,7 +53,7 @@ def _get_template_filtered_operators(
         return all_operators
 
     # Filter operators based on allowed_ops
-    filtered_ops = {}
+    filtered_ops: dict[str, Operator] = {}
     allowed_ops_set = set(allowed_ops)
 
     for op_name, operator in all_operators.items():
@@ -134,7 +132,7 @@ class OperationGraph:
     root_node_id: str  # The output node - produces the final result of the graph
     target_spec: Spec
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate the graph structure after initialization."""
         if self.root_node_id not in self.nodes:
             raise ValueError(f"Root node {self.root_node_id} not found in nodes")
@@ -150,7 +148,7 @@ class OperationGraph:
         temp_visited = set()
         result = []
 
-        def visit(node_id: str):
+        def visit(node_id: str) -> None:
             if node_id in temp_visited:
                 raise ValueError(f"Cycle detected involving node {node_id}")
             if node_id in visited:
@@ -184,7 +182,7 @@ class OperationGraph:
         visited = set()
         dependencies = []
 
-        def collect_deps(current_id: str):
+        def collect_deps(current_id: str) -> None:
             if current_id in visited or current_id not in self.nodes:
                 return
             visited.add(current_id)
@@ -246,8 +244,8 @@ def fuzz_spec(template: str = "default") -> Spec:
 
 def fuzz_op(
     target_spec: Spec,
-    depth,
-    stack_size,
+    depth: int,
+    stack_size: int,
     template: str = "default",
     supported_ops: list[str] | None = None,
 ) -> tuple[str, list[Spec]]:
@@ -270,7 +268,7 @@ def fuzz_op(
 
     # Filter operators that can produce the target spec
     # IMPORTANT: iterate in a deterministic order to avoid dict-order nondeterminism
-    compatible_ops = []
+    compatible_ops: list[tuple[str, Operator]] = []
     for op_name in sorted(available_operators.keys()):
         operator = available_operators[op_name]
         if operator.can_produce(target_spec):
@@ -283,8 +281,8 @@ def fuzz_op(
         raise ValueError(f"No operators available that can produce {target_spec}")
 
     # Categorize operators into leaf and non-leaf
-    leaf_ops = []
-    non_leaf_ops = []
+    leaf_ops: list[tuple[str, Operator]] = []
+    non_leaf_ops: list[tuple[str, Operator]] = []
 
     for op_name, operator in compatible_ops:
         if op_name in ["constant", "arg"] or op_name.startswith("arg_"):
@@ -454,7 +452,7 @@ def fuzz_operation_graph(
         node_counter += 1
 
         # Generate input nodes
-        input_node_ids = []
+        input_node_ids: list[str] = []
         if input_specs:  # Non-leaf operations
             for input_spec in input_specs:
                 input_node_id = _generate_node(

--- a/tools/experimental/torchfuzz/tensor_descriptor.py
+++ b/tools/experimental/torchfuzz/tensor_descriptor.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 """Utility functions for generating tensor descriptors in code comments."""
 
 from torchfuzz.tensor_fuzzer import ScalarSpec, Spec, TensorSpec

--- a/tools/experimental/torchfuzz/tensor_fuzzer.py
+++ b/tools/experimental/torchfuzz/tensor_fuzzer.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 import random
 from typing import NamedTuple, TypeAlias
 
@@ -481,7 +480,9 @@ def fuzz_non_contiguous_dense_tensor(
     return tensor
 
 
-def fuzz_scalar(spec, seed: int | None = None) -> float | int | bool | complex:
+def fuzz_scalar(
+    spec: ScalarSpec, seed: int | None = None
+) -> float | int | bool | complex:
     """
     Create a Python scalar value from a ScalarSpec.
 

--- a/tools/experimental/torchfuzz/visualize_graph.py
+++ b/tools/experimental/torchfuzz/visualize_graph.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 """
 Visualization tools for operation stacks and graphs as DAGs.
 """
@@ -10,7 +8,7 @@ from torchfuzz.ops_fuzzer import OperationGraph
 from torchfuzz.tensor_fuzzer import TensorSpec
 
 
-def save_and_render_dot(dot_content: str, filename: str = "operation_stack"):
+def save_and_render_dot(dot_content: str, filename: str = "operation_stack") -> None:
     """
     Save DOT content to file and render as PNG/PDF.
 
@@ -137,7 +135,7 @@ def visualize_operation_graph(
     graph: OperationGraph,
     title: str = "Operation Graph",
     output_folder: str = ".",
-):
+) -> None:
     """
     Complete visualization pipeline for an operation graph.
 
@@ -156,7 +154,7 @@ def visualize_operation_graph(
     save_and_render_dot(dot_content, filename)
 
 
-def operation_graph_to_networkx(graph: OperationGraph):
+def operation_graph_to_networkx(graph: OperationGraph) -> None:
     """
     Convert operation graph to NetworkX graph for Python visualization.
     Requires: pip install networkx matplotlib


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195739

Removes `# mypy: ignore-errors` from the seven files under
tools/experimental/torchfuzz/ that carried it and enables strict pyrefly checking
for them, with no net-new pyrefly errors. pyrefly honors that header as a blanket
mute on the whole file, so these were entirely unchecked; removing it surfaced 86
errors, of which 63 were simply missing annotations.

The sub-configs are per-file rather than a `tools/experimental/torchfuzz/**` glob
on purpose. The package has 44 files and only these 7 were suppressed; a glob
would additionally impose strict checking on the other 37 (194 errors across 28
files, including two test modules), which is a separate piece of work. Converting
the rest of the package and then collapsing to a glob is a reasonable follow-up.

Suggested review order: codegen.py first, since it defines the FuzzTemplate base
class and the plugin registry that the other files build on; then cuda/_codegen.py,
whose five template subclasses override those hooks; then the remaining files,
which are mostly mechanical.

Two things in codegen.py are worth a closer look. The module-level
`_TEMPLATE_REGISTRY` and `_DEVICE_INFO` are lazily populated by
`initialize_codegen()`, so every consumer had to be taught that they are non-None
after that call; this is done with an explicit check that raises rather than an
assert. The registry is typed `dict[str, Callable[[], FuzzTemplate]]` rather than
`dict[str, type[FuzzTemplate]]` because the values are only ever called with no
arguments, while the base `FuzzTemplate.__init__` requires two; every registered
subclass defines a zero-argument `__init__`. One behavioral edge changes as a
result: `get_device_info()` used to return None while declaring `DeviceInfo`, so a
plugin that failed to supply one produced a confusing AttributeError later; it now
raises RuntimeError at the same point in the flow. No working path is affected.

fuzzer.py keeps three suppressions. Two cover the intentional sys.path fallback
import of the sibling `multi_process_fuzzer` module, which is unresolvable
statically. The third covers a latent bug that is deliberately left in place: the
`import sys` inside the `except ImportError` branch makes `sys` function-local for
all of `main()`, shadowing the module-level import, so on the common path where
the first import succeeds every `sys.exit()` in `main()` raises UnboundLocalError
instead of exiting. Fixing that needs a test, so it is only annotated with an NB
comment here.

Test Plan:

No net-new pyrefly errors (164 before and after, matching the baseline on this
merge base) and no remaining errors in the converted files:

```
pyrefly check
pyrefly check 2>&1 | grep tools/experimental/torchfuzz   # no output
```

Lint clean:

```
lintrunner -a pyrefly.toml tools/experimental/torchfuzz/*.py tools/experimental/torchfuzz/cuda/_codegen.py
```

The change is annotations plus the None-checks described above; no behavioral
change other than the `get_device_info()` edge. The torchfuzz entry points were
not executed because the local torch._C extension in this worktree is stale
(`import torch` fails with an unrelated missing symbol); `python -m py_compile`
passes on all seven files. Please run the fuzzer once after a rebuild.

Authored with Claude.