### PR TITLE
[ROCm] Add {float, int32, int32} to rt_binary_specializations

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -888,7 +888,19 @@ constexpr std::array rt_binary_specializations = {
     std::array<c10::ScalarType, 3>(
         {c10::CppTypeToScalarType<Half>::value,
          c10::CppTypeToScalarType<Half>::value,
-         c10::CppTypeToScalarType<float>::value})};
+         c10::CppTypeToScalarType<float>::value}),
+    // Integer true division promotes to float, so int32/int32 needs a cast and
+    // lands on the manual-unroll path with a runtime ScalarType switch per
+    // element. That switch, not the narrow loads, is what costs: isolating it
+    // gives 1.536x on gfx950 and 1.631x on gfx1250, while widening the loads on
+    // top adds 0.994x (unresolved) and 1.048x respectively. int32 is listed
+    // alone among the integer widths because can_vectorize_up_to keys off the
+    // functor's argument type (float), which agrees with int32 byte for byte
+    // but is merely the stricter check for narrower inputs.
+    std::array<c10::ScalarType, 3>(
+        {c10::CppTypeToScalarType<float>::value,
+         c10::CppTypeToScalarType<int32_t>::value,
+         c10::CppTypeToScalarType<int32_t>::value})};
 
 bool check_binary_rt_types_for_specialization(TensorIteratorBase& iter) {
   if (iter.ninputs() != 2)

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -889,14 +889,11 @@ constexpr std::array rt_binary_specializations = {
         {c10::CppTypeToScalarType<Half>::value,
          c10::CppTypeToScalarType<Half>::value,
          c10::CppTypeToScalarType<float>::value}),
-    // Integer true division promotes to float, so int32/int32 needs a cast and
-    // lands on the manual-unroll path with a runtime ScalarType switch per
-    // element. That switch, not the narrow loads, is what costs: isolating it
-    // gives 1.536x on gfx950 and 1.631x on gfx1250, while widening the loads on
-    // top adds 0.994x (unresolved) and 1.048x respectively. int32 is listed
-    // alone among the integer widths because can_vectorize_up_to keys off the
-    // functor's argument type (float), which agrees with int32 byte for byte
-    // but is merely the stricter check for narrower inputs.
+    // Integer true division promotes to the default dtype (float32 unless
+    // changed), so int32/int32 otherwise lands on the manual-unroll path with a
+    // runtime ScalarType switch per element. int32 is listed alone among the
+    // integer widths because can_vectorize_up_to keys off the functor's
+    // argument type (float), which matches int32 byte for byte.
     std::array<c10::ScalarType, 3>(
         {c10::CppTypeToScalarType<float>::value,
          c10::CppTypeToScalarType<int32_t>::value,


### PR DESCRIPTION
## Summary

Integer true division promotes to the default dtype, so `int32 / int32` produces a
`TensorIterator` whose common dtype differs from its operand dtypes. `needs_dynamic_casting` is
true, and on ROCm the launch routes to `elementwise_kernel_manual_unroll<128, 4>`, which performs
a runtime `ScalarType` switch on every element loaded and stored, instead of the statically typed
path already available for in-table dtype triples.

`div` misses that path for one reason: its dtype triple is absent from a six-entry table. The
other gates already pass — the functor is `BinaryFunctor<float, float, float, DivFunctor<float>>`,
exactly the `(float, float) -> float` shape the `if constexpr` at `CUDALoops.cuh:1049-1058`
requires. The change is therefore one table row.

This is ROCm-only: `rt_binary_specializations` (`CUDALoops.cuh:867`) sits inside the
`#ifdef USE_ROCM` opened at `:796` and closed at `:1013`, and both consumers (`:1040`, `:1131`)
are inside it too. On a CUDA build the row is not preprocessed.

## Measurements

Standalone HIP port, mirrored-pair A/B. Isolating the removal of the runtime switch at identical
launch geometry, unroll, and byte traffic:

| | gfx950 (MI350X) | gfx1250 |
|---|---|---|
| remove runtime dtype switch | 1.536x (16/16) | 1.631x (16/16) |
| additionally widen the loads | 0.994x (7/16, inside noise) | 1.048x |

The cost is dtype dispatch, not vector width, on both parts.

Caveat on provenance: the standalone port runs about 21% faster than the kernel it models, and
the only in-ATen A/B available pairs `{float32, int16, float32}` against an out-of-table triple —
not `{float32, int32, int32}` — and only on gfx1250. So the headline ratio is not yet established
for the triple this PR actually adds.

## Known open items

These are the reasons this is still a draft.

1. **Not built.** Everything below the build step in the test plan is unrun.

2. **Small-tensor occupancy.** `vectorized_templated_config::block_work_size()` is
   `512 * 32 = 16384`. Below that, `vectorized_templated_elementwise_kernel:447-454` falls back to
   `unroll_base` with `LoadWithCast` — the same per-element dispatch this PR removes — while the
   launch geometry has already changed from `grid = ceil(N/512)` of 128 threads to
   `grid = ceil(N/16384)` of 512 threads. At `N = 16383` that is 32 workgroups becoming 1,
   confined to a single CU, at unchanged per-element cost. The alignment guard at `:1044` does not
   prevent this, since allocator pointers are always 16-byte aligned. The smallest size measured
   here is 524288; nothing between 1 and 524288 has been measured on either part. If the
   regression reproduces, the specialization should be gated on
   `numel >= vectorized_templated_config::block_work_size()`.

3. **No test can reach the changed path.** `div_no_rounding_mode` has `ref=None`, so it is
   filtered out of every `test_reference_numerics*` test by `test_binary_ufuncs.py:420-422`, and
   `test_compare_cpu` resolves div to `float32`, never int32. The largest int32 div checked
   against an independent reference is 4096 elements — below the 16384 threshold. The two tests
   that do exceed it are self-consistency checks, and this PR changes both of their arms.
   `grep -rn "rt_binary_specializations\|vectorized_templated" test/` returns nothing.

4. **The table's safety invariants are prose, not code.** `can_vectorize_up_to<func_t>(data)`
   computes alignment from the functor's `float` args for all three pointers, while the loads use
   the row's C++ types. The new row is safe only because `sizeof(int32_t) == sizeof(float)`; a
   future row wider than `float` would under-estimate alignment. A `static_assert` on row width
   would make that a compile error rather than a silent bug.

5. **Arch coverage.** The ROCm build ships `gfx90a;gfx942;gfx950;gfx1100`
   (`.ci/docker/build.sh:211`). gfx1250 is not in any shipping wheel
   (`.ci/docker/manywheel/build.sh:81`). gfx90a, gfx942 and gfx1100 are affected and unmeasured.

6. **Instantiation cost.** `static_unroll<..., rt_binary_specializations.size()>` at `:1068` and
   `:1147` instantiates a launcher per row per eligible functor: 24 -> 28 device kernels per
   eligible functor, +16.7%, across roughly 73 `gpu_kernel_with_scalars` call sites. The
   `libtorch_hip.so` size and build-time deltas are unmeasured.

## Test plan

- [ ] Build for ROCm.
- [ ] Confirm the dispatched kernel changes for `int32 / int32` (rocprof kernel trace).
- [ ] Confirm `div_float` and `div_` do not change kernel.
- [ ] `python test/test_binary_ufuncs.py -k div` on gfx950 and gfx942.
- [ ] `numel` sweep 1K-1M for int32 `torch.div`, before and after, to settle open item 2.
- [ ] Report `libtorch_hip.so` size and build-time delta.
- [ ] Add a reference test that reaches a >= 16384-element contiguous int32 div, including an
      offset-sliced operand for the `vec_size == 1` path.

cc @jeffdaily @jithunnair-amd @hongxiayang @naromero77amd @pruthvistony @jataylo @pragupta

> This PR was prepared with the assistance of an AI coding assistant. I have read and understand
> the change and take responsibility for it.
