### PR TITLE
[distributed] Validate the parent backend before split_group

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1241,6 +1241,35 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_comm_split_initialized_parent_with_lazy_default(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        default_pg = self._create_process_group_nccl(store, self.opts())
+        default_backend = default_pg._get_backend(device)
+        self.assertFalse(default_backend._is_initialized())
+
+        ranks = list(range(self.world_size))
+        parent = c10d.new_group(ranks)
+        parent_backend = parent._get_backend(device)
+        self.assertFalse(parent_backend._is_initialized())
+        with self.assertRaisesRegex(RuntimeError, "Parent process group backend"):
+            c10d.split_group(parent, [ranks])
+
+        tensor = torch.full((1,), self.rank, device=device)
+        dist.all_reduce(tensor, group=parent)
+        self.assertTrue(parent_backend._is_initialized())
+        self.assertFalse(default_backend._is_initialized())
+
+        child = c10d.split_group(parent, [ranks])
+        self.assertIsInstance(child, c10d.ProcessGroup)
+        self.assertIsNone(child.bound_device_id)
+        dist.broadcast(tensor, 0, group=child)
+        self.assertEqual(tensor, torch.full_like(tensor, sum(ranks)))
+
+        c10d.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_comm_split_world_pg_created_after_another_nccl_pg(self):
         # Regression test: ProcessGroupNCCL::groupRanks() used to derive the
         # identity rank mapping only when local_id_ == 0. local_id_ is a

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -158,6 +158,13 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     return false;
   }
 
+  // Most backends initialize their communication resources eagerly. Backends
+  // with lazy initialization must override this method so split() callers can
+  // verify that the parent communicator exists.
+  virtual bool isInitialized() {
+    return true;
+  }
+
   virtual bool supportsCoalescing() const {
     return false;
   }

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -225,6 +225,19 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
             deviceTypeFilter.contains(defaultBackendIt->first),
         "splitGroup deviceTypes filter must include the parent process group's default backend device type.");
   }
+  std::unordered_set<BackendType> validatedBackendTypes;
+  for (const auto& [deviceType, backendType] : deviceTypeToBackendType_) {
+    if (!deviceTypeFilter.empty() && !deviceTypeFilter.contains(deviceType)) {
+      continue;
+    }
+    if (!validatedBackendTypes.insert(backendType).second) {
+      continue;
+    }
+    TORCH_CHECK(
+        getBackend(deviceType)->isInitialized(),
+        "Parent process group backend is not initialized; pass device_id "
+        "when creating it or run a collective before split_group");
+  }
   c10::intrusive_ptr<ProcessGroup> newGroup;
   std::string groupName = name.has_value()
       ? name.value()

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1010,7 +1010,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   void performNocolorSplit(at::Device device);
 
   // If all comms on this PG are fully initialized, return true.
-  bool isInitialized();
+  bool isInitialized() override;
 
   ErrorType getError() override;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -590,6 +590,10 @@ bool ProcessGroupWrapper::supportsSplitting() const {
   return backend_->supportsSplitting();
 }
 
