### PR TITLE
Port the CPU kernel's checks into the flash-attention meta kernel

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2631,6 +2631,33 @@ class TestMetaKernelRegistrations(TestCase):
             torch.fill(x_meta, value_meta)
 
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_sdpa_flash_cpu_meta_matches_kernel_checks(self):
+        # The meta kernel is a port of _scaled_dot_product_flash_attention_cpu
+        # in aten/src/ATen/native/transformers/attention.cpp; without its checks
+        # a compiled graph is built around a call the CPU kernel then rejects.
+        op = torch.ops.aten._scaled_dot_product_flash_attention_for_cpu
+        q = torch.randn(1, 2, 1, 8, device="meta")
+        k = torch.randn(1, 2, 2, 8, device="meta")
+        v = torch.randn(1, 2, 2, 8, device="meta")
+
+        # the valid case still goes through
+        out = op(q, k, v)[0]
+        self.assertEqual(out.shape, q.shape)
+
+        with self.assertRaisesRegex(RuntimeError, "Accept only 4 dims inputs"):
+            op(q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0))
+        with self.assertRaisesRegex(RuntimeError, "Expected data type"):
+            op(q.to(torch.int64), k.to(torch.int64), v.to(torch.int64))
+        with self.assertRaisesRegex(RuntimeError, "do not support dropout"):
+            op(q, k, v, 0.5)
+        with self.assertRaisesRegex(RuntimeError, "same head size"):
+            op(q, k, torch.randn(1, 2, 2, 4, device="meta"))
+        with self.assertRaisesRegex(RuntimeError, "Attention mask is the same"):
+            op(q, k, v, attn_mask=torch.zeros(1, 2, dtype=torch.int64, device="meta"))
+        with self.assertRaisesRegex(RuntimeError, "Attention mask dim"):
+            op(q, k, v, attn_mask=torch.zeros(1, 1, 2, device="meta"))
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
     def test_fill_out_of_place_tensor_scalar_ok(self):
         x_cpu = torch.randn(3, 4)
         value_cpu = torch.tensor(1.0)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6653,11 +6653,15 @@ def meta__scaled_dot_product_flash_attention_for_cpu(
         lambda: "scaled_dot_product_attention_flash_attention: Currently do not "
         "support dropout > 0",
     )
-    torch._check(
-        query.size(3) == value.size(3) and key.size(3) == value.size(3),
-        lambda: "scaled_dot_product_attention_flash_attention: Q/K/V should have "
-        "the same head size",
+    # Checked as two separate torch._check calls rather than one `and`: `and`
+    # forces bool() on the first SymBool, which is an unbacked guard, while
+    # torch._check takes the SymBool and defers it to a runtime assert.
+    head_size_msg = (
+        "scaled_dot_product_attention_flash_attention: Q/K/V should have "
+        "the same head size"
     )
+    torch._check(query.size(3) == value.size(3), lambda: head_size_msg)
+    torch._check(key.size(3) == value.size(3), lambda: head_size_msg)
     if attn_mask is not None:
         torch._check(
             attn_mask.dtype == torch.float or attn_mask.dtype == query.dtype,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6634,6 +6634,42 @@ def meta__scaled_dot_product_flash_attention_for_cpu(
     attn_mask: Tensor | None = None,
     scale: float | None = None,
 ):
+    # Ported from _scaled_dot_product_flash_attention_cpu in
+    # aten/src/ATen/native/transformers/attention.cpp. Without these the meta
+    # kernel accepts inputs the CPU kernel rejects, so a compiled graph is built
+    # around a call that cannot run.
+    torch._check(
+        torch.is_floating_point(query),
+        lambda: "scaled_dot_product_attention_flash_attention: Expected data type "
+        f"in FP32, FP64, BF16, FP16, but got {query.dtype} instead.",
+    )
+    torch._check(
+        query.dim() == 4 and key.dim() == 4 and value.dim() == 4,
+        lambda: "scaled_dot_product_attention_flash_attention: Accept only 4 dims "
+        "inputs shape of {B, H, T, K}",
+    )
+    torch._check(
+        dropout_p == 0.0,
+        lambda: "scaled_dot_product_attention_flash_attention: Currently do not "
+        "support dropout > 0",
+    )
+    torch._check(
+        query.size(3) == value.size(3) and key.size(3) == value.size(3),
+        lambda: "scaled_dot_product_attention_flash_attention: Q/K/V should have "
+        "the same head size",
+    )
+    if attn_mask is not None:
+        torch._check(
+            attn_mask.dtype == torch.float or attn_mask.dtype == query.dtype,
+            lambda: "scaled_dot_product_attention_flash_attention: Attention mask "
+            "is the same data type as query",
+        )
+        torch._check(
+            attn_mask.dim() == 2 or attn_mask.dim() == 4,
+            lambda: "scaled_dot_product_attention_flash_attention: Attention mask "
+            "dim in {2, 4}",
+        )
+
     batch_size = query.size(0)
     num_heads = query.size(1)
     max_seqlen_batch_q = query.size(2)


### PR DESCRIPTION
Fixes #195743.

`meta__scaled_dot_product_flash_attention_for_cpu` did no validation: it read `query.size(0..2)` and returned `torch.empty_like(query)`. The kernel it stands in for, `_scaled_dot_product_flash_attention_cpu` (`aten/src/ATen/native/transformers/attention.cpp:1000-1014`), rejects six things the meta accepted, so tracing built a graph around a call that could not then run.

Measured against the real kernel on CPU:

| case | eager | meta (before) |
|---|---|---|
| valid 4-D | ok | ok |
| 5-D operands | `RuntimeError` | returns |
| 3-D operands | `RuntimeError` | returns |
| `int64` dtype | `RuntimeError` | returns |
| `dropout_p=0.5` | `RuntimeError` | returns |
| mismatched head size | `RuntimeError` | returns |
| `attn_mask` dtype `int64` | `RuntimeError` | returns |
| `attn_mask.dim() == 3` | `RuntimeError` | returns |

The C++ uses plain `TORCH_CHECK` for all six, so `torch._check` is the matching helper and the messages are copied verbatim.

### Test

```
python -m pytest test/test_meta.py -k sdpa_flash_cpu_meta -q
```

`1 passed`; with the meta reverted, `AssertionError: RuntimeError not raised`.

No regressions:

```
test/test_meta.py                   -k "sdpa or attention or scaled_dot"     34 passed,  50 skipped
test/test_transformers.py           -k "scaled_dot_product and cpu"        3167 passed
test/inductor/test_fused_attention.py                                        57 passed,  1 skipped
```

The last one is the one that mattered — a meta that starts rejecting could have broken the SDPA fusion, and it does not.

Also checked by hand, since none of the suites above covers them:

```
is_causal=True                       eager and meta agree
torch.compile, static and dynamic    unaffected (mark_dynamic on the batch dim)
autograd                             gradients still flow through SDPA
```

### Not a fix for #195589

That failure never reaches this kernel — I confirmed it by counting calls into the meta while compiling the reproducer, and the count is zero. #195706 fixes that one, in the fusion pass. This PR is an independent divergence found while investigating it.

Developed with AI assistance (Claude); I measured each divergence above.
