### PR TITLE
[ROCm] Fix data race in test_triton_signal_wait_until

### DIFF
--- a/test/distributed/test_shmem_triton.py
+++ b/test/distributed/test_shmem_triton.py
@@ -451,6 +451,9 @@ class SHMEMTritonTest(MultiProcContinuousTest):
         SIGNAL_VAL = 1  # Signal completion value
         NVSHMEM_CMP_EQ = 0  # compare equal for signal wait until
 
+        # Barrier so rank 1's pad zeroing cannot erase rank 0's incoming signal.
+        dist.barrier()
+
         if rank == 0:
             # Rank 0 puts into Rank 1
             my_putmem_signal_block_kernel[(1, 1, 1)](
@@ -508,6 +511,9 @@ class SHMEMTritonTest(MultiProcContinuousTest):
         NVSHMEM_SIGNAL_ADD = 1 if TEST_WITH_ROCM else 5
         SIGNAL_VAL = 16  # val + NVSHMEM_SIGNAL_ADD
         NVSHMEM_CMP_EQ = 0
+
+        # Barrier so rank 1's pad zeroing cannot erase rank 0's incoming signal.
+        dist.barrier()
 
         if rank == 0:
             # Rank 0 puts into Rank 1
@@ -610,6 +616,9 @@ class SHMEMTritonTest(MultiProcContinuousTest):
         # Use the signal pad for synchronization, as in previous tests
         flag_dtype = torch.int64
         flag = out_hdl.get_signal_pad(rank, (1,), dtype=flag_dtype).fill_(0)
+
+        # Barrier so rank 1's pad zeroing cannot erase rank 0's incoming signal.
+        dist.barrier()
 
         if rank == 0:
             # Producer (rank 0): Puts data into rank 1's `out` buffer and then sets the flag

--- a/test/distributed/test_shmem_triton.py
+++ b/test/distributed/test_shmem_triton.py
@@ -563,6 +563,9 @@ class SHMEMTritonTest(MultiProcContinuousTest):
             [FLAG_FINAL_VALUE], dtype=torch.int32, device=self.device
         )
 
+        # Barrier so the local flag init cannot erase the peer's incoming write.
+        dist.barrier()
+
         if rank == 0:
             # Rank 0 (the waiter)
             my_wait_until_kernel[(1,)](
@@ -689,6 +692,9 @@ class SHMEMTritonTest(MultiProcContinuousTest):
             [flag_val], dtype=torch.int32, device=self.device
         )
         NVSHMEM_CMP_EQ = 0  # compare equal
+
+        # Barrier so the local flag init cannot erase the peer's incoming write.
+        dist.barrier()
 
         if rank == 0:
             my_put_with_fence_kernel[(1,)](


### PR DESCRIPTION
Currently there isn't a barrier to sync ranks between 2 write operations to `flag`:
```
flag = out_hdl.get_signal_pad(rank, (1,), dtype=flag_dtype).fill_(0)
```
and
```
            my_putmem_signal_block_kernel[(1, 1, 1)](
                out,
                inp,
                size_bytes=msg_size_bytes,
                signal=flag,                              <--- here
                sig_val=COMPLETION_FLAG_VAL,              <--- equals 1
                sig_op=NVSHMEM_SIGNAL_SET,
                peer=peer,
            )
```
Therefore causing a data race, and if the first `fill_(0)` comes later and win the race, then the following code will wait forever and cause the test to time out:
```
            my_signal_wait_until_kernel[(1, 1, 1)](
                flag,
                cmp_op=NVSHMEM_CMP_EQ,
                cmp_val=COMPLETION_FLAG_VAL,
            )
```

Example failure: https://github.com/pytorch/pytorch/actions/runs/33469990076/job/99744122884

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang