### PR TITLE
Adjust tolerance in test_forward_nn_LinearCrossEntropyLoss for xpu

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4743,6 +4743,8 @@ module_db: list[ModuleInfo] = [
                                 "test_save_load", device_type="xpu", dtypes=[torch.float16]),
                    DecorateInfo(toleranceOverride({torch.float16: tol(atol=2e-3, rtol=2e-3)}), "TestModule",
                                 "test_forward", dtypes=[torch.float16]),
+                   DecorateInfo(toleranceOverride({torch.float16: tol(atol=2e-3, rtol=5e-3)}), "TestModule",
+                                "test_forward", device_type="xpu", dtypes=[torch.float16]),
                    DecorateInfo(toleranceOverride({torch.bfloat16: tol(atol=5e-2, rtol=5e-2)}), "TestModule",
                                 "test_forward", dtypes=[torch.bfloat16]),
                    DecorateInfo(toleranceOverride({torch.bfloat16: tol(atol=2e-1, rtol=5e-2)}), "TestModule",

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4743,7 +4743,7 @@ module_db: list[ModuleInfo] = [
                                 "test_save_load", device_type="xpu", dtypes=[torch.float16]),
                    DecorateInfo(toleranceOverride({torch.float16: tol(atol=2e-3, rtol=2e-3)}), "TestModule",
                                 "test_forward", dtypes=[torch.float16]),
-                   DecorateInfo(toleranceOverride({torch.float16: tol(atol=2e-3, rtol=5e-3)}), "TestModule",
+                   DecorateInfo(toleranceOverride({torch.float16: tol(atol=2e-3, rtol=4e-3)}), "TestModule",
                                 "test_forward", device_type="xpu", dtypes=[torch.float16]),
                    DecorateInfo(toleranceOverride({torch.bfloat16: tol(atol=5e-2, rtol=5e-2)}), "TestModule",
                                 "test_forward", dtypes=[torch.bfloat16]),


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/5045

Bump the tolerance for test_forward_nn_LinearCrossEntropyLoss as "nll_loss2d_forward_xpu is nondeterministic(bf16 atomicAdd across batch blocks);" and on iGPUs this tends to show more often leading to https://github.com/intel/torch-xpu-ops/issues/5045.