### PR TITLE
[BE][Ez]: Use transparent functors to remove cast and UB

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -12,6 +12,7 @@
 #include <c10/macros/Export.h>
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/intrusive_ptr.h>
+#include <functional>
 #include <limits>
 #include <type_traits>
 #include <unordered_map>
@@ -1126,9 +1127,10 @@ struct TORCH_API IValue final {
         // Opaque tensors such as the ones constructed by the MKL-DNN backend
         // don't have storage so we just use their TensorImpls.
         // TODO: Find way to expose alias info for opaque tensors.
-        return reinterpret_cast<size_t>(ten.unsafeGetTensorImpl());
+        return std::hash<const void*>()(ten.unsafeGetTensorImpl());
       } else {
-        return reinterpret_cast<size_t>(ten.storage().unsafeGetStorageImpl());
+        return std::hash<const void*>()(
+            ten.storage().unsafeGetStorageImpl());
       }
     }
     size_t operator()(const IValue& val) const {

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -9,6 +9,7 @@
 #include <c10/util/flat_hash_map.h>
 #include <mach/vm_page_size.h>
 #include <cstdio>
+#include <functional>
 #include <mutex>
 #include <set>
 #include <unordered_set>
@@ -102,7 +103,7 @@ struct BufferComparison {
       return a->size < b->size;
     }
     if (a->heap != b->heap) {
-      return reinterpret_cast<uintptr_t>(a->heap) < reinterpret_cast<uintptr_t>(b->heap);
+      return std::less<>{}(a->heap, b->heap);
     }
     return a->offset < b->offset;
   }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -41,6 +41,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <new>
@@ -1205,7 +1206,7 @@ bool BlockComparatorSizeCounterAddress::operator()(
     const Block* a,
     const Block* b) const {
   if (a->stream != b->stream) {
-    return (uintptr_t)a->stream < (uintptr_t)b->stream;
+    return std::less<>{}(a->stream, b->stream);
   }
   if (a->size != b->size) {
     return a->size < b->size;
@@ -1213,14 +1214,14 @@ bool BlockComparatorSizeCounterAddress::operator()(
   if (a->registration_counter != b->registration_counter) {
     return a->registration_counter < b->registration_counter;
   }
-  return (uintptr_t)a->ptr < (uintptr_t)b->ptr;
+  return std::less<>{}(a->ptr, b->ptr);
 }
 
 bool BlockComparatorAddress::operator()(const Block* a, const Block* b) const {
   if (a->stream != b->stream) {
-    return (uintptr_t)a->stream < (uintptr_t)b->stream;
+    return std::less<>{}(a->stream, b->stream);
   }
-  return (uintptr_t)a->ptr < (uintptr_t)b->ptr;
+  return std::less<>{}(a->ptr, b->ptr);
 }
 
 // Info about OOM rejection, used to defer observer callbacks outside of lock

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -3,6 +3,7 @@
 #include <c10/xpu/XPUCachingAllocator.h>
 
 #include <deque>
+#include <functional>
 #include <mutex>
 #include <set>
 #include <vector>
@@ -105,23 +106,19 @@ struct Block {
 
 bool BlockComparatorSize::operator()(const Block* a, const Block* b) const {
   if (a->queue != b->queue) {
-    return reinterpret_cast<uintptr_t>(a->queue) <
-        reinterpret_cast<uintptr_t>(b->queue);
+    return std::less<>{}(a->queue, b->queue);
   }
   if (a->size != b->size) {
     return a->size < b->size;
   }
-  return reinterpret_cast<uintptr_t>(a->ptr) <
-      reinterpret_cast<uintptr_t>(b->ptr);
+  return std::less<>{}(a->ptr, b->ptr);
 }
 
 bool BlockComparatorAddress::operator()(const Block* a, const Block* b) const {
   if (a->queue != b->queue) {
-    return reinterpret_cast<uintptr_t>(a->queue) <
-        reinterpret_cast<uintptr_t>(b->queue);
+    return std::less<>{}(a->queue, b->queue);
   }
-  return reinterpret_cast<uintptr_t>(a->ptr) <
-      reinterpret_cast<uintptr_t>(b->ptr);
+  return std::less<>{}(a->ptr, b->ptr);
 }
 
 // Represents a contiguous virtual memory segment mapped for allocation.

--- a/torch/csrc/jit/frontend/source_range.cpp
+++ b/torch/csrc/jit/frontend/source_range.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/source_range.h>
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
+#include <functional>
 #include <iostream>
 #include <regex>
 
@@ -185,7 +186,7 @@ StringCordView::IteratorImpl& StringCordView::IteratorImpl::operator+=(
 
 size_t SourceRangeHasher::operator()(const torch::jit::SourceRange& key) const {
   return (
-      std::hash<uintptr_t>()(reinterpret_cast<uintptr_t>(key.source().get())) ^
+      std::hash<const void*>()(key.source().get()) ^
       std::hash<size_t>()(key.start()) ^ std::hash<size_t>()(key.end()));
 }
 

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -218,7 +218,7 @@ class MemoryPlanner {
     if (storages_.empty()) {
       return false;
     }
-    const std::less<> less;
+    constexpr std::less<> less;
     const auto* start = &storages_[0];
     const auto* end = start + storages_.size();
     return !less(impl, start) && less(impl, end);

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -2,6 +2,8 @@
 
 #include <torch/csrc/jit/runtime/static/impl.h>
 
+#include <functional>
+
 namespace torch::jit {
 
 // A StorageGroup represents a collection of tensors that share backing storage.
@@ -216,14 +218,10 @@ class MemoryPlanner {
     if (storages_.empty()) {
       return false;
     }
-    // Comparing pointers that aren't within the same array is
-    // UB. We're doing fancy memory allocation stuff, so we cast to an
-    // integer type and carry on.
-    const auto impl_p = reinterpret_cast<uintptr_t>(impl);
-    const auto start = reinterpret_cast<uintptr_t>(&storages_[0]);
-    const auto end =
-        reinterpret_cast<uintptr_t>(&storages_[0] + storages_.size());
-    return impl_p >= start && impl_p < end;
+    const std::less<> less;
+    const auto* start = &storages_[0];
+    const auto* end = start + storages_.size();
+    return !less(impl, start) && less(impl, end);
   }
 
   bool overlapWithInternalBuffer(void* data_ptr) {


### PR DESCRIPTION
We can use CPP20 transparent functors to remove some UB and clean up the code a bit. Also improves pointer provenance preservation