### PR TITLE
Fix the unbacked guard in linalg_cross's meta length-3 check

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -76,6 +76,21 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(x)
         torch.testing.assert_close(actual, expected)
 
+    def test_linalg_cross_unbacked_last_dim(self, device):
+        # Regression: linalg_cross's meta check was written as
+        # `self.size(dim) == 3 and other.size(dim) == 3`. `and` has to decide
+        # the truthiness of its left operand, so it called bool() on the first
+        # SymBool - a guard - and an unbacked last dim raised Eq(u0, 3).
+        def fn(x):
+            nz = x.nonzero()
+            a = torch.ones(4, nz.size(0), device=x.device)
+            return torch.linalg.cross(a, a)
+
+        x = torch.tensor([1, 0, 1, 1], device=device)
+        actual = torch.compile(fn, fullgraph=True)(x)
+        expected = fn(x)
+        torch.testing.assert_close(actual, expected)
+
     def test_remove_no_ops_unbacked_shape_dde(self, device):
         # Regression: fake_tensors_eq in remove_no_ops used `shape1 != shape2`,
         # which raises GuardOnDataDependentSymNode when the tuples contain

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -240,6 +240,8 @@ def meta__transformer_encoder_layer_fwd(
 @register_meta([aten.linalg_cross.default, aten.linalg_cross.out])
 @out_wrapper()
 def linalg_cross(self, other, *, dim=-1):
+    from torch.fx.experimental.symbolic_shapes import sym_and
+
     x_d = self.ndim
     y_d = other.ndim
     torch._check(
@@ -247,7 +249,7 @@ def linalg_cross(self, other, *, dim=-1):
         lambda: "linalg.cross: inputs must have the same number of dimensions.",
     )
     torch._check(
-        self.size(dim) == 3 and other.size(dim) == 3,
+        sym_and(self.size(dim) == 3, other.size(dim) == 3),
         lambda: (
             f"linalg.cross: inputs dimension {dim} must have length 3. "
             f"Got {self.size(dim)} and {other.size(dim)}"


### PR DESCRIPTION
`linalg_cross`'s meta kernel checks the length-3 requirement with a single `torch._check` and an `and`:

```python
torch._check(
    self.size(dim) == 3 and other.size(dim) == 3,
    lambda: (...),
)
```

Python's `and` has to decide the truthiness of its left operand, so it calls `bool()` on the first `SymBool`. On an unbacked size that is a guard, and tracing fails instead of recording the constraint:

```python
def fn(x):
    nz = x.nonzero()
    a = torch.ones(4, nz.size(0))   # last dim unbacked
    return torch.linalg.cross(a, a)

torch.compile(fn, fullgraph=True)(torch.tensor([1, 0, 1, 1]))
```

```
torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode:
Could not guard on data-dependent expression Eq(u0, 3) (unhinted: Eq(u0, 3))
```

`sym_and` combines the two without the bool cast. It is what the rest of the file already reaches for on compound conditions - `_padding_check_valid_input` and the pooling checks both do this.

### Only the left operand is the problem

`a and b` evaluates `bool(a)` and, if truthy, returns `b` untouched. So a symbolic *right* operand is fine, and the many `x.dim() == n and <symbolic>` checks in this file are correct as written. I measured each shape rather than assuming:

| written as | result |
|---|---|
| `a_sym and b` | guard error |
| `plain and a_sym` | traces cleanly |
| `a_sym` alone | recorded as a deferred runtime assert |
| `all(<symbolic> ...)` | guard error |
| `a_sym or b` | guard error |

I swept `_meta_registrations.py` for `torch._check` conditions combining `and`/`or` over `size`/`shape`, and 18 sites matched textually - but on this rule most are safe, and of the ones that are not, only `linalg_cross` turned out to be reachable in a way I could actually trigger. I am only claiming the one I can demonstrate.

One adjacent finding, offered as information rather than as part of this PR: `meta_upsample_bimode2d_aa` has the same shape (`input.numel() != 0 or all(size > 0 ...)`, symbolic on the left). Rewriting it does remove that guard, but the op still cannot trace with an unbacked channel dim because `utils.suggest_memory_format` then guards on `u0 > 1`. That is a much deeper change, so I left the op alone rather than ship a hunk whose benefit I could not show.

### Test plan

New regression in `test/inductor/test_unbacked_symints.py`. It makes the **last** dim unbacked; the op_db samples only exercise concrete ones, which is why CI did not already cover this.

```
python -m pytest test/inductor/test_unbacked_symints.py -k linalg_cross
```

before: `Could not guard on data-dependent expression Eq(u0, 3)`
after: `1 passed`

The check still rejects a bad length in eager:

```
python -c "import torch; a = torch.ones(4, 5); torch.linalg.cross(a, a)"
```

```
RuntimeError: linalg.cross: inputs dimension -1 must have length 3. Got 5 and 5
```

Surrounding suites:

```
python -m pytest test/inductor/test_unbacked_symints.py
python -m pytest test/test_ops.py -k linalg_cross
python -m pytest test/test_meta.py -k cross
```

```
50 passed, 11 skipped
66 passed, 15 skipped, 2 xfailed
130 passed, 154 skipped, 8 xfailed
```

---

This change was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo