### PR TITLE
inductor: add 2CTA support to Blackwell BMM

### DIFF
--- a/test/inductor/test_blackwell_bmm.py
+++ b/test/inductor/test_blackwell_bmm.py
@@ -25,6 +25,16 @@ def _(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     return a.new_empty((a.shape[0], a.shape[1], b.shape[2]))
 
 
+@torch.library.custom_op("inductor_test::blackwell_bmm_flat", mutates_args={})
+def blackwell_bmm_flat(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return torch.bmm(a, b).flatten(0, 1)
+
+
+@blackwell_bmm_flat.register_fake
+def _(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return a.new_empty((a.shape[0] * a.shape[1], b.shape[2]))
+
+
 @unittest.skipUnless(HAS_GPU and SM100OrLater, "requires NVIDIA SM100+")
 class TestBlackwellBMM(TestCase):
     def _run(self, broadcast_b: bool) -> None:
@@ -84,6 +94,54 @@ class TestBlackwellBMM(TestCase):
 
     def test_1cta_broadcast_batch_stride(self):
         self._run(True)
+
+    def test_2cta_flat_output(self):
+        bsz, m, k, n = 2, 256, 8193, 128
+        a_storage = torch.randn(bsz, k, m, device="cuda", dtype=torch.bfloat16)
+        a = a_storage.transpose(1, 2)
+        b = torch.randn(bsz, k, n, device="cuda", dtype=torch.bfloat16)
+        template_config = BlackwellBMMConfig(
+            block_m=128,
+            block_n=128,
+            block_k=64,
+            num_stages=4,
+            epilogue_subtile=1,
+            two_ctas=True,
+        )
+
+        def lowering(a_node, b_node):
+            layout = ir.FixedLayout(
+                a_node.get_device(),
+                a_node.get_dtype(),
+                [bsz * m, n],
+                [n, 1],
+            )
+            choices = []
+            append_blackwell_bmm_choice(
+                choices, (a_node, b_node), layout, config=template_config
+            )
+            return choices[0].output_node()
+
+        with (
+            mock.patch.dict(
+                lowerings,
+                {torch.ops.inductor_test.blackwell_bmm_flat.default: lowering},
+            ),
+            config.patch(
+                compile_threads=1,
+                **{"triton.enable_template_tma_store": True},
+            ),
+        ):
+            actual, codes = run_and_get_code(
+                torch.compile(blackwell_bmm_flat, fullgraph=True), a, b
+            )
+
+        torch.testing.assert_close(
+            actual.view(bsz, m, n), torch.bmm(a, b), atol=16.0, rtol=1e-1
+        )
+        self.assertIn("TWO_CTAS : tl.constexpr = True", codes[0])
+        self.assertIn("ctas_per_cga=(2, 1, 1)", codes[0])
+        self.assertIn("make_tensor_descriptor(out_ptr0", codes[0])
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import dataclasses
 import logging
+import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -71,8 +72,12 @@ bmm_template = TritonTemplate(
 @SymbolicGridFn
 def blackwell_bmm_grid(b, m, n, meta, *, cdiv, max, min):
     grid_m = cdiv(m, meta["BLOCK_M"])
+    if meta["TWO_CTAS"]:
+        grid_m = cdiv(grid_m, 2) * 2
     tiles = grid_m * cdiv(n, meta["BLOCK_N"])
     grid_x = min(meta["NUM_SMS"], tiles)
+    if meta["TWO_CTAS"]:
+        grid_x = grid_x // 2 * 2
     max_y_grid = get_max_y_grid()
     grid_z = max(cdiv(b, max_y_grid), 1)
     return (grid_x, cdiv(b, grid_z), grid_z)
@@ -94,6 +99,7 @@ class BlackwellBMMConfig:
     block_k: int
     num_stages: int
     epilogue_subtile: int = 1
+    two_ctas: bool = False
 
 
 def append_blackwell_bmm_choice(
@@ -110,7 +116,9 @@ def append_blackwell_bmm_choice(
     batch_b, k_b, n = map(int, mat2.get_size())
     if batch != batch_b or k != k_b:
         raise NotImplementedError("Blackwell BMM does not broadcast logical batches")
-    if list(map(int, layout.size)) != [batch, m, n]:
+    output_size = list(map(int, layout.size))
+    flattened_output = output_size == [batch * m, n]
+    if output_size != [batch, m, n] and not flattened_output:
         raise NotImplementedError("unexpected Blackwell BMM output layout")
     a_row_major = mat1.get_stride()[2] == 1
     a_col_major = mat1.get_stride()[1] == 1
@@ -120,6 +128,14 @@ def append_blackwell_bmm_choice(
         raise NotImplementedError(
             "Blackwell BMM requires one contiguous matrix dimension"
         )
+    m_tiles = math.ceil(m / config.block_m)
+    if config.two_ctas:
+        if not flattened_output:
+            raise NotImplementedError(
+                "2CTA Blackwell BMM requires a flattened rank-2 output descriptor"
+            )
+        if m_tiles % 2:
+            raise NotImplementedError("2CTA Blackwell BMM requires two useful M peers")
     kwargs = {
         "BLOCK_M": config.block_m,
         "BLOCK_N": config.block_n,
@@ -135,18 +151,22 @@ def append_blackwell_bmm_choice(
         "DATA_PARTITION_FACTOR": 1,
         "SEPARATE_EPILOGUE_STORE": True,
         "EPILOGUE_SUBTILE": config.epilogue_subtile,
+        "TWO_CTAS": config.two_ctas,
+        "FLATTEN_OUTPUT": flattened_output,
         "TMA_EXPERIMENTAL_API": not has_triton_stable_tma_api(),
         # Keep the output a normal logical rank-3 tensor.  Until 2CTA output
         # transformation supports rank-3 descriptors, use the generic pointer
         # store emitted by store_output.
-        "tma_store": False,
+        "tma_store": flattened_output,
         "transpose_discontiguous_tensor_descriptors_override": True,
     }
+    if config.two_ctas:
+        kwargs["ctas_per_cga"] = (2, 1, 1)
     error = blackwell_bmm_template.maybe_append_choice(
         choices,
         input_nodes=input_nodes,
         layout=layout,
-        call_sizes=layout.size,
+        call_sizes=[batch, m, n],
         num_stages=config.num_stages,
         num_warps=8,
         **kwargs,

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
@@ -34,6 +34,9 @@
 
     start_pid = tl.program_id(0)
     grid_m = tl.cdiv(M, BLOCK_M)
+    {%- if TWO_CTAS %}
+    grid_m = (grid_m + 1) // 2 * 2
+    {%- endif %}
     grid_n = tl.cdiv(N, BLOCK_N)
     num_tiles = grid_m * grid_n
     num_pid_in_group = GROUP_M * grid_n
@@ -69,6 +72,7 @@
                 a if A_ROW_MAJOR else a.T,
                 b if B_ROW_MAJOR else b.T,
                 allow_tf32=ALLOW_TF32,
+                two_ctas=TWO_CTAS,
             )
 
         tile_id_c += NUM_SMS
@@ -82,6 +86,15 @@
         )
         for i in tl.static_range(EPILOGUE_SUBTILE):
             offs_cn_i = offs_cn + i * (BLOCK_N // EPILOGUE_SUBTILE)
+            {%- if FLATTEN_OUTPUT %}
+            {{store_output(
+                ("batch * M + offs_cm", "offs_cn_i"),
+                "subtiles[i]",
+                indent_width=12,
+                val_shape=("BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE"),
+                block_indexing=True
+            )}}
+            {%- else %}
             rm = offs_cm + tl.arange(0, BLOCK_M)[:, None]
             rn = offs_cn_i + tl.arange(0, BLOCK_N // EPILOGUE_SUBTILE)[None, :]
             mask = (rm < M) & (rn < N)
@@ -92,6 +105,7 @@
                 indent_width=12,
                 val_shape=("BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE")
             )}}
+            {%- endif %}
 
 
 @triton.jit


### PR DESCRIPTION
## Summary

Adds 2CTA support as a separate layer on the Blackwell BMM template introduced below.

- Adds a bounded `TWO_CTAS` configuration.
- Uses a flattened rank-2 `[B * M, N]` TMA output descriptor, then restores logical rank-3 output with a view.
- Keeps 2CTA isolated from the 1CTA foundation because current 2CTA descriptor transformation is rank-2-specific.

## Testing

- 2CTA numerical correctness.
- Rank-2 TMA output-store coverage.
- Generated TTGIR/PTX/SASS verification for a real two-CTA cluster.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>