### PR TITLE
[RAWTHROW][9] torch/csrc/distributed/c10d/nccl2: 43 conversions

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -605,9 +605,6 @@ exclude_patterns = [
     'c10/util/SmallVector.cpp',  # length_error -> ValueError, bad_alloc -> MemoryError
     'c10/util/StringUtil.cpp',  # range_error -> ValueError
     # Burned down later in this stack. Nothing may be added here.
-    # nccl2 is all that is left of torch/csrc/distributed/**: its NCCLException
-    # needs a decision that does not belong in a mechanical PR.
-    'torch/csrc/distributed/c10d/nccl2/**',
     'torch/csrc/jit/**',
 ]
 command = [

--- a/tools/linter/adapters/raw_throw_linter.py
+++ b/tools/linter/adapters/raw_throw_linter.py
@@ -64,6 +64,9 @@ ALLOWED_EXCEPTION_TYPES = {
     "py::stop_iteration": "",
     # Carries the device error code alongside the message.
     "c10::AcceleratorError": "",
+    # Same shape as AcceleratorError: carries the ncclResult_t alongside the
+    # message, and is what this backend's own NCCL_CHECK macros raise.
+    "NCCLException": "torch/csrc/distributed/c10d/nccl2/",
 }
 
 

--- a/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
@@ -65,11 +65,10 @@ std::vector<ncclUniqueId> NCCLBootstrap::exchangeUniqueIds(
   if (rootIndex >= 0) {
     ncclUniqueId uniqueId;
     const ncclResult_t ncclErr = nccl_api_->getUniqueId(&uniqueId);
-    if (ncclErr != ncclSuccess) {
-      throw std::runtime_error(
-          "Failed to get NCCL unique ID: " +
-          std::string(nccl_api_->getErrorString(ncclErr)));
-    }
+    TORCH_CHECK(
+        ncclErr == ncclSuccess,
+        "Failed to get NCCL unique ID: ",
+        nccl_api_->getErrorString(ncclErr));
 
     std::vector<uint8_t> vec(
         reinterpret_cast<uint8_t*>(&uniqueId),
@@ -81,9 +80,9 @@ std::vector<ncclUniqueId> NCCLBootstrap::exchangeUniqueIds(
   auto values = store->multiGet(keys);
   std::vector<ncclUniqueId> uniqueIds(numIds);
   for (int index = 0; index < numIds; ++index) {
-    if (values[index].size() != sizeof(ncclUniqueId)) {
-      throw std::runtime_error("Invalid NCCL unique ID size");
-    }
+    TORCH_CHECK(
+        values[index].size() == sizeof(ncclUniqueId),
+        "Invalid NCCL unique ID size");
     std::memcpy(&uniqueIds[index], values[index].data(), sizeof(ncclUniqueId));
   }
   return uniqueIds;
@@ -225,11 +224,10 @@ ncclComm_t NCCLBootstrap::createNcclComm(
     ncclErr = nccl_api_->commInitRankConfig(
         &nccl_comm, comm_size_, uniqueId, rank_, &config);
   }
-  if (nccl_comm == nullptr) {
-    throw std::runtime_error(
-        "Failed to initialize NCCL communicator: " +
-        std::string(nccl_api_->getErrorString(ncclErr)));
-  }
+  TORCH_CHECK(
+      nccl_comm != nullptr,
+      "Failed to initialize NCCL communicator: ",
+      nccl_api_->getErrorString(ncclErr));
   try {
     waitForNcclCompletion(
         *nccl_api_,

--- a/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
@@ -154,9 +154,11 @@ ncclResult_t DefaultNcclApi::commRegister(
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
   return ncclCommRegister(comm, buffer, size, handle);
 #else
-  throw std::runtime_error(fmt::format(
-      "NCCL version {} does not support ncclCommRegister API",
-      NCCL_VERSION_CODE));
+  TORCH_CHECK(
+      false,
+      fmt::format(
+          "NCCL version {} does not support ncclCommRegister API",
+          NCCL_VERSION_CODE));
 #endif
 }
 
@@ -165,9 +167,11 @@ ncclResult_t DefaultNcclApi::commDeregister(ncclComm_t comm, void* handle) {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
   return ncclCommDeregister(comm, handle);
 #else
-  throw std::runtime_error(fmt::format(
-      "NCCL version {} does not support ncclCommDeregister API",
-      NCCL_VERSION_CODE));
+  TORCH_CHECK(
+      false,
+      fmt::format(
+          "NCCL version {} does not support ncclCommDeregister API",
+          NCCL_VERSION_CODE));
 #endif
 }
 
@@ -331,8 +335,11 @@ ncclResult_t DefaultNcclApi::memAlloc(void** buff, size_t size) {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
   return ncclMemAlloc(buff, size);
 #else
-  throw std::runtime_error(fmt::format(
-      "NCCL version {} does not support ncclMemAlloc API", NCCL_VERSION_CODE));
+  TORCH_CHECK(
+      false,
+      fmt::format(
+          "NCCL version {} does not support ncclMemAlloc API",
+          NCCL_VERSION_CODE));
 #endif
 }
 
@@ -341,8 +348,11 @@ ncclResult_t DefaultNcclApi::memFree(void* buff) {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 19, 0)
   return ncclMemFree(buff);
 #else
-  throw std::runtime_error(fmt::format(
-      "NCCL version {} does not support ncclMemFree API", NCCL_VERSION_CODE));
+  TORCH_CHECK(
+      false,
+      fmt::format(
+          "NCCL version {} does not support ncclMemFree API",
+          NCCL_VERSION_CODE));
 #endif
 }
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -205,11 +205,12 @@ void ProcessGroupNCCL::init(at::Device device) {
   TC_LOG(INFO, this) << "Initializing ProcessGroupNCCL for device: " << device;
   device_ = device;
 
-  if (init_state_ == InitializationState::INITIALIZED) {
-    throw std::runtime_error("ProcessGroupNCCL already initialized");
-  } else if (init_state_ == InitializationState::FINALIZED) {
-    throw std::runtime_error("ProcessGroupNCCL already finalized");
-  }
+  TORCH_CHECK(
+      init_state_ != InitializationState::INITIALIZED,
+      "ProcessGroupNCCL already initialized");
+  TORCH_CHECK(
+      init_state_ != InitializationState::FINALIZED,
+      "ProcessGroupNCCL already finalized");
 
   if (!nccl_api_) {
     nccl_api_ = std::make_unique<DefaultNcclApi>();
@@ -504,11 +505,12 @@ std::unordered_map<std::string, uint64_t> ProcessGroupNCCL::getMemoryStats() {
 }
 
 void ProcessGroupNCCL::finalize() {
-  if (init_state_ == InitializationState::UNINITIALIZED) {
-    throw std::runtime_error("ProcessGroupNCCL not initialized");
-  } else if (init_state_ == InitializationState::FINALIZED) {
-    throw std::runtime_error("ProcessGroupNCCL already finalized");
-  }
+  TORCH_CHECK(
+      init_state_ != InitializationState::UNINITIALIZED,
+      "ProcessGroupNCCL not initialized");
+  TORCH_CHECK(
+      init_state_ != InitializationState::FINALIZED,
+      "ProcessGroupNCCL already finalized");
   init_state_ = InitializationState::FINALIZED;
 
   // Stop the watchdog first: draining the work queue below may surface a
@@ -519,23 +521,20 @@ void ProcessGroupNCCL::finalize() {
   // Wait for all pending work objects to complete and get final status
   auto work_status = workq_.finalize();
 
-  if (work_status == WorkNCCL::WorkStatus::NOT_STARTED ||
-      work_status == WorkNCCL::WorkStatus::INPROGRESS) {
-    throw std::runtime_error(
-        "WorkQ finalize returned in progress or not started state");
-  }
+  TORCH_CHECK(
+      work_status != WorkNCCL::WorkStatus::NOT_STARTED &&
+          work_status != WorkNCCL::WorkStatus::INPROGRESS,
+      "WorkQ finalize returned in progress or not started state");
 
   // Update comm_state_ based on the work status
   if (work_status == WorkNCCL::WorkStatus::TIMEDOUT) {
     comm_state_ = CommState::TIMEOUT;
     abortNcclComm();
-    throw std::runtime_error("Work timed out during finalize");
+    TORCH_CHECK(false, "Work timed out during finalize");
   } else if (work_status == WorkNCCL::WorkStatus::ERROR) {
     comm_state_ = CommState::ERROR;
-    if (!nccl_comm_) {
-      throw std::runtime_error(
-          "NCCL communicator was aborted after a previous error");
-    }
+    TORCH_CHECK(
+        nccl_comm_, "NCCL communicator was aborted after a previous error");
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -545,6 +544,10 @@ void ProcessGroupNCCL::finalize() {
     NCCLException ncclException(
         *nccl_api_, "NCCL Async Error", asyncErr, nccl_comm_);
     abortNcclComm();
+    // The constructor reads the communicator for getLastError(), and
+    // abortNcclComm() has just set nccl_comm_ to nullptr, so the exception has
+    // to be built first. A check macro would raise before the cleanup ran.
+    // @allow-raw-throw: abortNcclComm() nulls the comm it reads
     throw std::move(ncclException);
   }
 
@@ -822,9 +825,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::batch_op_issue(
     std::chrono::milliseconds timeout) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (ops.empty()) {
-    throw std::runtime_error("Cannot issue empty batch operation");
-  }
+  TORCH_CHECK(!ops.empty(), "Cannot issue empty batch operation");
 
   // Collect input and output tensors for work tracking
   std::vector<at::Tensor> input_tensors;
@@ -841,7 +842,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::batch_op_issue(
       ensureTensorContiguous(tensor);
       output_tensors.push_back(tensor);
     } else {
-      throw std::runtime_error("Unknown op type");
+      TORCH_CHECK(false, "Unknown op type");
     }
   }
 
@@ -1049,10 +1050,9 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_gather(
     std::chrono::milliseconds timeout) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
-  if (tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "tensor_list size must equal comm_size for all_gather");
-  }
+  TORCH_CHECK(
+      tensor_list.size() == static_cast<size_t>(comm_size_),
+      "tensor_list size must equal comm_size for all_gather");
 
   // Ensure input tensor is contiguous
   ensureTensorContiguous(tensor);
@@ -1166,10 +1166,9 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::allGatherSingleImpl(
   checkTensorDevice(input);
   checkSameDtype(input, output);
 
-  if (output.numel() != input.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Output tensor size must be input_size * comm_size for allGatherSingleImpl");
-  }
+  TORCH_CHECK(
+      output.numel() == input.numel() * comm_size_,
+      "Output tensor size must be input_size * comm_size for allGatherSingleImpl");
 
   TracingGuard tracingGuard(
       name_,
@@ -1216,10 +1215,9 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::reduce_scatter(
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
 
-  if (input_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_list size must equal comm_size for reduce_scatter");
-  }
+  TORCH_CHECK(
+      input_list.size() == static_cast<size_t>(comm_size_),
+      "input_list size must equal comm_size for reduce_scatter");
 
   // Check that all input tensors are contiguous.
   for (const auto& t : input_list) {
@@ -1317,10 +1315,9 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::reduceScatterSingleImpl(
   checkTensorDevice(input);
   checkSameDtype(input, output);
 
-  if (input.numel() != output.numel() * comm_size_) {
-    throw std::runtime_error(
-        "Input tensor size must be output_size * comm_size for reduceScatterSingleImpl");
-  }
+  TORCH_CHECK(
+      input.numel() == output.numel() * comm_size_,
+      "Input tensor size must be output_size * comm_size for reduceScatterSingleImpl");
 
   TracingGuard tracingGuard(
       name_,
@@ -1374,15 +1371,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::allToAllSingleImpl(
   checkTensorDevice(input);
   checkSameDtype(input, output);
 
-  if (input.numel() != output.numel()) {
-    throw std::runtime_error(
-        "Input and output tensors must have same size for allToAllSingleImpl");
-  }
+  TORCH_CHECK(
+      input.numel() == output.numel(),
+      "Input and output tensors must have same size for allToAllSingleImpl");
 
-  if (input.numel() % comm_size_ != 0) {
-    throw std::runtime_error(
-        "Tensor size must be divisible by comm_size for allToAllSingleImpl");
-  }
+  TORCH_CHECK(
+      input.numel() % comm_size_ == 0,
+      "Tensor size must be divisible by comm_size for allToAllSingleImpl");
 
   TracingGuard tracingGuard(
       name_,
@@ -1473,15 +1468,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_to_all_v_single(
   checkSameDtype(input, output);
 
   // Validate split sizes vectors
-  if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "input_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
+  TORCH_CHECK(
+      input_split_sizes.size() == static_cast<size_t>(comm_size_),
+      "input_split_sizes length must equal comm_size for all_to_all_v_single");
 
-  if (output_split_sizes.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "output_split_sizes length must equal comm_size for all_to_all_v_single");
-  }
+  TORCH_CHECK(
+      output_split_sizes.size() == static_cast<size_t>(comm_size_),
+      "output_split_sizes length must equal comm_size for all_to_all_v_single");
 
   // Validate that split sizes sum does not exceed tensor dimensions
   uint64_t input_total = 0;
@@ -1491,15 +1484,13 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_to_all_v_single(
     output_total += output_split_sizes[i];
   }
 
-  if (input_total > static_cast<uint64_t>(input.size(0))) {
-    throw std::runtime_error(
-        "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
-  }
+  TORCH_CHECK(
+      input_total <= static_cast<uint64_t>(input.size(0)),
+      "Sum of input_split_sizes exceeds input tensor size for all_to_all_v_single");
 
-  if (output_total > static_cast<uint64_t>(output.size(0))) {
-    throw std::runtime_error(
-        "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
-  }
+  TORCH_CHECK(
+      output_total <= static_cast<uint64_t>(output.size(0)),
+      "Sum of output_split_sizes exceeds output tensor size for all_to_all_v_single");
 
   TracingGuard tracingGuard(
       name_,
@@ -1602,11 +1593,10 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_to_all(
   checkAndAbortIfTimedOutOrError();
   checkTensorsDevice(output_tensor_list);
   checkTensorsDevice(input_tensor_list);
-  if (output_tensor_list.size() != static_cast<size_t>(comm_size_) ||
-      input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-    throw std::runtime_error(
-        "Tensor list sizes must equal comm_size for all_to_all");
-  }
+  TORCH_CHECK(
+      output_tensor_list.size() == static_cast<size_t>(comm_size_) &&
+          input_tensor_list.size() == static_cast<size_t>(comm_size_),
+      "Tensor list sizes must equal comm_size for all_to_all");
 
   // Validate all tensors
   for (int i = 0; i < comm_size_; ++i) {
@@ -1749,18 +1739,16 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::scatterImpl(
 
   // Only the root rank needs valid input tensors
   if (rank_ == root) {
-    if (input_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "input_tensor_list size must equal comm_size for scatter");
-    }
+    TORCH_CHECK(
+        input_tensor_list.size() == static_cast<size_t>(comm_size_),
+        "input_tensor_list size must equal comm_size for scatter");
 
     for (const auto& t : input_tensor_list) {
       ensureTensorContiguous(t);
       checkSameDtype(output_tensor, t);
-      if (t.numel() != output_tensor.numel()) {
-        throw std::runtime_error(
-            "All input tensors must have same size as output tensor");
-      }
+      TORCH_CHECK(
+          t.numel() == output_tensor.numel(),
+          "All input tensors must have same size as output tensor");
     }
   }
 
@@ -1870,18 +1858,16 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::gatherImpl(
 
   // Only the root rank needs valid output tensors
   if (rank_ == root) {
-    if (output_tensor_list.size() != static_cast<size_t>(comm_size_)) {
-      throw std::runtime_error(
-          "output_tensor_list size must equal comm_size for gather");
-    }
+    TORCH_CHECK(
+        output_tensor_list.size() == static_cast<size_t>(comm_size_),
+        "output_tensor_list size must equal comm_size for gather");
 
     for (const auto& t : output_tensor_list) {
       ensureTensorContiguous(t);
       checkSameDtype(input_tensor, t);
-      if (t.numel() != input_tensor.numel()) {
-        throw std::runtime_error(
-            "All output tensors must have same size as input tensor");
-      }
+      TORCH_CHECK(
+          t.numel() == input_tensor.numel(),
+          "All output tensors must have same size as input tensor");
     }
   }
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -82,7 +82,7 @@ ncclDataType_t getNcclDataTypeInternal(const at::Tensor& tensor) {
     case at::ScalarType::Float4_e2m1fn_x2:
       return ncclUint8;
     default:
-      throw std::runtime_error("Unsupported tensor data type for NCCL");
+      TORCH_CHECK(false, "Unsupported tensor data type for NCCL");
   }
 }
 
@@ -142,8 +142,8 @@ ProcessGroupNCCL::RedOpRAII::RedOpRAII(
           &ncclRedOp_, factor, comm, nccl_api_.get());
       break;
     default:
-      throw std::runtime_error(
-          "PreMulSum Data type must be half, float, bfloat16 or double");
+      TORCH_CHECK(
+          false, "PreMulSum Data type must be half, float, bfloat16 or double");
   }
 }
 
@@ -186,8 +186,7 @@ size_t ProcessGroupNCCL::wordSize(ncclDataType_t type) const {
       // case ncclFloat64:
       return 8;
     default:
-      throw std::runtime_error(
-          "Unsupported ncclDataType_t in wordSize: " + std::to_string(type));
+      TORCH_CHECK(false, "Unsupported ncclDataType_t in wordSize: ", type);
   }
 }
 
@@ -371,18 +370,16 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
   if (comm_state_ == CommState::TIMEOUT) {
     if (options_c10d_->enable_reconfigure) {
       revokeNcclComm();
-      throw std::runtime_error("NCCL operation timed out");
+      TORCH_CHECK(false, "NCCL operation timed out");
     } else {
       handleWatchdogFailure("timeout - collective operation timed out");
-      throw std::runtime_error("NCCL operation timed out");
+      TORCH_CHECK(false, "NCCL operation timed out");
     }
   } else if (comm_state_ == CommState::ERROR) {
     // CleanUpOnly may have already removed the communicator on the watchdog
     // thread, so a later collective cannot query the original NCCL error.
-    if (!nccl_comm_) {
-      throw std::runtime_error(
-          "NCCL communicator was aborted after a previous error");
-    }
+    TORCH_CHECK(
+        nccl_comm_, "NCCL communicator was aborted after a previous error");
     ncclResult_t asyncErr{};
     NCCL_CHECK(
         nccl_api_,
@@ -395,9 +392,14 @@ void ProcessGroupNCCL::checkAndAbortIfTimedOutOrError() {
       // In reconfigurable mode we never abort the process: revoke the comm so
       // it can be reconfigured and surface the error to the caller.
       revokeNcclComm();
+      // The constructor reads the communicator's last error, which the
+      // commRevoke() inside revokeNcclComm() overwrites, so the exception has
+      // to be built first. A check macro would raise before the revoke ran.
+      // @allow-raw-throw: the revoke above clobbers its last error
       throw std::move(ncclException);
     }
     handleWatchdogFailure(std::string("error - ") + ncclException.what());
+    // @allow-raw-throw: its what() is an argument to the call above
     throw std::move(ncclException);
   }
 }
@@ -488,9 +490,9 @@ void ProcessGroupNCCL::enqueueWork(
 // Static callback function for CUDA user object cleanup
 void ProcessGroupNCCL::graphCleanupCallback(void* userData) {
   auto* cleanup_data = static_cast<GraphCleanupData*>(userData);
-  if (cleanup_data == nullptr || cleanup_data->comm == nullptr) {
-    throw std::runtime_error("Invalid cleanup data");
-  }
+  TORCH_CHECK(
+      cleanup_data != nullptr && cleanup_data->comm != nullptr,
+      "Invalid cleanup data");
 
   // Clear the work references for this graph
   std::lock_guard<std::mutex> lock(
@@ -505,9 +507,9 @@ cudaStream_t ProcessGroupNCCL::getOperationStream(bool async_op) {
   c10::cuda::CUDAGuard gpuGuard(device_);
   if (async_op) {
     auto current_stream = at::cuda::getCurrentCUDAStream(device_.index());
-    if (!dependency_event_.has_value() || !internal_stream_.has_value()) {
-      throw std::runtime_error("NCCL stream resources are not initialized");
-    }
+    TORCH_CHECK(
+        dependency_event_.has_value() && internal_stream_.has_value(),
+        "NCCL stream resources are not initialized");
     auto& dependency_event = dependency_event_.value();
     auto& internal_stream = internal_stream_.value();
 

--- a/torch/csrc/distributed/c10d/nccl2/Utils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/Utils.cpp
@@ -2,10 +2,10 @@
 
 #ifdef USE_C10D_NCCL
 
+#include <c10/util/Exception.h>
 #include <torch/csrc/distributed/c10d/nccl2/Utils.hpp>
 #include <algorithm>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -72,11 +72,8 @@ bool string_to_bool(std::string_view str) {
       (lowercase_str == "0" || lowercase_str == "false" ||
        lowercase_str == "no" || lowercase_str == "n");
 
-  if (!is_true && !is_false) {
-    throw std::runtime_error("Invalid value for string " + std::string(str));
-  } else {
-    return is_true;
-  }
+  TORCH_CHECK(is_true || is_false, "Invalid value for string ", str);
+  return is_true;
 }
 
 template <typename T>
@@ -105,15 +102,16 @@ T env_to_value(std::string_view env_key, const T& default_value) {
       std::istringstream ss(value);
       ss >> result;
 
-      if (ss.fail() || !ss.eof()) {
-        throw std::runtime_error("Conversion failed");
-      }
+      TORCH_CHECK(!ss.fail() && ss.eof(), "Conversion failed");
 
       return result;
     } catch (const std::exception&) {
-      throw std::runtime_error(
-          "Invalid value for environment variable " + std::string(env_key) +
-          ": " + value);
+      TORCH_CHECK(
+          false,
+          "Invalid value for environment variable ",
+          env_key,
+          ": ",
+          value);
     }
   }
 }
@@ -208,7 +206,8 @@ std::pair<int, int> query_ranksize() {
   };
 
   if (!tryQueryRankSize()) {
-    throw std::runtime_error(
+    TORCH_CHECK(
+        false,
         "Unable to determine rank and size from environment variables. "
         "Please set TORCHCOMM_RANK and TORCHCOMM_SIZE, or ensure you are "
         "running in a supported environment (Torchrun, MPI, or PALS).");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #195764
* __->__ #195763

## Author Notes

The nccl2 custom exception is allowlisted even though no one does anything with it and it translates to a regular error afaict.
I'm happy to remove it and change eveyrthing to TORCH_CHECK() but waiting on @d4l3k guidance on that.

## Agent Notes

Written by Claude Code:

> Deletes the last `torch/csrc/distributed/**` entry from RAWTHROW's
> `exclude_patterns`, so the whole distributed tree is now covered. 49
> findings: 43 plain `std::runtime_error` become `TORCH_CHECK`, and the
> remaining six are all `NCCLException`.
>
> `NCCLException` gets an `ALLOWED_EXCEPTION_TYPES` entry scoped to
> `torch/csrc/distributed/c10d/nccl2/`. It is this backend's own error type,
> carries the `ncclResult_t` alongside the message, and is what the
> `NCCL_CHECK` / `NCCL_CHECK_NONBLOCKING` macros in `ProcessGroupNCCL.hpp`
> raise -- converting the three call sites while those macros keep throwing
> it would leave the file arguing with itself. The rationale is the same
> shape as the existing `c10::AcceleratorError` entry.
>
> Stating the weakness plainly, because it is the one thing a reviewer
> should push back on: nothing catches `NCCLException` by name anywhere in
> `torch/` or `test/`, and `getResult()` -- the accessor that makes carrying
> the result code worth anything -- has no caller. So the entry rests on the
> type being the backend's designed error channel rather than on a
> demonstrated consumer. If the torchcomm owners would rather it became a
> `c10::DistBackendError` subclass, or the call sites became `TORCH_CHECK`,
> say so and this becomes that instead.
>
> The other three sites keep a raw throw with a line-scoped reason, one
> reason each because they are not the same reason. All three read
>
>     NCCLException ncclException(*nccl_api_, ..., nccl_comm_);
>     abortNcclComm();            // or revokeNcclComm()
>     throw std::move(ncclException);
>
> and the constructor reads the communicator, for
> `getLastError(comm)`. What the cleanup does to it differs:
> `abortNcclComm()` sets `nccl_comm_` to nullptr, while `revokeNcclComm()`
> leaves the pointer alone but calls `commRevoke`, which overwrites the last
> error the constructor wants to report. The third site is simpler still --
> `ncclException.what()` is an argument to the `handleWatchdogFailure` call
> above it, so the object provably has to exist first. In all three, no check
> macro can express build-then-clean-up-then-raise: it would raise before the
> cleanup ran. These are correct as written, which is what the annotation is
> for.
>
> Nothing else in the diff changes an exception type. `c10::Error` reaches
> Python as `RuntimeError`, same as `std::runtime_error`, and nothing in the
> tree catches `std::runtime_error` on any of these paths. Two message
> details worth naming: `wordSize`'s "Unsupported ncclDataType_t" and
> `string_to_bool`'s "Invalid value for string" now stream the value through
> `c10::str` instead of `std::to_string` / `operator+`, which renders
> identically; and every converted site gains the usual `Exception raised
> from ...` suffix.
>
> Test Plan:
>
> **These files are not compiled by any build available here.** They live in
> `libtorch_cuda_distributed_extra_sources`, which is CUDA-only, and this
> machine has no NCCL headers, so a `USE_CUDA=1` build is not an option
> either. CI's CUDA jobs are the first thing that compiles them. What I could
> check:
>
> ```
> spin lint -- --take RAWTHROW --all-files
> spin lint -- --take CLANGFORMAT,RAWTHROW,NEWLINE,SPACES,TABS,TOML,RUFF,MYPY <changed files>
> python3 tools/linter/adapters/raw_throw_linter.py \
>     $(git ls-files | grep -E '^torch/csrc/distributed/c10d/nccl2/.*\.(cpp|h)$')
> ```
>
> All clean; nccl2 goes from 49 findings to 0, and the whole-tree run passes
> with the exclude deleted.
>
> A local pre-submit review caught a build break the CPU build could not:
> `Utils.cpp` was the one changed file with no existing `TORCH_CHECK` and no
> include path to `c10/util/Exception.h`, so it failed to compile. It now
> includes it directly, in place of the `<stdexcept>` the conversion
> orphaned. That file needs no CUDA or NCCL headers, so it can be checked
> here:
>
> ```
> g++ -std=c++17 -DUSE_C10D_NCCL -c -Wall -Wextra -Wreturn-type -I. -Ibuild \
>     -Iaten/src -Ibuild/aten/src -Ithird_party/fmt/include \
>     torch/csrc/distributed/c10d/nccl2/Utils.cpp -o /dev/null
> ```
>
> The other four changed files already reached `TORCH_CHECK` before this
> commit -- three used it directly, and `NcclApi.cpp` gets it through
> `nccl2/Logging.hpp`, outside the `NCCL_VERSION_CODE` guards.
>
> ```
> CMAKE_GENERATOR=Ninja USE_DISTRIBUTED=1 USE_CUDA=0 BUILD_TEST=0 \
>     pip install -e . -v --no-build-isolation
> ```
>
> Green, but only proves the linter and `.lintrunner.toml` edits break
> nothing -- it compiles none of the changed C++.
>
> So the shapes this PR introduces were compiled standalone against mock
> `ncclDataType_t` / `ncclResult_t` enums, with `-c` rather than
> `-fsyntax-only` because the latter does not run the -Wreturn-type analysis:
> `TORCH_CHECK(false, fmt::format(...))` ending a non-void function in the
> `#else` arm of a version gate, a `switch` default ending a non-void
> function, the enum streamed into a message where `std::to_string` used to
> be, and `std::string_view` streamed into a message. All clean under
> `-Wall -Wextra -Wreturn-type`.
>
> ```
> g++ -std=c++20 -c -Wall -Wextra -Wreturn-type -I. -Ibuild -Iaten/src \
>     -Ibuild/aten/src -Itorch/include -Ithird_party/fmt/include tu.cpp -o /dev/null
> ```
>
> The four `NcclApi.cpp` sites are in `#else` arms taken only below NCCL
> 2.19, so even a CUDA CI job will not compile them unless it pins an old
> NCCL.
>
> This change was authored with the help of an AI assistant (Claude Code).