### PR TITLE
[pipelining] Derive directed P2P groups from schedule topology

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from model_registry import MultiMLP
 
 import torch
+import torch.distributed.config as dist_config
 from torch._dynamo import OptimizedModule
 from torch.distributed.pipelining import (
     Schedule1F1B,
@@ -50,6 +51,8 @@ from torch.distributed.pipelining.schedules import (
     W,
 )
 from torch.distributed.pipelining.stage import (
+    _p2p_edge_matchings,
+    _p2p_topology,
     _PipelineStageBase,
     _RecvInfo,
     PipelineStage,
@@ -76,6 +79,42 @@ logger = logging.getLogger(__name__)
 torch.manual_seed(0)
 
 
+class P2PTopologyTest(TestCase):
+    def test_loop_topology_uses_four_disjoint_split_rounds(self):
+        topology = _p2p_topology({stage: stage % 4 for stage in range(8)}, group_size=4)
+
+        self.assertEqual(
+            _p2p_edge_matchings(topology),
+            (
+                ((0, 1), (2, 3)),
+                ((1, 0), (3, 2)),
+                ((0, 3), (1, 2)),
+                ((3, 0), (2, 1)),
+            ),
+        )
+
+    def test_v_topology_excludes_same_rank_turn_and_wraparound(self):
+        topology = _p2p_topology(
+            dict(enumerate((0, 1, 2, 3, 3, 2, 1, 0))),
+            group_size=4,
+        )
+
+        rounds = _p2p_edge_matchings(topology)
+        edges = {edge for round_edges in rounds for edge in round_edges}
+        self.assertEqual(
+            edges,
+            {(0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2)},
+        )
+        self.assertNotIn((0, 3), edges)
+        self.assertNotIn((3, 3), edges)
+
+    def test_topology_requires_contiguous_valid_stage_mapping(self):
+        with self.assertRaisesRegex(ValueError, "contiguous indices"):
+            _p2p_topology({0: 0, 2: 1}, group_size=2)
+        with self.assertRaisesRegex(ValueError, "outside"):
+            _p2p_topology({0: 0, 1: 2}, group_size=2)
+
+
 class MockPipelineStage(_PipelineStageBase):
     def __init__(self, *args, **kwargs):
         # Mock the necessary attributes
@@ -84,6 +123,7 @@ class MockPipelineStage(_PipelineStageBase):
         self.group_size = kwargs.get("group_size", 1)
         self.group_rank = kwargs.get("group_rank", 0)
         self.group = kwargs.get("group")
+        self.p2p_per_direction = False
 
     def _create_grad_recv_info(self, *args, **kwargs):
         return None
@@ -525,7 +565,8 @@ class ScheduleTest(TestCase):
             torch.distributed.destroy_process_group()
 
     @parametrize("rank", [0, 1])
-    def test_fake_pg_cross_rank_uses_static_metadata(self, rank):
+    @parametrize("per_direction", [False, True])
+    def test_fake_pg_cross_rank_uses_static_metadata(self, rank, per_direction):
         """
         With a fake process group, the cross-rank warm-up vote cannot exchange
         real data, so the schedule must infer the metadata mode locally:
@@ -544,19 +585,20 @@ class ScheduleTest(TestCase):
         x = torch.randn(batch_size, d_hid, device=device)
         mb = torch.randn(batch_size // num_microbatches, d_hid, device=device)
         try:
-            stage = PipelineStage(
-                mod, rank, n_stages, device, input_args=mb, output_args=mod(mb)
-            )
-            schedule = ScheduleGPipe(stage, num_microbatches)
-            schedule.step(x) if rank == 0 else schedule.step()
-            self.assertEqual(stage._inference_mode, InferenceMode.STATIC)
+            with dist_config.patch(pipeline_per_direction_p2p=per_direction):
+                stage = PipelineStage(
+                    mod, rank, n_stages, device, input_args=mb, output_args=mod(mb)
+                )
+                schedule = ScheduleGPipe(stage, num_microbatches)
+                schedule.step(x) if rank == 0 else schedule.step()
+                self.assertEqual(stage._inference_mode, InferenceMode.STATIC)
 
-            # Without static metadata, dynamic inference is required, which
-            # cannot work over a fake group and must fail loudly.
-            stage_dyn = PipelineStage(mod, rank, n_stages, device)
-            schedule_dyn = ScheduleGPipe(stage_dyn, num_microbatches)
-            with self.assertRaisesRegex(RuntimeError, "fake process group"):
-                schedule_dyn.step(x) if rank == 0 else schedule_dyn.step()
+                # Without static metadata, dynamic inference is required, which
+                # cannot work over a fake group and must fail loudly.
+                stage_dyn = PipelineStage(mod, rank, n_stages, device)
+                schedule_dyn = ScheduleGPipe(stage_dyn, num_microbatches)
+                with self.assertRaisesRegex(RuntimeError, "fake process group"):
+                    schedule_dyn.step(x) if rank == 0 else schedule_dyn.step()
         finally:
             torch.distributed.destroy_process_group()
 

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -1622,12 +1622,9 @@ instantiate_parametrized_tests(CustomSchedulesTest)
 class PerDirectionScheduleTest(MultiProcContinuousTest):
     """Per-direction PP communicators (``config.pipeline_per_direction_p2p``).
 
-    A single PP communicator serializes all send/recv in one FIFO; splitting
-    downstream (r -> r+1 activations) and upstream (r -> r-1 gradients) onto two
-    communicators removes the cross-batch deadlock hazard. PipelineStage builds
-    the two subgroups with ``split_group``, which requires a device-bound default
-    PG -- so this class binds ``device_id`` in ``_init_pg`` (see below) rather
-    than relying on the shared MultiProcContinuousTest path.
+    A single PP communicator serializes all send/recv in one FIFO. The schedule
+    initializes the PP parent and derives directed children from its final
+    logical-stage placement.
     """
 
     world_size = 4
@@ -1638,21 +1635,11 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
-        # Bind device_id so PipelineStage can split the default PG into
-        # downstream/upstream subgroups. We override here instead of changing
-        # MultiProcContinuousTest._init_pg, which also serves CPU/Gloo callers
-        # where device_id would alter PG initialization semantics.
+        """Initialize a lazy default PG to exercise parent-local initialization."""
         if rdvz_file is None:
             raise AssertionError("Expected rdvz_file to not be None")
         os.environ["LOCAL_RANK"] = str(rank)
         store = dist.FileStore(rdvz_file, world_size)
-        # _init_pg runs at class spawn, before the per-test skip_if_lt_x_gpu(4).
-        # Only bind device_id when every rank maps to a real accelerator;
-        # otherwise the tests are skipped anyway and an out-of-range device_id
-        # would make init_process_group raise instead of skip.
-        device_id = None
-        if torch.accelerator.device_count() >= world_size:
-            device_id = torch.device(cls.device_type(), rank)
         dist.init_process_group(
             backend=cls.backend_str(),
             world_size=world_size,
@@ -1660,7 +1647,6 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
             store=store,
             pg_options=cls.opts(),
             timeout=cls.timeout,
-            device_id=device_id,
         )
         cls.pg = dist.distributed_c10d._get_default_group()
 
@@ -1680,8 +1666,7 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
     )
     @skip_if_lt_x_gpu(4)
     def test_creates_distinct_direction_groups(self):
-        """PipelineStage builds two distinct, non-WORLD direction groups when the
-        config flag is set (no constructor arg)."""
+        """Schedule warm-up builds only the directed edges in its topology."""
         with dist_config.patch(pipeline_per_direction_p2p=True):
             mod, _, x, _, _ = setup_models_and_data(self.config)
             chunks = 2 * self.world_size
@@ -1689,17 +1674,39 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
                 self.config, mod, x, chunks, use_tracer=False
             )
             self.assertTrue(stage.p2p_per_direction)
-            self.assertIsNot(stage._downstream_group, dist.group.WORLD)
-            self.assertIsNot(stage._upstream_group, dist.group.WORLD)
-            self.assertIsNot(stage._downstream_group, stage._upstream_group)
+            self.assertFalse(stage._p2p_direction_groups)
+
+            schedule = ScheduleGPipe(stage, chunks, scale_grads=False)
+            schedule._warmup_p2p([stage], has_backward=False, p2p_done=False)
+
+            directed_edges = {
+                edge
+                for rank in range(self.world_size - 1)
+                for edge in ((rank, rank + 1), (rank + 1, rank))
+            }
+            self.assertEqual(
+                set(stage._p2p_direction_groups),
+                {edge for edge in directed_edges if self.rank in edge},
+            )
+            groups = list(stage._p2p_direction_groups.values())
+            self.assertEqual(len({id(group) for group in groups}), len(groups))
+            self.assertTrue(all(group is not dist.group.WORLD for group in groups))
+            self.assertTrue(
+                all(
+                    {group_device.type for group_device in group._device_types}
+                    == {self.device.type}
+                    for group in groups
+                )
+            )
 
     @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
         not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
     )
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
+    @parametrize("use_tracer", [False, True])
     @skip_if_lt_x_gpu(4)
-    def test_grad_with_manual_per_direction(self, ScheduleClass):
+    def test_grad_with_per_direction(self, ScheduleClass, use_tracer):
         """Per-direction P2P only changes which communicator carries the bytes,
         not the math: gradients/outputs must still match the reference model."""
         with dist_config.patch(pipeline_per_direction_p2p=True):
@@ -1708,14 +1715,12 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
             # Run reference
             ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
 
-            # Create manual pipeline stage; the per-direction groups are built
-            # inside PipelineStage from the config flag set above.
             chunks = 2 * self.world_size
             stage, stage_module, _ = create_single_stage_pipeline(
-                self.config, mod, x, chunks, use_tracer=False
+                self.config, mod, x, chunks, use_tracer=use_tracer
             )
             self.assertTrue(stage.p2p_per_direction)
-            self.assertIsNot(stage._downstream_group, stage._upstream_group)
+            self.assertFalse(stage._p2p_direction_groups)
 
             schedule = ScheduleClass(stage, chunks, loss_fn=loss_fn, scale_grads=False)
 
@@ -1731,6 +1736,8 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
                 else:
                     schedule.step()
 
+            self.assertGreater(len(stage._p2p_direction_groups), 1)
+
             dist.barrier(device_ids=[self.rank])
 
             # Last rank checks result
@@ -1741,6 +1748,59 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
 
             # Check gradients using helper method
             check_gradients(self.config, stage_module, ref_mod)
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_grad_with_interleaved_virtual_stages(self):
+        """Directed edge groups preserve looped-schedule P2P ordering."""
+        with dist_config.patch(pipeline_per_direction_p2p=True):
+            num_stages = 2 * self.world_size
+            mod, ref_mod, x, target, loss_fn = setup_models_and_data(
+                self.config, n_layers=num_stages
+            )
+            ref_out, ref_loss = run_reference_model(ref_mod, x, target, loss_fn)
+            stages, stage_modules, submod_names = create_multi_stage_pipeline(
+                self.config, mod, 2, num_stages
+            )
+            schedule = ScheduleInterleaved1F1B(
+                stages,
+                2 * self.world_size,
+                loss_fn=loss_fn,
+                scale_grads=False,
+            )
+
+            out = None
+            losses = []
+            for _ in range(2):
+                zero_gradients(stage_modules)
+                if self.rank == 0:
+                    schedule.step(x)
+                elif self.rank == self.world_size - 1:
+                    out = schedule.step(target=target, losses=losses)
+                else:
+                    schedule.step()
+
+            expected_edges = {
+                edge
+                for rank in range(self.world_size)
+                for edge in (
+                    (rank, (rank + 1) % self.world_size),
+                    ((rank + 1) % self.world_size, rank),
+                )
+            }
+            self.assertEqual(
+                set(stages[0]._p2p_direction_groups),
+                {edge for edge in expected_edges if self.rank in edge},
+            )
+
+            dist.barrier(device_ids=[self.rank])
+            if self.rank == self.world_size - 1:
+                torch.testing.assert_close(out, ref_out)
+                torch.testing.assert_close(sum(losses), ref_loss)
+            check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
 
 instantiate_parametrized_tests(PerDirectionScheduleTest)

--- a/torch/distributed/config.py
+++ b/torch/distributed/config.py
@@ -28,14 +28,11 @@ use_torchcomms: bool = Config(
     env_name_default="TORCH_DISTRIBUTED_USE_TORCHCOMMS",
 )
 
-# When enabled, pipeline stages carry downstream (r -> r+1, forward activations)
-# and upstream (r -> r-1, backward gradients) P2P on two separate communicators
-# instead of sharing one. A single PP communicator serializes all send/recv in one
-# FIFO: coalescing makes a single mixed batch deadlock-free, but across batches
-# (pipeline skew, looped / V schedules, skip connections) the shared FIFO can
-# still form a dependency cycle and deadlock. Splitting by direction removes that
-# hazard and restores full-duplex bandwidth. Requires a device-bound default
-# process group.
+# When enabled, pipeline stages carry each adjacent directed physical rank edge
+# on a separate communicator instead of sharing one FIFO. This preserves P2P
+# ordering across looped schedules where distinct virtual-stage edges can reach
+# the same ranks in different orders. The schedule initializes the actual PP
+# parent before deriving child communicators.
 #
 # This flag force-enables the behavior; it is auto-enabled when TorchComms is in
 # use regardless of this flag (see PipelineStage), so it mainly matters for the

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -347,10 +347,10 @@ class _PipelineSchedule(ABC):
     ) -> None:
         """Run the P2P warm-up protocol for the given stages.
 
-        For ``PipelineStage`` instances this executes the forward/backward vote
-        protocol (which warms up 2-rank sub-communicators) and sets each
-        stage's ``_inference_mode``.  For other stage types it falls back to
-        the legacy ``_get_init_p2p_neighbors_ops`` + ``_batch_p2p`` path.
+        For ``PipelineStage`` instances this determines the metadata mode. When
+        directed-edge communicators are enabled, it also initializes the PP
+        parent, creates the children from the final schedule topology, and
+        warms every child before CUDA graph capture.
 
         Args:
             stages: The pipeline stages owned by this rank.
@@ -358,6 +358,101 @@ class _PipelineSchedule(ABC):
             p2p_done: ``True`` if P2P neighbours have already been initialised
                 (avoids redundant init on eval↔train mode switches).
         """
+        per_direction = {stage.p2p_per_direction for stage in stages}
+        if len(per_direction) != 1:
+            raise RuntimeError(
+                "All local pipeline stages must use the same P2P communicator mode"
+            )
+
+        if next(iter(per_direction)):
+            parent = (
+                stages[0].group
+                if stages[0].group is not None
+                else dist.distributed_c10d._get_default_group()
+            )
+            if any(
+                (
+                    stage.group
+                    if stage.group is not None
+                    else dist.distributed_c10d._get_default_group()
+                )
+                is not parent
+                for stage in stages
+            ):
+                raise RuntimeError("All local pipeline stages must share one PP group")
+
+            pipeline_stages = [
+                stage for stage in stages if isinstance(stage, PipelineStage)
+            ]
+            all_manual = len(pipeline_stages) == len(stages)
+            if pipeline_stages and not all_manual:
+                raise RuntimeError(
+                    "A pipeline schedule cannot mix manual and traced stages"
+                )
+            backend = dist.get_backend(parent)
+            if backend == "fake":
+                if all_manual:
+                    inference_mode = (
+                        InferenceMode.DYNAMIC
+                        if any(
+                            InferenceMode.needs_dynamic(stage._user_meta, has_backward)
+                            for stage in pipeline_stages
+                        )
+                        else InferenceMode.STATIC
+                    )
+                    has_cross_rank = any(
+                        (
+                            not stage.is_first
+                            and not stage._is_same_rank(stage.stage_index - 1)
+                        )
+                        or (
+                            not stage.is_last
+                            and not stage._is_same_rank(stage.stage_index + 1)
+                        )
+                        for stage in pipeline_stages
+                    )
+                    if has_cross_rank and inference_mode == InferenceMode.DYNAMIC:
+                        raise RuntimeError(
+                            "Dynamic shape inference is not supported with a fake "
+                            "process group. Provide complete static metadata to "
+                            "PipelineStage."
+                        )
+                    for stage in pipeline_stages:
+                        stage._inference_mode = inference_mode
+            else:
+                vote = torch.tensor(
+                    [
+                        int(
+                            not all_manual
+                            or all(
+                                not InferenceMode.needs_dynamic(
+                                    stage._user_meta, has_backward
+                                )
+                                for stage in pipeline_stages
+                            )
+                        )
+                    ],
+                    dtype=torch.int32,
+                    device=stages[0].device,
+                )
+                dist.all_reduce(vote, op=dist.ReduceOp.MIN, group=parent)
+                vote_result = vote.item()
+                if all_manual:
+                    inference_mode = (
+                        InferenceMode.STATIC
+                        if vote_result == 1
+                        else InferenceMode.DYNAMIC
+                    )
+                    for stage in pipeline_stages:
+                        stage._inference_mode = inference_mode
+
+            if not p2p_done:
+                for stage in stages:
+                    stage._configure_p2p_direction_groups()
+                if backend != "fake":
+                    self._warmup_p2p_direction_groups(stages, parent)
+            return
+
         if all(isinstance(stage, PipelineStage) for stage in stages):
             # A fake process group cannot exchange real data: a cross-rank
             # vote recv reads zeros and selects DYNAMIC, which then fails in
@@ -419,17 +514,43 @@ class _PipelineSchedule(ABC):
                 all_ops.extend(stage._get_init_p2p_neighbors_ops())
             _wait_batch_p2p(_batch_p2p(all_ops))
 
-        # TODO: STATIC mode group communicator warm-up gap
-        # The vote protocol above warms up 2-rank sub-communicators
-        # (used by `_batch_p2p` homogeneous fast-path).  In DYNAMIC mode,
-        # `_send_meta`/`_recv_meta` (called during `_prepare_forward_infra` →
-        # `_forward_metadata_inference`) also warm up the *group* communicator
-        # (used by `_batch_p2p` mixed-op path).  In STATIC mode, metadata
-        # inference is skipped, so the group communicator is NOT warmed up —
-        # it will be lazily created on the first mixed `_batch_p2p` call
-        # (e.g., 1F1B steady-state with both sends and recvs).
-        # Fix: run `_get_init_p2p_neighbors_ops` + `_batch_p2p` after the
-        # vote, gated by `not p2p_done`.
+    @staticmethod
+    def _warmup_p2p_direction_groups(
+        stages: list[_PipelineStageBase], parent: dist.ProcessGroup
+    ) -> None:
+        """Exercise every directed child communicator once before capture."""
+        topology = stages[0]._p2p_direction_topology
+        if any(stage._p2p_direction_topology != topology for stage in stages):
+            raise RuntimeError("Local stages disagree on P2P communicator topology")
+        rounds = stages[0]._p2p_direction_warmup_rounds
+        if any(stage._p2p_direction_warmup_rounds != rounds for stage in stages):
+            raise RuntimeError("Local stages disagree on P2P warm-up topology")
+
+        group_rank = dist.get_rank(parent)
+        tensor = torch.zeros(1, dtype=torch.int32, device=stages[0].device)
+        for round_edges in rounds:
+            local_edges = [edge for edge in round_edges if group_rank in edge]
+            if not local_edges:
+                continue
+            if len(local_edges) != 1:
+                raise AssertionError("P2P warm-up round is not a matching")
+            source, destination = local_edges[0]
+            child = stages[0]._p2p_direction_groups[(source, destination)]
+            if group_rank == source:
+                op = dist.P2POp(
+                    dist.isend,
+                    tensor,
+                    dist.get_global_rank(parent, destination),
+                    child,
+                )
+            else:
+                op = dist.P2POp(
+                    dist.irecv,
+                    tensor,
+                    dist.get_global_rank(parent, source),
+                    child,
+                )
+            _wait_batch_p2p(dist.batch_isend_irecv([op]))
 
     def _initialize_pp_stages(
         self,

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
+import itertools
 import logging
 import operator
 import warnings
@@ -129,16 +130,65 @@ class _RecvInfo:
         return f"_RecvInfo(input={self.input_name}, source={self.source}, shape={buffer_shape}, meta={meta_type})"
 
 
-# Cache of per-direction P2P communicators, keyed (weakly) by the PP process
-# group they are derived from. Looped/V schedules construct several stage chunks
-# per rank that share one PP group; they must share the same forward/backward
-# comms (and issue the split_group collective only once) so creation stays
-# consistent and cheap across all ranks. Stage chunks are constructed serially
-# within a rank, so the first miss performs the split and the rest hit the cache.
-# The key is a weakref, so entries are
-# dropped automatically once the parent group is destroyed (e.g. via
-# destroy_process_group / reinitialization), avoiding stale dead communicators.
-_PP_DIRECTION_GROUP_CACHE: "weakref.WeakKeyDictionary[dist.ProcessGroup, tuple[dist.ProcessGroup, dist.ProcessGroup]]" = weakref.WeakKeyDictionary()
+_P2PTopology = tuple[int, ...]
+_P2PWarmupRound = tuple[tuple[int, int], ...]
+_P2PGroupCacheEntry = tuple[
+    dict[tuple[int, int], dist.ProcessGroup], tuple[_P2PWarmupRound, ...]
+]
+_PP_DIRECTION_GROUP_CACHE: weakref.WeakKeyDictionary[
+    dist.ProcessGroup, dict[_P2PTopology, _P2PGroupCacheEntry]
+] = weakref.WeakKeyDictionary()
+
+
+def _p2p_topology(
+    stage_index_to_group_rank: dict[int, int], group_size: int
+) -> _P2PTopology:
+    """Validate and return the physical-rank assignment for logical stages."""
+    stage_indices = set(stage_index_to_group_rank)
+    expected_indices = set(range(len(stage_index_to_group_rank)))
+    if stage_indices != expected_indices:
+        raise ValueError(
+            "Pipeline stage mapping must contain contiguous indices starting at 0"
+        )
+    topology = tuple(
+        stage_index_to_group_rank[stage_index]
+        for stage_index in range(len(expected_indices))
+    )
+    if any(rank < 0 or rank >= group_size for rank in topology):
+        raise ValueError(
+            f"Pipeline stage mapping contains a rank outside [0, {group_size})"
+        )
+    return topology
+
+
+def _p2p_edge_matchings(topology: _P2PTopology) -> tuple[_P2PWarmupRound, ...]:
+    """Partition used physical edges into deterministic directed matchings."""
+    remaining = sorted(
+        {
+            tuple(sorted((source, destination)))
+            for source, destination in itertools.pairwise(topology)
+            if source != destination
+        }
+    )
+    matchings: list[tuple[tuple[int, int], ...]] = []
+    while remaining:
+        used_ranks: set[int] = set()
+        matching: list[tuple[int, int]] = []
+        deferred: list[tuple[int, int]] = []
+        for edge in remaining:
+            if edge[0] in used_ranks or edge[1] in used_ranks:
+                deferred.append(edge)
+                continue
+            matching.append(edge)
+            used_ranks.update(edge)
+        matchings.append(tuple(matching))
+        remaining = deferred
+
+    rounds: list[_P2PWarmupRound] = []
+    for matching in matchings:
+        rounds.append(matching)
+        rounds.append(tuple((destination, source) for source, destination in matching))
+    return tuple(rounds)
 
 
 def _warn_if_eager_nccl(group: dist.ProcessGroup | None) -> None:
@@ -155,48 +205,62 @@ def _warn_if_eager_nccl(group: dist.ProcessGroup | None) -> None:
 
 def _build_p2p_direction_groups(
     group: dist.ProcessGroup | None,
-) -> tuple[dist.ProcessGroup, dist.ProcessGroup]:
-    """Create two communicators over the same ranks as ``group``, one per data-flow
-    direction: ``downstream`` carries traffic flowing ``r -> r+1`` (forward
-    activations) and ``upstream`` carries ``r -> r-1`` (backward gradients).
-
-    Pipeline P2P normally shares a single communicator for both directions, which
-    serializes every send/recv in one FIFO. Coalescing makes a single mixed
-    send+recv batch deadlock-free, but across *separate* batches (pipeline skew,
-    looped / V schedules, skip connections) the shared FIFO can still form a
-    dependency cycle and deadlock. Routing the two directions onto separate
-    communicators / streams removes that cross-batch coupling and restores
-    full-duplex bandwidth.
-
-    Uses ``split_group``, which is collective over ``group``'s own ranks (not the
-    whole world), so it composes with PP as a sub-axis of a larger device mesh.
-    Requires the default process group to be device-bound (e.g.
-    ``init_process_group(..., device_id=...)``), which ``split_group`` needs for
-    NCCL; torchcomms binds the device automatically.
-    """
+    stage_index_to_group_rank: dict[int, int],
+) -> tuple[dict[tuple[int, int], dist.ProcessGroup], tuple[_P2PWarmupRound, ...]]:
+    """Create communicators for the directed rank edges used by a schedule."""
     parent = group if group is not None else dist.distributed_c10d._get_default_group()
-    cached = _PP_DIRECTION_GROUP_CACHE.get(parent)
+    group_size = dist.get_world_size(parent)
+    topology = _p2p_topology(stage_index_to_group_rank, group_size)
+    cached = _PP_DIRECTION_GROUP_CACHE.get(parent, {}).get(topology)
     if cached is not None:
         return cached
 
-    split_ranks = [list(range(dist.get_world_size(parent)))]
-    # split_group splits the parent's communicator, so the default process group
-    # must be device-bound (NCCL) -- torchcomms binds the device automatically. If
-    # it is not, split_group raises its own device error.
-    downstream = dist.split_group(
-        parent_pg=group, split_ranks=split_ranks, group_desc="pp_p2p_downstream"
+    group_rank = dist.get_rank(parent)
+    rounds = _p2p_edge_matchings(topology)
+    groups: dict[tuple[int, int], dist.ProcessGroup] = {}
+    if str(dist.get_backend(parent)) == "fake":
+        for round_edges in rounds:
+            for edge in round_edges:
+                if group_rank in edge:
+                    groups[edge] = parent
+        _PP_DIRECTION_GROUP_CACHE.setdefault(parent, {})[topology] = (groups, rounds)
+        return groups, rounds
+
+    accelerator = torch.accelerator.current_accelerator()
+    if accelerator is None:
+        raise RuntimeError("Directed pipeline P2P requires an accelerator backend")
+    parent_backend_config = dist.BackendConfig(dist.get_backend_config(parent))
+    accelerator_backend = parent_backend_config.get_device_backend_map().get(
+        accelerator.type
     )
-    upstream = dist.split_group(
-        parent_pg=group, split_ranks=split_ranks, group_desc="pp_p2p_upstream"
+    if accelerator_backend is None:
+        raise RuntimeError(
+            f"Pipeline process group has no backend for {accelerator.type}"
+        )
+    for round_index, round_edges in enumerate(rounds):
+        child = dist.split_group(
+            parent_pg=parent,
+            split_ranks=[list(edge) for edge in round_edges],
+            group_desc=f"pp_p2p_round_{round_index}",
+            backend=f"{accelerator.type}:{accelerator_backend}",
+        )
+        local_edges = [edge for edge in round_edges if group_rank in edge]
+        if local_edges:
+            if len(local_edges) != 1:
+                raise AssertionError("P2P split round is not a matching")
+            if not isinstance(child, dist.ProcessGroup):
+                raise AssertionError(
+                    f"expected process group for edge {local_edges[0]}, "
+                    f"got {type(child)}"
+                )
+            groups[local_edges[0]] = child
+
+    logger.info(
+        "Pipeline P2P: using %d directed rank-edge split rounds",
+        len(rounds),
     )
-    # All parent ranks are members of the single split.
-    if not isinstance(downstream, dist.ProcessGroup):
-        raise AssertionError(f"expected dist.ProcessGroup, got {type(downstream)}")
-    if not isinstance(upstream, dist.ProcessGroup):
-        raise AssertionError(f"expected dist.ProcessGroup, got {type(upstream)}")
-    logger.info("Pipeline P2P: using per-direction (downstream/upstream) communicators")
-    _PP_DIRECTION_GROUP_CACHE[parent] = (downstream, upstream)
-    return downstream, upstream
+    _PP_DIRECTION_GROUP_CACHE.setdefault(parent, {})[topology] = (groups, rounds)
+    return groups, rounds
 
 
 class _PipelineStageBase(ABC):
@@ -242,27 +306,18 @@ class _PipelineStageBase(ABC):
 
         _warn_if_eager_nccl(group)
 
-        # Downstream (data flowing r -> r+1: forward activations) and upstream
-        # (r -> r-1: backward gradients) P2P communicators. Auto-enabled when
-        # TorchComms is in use (its split path is always available and the
-        # single-comm FIFO deadlock is most acute there); the config flag
+        # Directed physical rank-edge communicators. Auto-enabled when TorchComms
+        # is in use; the config flag
         # torch.distributed.config.pipeline_per_direction_p2p (env
         # TORCH_DISTRIBUTED_PIPELINE_PER_DIRECTION_P2P) force-enables it on other
-        # backends. When disabled both alias ``self.group`` so behavior is
-        # byte-for-byte unchanged.
+        # backends. When disabled every P2P op uses ``self.group``.
         self.p2p_per_direction = (
             dist_config.pipeline_per_direction_p2p
             or dist.distributed_c10d._use_torchcomms_enabled()
         )
-        self._downstream_group: dist.ProcessGroup | None
-        self._upstream_group: dist.ProcessGroup | None
-        if self.p2p_per_direction:
-            self._downstream_group, self._upstream_group = _build_p2p_direction_groups(
-                group
-            )
-        else:
-            self._downstream_group = group
-            self._upstream_group = group
+        self._p2p_direction_groups: dict[tuple[int, int], dist.ProcessGroup] = {}
+        self._p2p_direction_warmup_rounds: tuple[_P2PWarmupRound, ...] = ()
+        self._p2p_direction_topology: _P2PTopology | None = None
 
         self.dw_builder = dw_builder
 
@@ -318,6 +373,25 @@ class _PipelineStageBase(ABC):
         # DTensor support: consolidated stage metadata container
         # Contains inputs, outputs, input_grads, output_grads metadata
         self._stage_meta = _StageMeta()
+
+    def _configure_p2p_direction_groups(self) -> None:
+        """Create directed P2P groups from the schedule's final stage mapping."""
+        if not self.p2p_per_direction:
+            return
+        topology = _p2p_topology(self.stage_index_to_group_rank, self.group_size)
+        if (
+            self._p2p_direction_topology is not None
+            and self._p2p_direction_topology != topology
+        ):
+            raise RuntimeError(
+                "Pipeline stage mapping changed after P2P communicator initialization"
+            )
+        groups, rounds = _build_p2p_direction_groups(
+            self.group, self.stage_index_to_group_rank
+        )
+        self._p2p_direction_groups = groups
+        self._p2p_direction_warmup_rounds = rounds
+        self._p2p_direction_topology = topology
 
     @property
     def has_backward(self) -> bool:
@@ -443,16 +517,34 @@ class _PipelineStageBase(ABC):
             peer_rank,
         )
 