+bool ProcessGroupWrapper::isInitialized() {
+  return backend_->isInitialized();
+}
+
 bool ProcessGroupWrapper::supportsCoalescing() const {
   return backend_->supportsCoalescing();
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -148,6 +148,7 @@ class TORCH_API ProcessGroupWrapper : public Backend {
 
   // Forward methods to wrapped backend
   bool supportsSplitting() const override;
+  bool isInitialized() override;
   bool supportsCoalescing() const override;
   bool supportsTimeEstimation() const override;
   void startTimeEstimate() override;

--- a/torch/csrc/distributed/c10d/lazy/LazyBackend.hpp
+++ b/torch/csrc/distributed/c10d/lazy/LazyBackend.hpp
@@ -372,6 +372,9 @@ class LazyBackend : public Backend {
   bool supportsSplitting() const override {
     return primary_->supportsSplitting();
   }
+  bool isInitialized() override {
+    return primary_->isInitialized();
+  }
   // Split just the primary comm; the child is a bare backend for the subgroup.
   // We deliberately don't split the P2P pair comms: like a reconfigure, they
   // encode the parent membership's global ranks and can't be carried into the

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -303,6 +303,10 @@ void ProcessGroupNCCL::initFromComm(
                      << rank_;
 }
 
+bool ProcessGroupNCCL::isInitialized() {
+  return init_state_ == InitializationState::INITIALIZED;
+}
+
 void ProcessGroupNCCL::performNocolorSplit(at::Device device) {
   checkInitialized();
   TORCH_CHECK(

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -242,6 +242,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   bool supportsSplitting() const override {
     return true;
   }
+  bool isInitialized() override;
   bool supportsShrinking() const override {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
     return true;

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6780,19 +6780,6 @@ def split_group(
             "No backend for the parent process group or its backend does not support splitting"
         )
 
-    if not _use_torchcomms_enabled():
-        is_initialized = getattr(parent_backend, "_is_initialized", None)
-        parent_is_initialized = (
-            is_initialized()
-            if is_initialized is not None
-            else parent_pg.bound_device_id is not None
-        )
-        if not parent_is_initialized:
-            raise RuntimeError(
-                "Parent process group backend is not initialized; pass device_id "
-                "when creating it or run a collective before split_group"
-            )
-
     device_id = parent_pg.bound_device_id
 
     # set the group_desc before the color or no_color split

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6678,16 +6678,6 @@ def _get_backend_from_str(backend: str | None = None) -> str:
     return Backend(backend)
 
 
-def _is_safe_to_split() -> bool:
-    """
-    Checks if it is safe to split the any process group in the world.
-    This is only safe if the default pg has a bound device id, otherwise
-    users must be aware that a pg is only splittable after the first collective is
-    issued.
-    """
-    return _get_default_group().bound_device_id is not None
-
-
 @_time_logger
 def split_group(
     parent_pg: ProcessGroup | None = None,
@@ -6746,11 +6736,6 @@ def split_group(
 
     global _world
     default_pg = _get_default_group()
-    device_id = default_pg.bound_device_id
-    if not device_id and not _use_torchcomms_enabled():
-        raise RuntimeError(
-            "No device associated with the default pg, not safe to split any process groups"
-        )
     global_rank = default_pg.rank()
     global_world_size = default_pg.size()
 
@@ -6794,6 +6779,21 @@ def split_group(
         raise RuntimeError(
             "No backend for the parent process group or its backend does not support splitting"
         )
+
+    if not _use_torchcomms_enabled():
+        is_initialized = getattr(parent_backend, "_is_initialized", None)
+        parent_is_initialized = (
+            is_initialized()
+            if is_initialized is not None
+            else parent_pg.bound_device_id is not None
+        )
+        if not parent_is_initialized:
+            raise RuntimeError(
+                "Parent process group backend is not initialized; pass device_id "
+                "when creating it or run a collective before split_group"
+            )
+
+    device_id = parent_pg.bound_device_id
 
     # set the group_desc before the color or no_color split
     if hasattr(parent_backend, "comm_split_count") and group_desc is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195760
* #195759
* __->__ #195758

Extracted out from @sanketpurandare's D116739193.

split_group currently decides whether splitting is safe from the default
process group. That rejects a valid split when an independently created parent
has initialized its device backend but a lazily created default group has not.

Resolve and validate the backend from parent_pg itself. For backends that expose
initialization state, require that exact backend to have completed a collective;
otherwise retain the bound-device fallback. This keeps the safety check while
allowing lazy world groups and independently initialized pipeline parents.

Add an NCCL regression test covering both sides of the contract: an
uninitialized parent is rejected, then the same parent can be split after its
first collective while the default backend remains uninitialized.

In the case of PP, we hit this issue:

| Default group | Parent group | Old behavior | Correct behavior |
|---|---|---|---|
| Uninitialized | Initialized | Incorrectly rejects | Allow |
| Initialized | Uninitialized | Incorrectly allows | Reject |
| Initialized | Initialized | Allow | Allow |
| Uninitialized | Uninitialized | Reject | Reject |


```python
  schedule initialization
      |
      +-- _initialize_pp_stages()
            |
            +-- _warmup_p2p()
                  |
                  +-- all_reduce(..., group=PP parent)
                  |     -> initializes PP parent's NCCL communicator
                  |
                  +-- _configure_p2p_direction_groups()
                        |
                        +-- split_group(parent_pg=PP parent)
```

usage of _is_initialized():
| Backend | `_is_initialized()` |
|---|---|
| `ProcessGroupNCCL` | Yes |
| `ProcessGroupXCCL` | Yes |
| Custom plugin | Only if the plugin defines it |
| `ProcessGroupGloo` | No |
| `FakeProcessGroup` | No |
| `ProcessGroupUCC` | No |
| `ProcessGroupMPI` | No |
| `ProcessGroupNCCL2` | No |
| `ProcessGroupNCCLLazy` | No |
| `_ProcessGroupWrapper` | No |
| TorchComms wrapper | Irrelevant—the entire check is skipped |


Test Plan:
- python test/distributed/test_c10d_nccl.py ProcessGroupNCCLGroupTest.test_comm_split_initialized_parent_with_lazy_default
- UV_NO_CONFIG=1 UV_OFFLINE=1 spin develop
- python -m ruff check test/distributed/test_c10d_nccl.py torch/distributed/distributed_c10d.py