### PR TITLE
[BE][Ez]: Use STL midpoint for better int overflow safety and intent

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -150,7 +150,7 @@ void quick_select_template(
     }
 
     // Use median of three for pivot choice
-    auto P = L + (R - L) / 2;
+    auto P = std::midpoint(L, R);
     swap_fn(P, L + 1);
     if (gt_or_nan(arr[L + 1], arr[R])) {
       swap_fn(L + 1, R);
@@ -204,7 +204,7 @@ void quantile_select_recurse(
   if (ulo >= uhi) {
     return;
   }
-  const int64_t umid = ulo + (uhi - ulo) / 2;
+  const int64_t umid = std::midpoint(ulo, uhi);
   const int64_t r = ranks[umid];
   std::nth_element(
       idx + lo, idx + r, idx + hi, [data](int64_t a, int64_t b) {

--- a/aten/src/ATen/native/cpu/MultinomialKernel.cpp
+++ b/aten/src/ATen/native/cpu/MultinomialKernel.cpp
@@ -15,6 +15,8 @@
 #include <ATen/ops/empty.h>
 #endif
 
+#include <numeric>
+
 namespace at::native {
 namespace {
 
@@ -96,7 +98,7 @@ multinomial_with_replacement_apply(
       cum_dist_ptr[(n_categories - 1) * cum_dist_stride_0] = 1;
 
       while (right_pointer - left_pointer > 0) {
-        int64_t mid_pointer = left_pointer + (right_pointer - left_pointer) / 2;
+        int64_t mid_pointer = std::midpoint(left_pointer, right_pointer);
         scalar_t cum_prob = cum_dist_ptr[mid_pointer * cum_dist_stride_0];
         if (cum_prob < uniform_sample) {
           left_pointer = mid_pointer + 1;
@@ -192,7 +194,7 @@ multinomial_with_replacement_apply(
       cum_dist_ptr[(n_categories - 1) * cum_dist_stride_0] = 1;
 
       while (right_pointer - left_pointer > 0) {
-        int64_t mid_pointer = left_pointer + (right_pointer - left_pointer) / 2;
+        int64_t mid_pointer = std::midpoint(left_pointer, right_pointer);
         float cum_prob = cum_dist_ptr[mid_pointer * cum_dist_stride_0];
         if (cum_prob < uniform_sample) {
           left_pointer = mid_pointer + 1;

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -19,6 +19,8 @@
 #include <ATen/native/CPUBlas.h>
 #include <ATen/native/SparseTensorUtils.h>
 
+#include <numeric>
+
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -1865,7 +1867,7 @@ Tensor _sparse_sum_backward_cpu(const Tensor& grad_, const SparseTensor& input_,
           int64_t input_idx = input_indices_1D_accessor[i];
           int64_t l = 0, r = grad_nnz - 1;
           while (l <= r) {
-            int64_t m = l + (r - l) / 2;
+            int64_t m = std::midpoint(l, r);
             if (grad_indices_1D_accessor[m] == input_idx) {
               // grad_input_values[i].copy_(grad_values_expand[m])
               copy_iter_local.unsafe_replace_operand(0, gIv_data + i * gIv_stride);
@@ -1922,7 +1924,7 @@ static scalar_t binary_search_strided_rightmost(scalar_t search_val, TensorAcces
   bool done_searching = false;
 
   while (!done_searching) {
-    mid_ind = left_ind + (right_ind - left_ind) / 2;
+    mid_ind = std::midpoint(left_ind, right_ind);
     scalar_t mid_val = sorted_arr_accessor[sorted_arr_begin_idx + mid_ind];
 
     if (mid_val > search_val) {

--- a/c10/util/ApproximateClock.cpp
+++ b/c10/util/ApproximateClock.cpp
@@ -2,6 +2,8 @@
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 
+#include <numeric>
+
 namespace c10 {
 
 ApproximateClockToUnixTimeConverter::ApproximateClockToUnixTimeConverter()
@@ -18,8 +20,7 @@ ApproximateClockToUnixTimeConverter::measurePair() {
   auto t = std::chrono::duration_cast<std::chrono::nanoseconds>(
       wall.time_since_epoch());
 
-  // `x + (y - x) / 2` is a more numerically stable average than `(x + y) / 2`.
-  return {t.count(), fast_0 + (fast_1 - fast_0) / 2};
+  return {t.count(), std::midpoint(fast_0, fast_1)};
 }
 
 ApproximateClockToUnixTimeConverter::time_pairs

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -10,6 +10,7 @@
 #include <torch/csrc/jit/runtime/register_ops_utils.h>
 #include <torch/csrc/jit/runtime/slice_indices_adjust.h>
 #include <limits>
+#include <numeric>
 
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
@@ -140,7 +141,7 @@ int64_t partProduct(int n, int m) {
     return (int64_t)n;
   if (m == (n + 2))
     return (int64_t)n * m;
-  auto k = n + (m - n) / 2; // Overflow-safe midpoint
+  auto k = std::midpoint(n, m);
   if ((k & 1) != 1)
     k = k - 1;
   return partProduct(n, k) * partProduct(k + 2, m);

--- a/torch/csrc/profiler/unwind/eh_frame_hdr.h
+++ b/torch/csrc/profiler/unwind/eh_frame_hdr.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <numeric>
 #include <ostream>
 
 #include <torch/csrc/profiler/unwind/lexer.h>
@@ -68,7 +69,7 @@ struct EHFrameHdr {
     uint64_t low = 0;
     uint64_t high = nentries();
     while (low + 1 < high) {
-      auto mid = (low + high) / 2;
+      auto mid = std::midpoint(low, high);
       if (addr < lowpc(mid)) {
         high = mid;
       } else {

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -46,6 +46,7 @@ Stats stats() {
 #include <climits>
 #include <cstring>
 #include <limits>
+#include <numeric>
 #include <vector>
 
 #include <c10/util/irange.h>
@@ -279,7 +280,7 @@ struct UnwindCache {
     uint64_t low = 0;
     uint64_t high = all_libraries_.size();
     while (low + 1 < high) {
-      auto mid = (low + high) / 2;
+      auto mid = std::midpoint(low, high);
       if (addr < all_libraries_.at(mid).first_addr()) {
         high = mid;
       } else {


### PR DESCRIPTION
* std::midpoint is a new CPP20 STL utility that more clearly expresses midpoint selection which is overflow and underflow safe. 
* Fixes a few midpoint calculations our codebase too that could overflow otherwise. Only applied to the safest parts of the code (CPU hostcode applied to integers only). Bitwise identical output for integers in defined ranges.
* Also mostly applied to CPP20 TranslationUnits (not headers) so executorch should be safe for now
* Will follow up in another PR to see if this useful in CUDA kernels with int32 indices or to use it on FP (which are safer)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01