+    def _get_p2p_group(
+        self, source_stage: int, destination_stage: int
+    ) -> dist.ProcessGroup | None:
+        """Return the communicator for one directed logical-stage edge."""
+        if not self.p2p_per_direction:
+            return self.group
+        source_rank = self.stage_index_to_group_rank[source_stage]
+        destination_rank = self.stage_index_to_group_rank[destination_stage]
+        if source_rank == destination_rank:
+            raise RuntimeError(
+                "Same-rank pipeline stages must use local transfer, not P2P"
+            )
+        try:
+            return self._p2p_direction_groups[(source_rank, destination_rank)]
+        except KeyError as error:
+            raise RuntimeError(
+                "Missing directed pipeline communicator for group ranks "
+                f"{source_rank}->{destination_rank}"
+            ) from error
+
     def _get_recv_ops(
         self,
         recv_infos: tuple[_RecvInfo, ...],
-        group: dist.ProcessGroup | None,
+        destination_stage: int,
     ) -> list[dist.P2POp]:
         """
         Helper function shared by `get_fwd_recv_ops` and `get_bwd_recv_ops`.
-        Returns a list of ops that correspond to the recv infos. ``group`` is the
-        direction-specific communicator (downstream vs upstream); it equals
-        ``self.group`` unless per-direction P2P is enabled.
+        Returns a list of ops that correspond to the recv infos.
         """
         ops: list[dist.P2POp] = []
         for info in recv_infos:
