### PR TITLE
[c10d] [PyBackend] Fix nccl4py backend binding subgroup communicators to the wrong GPU

### DIFF
--- a/test/distributed/test_c10d_nccl4py.py
+++ b/test/distributed/test_c10d_nccl4py.py
@@ -332,6 +332,23 @@ class TestNCCL4PyBackendCollectives(MultiProcessTestCase):
         self._destroy_pg()
 
     @skip_if_lt_x_gpu(2)
+    def test_subgroup_preserves_device(self):
+        # Subgroup {1}: the backend creator only sees the group-local rank (0),
+        # which differs from this process's physical device (cuda:1). The
+        # communicator must be created on cuda:1, not cuda:(group_rank), or the
+        # collective runs against a comm on the wrong GPU.
+        self._init_pg()
+        device = torch.device(f"cuda:{self.rank}")
+        subgroup = dist.new_group([1])
+        if self.rank == 1:
+            t = torch.ones(4, device=device) * 7.0
+            dist.all_reduce(t, group=subgroup)
+            torch.cuda.synchronize(device)
+            self.assertEqual(t, torch.full((4,), 7.0, device=device))
+        dist.barrier()
+        self._destroy_pg()
+
+    @skip_if_lt_x_gpu(2)
     def test_get_future(self):
         self._init_pg()
         device = torch.device(f"cuda:{self.rank}")

--- a/torch/distributed/nccl4py_backend.py
+++ b/torch/distributed/nccl4py_backend.py
@@ -86,8 +86,19 @@ class NCCL4PyBackend(C10DBackend):
         self._store = store
         self._options = C10DBackend.Options("nccl4py", timeout=timeout)
 
+        # TODO (thisisatharva-rh): workaround. The basic creator API only passes the group-local
+        # rank, which is not a valid device index for a subgroup, so we recover
+        # the device from the default group. The proper fix is to migrate to the
+        # extended_api=True, which supplies the resolved device directly
+
         device_count = torch.cuda.device_count()
-        self._device = torch.device("cuda", rank % device_count)
+        if dist.is_initialized():
+            default_pg = dist.distributed_c10d._get_default_group()
+            self._device = default_pg.bound_device_id or torch.device(
+                "cuda", default_pg.rank() % device_count
+            )
+        else:
+            self._device = torch.device("cuda", rank % device_count)
         torch.cuda.set_device(self._device)
 
         if rank == 0:


### PR DESCRIPTION
### Summary 
`NCCL4PyBackend.__init__` derived its device from the rank passed by the
  backend-creator API (`torch.device("cuda", rank % device_count)`). That API
  passes the **group-local** rank, not the global rank. For the default group the
  two coincide, but for a subgroup they don't: on a process running on `cuda:1`,
  `dist.new_group([1])` constructs the backend with group-local rank `0`, so the
  communicator binds to `cuda:0` and every later collective on that subgroup fails
  (tensors on `cuda:1`, comm on `cuda:0`).

### Fix (workaround) 

 Resolve the device the way `ProcessGroupNCCL` does: prefer the default group's
  `bound_device_id`, else `default_pg.rank() % device_count`, falling back to the
  This is a targeted workaround, not the canonical fix. The root issue is that the
  backend registers with the *basic* creator API, which never provides the device.
  The proper fix is migrating to the extended creator API (`extended_api=True`),
  which supplies the resolved device directly (see `_nccl2_device`), plus
  eager-split support. That is a larger change and is left as a follow-up. 

### Test Plan 
```
 python test/distributed/test_c10d_nccl4py.py
```

Authored with the assistance of an AI agent