### PR TITLE
[inductor] Use amax/amin for max/min(dim) values when the sign of zero is unobservable

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -286,6 +286,48 @@ class KernelTests(torch._inductor.test_case.TestCase):
         self.assertIsNone(_re.search(r"\b__dunder_add_kernel_0\b", code))
         self.assertIsNotNone(_re.search(r"\b_dunder_add_kernel_0\b", code))
 
+    @requires_cuda_and_triton
+    def test_dim_max_min_value_uses_plain_reduction_when_sign_unobservable(self):
+        # The indexed reduction may be replaced by a plain amax/amin only when
+        # no use of the value can observe the sign of a zero.
+        cases = {
+            "softmax": (
+                lambda x, op: (x - op(x, -1, keepdim=True).values).exp().sum(-1),
+                True,
+            ),
+            "compare": (lambda x, op: (op(x, -1).values > 0).float(), True),
+            "int_cast": (lambda x, op: op(x, -1).values.to(torch.int32), True),
+            "returned": (lambda x, op: op(x, -1).values, False),
+            "reciprocal": (lambda x, op: 1.0 / op(x, -1).values, False),
+            "copysign": (
+                lambda x, op: torch.copysign(x, op(x, -1, keepdim=True).values),
+                False,
+            ),
+        }
+        for op, indexed_helper, value_helper in (
+            (torch.max, "max_with_index", "max2"),
+            (torch.min, "min_with_index", "min2"),
+        ):
+            for name, (fn, plain) in cases.items():
+                torch._dynamo.reset()
+                x = torch.randn(8, 4097, dtype=torch.bfloat16, device=GPU_TYPE)
+                with fresh_cache():
+                    actual, codes = run_and_get_code(
+                        torch.compile(lambda t: fn(t, op)), x
+                    )
+                self.assertEqual(actual, fn(x, op))
+                source = "\n".join(codes)
+                self.assertEqual(
+                    f"triton_helpers.{value_helper}" in source,
+                    plain,
+                    f"{op.__name__} {name}",
+                )
+                self.assertEqual(
+                    f"triton_helpers.{indexed_helper}" in source,
+                    not plain,
+                    f"{op.__name__} {name}",
+                )
+
     @inductor_config.patch(strict_signed_zero=True)
     @requires_cuda_and_triton
     def test_dim_max_min_reuse_argreduce_value(self):

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -68,6 +68,7 @@ from .micro_pipeline_tp import micro_pipeline_tp_pass
 from .pre_grad import is_same_dict, save_inductor_dict
 from .reduced_atomic_contention import partitioned_scatter_optimization_pass
 from .reinplace import reinplace_inplaceable_ops
+from .signed_zero import mark_arg_reductions_with_unobservable_signed_zero
 from .split_cat import POST_GRAD_PATTERNS
 
 
@@ -483,6 +484,9 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         decompose_map_to_while_loop
     )
 
+    GraphTransformObserver(gm, "mark_signed_zero_unobservable").apply_graph_pass(
+        mark_arg_reductions_with_unobservable_signed_zero
+    )
     gm.recompile()
     gm.graph.lint()
 

--- a/torch/_inductor/fx_passes/signed_zero.py
+++ b/torch/_inductor/fx_passes/signed_zero.py
@@ -1,0 +1,137 @@
+"""
+Prove that the sign of a zero produced by the value output of max.dim/min.dim
+can never be observed, so the value can come from a plain amax/amin instead of
+the indexed reduction that orders +0.0/-0.0 ties.
+
+Short forward walk from the value with a small allowlist: ops in _PROPAGATES
+change at most the sign of a zero in their result, ops in _KILLS give identical
+results for either zero, and anything else (graph outputs, mutations, unknown
+ops) is an observer. The walk gives up after _MAX_VISITED nodes.
+"""
+
+from __future__ import annotations
+
+import operator
+
+import torch
+from torch.utils._ordered_set import OrderedSet
+
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+SIGNED_ZERO_UNOBSERVABLE = "signed_zero_unobservable"
+_MAX_VISITED = 64
+
+_KILLS = OrderedSet(
+    [
+        aten.exp,
+        aten.exp2,
+        aten.abs,
+        aten.cos,
+        aten.cosh,
+        aten.log,
+        aten.log2,
+        aten.log10,
+        aten.sigmoid,
+        aten.eq,
+        aten.ne,
+        aten.lt,
+        aten.le,
+        aten.gt,
+        aten.ge,
+        aten.isnan,
+        aten.isinf,
+        aten.isfinite,
+    ]
+)
+
+_PROPAGATES = OrderedSet(
+    [
+        aten.add,
+        aten.sub,
+        aten.mul,
+        aten.neg,
+        aten.where,
+        aten.maximum,
+        aten.minimum,
+        aten.amax,
+        aten.amin,
+        aten.max,
+        aten.min,
+        aten.sum,
+        aten.view,
+        aten.reshape,
+        aten._unsafe_view,
+        aten.permute,
+        aten.expand,
+        aten.slice,
+        aten.select,
+        aten.squeeze,
+        aten.unsqueeze,
+        aten.clone,
+        aten.cat,
+        prims.prepare_softmax_online,
+    ]
+)
+
+_CASTS = OrderedSet([aten._to_copy, prims.convert_element_type])
+
+
+def _classify(user: torch.fx.Node, node: torch.fx.Node) -> str:
+    if user.op != "call_function":
+        return "observe"
+    if user.target is operator.getitem:
+        # prepare_softmax_online returns (max, sum(exp(x - max))): the sign of
+        # a zero survives in the max but not in the sum.
+        if node.target is prims.prepare_softmax_online.default and user.args[1] == 1:
+            return "kill"
+        return "propagate"
+    packet = getattr(user.target, "overloadpacket", None)
+    if packet in _KILLS:
+        return "kill"
+    if packet in _CASTS:
+        dtype = (
+            user.args[1]
+            if user.target is prims.convert_element_type.default
+            else user.kwargs.get("dtype")
+        )
+        if dtype is None:
+            return "propagate"
+        return "propagate" if dtype.is_floating_point else "kill"
+    if packet in _PROPAGATES:
+        return "propagate"
+    return "observe"
+
+
+def signed_zero_unobservable(value: torch.fx.Node) -> bool:
+    worklist = [value]
+    seen: OrderedSet[torch.fx.Node] = OrderedSet([value])
+    while worklist:
+        node = worklist.pop()
+        for user in node.users:
+            kind = _classify(user, node)
+            if kind == "observe":
+                return False
+            if kind == "propagate" and user not in seen:
+                if len(seen) >= _MAX_VISITED:
+                    return False
+                seen.add(user)
+                worklist.append(user)
+    return True
+
+
+def mark_arg_reductions_with_unobservable_signed_zero(graph: torch.fx.Graph) -> None:
+    for node in graph.nodes:
+        if node.op != "call_function" or node.target not in (
+            aten.max.dim,
+            aten.min.dim,
+        ):
+            continue
+        values = [
+            user
+            for user in node.users
+            if user.target is operator.getitem and user.args[1] == 0
+        ]
+        if all(signed_zero_unobservable(v) for v in values):
+            node.meta[SIGNED_ZERO_UNOBSERVABLE] = True

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8147,6 +8147,20 @@ def _current_node_uses_all_tuple_outputs(indices: tuple[int, ...]) -> bool:
     return all(index in used_indices for index in indices)
 
 