@@ -468,7 +560,14 @@ class _PipelineStageBase(ABC):
             if info.source is None:
                 raise AssertionError("expected info.source to be not None")
             peer_global_rank = self._resolve_peer_global_rank(info.source)
-            ops.append(dist.P2POp(dist.irecv, info.buffer, peer_global_rank, group))
+            ops.append(
+                dist.P2POp(
+                    dist.irecv,
+                    info.buffer,
+                    peer_global_rank,
+                    self._get_p2p_group(info.source, destination_stage),
+                )
+            )
 
         return ops
 
@@ -567,7 +666,7 @@ class _PipelineStageBase(ABC):
         """
         recv_infos: tuple[_RecvInfo, ...] = self.args_recv_info[fwd_chunk_id]
 
-        return self._get_recv_ops(recv_infos, self._downstream_group)
+        return self._get_recv_ops(recv_infos, self.stage_index)
 
     def get_bwd_recv_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
         """
@@ -578,7 +677,7 @@ class _PipelineStageBase(ABC):
             return []
 
         recv_infos = self.grad_recv_info[bwd_chunk_id]
-        return self._get_recv_ops(recv_infos, self._upstream_group)
+        return self._get_recv_ops(recv_infos, self.stage_index)
 
     def get_fwd_send_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
@@ -608,7 +707,7 @@ class _PipelineStageBase(ABC):
                         dist.isend,
                         send_tensor,
                         peer_global_rank,
