### PR TITLE
[optional?][c10d] Share one Store connection across split children

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1430,6 +1430,11 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # cuda comm split happened on this rank.
         self.assertEqual(cuda_backend.comm_split_count(), 1)
 
+        ng2 = c10d.split_group(pg, [subg_ranks], backend="cuda:nccl-legacy")
+        if self.rank in subg_ranks:
+            self.assertIsInstance(ng2, c10d.ProcessGroup)
+        self.assertEqual(cuda_backend.comm_split_count(), 2)
+
         dist.destroy_process_group()
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -184,6 +184,7 @@ void ProcessGroup::enableCollectivesTiming() {
 }
 
 void ProcessGroup::release_resources() {
+  split_store_.reset();
   store_.reset();
   deviceTypeToBackend_.clear();
   backendTypeToBackend_.clear();
@@ -229,9 +230,12 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   std::string groupName = name.has_value()
       ? name.value()
       : c10::str(getGroupName(), ":split:", fmt::format("{}", ranks));
+  if (!split_store_) {
+    split_store_ = store_->clone();
+  }
   c10::intrusive_ptr<Store> store = c10::static_intrusive_pointer_cast<Store>(
       c10::make_intrusive<PrefixStore>(
-          fmt::format("{}/", groupName), store_->clone()));
+          fmt::format("{}/", groupName), split_store_));
   std::string groupDesc = desc.has_value()
       ? desc.value()
       : c10::str(getGroupDesc(), ":split:", incrementSplitCount());

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -1202,6 +1202,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   c10::intrusive_ptr<c10d::Store> store_;
+  // Split children use distinct prefixes over one parent-owned connection.
+  c10::intrusive_ptr<c10d::Store> split_store_;
   // Fallback rank/size used only when there is no default backend; the default
   // backend is otherwise the source of truth (see getRank/getSize).
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1358,7 +1358,7 @@ c10::intrusive_ptr<Backend> ProcessGroupNCCL::split(
   // This value must be non-negative int32 and all ranks are.
   ncclOpts->split_color = *std::min_element(ranks.cbegin(), ranks.cend());
   auto pg = c10::make_intrusive<ProcessGroupNCCL>(
-      store->clone(), groupRank, ranks.size(), ncclOpts);
+      store, groupRank, ranks.size(), ncclOpts);
 #ifdef NCCL_COMM_DESCRIPTION
   // We need to set the desc here so that when eager init the nccl, we can
   // propagate desc to the nccl comm.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195759
* #195760

Extracted out from @sanketpurandare's D116739193.

# Motivation

The directed P2P communicators introduced by #195760 create four local child
ProcessGroups per rank for a looped PP topology: one communicator in each
direction for both physical neighbors.

Previously, each child caused two Store clones:

1. `ProcessGroup::splitGroup()` cloned the parent Store for the child's
   `PrefixStore`.
2. `ProcessGroupNCCL::split()` cloned that prefixed Store again.

For `TCPStore`, every clone opens another TCP connection. At 128 ranks, 512
local child ProcessGroups can therefore create roughly 1,024 additional Store
connections.

# Change

Lazily clone one Store per parent ProcessGroup and share it across split
children. Each child retains a distinct `PrefixStore` namespace, so rendezvous
keys remain isolated. `ProcessGroupNCCL` now retains that prefixed Store
directly instead of cloning it again.

This shares only the control-plane Store connection. Every child still has its
own NCCL communicator, and tensor communication is unchanged.

## Test Plan

- `UV_NO_CONFIG=1 UV_OFFLINE=1 spin develop`
- `python test/distributed/test_c10d_nccl.py ProcessGroupNCCLGroupTest.test_comm_split_group_backend_filter`
- `python -m ruff check test/distributed/test_c10d_nccl.py`