### PR TITLE
inductor: add a Blackwell persistent TMA BMM template

### DIFF
--- a/test/inductor/test_blackwell_bmm.py
+++ b/test/inductor/test_blackwell_bmm.py
@@ -1,0 +1,91 @@
+# Owner(s): ["module: inductor"]
+import unittest
+from unittest import mock
+
+import torch
+from torch._inductor import config, ir
+from torch._inductor.kernel.bmm import (
+    append_blackwell_bmm_choice,
+    BlackwellBMMConfig,
+)
+from torch._inductor.lowering import lowerings
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_cuda import SM100OrLater
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
+
+
+@torch.library.custom_op("inductor_test::blackwell_bmm", mutates_args={})
+def blackwell_bmm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return torch.bmm(a, b)
+
+
+@blackwell_bmm.register_fake
+def _(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return a.new_empty((a.shape[0], a.shape[1], b.shape[2]))
+
+
+@unittest.skipUnless(HAS_GPU and SM100OrLater, "requires NVIDIA SM100+")
+class TestBlackwellBMM(TestCase):
+    def _run(self, broadcast_b: bool) -> None:
+        bsz, m, k, n = 3, 256, 8193, 128
+        a_storage = torch.randn(bsz, k, m, device="cuda", dtype=torch.bfloat16)
+        a = a_storage.transpose(1, 2)
+        if broadcast_b:
+            b = torch.randn(k, n, device="cuda", dtype=torch.bfloat16)
+            b = b.unsqueeze(0).expand(bsz, -1, -1)
+        else:
+            b = torch.randn(bsz, k, n, device="cuda", dtype=torch.bfloat16)
+        template_config = BlackwellBMMConfig(
+            block_m=128,
+            block_n=128,
+            block_k=128,
+            num_stages=3,
+            epilogue_subtile=1,
+        )
+
+        def lowering(a_node, b_node):
+            layout = ir.FixedLayout(
+                a_node.get_device(),
+                a_node.get_dtype(),
+                [bsz, m, n],
+                [m * n, n, 1],
+            )
+            choices = []
+            append_blackwell_bmm_choice(
+                choices, (a_node, b_node), layout, config=template_config
+            )
+            return choices[0].output_node()
+
+        with (
+            mock.patch.dict(
+                lowerings,
+                {torch.ops.inductor_test.blackwell_bmm.default: lowering},
+            ),
+            config.patch(
+                compile_threads=1,
+                **{"triton.enable_template_tma_store": True},
+            ),
+        ):
+            actual, codes = run_and_get_code(
+                torch.compile(
+                    lambda x, y: blackwell_bmm(x, y), fullgraph=True
+                ),
+                a,
+                b,
+            )
+
+        torch.testing.assert_close(actual, torch.bmm(a, b), atol=16.0, rtol=1e-1)
+        self.assertIn("make_tensor_descriptor", codes[0])
+        self.assertNotIn("two_ctas=True", codes[0])
+
+    def test_1cta_strided_batch(self):
+        self._run(False)
+
+    def test_1cta_broadcast_batch_stride(self):
+        self._run(True)
+
+
+if __name__ == "__main__":
+    if HAS_GPU and HAS_CPU:
+        run_tests()

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import dataclasses
 import logging
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,7 @@ from ..select_algorithm import (
 )
 from ..utils import (
     _use_cutlass_for_op,
+    get_num_sms,
     use_aten_gemm_kernels,
     use_ck_gemm_template,
     use_cpp_bmm_template,
@@ -26,6 +28,7 @@ from ..utils import (
     use_nv_universal_gemm_template,
     use_triton_template,
 )
+from torch.utils._triton import has_triton_stable_tma_api
 from ..virtualized import ops, V
 from .mm_common import (
     _is_static_problem,
@@ -63,6 +66,93 @@ bmm_template = TritonTemplate(
     source=load_kernel_template("triton_bmm"),
     cache_codegen_enabled_for_template=True,
 )
+
+
+@SymbolicGridFn
+def blackwell_bmm_grid(b, m, n, meta, *, cdiv, max, min):
+    grid_m = cdiv(m, meta["BLOCK_M"])
+    tiles = grid_m * cdiv(n, meta["BLOCK_N"])
+    grid_x = min(meta["NUM_SMS"], tiles)
+    max_y_grid = get_max_y_grid()
+    grid_z = max(cdiv(b, max_y_grid), 1)
+    return (grid_x, cdiv(b, grid_z), grid_z)
+
+
+blackwell_bmm_template = TritonTemplate(
+    name="blackwell_bmm",
+    grid=blackwell_bmm_grid,
+    source=load_kernel_template("triton_blackwell_ws_persistent_device_tma_bmm"),
+    cache_codegen_enabled_for_template=True,
+    prologue_loads_all_inputs=True,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class BlackwellBMMConfig:
+    block_m: int
+    block_n: int
+    block_k: int
+    num_stages: int
+    epilogue_subtile: int = 1
+
+
+def append_blackwell_bmm_choice(
+    choices,
+    input_nodes,
+    layout,
+    *,
+    config: BlackwellBMMConfig,
+):
+    mat1, mat2 = input_nodes
+    if len(mat1.get_size()) != 3 or len(mat2.get_size()) != 3:
+        raise NotImplementedError("Blackwell BMM requires rank-3 operands")
+    batch, m, k = map(int, mat1.get_size())
+    batch_b, k_b, n = map(int, mat2.get_size())
+    if batch != batch_b or k != k_b:
+        raise NotImplementedError("Blackwell BMM does not broadcast logical batches")
+    if list(map(int, layout.size)) != [batch, m, n]:
+        raise NotImplementedError("unexpected Blackwell BMM output layout")
+    a_row_major = mat1.get_stride()[2] == 1
+    a_col_major = mat1.get_stride()[1] == 1
+    b_row_major = mat2.get_stride()[2] == 1
+    b_col_major = mat2.get_stride()[1] == 1
+    if not (a_row_major or a_col_major) or not (b_row_major or b_col_major):
+        raise NotImplementedError(
+            "Blackwell BMM requires one contiguous matrix dimension"
+        )
+    kwargs = {
+        "BLOCK_M": config.block_m,
+        "BLOCK_N": config.block_n,
+        "BLOCK_K": config.block_k,
+        "GROUP_M": 8,
+        "NUM_SMS": get_num_sms(),
+        "A_ROW_MAJOR": a_row_major,
+        "B_ROW_MAJOR": b_row_major,
+        "ALLOW_TF32": False,
+        "USE_META_WS": True,
+        "WARP_SPECIALIZE": True,
+        "FLATTEN": False,
+        "DATA_PARTITION_FACTOR": 1,
+        "SEPARATE_EPILOGUE_STORE": True,
+        "EPILOGUE_SUBTILE": config.epilogue_subtile,
+        "TMA_EXPERIMENTAL_API": not has_triton_stable_tma_api(),
+        # Keep the output a normal logical rank-3 tensor.  Until 2CTA output
+        # transformation supports rank-3 descriptors, use the generic pointer
+        # store emitted by store_output.
+        "tma_store": False,
+        "transpose_discontiguous_tensor_descriptors_override": True,
+    }
+    error = blackwell_bmm_template.maybe_append_choice(
+        choices,
+        input_nodes=input_nodes,
+        layout=layout,
+        call_sizes=layout.size,
+        num_stages=config.num_stages,
+        num_warps=8,
+        **kwargs,
+    )
+    if error is not None:
+        raise error
 
 aten_bmm = ExternKernelChoice(torch.bmm, "at::bmm_out", op_overload=aten.bmm.out)
 aten_bmm_dtype = ExternKernelChoice(

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
@@ -1,0 +1,120 @@
+{{def_kernel("A", "B")}}
+    BATCH = {{size("A", 0)}}
+    M = {{size("A", 1)}}
+    N = {{size("B", 2)}}
+    K = {{size("A", 2)}}
+    batch = (tl.program_id(1) + tl.program_id(2) * tl.num_programs(1)).to(tl.int32)
+    if batch >= BATCH or M * N == 0:
+        return
+
+    stride_ab = {{stride("A", 0)}}
+    stride_am = {{stride("A", 1)}}
+    stride_ak = {{stride("A", 2)}}
+    stride_bb = {{stride("B", 0)}}
+    stride_bk = {{stride("B", 1)}}
+    stride_bn = {{stride("B", 2)}}
+    a_base = A + batch * stride_ab
+    b_base = B + batch * stride_bb
+
+    # A logical rank-3 BMM is represented by one rank-2 descriptor per batch.
+    # This supports arbitrary/zero batch strides and keeps the descriptor-load
+    # shape compatible with today's rank-2 Transform2CTALoads implementation.
+    a_desc = triton.language.make_tensor_descriptor(
+        base=a_base,
+        shape=[M, K] if A_ROW_MAJOR else [K, M],
+        strides=[stride_am, 1] if A_ROW_MAJOR else [stride_ak, 1],
+        block_shape=[BLOCK_M, BLOCK_K] if A_ROW_MAJOR else [BLOCK_K, BLOCK_M],
+    )
+    b_desc = triton.language.make_tensor_descriptor(
+        base=b_base,
+        shape=[K, N] if B_ROW_MAJOR else [N, K],
+        strides=[stride_bk, 1] if B_ROW_MAJOR else [stride_bn, 1],
+        block_shape=[BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
+    )
+
+    start_pid = tl.program_id(0)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    num_tiles = grid_m * grid_n
+    num_pid_in_group = GROUP_M * grid_n
+    k_tiles = tl.cdiv(K, BLOCK_K)
+    tile_id_c = start_pid - NUM_SMS
+
+    for tile_id in tl.range(
+        start_pid,
+        num_tiles,
+        NUM_SMS,
+        flatten=FLATTEN,
+        warp_specialize=WARP_SPECIALIZE,
+        data_partition_factor=DATA_PARTITION_FACTOR,
+        separate_epilogue_store=SEPARATE_EPILOGUE_STORE,
+    ):
+        pid_m, pid_n = _blackwell_bmm_pid(
+            tile_id, num_pid_in_group, grid_m, GROUP_M
+        )
+        offs_am = (pid_m * BLOCK_M).to(tl.int32)
+        offs_bn = (pid_n * BLOCK_N).to(tl.int32)
+        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = (ki * BLOCK_K).to(tl.int32)
+            a = tl.load_tensor_descriptor(
+                a_desc,
+                [offs_am, offs_k] if A_ROW_MAJOR else [offs_k, offs_am],
+            )
+            b = tl.load_tensor_descriptor(
+                b_desc,
+                [offs_k, offs_bn] if B_ROW_MAJOR else [offs_bn, offs_k],
+            )
+            accumulator += tl.dot(
+                a if A_ROW_MAJOR else a.T,
+                b if B_ROW_MAJOR else b.T,
+                allow_tf32=ALLOW_TF32,
+            )
+
+        tile_id_c += NUM_SMS
+        pid_m, pid_n = _blackwell_bmm_pid(
+            tile_id_c, num_pid_in_group, grid_m, GROUP_M
+        )
+        offs_cm = pid_m * BLOCK_M
+        offs_cn = pid_n * BLOCK_N
+        subtiles = _blackwell_bmm_subtiles(
+            accumulator, BLOCK_M, BLOCK_N, EPILOGUE_SUBTILE
+        )
+        for i in tl.static_range(EPILOGUE_SUBTILE):
+            offs_cn_i = offs_cn + i * (BLOCK_N // EPILOGUE_SUBTILE)
+            rm = offs_cm + tl.arange(0, BLOCK_M)[:, None]
+            rn = offs_cn_i + tl.arange(0, BLOCK_N // EPILOGUE_SUBTILE)[None, :]
+            mask = (rm < M) & (rn < N)
+            {{store_output(
+                ("batch", "rm", "rn"),
+                "subtiles[i]",
+                "mask",
+                indent_width=12,
+                val_shape=("BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE")
+            )}}
+
+
+@triton.jit
+def _blackwell_bmm_pid(tile_id, num_pid_in_group, grid_m, GROUP_M: tl.constexpr):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_M
+    group_m = min(grid_m - first_pid_m, GROUP_M)
+    pid_m = first_pid_m + tile_id % group_m
+    pid_n = (tile_id % num_pid_in_group) // group_m
+    return pid_m, pid_n
+
+
+@triton.jit
+def _blackwell_bmm_subtiles(
+    acc,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SUBTILE_FACTOR: tl.constexpr,
+):
+    if SUBTILE_FACTOR == 1:
+        return (acc,)
+    else:
+        tl.static_assert(SUBTILE_FACTOR == 2)
+        acc = tl.reshape(acc, (BLOCK_M, 2, BLOCK_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        return tl.split(acc)


### PR DESCRIPTION
## Summary

Adds an experimental Blackwell persistent TMA template for logical rank-3 BMM.

- Supports `[B, M, K] @ [B, K, N] -> [B, M, N]`.
- Uses one rank-2 TMA descriptor per batch, allowing arbitrary and zero batch strides without relying on rank-3 2CTA lowering.
- Establishes a 1CTA-only correctness baseline; this PR does not add 2CTA or enable the template by default.

## Testing

- Strided batched input correctness.
- Zero-stride broadcasted B correctness.
- Generated-code check that 2CTA is absent.
- TritonBench coverage across contiguous, transposed, tail, and production-derived shapes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>