-                        self._downstream_group,
+                        self._get_p2p_group(self.stage_index, dst),
                     )
                 )
 
@@ -690,7 +789,10 @@ class _PipelineStageBase(ABC):
                 peer_global_rank = self._resolve_peer_global_rank(grad_recv_stage)
                 ops.append(
                     dist.P2POp(
-                        dist.isend, send_tensor, peer_global_rank, self._upstream_group
+                        dist.isend,
+                        send_tensor,
+                        peer_global_rank,
+                        self._get_p2p_group(self.stage_index, grad_recv_stage),
                     )
                 )
             elif grad is None:
@@ -704,7 +806,12 @@ class _PipelineStageBase(ABC):
                 )
                 peer_global_rank = self._resolve_peer_global_rank(grad_recv_stage)
                 ops.append(
-                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
+                    dist.P2POp(
+                        dist.isend,
+                        send_tensor,
+                        peer_global_rank,
+                        self._get_p2p_group(self.stage_index, grad_recv_stage),
+                    )
                 )
         return ops
 
@@ -1220,26 +1327,31 @@ class _PipelineStageBase(ABC):
         from the previous stage.
         """
         ops: list[dist.P2POp] = []
-        next_stage_peer_rank = self.stage_index_to_group_rank.get(self.stage_index + 1)
-        prev_stage_peer_rank = self.stage_index_to_group_rank.get(self.stage_index - 1)
+        next_stage_peer = (
+            self._resolve_peer_global_rank(self.stage_index + 1)
+            if not self.is_last
+            else None
+        )
+        prev_stage_peer = (
+            self._resolve_peer_global_rank(self.stage_index - 1)
+            if not self.is_first
+            else None
+        )
 
-        # Separate recv buffers per direction: with per-direction P2P the
-        # downstream and upstream recvs run concurrently on different
-        # communicators/streams, so they must not share a buffer (concurrent
-        # writes = data race). The send buffer is only read, so it can be shared.
-        downstream_recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
-        upstream_recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
+        # Incoming edge groups may run concurrently, so each receive needs its
+        # own buffer. The send buffer is read-only and can be shared.
+        prev_recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
+        next_recv_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
         send_tensor = torch.tensor(
             self.stage_index, device=self.device, dtype=torch.float32
         )
-        # downstream traffic (r -> r+1: forward activations) -> downstream comm
         if not self.is_first:
             ops.append(
                 dist.P2POp(
                     dist.irecv,
-                    downstream_recv_tensor,
-                    group_peer=prev_stage_peer_rank,
-                    group=self._downstream_group,
+                    prev_recv_tensor,
+                    peer=prev_stage_peer,
+                    group=self._get_p2p_group(self.stage_index - 1, self.stage_index),
                 )
             )
         if not self.is_last:
@@ -1247,28 +1359,27 @@ class _PipelineStageBase(ABC):
                 dist.P2POp(
                     dist.isend,
                     send_tensor,
-                    group_peer=next_stage_peer_rank,
-                    group=self._downstream_group,
+                    peer=next_stage_peer,
+                    group=self._get_p2p_group(self.stage_index, self.stage_index + 1),
                 )
             )
 
-        # upstream traffic (r -> r-1: backward gradients) -> upstream comm
         if not self.is_first:
             ops.append(
                 dist.P2POp(
                     dist.isend,
                     send_tensor,
-                    group_peer=prev_stage_peer_rank,
-                    group=self._upstream_group,
+                    peer=prev_stage_peer,
+                    group=self._get_p2p_group(self.stage_index, self.stage_index - 1),
                 )
             )
         if not self.is_last:
             ops.append(
                 dist.P2POp(
                     dist.irecv,
-                    upstream_recv_tensor,
-                    group_peer=next_stage_peer_rank,
-                    group=self._upstream_group,
+                    next_recv_tensor,
+                    peer=next_stage_peer,
+                    group=self._get_p2p_group(self.stage_index + 1, self.stage_index),
                 )
             )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195759
* __->__ #195760

Extracted from @sanketpurandare's D116739193.

## Problem

  Per-direction PP currently creates two communicators over the entire PP group:
  one for forward traffic and one for backward traffic. Looped schedules place
  multiple logical stages on each rank, so unrelated physical edges still share
  one NCCL FIFO. A blocked transfer on one edge can delay another and form a
  cross-rank dependency cycle.

  The groups are also created before the schedule installs its final
  logical-stage placement, so they cannot reflect looped or V-shaped topologies.

Example:
```
Configuration: 2 microbatches, 8 stages, 4 GPUs

  GPU 0: S0, S4    GPU 1: S1, S5
  GPU 2: S2, S6    GPU 3: S3, S7

  Rank 0 compute order:
  0F0 -> 1F0 -> 0F4 -> 1F4

  Around the transition to stage 4:

  Rank 0                             Rank 3

  0F0 -> send to R1
  1F0 -> send to R1
               receive 0F3 <--------- 0F3
  0F4

  With one forward communicator:

  send(0F0, R0->R1)
  send(1F0, R0->R1)
  recv(0F3, R3->R0)   # queued behind those sends

  With directed communicators:

  R0->R1: send(0F0), send(1F0)
  R3->R0: recv(0F3)

  0F4 still waits for 0F3, but that receive no longer waits behind unrelated sends to rank 1.
```

  ## Change

```
 Before:

  PP group [0,1,2,3]
  ├── one communicator for every forward transfer
  └── one communicator for every backward transfer

  After:

  PP group [0,1,2,3]
  ├── communicator 0 -> 1
  ├── communicator 1 -> 0
  ├── communicator 1 -> 2
  ├── communicator 2 -> 1
  ├── communicator 2 -> 3
  └── communicator 3 -> 2
```

  After schedule initialization, derive the physical rank edges between adjacent
  logical stages and create a separate communicator for each direction. Pack
  non-overlapping edges into deterministic `split_group` rounds so every parent
  rank performs communicator creation in the same order.

  For a four-rank loop, eight directed edge groups are created in four split
  rounds. Sends and receives select their group by exact source and destination
  rank.

  The groups are accelerator-only, cached by parent and topology, and warmed
  before CUDA graph capture. Fake ProcessGroups retain the topology without
  creating real children.

  ## Test Plan

  - `python test/distributed/pipelining/test_schedule.py P2PTopologyTest`
  - `python test/distributed/pipelining/test_schedule.py ScheduleTest`
  - `python test/distributed/pipelining/test_schedule_multiproc.py PerDirectionScheduleTest`
  - Four-GPU TorchTitan `pp_looped_1f1b_cudagraph`: 10/10 steps
  - `python -m ruff check test/distributed/pipelining/test_schedule.py test/distributed/pipelining/test_schedule_multiproc.py torch/distributed/config.py torch/distributed/pipelining/schedules.py torch/distributed/pipelining/
  stage.py`