+def _value_only_signed_zero_unobservable() -> bool:
+    """True when only the value of the current max/min(dim) node is used and
+    fx_passes.signed_zero proved that the sign of that zero is unobservable."""
+    from .fx_passes.signed_zero import SIGNED_ZERO_UNOBSERVABLE
+
+    current_node = V.graph.current_node
+    return (
+        not config.strict_signed_zero
+        and current_node is not None
+        and bool(current_node.meta.get(SIGNED_ZERO_UNOBSERVABLE))
+        and not _current_node_uses_all_tuple_outputs((1,))
+    )
+
+
 @register_lowering(aten.any)
 def reduce_any(x, dim=None, keepdim=False):
     x = to_dtype(x, torch.bool)
@@ -8159,6 +8173,14 @@ def reduce_max(x, dim=None, keepdim=False):
         if is_triton(x) and x.get_dtype() != torch.bool:
             if _current_node_uses_all_tuple_outputs((0, 1)):
                 return reduce_argmax_with_value(x, axis=dim, keepdims=keepdim)
+            if _value_only_signed_zero_unobservable():
+                # Only the value is consumed and no use can observe the sign
+                # of a zero, so a plain amax is indistinguishable and avoids
+                # carrying the index accumulator.
+                return (
+                    reduce_amax(x, axis=dim, keepdims=keepdim),
+                    reduce_argmax(x, axis=dim, keepdims=keepdim),
+                )
             return (
                 reduce_argmax_value(x, axis=dim, keepdims=keepdim),
                 reduce_argmax(x, axis=dim, keepdims=keepdim),
@@ -8177,6 +8199,11 @@ def reduce_min(x, dim=None, keepdim=False):
         if is_triton(x) and x.get_dtype() != torch.bool:
             if _current_node_uses_all_tuple_outputs((0, 1)):
                 return reduce_argmin_with_value(x, axis=dim, keepdims=keepdim)
+            if _value_only_signed_zero_unobservable():
+                return (
+                    reduce_amin(x, axis=dim, keepdims=keepdim),
+                    reduce_argmin(x, axis=dim, keepdims=keepdim),
+                )
             return (
                 reduce_argmin_value(x, axis=dim, keepdims=keepdim),
                 reduce_argmin(x, axis=dim, keepdims=keepdim),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

`torch.max(x, dim).values` lowers on Triton through the `argmax_value`
reduction so it can share an accumulator with a paired `argmax` (#184149).
When the index output is dead there is nothing to share, but the kernel still
carries the int32 index accumulator, the `maximum_with_index` compare-and-select
combine, and an extra mask select per iteration. On bf16 rows this is the
dominant per-element cost: the GPT-OSS-20B softmax capture executes 27% fewer
instructions without it, and looped variants of the pattern turn from an
instruction-bound regression into a 1.1-1.5x win when their epilogue is fused.

A plain `amax` differs from the indexed value only in which zero wins a
`+0.0`/`-0.0` tie (eager `max.dim` returns the first tied element, `amax` does
not order ties). A small post-grad pass, `fx_passes/signed_zero.py`, walks
forward from the value with a short allowlist: ops that can change at most the
sign of a zero propagate, ops that give identical results for either zero
(`exp`, `abs`, `log`, comparisons, casts to integer types, the sum output of
`prepare_softmax_online`) end the walk, and anything else, including graph
outputs and unknown ops, is an observer. The walk gives up after 64 nodes.
`reduce_max`/`reduce_min` take the `amax`/`amin` path only for nodes the pass
marked, and never under `strict_signed_zero`.

Verified with a sweep over 15 row lengths, 8 tie layouts, fp32 and bf16: with
the value returned directly, compiled results match eager in all 232 cases;
the softmax patterns take the plain reduction and their outputs are bitwise
identical to eager even when the row maximum is a signed-zero tie.

Test Plan:

```bash
python test/inductor/test_triton_kernels.py -k dim_max_min
python test/inductor/test_torchinductor.py -k "argmax or argmin or max_min or softmax or signed_zero"
python test/inductor/test_torchinductor_dynamic_shapes.py -k "argmax or argmin or softmax"
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo