### PR TITLE
inductor: specialize Blackwell BMM for aligned decompose-K

### DIFF
--- a/test/inductor/test_blackwell_decompose_k_partial.py
+++ b/test/inductor/test_blackwell_decompose_k_partial.py
@@ -1,0 +1,152 @@
+# Owner(s): ["module: inductor"]
+import math
+import unittest
+from unittest import mock
+
+import torch
+from torch._inductor import config, ir
+from torch._inductor.kernel.decompose_k import (
+    append_blackwell_decompose_k_partial_choice,
+    BLACKWELL_DECOMPOSE_K_PARTIAL_CONFIGS,
+)
+from torch._inductor.kernel.mm import blackwell_decomposeK
+from torch._inductor.lowering import lowerings
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_cuda import SM100OrLater
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_GPU
+
+
+K_SPLIT = 8
+
+
+@torch.library.custom_op(
+    "inductor_test::blackwell_decompose_k_partial", mutates_args={}
+)
+def blackwell_decompose_k_partial(
+    a: torch.Tensor, b: torch.Tensor, two_ctas: bool
+) -> torch.Tensor:
+    del two_ctas
+    m, k = a.shape
+    n = b.shape[1]
+    m_pad = math.ceil(m / 128) * 128
+    k_part = math.ceil(math.ceil(k / K_SPLIT) / 128) * 128
+    out = torch.zeros(
+        (K_SPLIT, m_pad, n), device=a.device, dtype=torch.float32
+    )
+    for split in range(K_SPLIT):
+        begin = split * k_part
+        end = min(begin + k_part, k)
+        if begin < end:
+            out[split, :m] = torch.mm(
+                a[:, begin:end], b[begin:end], out_dtype=torch.float32
+            )
+    return out.view(K_SPLIT * m_pad, n)
+
+
+@blackwell_decompose_k_partial.register_fake
+def _(a: torch.Tensor, b: torch.Tensor, two_ctas: bool) -> torch.Tensor:
+    del two_ctas
+    m_pad = math.ceil(a.shape[0] / 128) * 128
+    return a.new_empty(
+        (K_SPLIT * m_pad, b.shape[1]), dtype=torch.float32
+    )
+
+
+@unittest.skipUnless(
+    HAS_GPU and SM100OrLater,
+    "requires NVIDIA SM100+",
+)
+class TestBlackwellDecomposeKPartial(TestCase):
+    def _run(self, two_ctas: bool) -> None:
+        config_index = 1 if two_ctas else 0
+        partial_config = BLACKWELL_DECOMPOSE_K_PARTIAL_CONFIGS[config_index]
+
+        def lowering(a, b, two_ctas_arg):
+            if bool(two_ctas_arg) != two_ctas:
+                raise AssertionError("unexpected 2CTA specialization")
+            m, _ = map(int, a.get_size())
+            n = int(b.get_size()[1])
+            m_tiles = math.ceil(m / partial_config.block_m)
+            if partial_config.two_ctas:
+                m_tiles = math.ceil(m_tiles / 2) * 2
+            m_pad = m_tiles * partial_config.block_m
+            layout = ir.FixedLayout(
+                a.get_device(),
+                torch.float32,
+                [K_SPLIT * m_pad, n],
+                [n, 1],
+            )
+            choices = []
+            append_blackwell_decompose_k_partial_choice(
+                choices,
+                (a, b),
+                layout,
+                k_split=K_SPLIT,
+                config=partial_config,
+            )
+            return choices[0].output_node()
+
+        m, k, n = 256, 8193, 128
+        a_storage = torch.randn(k, m, device="cuda", dtype=torch.bfloat16)
+        a = a_storage.T
+        b = torch.randn(k, n, device="cuda", dtype=torch.bfloat16)
+
+        def fn(x, y):
+            partial = blackwell_decompose_k_partial(x, y, two_ctas)
+            return partial.view(K_SPLIT, m, n).sum(0).to(torch.bfloat16)
+
+        with (
+            mock.patch.dict(
+                lowerings,
+                {
+                    torch.ops.inductor_test.blackwell_decompose_k_partial.default: lowering
+                },
+            ),
+            config.patch(
+                compile_threads=1,
+                **{"triton.enable_template_tma_store": True},
+            ),
+        ):
+            actual, codes = run_and_get_code(
+                torch.compile(fn, fullgraph=True), a, b
+            )
+
+        expected = a @ b
+        torch.testing.assert_close(actual, expected, atol=16.0, rtol=1e-1)
+        self.assertIn("make_tensor_descriptor", codes[0])
+        self.assertIn(
+            "make_tensor_descriptor(out_ptr0, shape=[2048, 128]", codes[0]
+        )
+        self.assertEqual(
+            "TWO_CTAS : tl.constexpr = True" in codes[0], two_ctas
+        )
+
+    def test_1cta(self):
+        self._run(False)
+
+    def test_2cta(self):
+        self._run(True)
+
+    def test_complete_plan_direct(self):
+        m, k, n = 256, 8193, 128
+        a_storage = torch.randn(k, m, device="cuda", dtype=torch.bfloat16)
+        a = a_storage.T
+        b = torch.randn(k, n, device="cuda", dtype=torch.bfloat16)
+        with config.patch(
+            compile_threads=1,
+            **{
+                "triton.enable_template_tma_store": True,
+                "triton.enable_persistent_tma_matmul": True,
+                "triton.use_tensor_descriptor": True,
+            },
+        ):
+            actual = torch.compile(
+                lambda x, y: blackwell_decomposeK(x, y, 33, 0), fullgraph=True
+            )(a, b)
+        torch.testing.assert_close(actual, a @ b, atol=16.0, rtol=1e-1)
+
+
+if __name__ == "__main__":
+    if HAS_GPU and HAS_CPU:
+        run_tests()

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import torch
 from torch import _prims, Tensor
+from torch.nn import functional as F
 from torch._utils import _get_device_index
 
 
@@ -16,6 +17,35 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+def _blackwell_decompose_k_partial_impl(
+    a: Tensor,
+    b: Tensor,
+    k_split: int,
+    config_index: int,
+) -> Tensor:
+    """Reference for the internal aligned decompose-K partial operation."""
+    configs = (
+        (128, 128, False),
+        (128, 64, True),
+        (128, 64, True),
+    )
+    block_m, block_k, two_ctas = configs[config_index]
+    m, k = a.shape
+    n = b.shape[1]
+    m_tiles = (m + block_m - 1) // block_m
+    if two_ctas:
+        m_tiles = (m_tiles + 1) // 2 * 2
+    m_pad = m_tiles * block_m
+    k_part = ((k + k_split - 1) // k_split + block_k - 1) // block_k * block_k
+    partials = []
+    for split in range(k_split):
+        start = split * k_part
+        end = min(start + k_part, k)
+        partial = torch.mm(a[:, start:end], b[start:end], out_dtype=torch.float32)
+        partials.append(F.pad(partial, (0, 0, 0, m_pad - m)))
+    return torch.stack(partials).view(k_split * m_pad, n)
 
 
 def make_prim(
@@ -96,6 +126,13 @@ randint = make_prim(
     "inductor_randint(SymInt low, SymInt high, SymInt[] size, Tensor seed) -> Tensor",
     lambda low, high, size, seed: torch.randint(low, high, size, device=seed.device),
     doc="torch.randint() using backend-specific RNG that can be fused",
+)
+
+# Internal plan component for the Blackwell aligned decompose-K prototype.
+# Its lowering is a dedicated TMA template over the original rank-2 operands.
+blackwell_decompose_k_partial = make_prim(
+    "blackwell_decompose_k_partial(Tensor a, Tensor b, int k_split, int config_index) -> Tensor",
+    _blackwell_decompose_k_partial_impl,
 )
 
 

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -153,6 +153,9 @@ def append_blackwell_bmm_choice(
         "EPILOGUE_SUBTILE": config.epilogue_subtile,
         "TWO_CTAS": config.two_ctas,
         "FLATTEN_OUTPUT": flattened_output,
+        "DECOMPOSE_K": False,
+        "K_SPLIT": 1,
+        "M_PAD": m,
         "TMA_EXPERIMENTAL_API": not has_triton_stable_tma_api(),
         # Keep the output a normal logical rank-3 tensor.  Until 2CTA output
         # transformation supports rank-3 descriptors, use the generic pointer

--- a/torch/_inductor/kernel/decompose_k.py
+++ b/torch/_inductor/kernel/decompose_k.py
@@ -1,0 +1,187 @@
+# mypy: allow-untyped-defs
+"""Blackwell kernels used to form decompose-K partial products.
+
+This module intentionally exposes only the partial template.  Choice wiring and
+the final reduction remain separate so autotuning can compare complete plans.
+"""
+
+import dataclasses
+import math
+from typing import Any
+
+import torch
+from torch._inductor import inductor_prims, ir
+from torch._inductor.lowering import register_lowering
+from torch._inductor.select_algorithm import SymbolicGridFn, TritonTemplate
+from torch._inductor.utils import get_num_sms
+from torch.utils._triton import has_triton_stable_tma_api
+
+from .mm_common import load_kernel_template
+
+
+@SymbolicGridFn
+def blackwell_decompose_k_partial_grid(
+    flattened_m: int,
+    n: int,
+    meta: dict[str, Any],
+    *,
+    cdiv,
+    min,
+):
+    """Launch one persistent MxN tile grid for every K partition."""
+    m_pad = flattened_m // meta["K_SPLIT"]
+    grid_m = cdiv(m_pad, meta["BLOCK_M"])
+    grid_n = cdiv(n, meta["BLOCK_N"])
+    grid_x = min(meta["NUM_SMS"], grid_m * grid_n)
+    if meta["TWO_CTAS"]:
+        grid_x = (grid_x // 2) * 2
+    return (grid_x, meta["K_SPLIT"], 1)
+
+
+blackwell_decompose_k_partial_template = TritonTemplate(
+    name="blackwell_decompose_k_partial",
+    grid=blackwell_decompose_k_partial_grid,
+    source=load_kernel_template("triton_blackwell_ws_persistent_device_tma_bmm"),
+    cache_codegen_enabled_for_template=True,
+    prologue_loads_all_inputs=True,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class BlackwellDecomposeKPartialConfig:
+    block_m: int
+    block_n: int
+    block_k: int
+    num_stages: int
+    epilogue_subtile: int
+    two_ctas: bool
+
+
+# Deliberately bounded proof set.  These are complete-plan winners from the
+# production-shaped handwritten sweep, not a replacement for a future cost
+# model.
+BLACKWELL_DECOMPOSE_K_PARTIAL_CONFIGS = (
+    BlackwellDecomposeKPartialConfig(128, 128, 128, 3, 2, False),
+    BlackwellDecomposeKPartialConfig(128, 128, 64, 4, 1, True),
+    BlackwellDecomposeKPartialConfig(128, 256, 64, 6, 2, True),
+)
+
+
+def append_blackwell_decompose_k_partial_choice(
+    choices: list[Any],
+    input_nodes: tuple[ir.IRNode, ir.IRNode],
+    layout: ir.Layout,
+    *,
+    k_split: int,
+    config: BlackwellDecomposeKPartialConfig,
+) -> None:
+    """Append one standalone partial-GEMM choice over the original rank-2 inputs.
+
+    The output layout is a flattened view of the physical contiguous
+    ``[split, M_pad, N]`` FP32 workspace.  Keeping the descriptor rank two is
+    intentional: current 2CTA descriptor-load/store transformation is rank-2.
+    """
+    mat1, mat2 = input_nodes
+    m, k = map(int, mat1.get_size())
+    k_b, n = map(int, mat2.get_size())
+    if k != k_b:
+        raise AssertionError(f"incompatible K dimensions: {k} and {k_b}")
+    if layout.dtype != torch.float32:
+        raise AssertionError("decompose-K partial workspace must be FP32")
+
+    m_tiles = math.ceil(m / config.block_m)
+    if config.two_ctas:
+        m_tiles = math.ceil(m_tiles / 2) * 2
+    m_pad = m_tiles * config.block_m
+    expected_size = [k_split * m_pad, n]
+    if list(map(int, layout.size)) != expected_size:
+        raise AssertionError(
+            f"expected flattened [split, M_pad, N] layout {expected_size}, "
+            f"got {layout.size}"
+        )
+
+    k_part = math.ceil(math.ceil(k / k_split) / config.block_k) * config.block_k
+    if (k_split - 1) * k_part >= k:
+        raise NotImplementedError("aligned split leaves an empty final partition")
+
+    kwargs: dict[str, Any] = {
+        "BLOCK_M": config.block_m,
+        "BLOCK_N": config.block_n,
+        "BLOCK_K": config.block_k,
+        "GROUP_M": 8,
+        "K_SPLIT": k_split,
+        "M_PAD": m_pad,
+        "NUM_SMS": min(get_num_sms(), m_tiles * math.ceil(n / config.block_n)),
+        "A_ROW_MAJOR": mat1.get_stride()[1] == 1,
+        "B_ROW_MAJOR": mat2.get_stride()[1] == 1,
+        "ALLOW_TF32": False,
+        "USE_META_WS": True,
+        "WARP_SPECIALIZE": True,
+        "FLATTEN": False,
+        "DATA_PARTITION_FACTOR": 1,
+        "SEPARATE_EPILOGUE_STORE": True,
+        "EPILOGUE_SUBTILE": config.epilogue_subtile,
+        "TWO_CTAS": config.two_ctas,
+        "FLATTEN_OUTPUT": True,
+        "DECOMPOSE_K": True,
+        "TMA_EXPERIMENTAL_API": not has_triton_stable_tma_api(),
+        "tma_store": True,
+        "transpose_discontiguous_tensor_descriptors_override": True,
+    }
+    if config.two_ctas:
+        kwargs["ctas_per_cga"] = (2, 1, 1)
+
+    error = blackwell_decompose_k_partial_template.maybe_append_choice(
+        choices,
+        input_nodes=input_nodes,
+        layout=layout,
+        call_sizes=layout.size,
+        num_stages=config.num_stages,
+        num_warps=8,
+        **kwargs,
+    )
+    if error is not None:
+        raise error
+
+
+@register_lowering(
+    inductor_prims.blackwell_decompose_k_partial,
+    type_promotion_kind=None,
+)
+def lower_blackwell_decompose_k_partial(
+    mat1,
+    mat2,
+    k_split: int,
+    config_index: int,
+):
+    try:
+        partial_config = BLACKWELL_DECOMPOSE_K_PARTIAL_CONFIGS[int(config_index)]
+    except IndexError as error:
+        raise NotImplementedError(
+            "unsupported Blackwell decompose-K partial config"
+        ) from error
+    except TypeError as error:
+        raise NotImplementedError(
+            "Blackwell decompose-K partial config must be static"
+        ) from error
+    m = int(mat1.get_size()[0])
+    n = int(mat2.get_size()[1])
+    m_tiles = math.ceil(m / partial_config.block_m)
+    if partial_config.two_ctas:
+        m_tiles = math.ceil(m_tiles / 2) * 2
+    m_pad = m_tiles * partial_config.block_m
+    layout = ir.FixedLayout(
+        mat1.get_device(),
+        torch.float32,
+        [int(k_split) * m_pad, n],
+        [n, 1],
+    )
+    choices: list[Any] = []
+    append_blackwell_decompose_k_partial_choice(
+        choices,
+        (mat1, mat2),
+        layout,
+        k_split=int(k_split),
+        config=partial_config,
+    )
+    return choices[0].output_node()

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -20,7 +20,12 @@ from torch.nn.functional import ScalingType  # type: ignore[attr-defined]
 from torch.torch_version import TorchVersion
 from torch.utils._ordered_set import OrderedSet
 
-from .. import config as inductor_config, distributed_autotune, lowering as L
+from .. import (
+    config as inductor_config,
+    distributed_autotune,
+    inductor_prims,
+    lowering as L,
+)
 from ..codegen.cutlass.gemm_template import CUTLASS2xGemmTemplate, CUTLASS3xGemmTemplate
 from ..codegen.rocm.ck_tile_universal_gemm_template import CKTileGemmTemplate
 from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
@@ -271,6 +276,59 @@ class DecomposeKSugraphTemplate(SubgraphTemplate):
 
 
 decompose_k_subgraph_template = DecomposeKSugraphTemplate()
+
+
+def blackwell_decomposeK(a, b, k_split, config_index):
+    """Aligned decompose-K using the dedicated rank-2 partial template."""
+    m = a.shape[0]
+    n = b.shape[1]
+    m_tiles = (m + 127) // 128
+    if config_index != 0:
+        m_tiles = (m_tiles + 1) // 2 * 2
+    m_pad = m_tiles * 128
+    partial_flat = inductor_prims.blackwell_decompose_k_partial(
+        a, b, k_split, config_index
+    )
+    partials = partial_flat.view(k_split, m_pad, n)
+    return partials[:, :m].sum(0).to(a.dtype)
+
+
+class BlackwellDecomposeKSubgraphTemplate(SubgraphTemplate):
+    def __init__(self):
+        super().__init__(name="blackwell_decompose_k")
+
+    def generate(  # type: ignore[override]
+        self,
+        input_nodes: list[Buffer],
+        layout: Layout,
+        k_split: int,
+        config_index: int,
+    ) -> SubgraphChoiceCaller:
+        from torch._dispatch.python import enable_python_dispatcher
+
+        from ..decomposition import select_decomp_table
+
+        name = f"blackwell_decompose_k_{k_split}_split_config_{config_index}"
+        description = f"{k_split=}, {config_index=}"
+        with enable_python_dispatcher():
+            fn = make_fx(
+                functools.partial(
+                    blackwell_decomposeK,
+                    k_split=k_split,
+                    config_index=config_index,
+                ),
+                decomposition_table=select_decomp_table(),
+            )
+            return super().generate(
+                name=name,
+                input_nodes=input_nodes,
+                layout=layout,
+                make_fx_graph=fn,
+                description=description,
+            )
+
+
+blackwell_decompose_k_subgraph_template = BlackwellDecomposeKSubgraphTemplate()
 
 
 class ContiguousTemplate(SubgraphTemplate):

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
@@ -1,4 +1,20 @@
 {{def_kernel("A", "B")}}
+    {%- if DECOMPOSE_K %}
+    BATCH = K_SPLIT
+    M = {{size("A", 0)}}
+    N = {{size("B", 1)}}
+    K = {{size("A", 1)}}
+    batch = tl.program_id(1).to(tl.int32)
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bk = {{stride("B", 0)}}
+    stride_bn = {{stride("B", 1)}}
+    a_base = A
+    b_base = B
+    k_base, k_tiles = _blackwell_bmm_aligned_partition(
+        batch, K, K_SPLIT, BLOCK_K
+    )
+    {%- else %}
     BATCH = {{size("A", 0)}}
     M = {{size("A", 1)}}
     N = {{size("B", 2)}}
@@ -15,6 +31,9 @@
     stride_bn = {{stride("B", 2)}}
     a_base = A + batch * stride_ab
     b_base = B + batch * stride_bb
+    k_base = 0
+    k_tiles = tl.cdiv(K, BLOCK_K)
+    {%- endif %}
 
     # A logical rank-3 BMM is represented by one rank-2 descriptor per batch.
     # This supports arbitrary/zero batch strides and keeps the descriptor-load
@@ -40,7 +59,6 @@
     grid_n = tl.cdiv(N, BLOCK_N)
     num_tiles = grid_m * grid_n
     num_pid_in_group = GROUP_M * grid_n
-    k_tiles = tl.cdiv(K, BLOCK_K)
     tile_id_c = start_pid - NUM_SMS
 
     for tile_id in tl.range(
@@ -59,7 +77,7 @@
         offs_bn = (pid_n * BLOCK_N).to(tl.int32)
         accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
         for ki in range(k_tiles):
-            offs_k = (ki * BLOCK_K).to(tl.int32)
+            offs_k = (k_base + ki * BLOCK_K).to(tl.int32)
             a = tl.load_tensor_descriptor(
                 a_desc,
                 [offs_am, offs_k] if A_ROW_MAJOR else [offs_k, offs_am],
@@ -87,8 +105,13 @@
         for i in tl.static_range(EPILOGUE_SUBTILE):
             offs_cn_i = offs_cn + i * (BLOCK_N // EPILOGUE_SUBTILE)
             {%- if FLATTEN_OUTPUT %}
+            {%- if DECOMPOSE_K %}
+            output_row = batch * M_PAD + offs_cm
+            {%- else %}
+            output_row = batch * M + offs_cm
+            {%- endif %}
             {{store_output(
-                ("batch * M + offs_cm", "offs_cn_i"),
+                ("output_row", "offs_cn_i"),
                 "subtiles[i]",
                 indent_width=12,
                 val_shape=("BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE"),
@@ -106,6 +129,17 @@
                 val_shape=("BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE")
             )}}
             {%- endif %}
+
+
+@triton.jit
+def _blackwell_bmm_aligned_partition(
+    split,
+    K,
+    K_SPLIT: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    k_part = tl.cdiv(tl.cdiv(K, K_SPLIT), BLOCK_K) * BLOCK_K
+    return split * k_part, k_part // BLOCK_K
 
 
 @triton.jit


### PR DESCRIPTION
## Summary

Specializes the shared Blackwell BMM kernel for aligned, uneven decompose-K partial products.

- Reads the original rank-2 MM operands.
- Synthesizes the batch dimension from K partitions.
- Uses aligned equal loop extents with TMA zero-fill for the shorter final partition.
- Writes a flattened FP32 `[split * M_pad, N]` workspace.
- Forms a complete subgraph with the final reduction kept outside the GEMM template.

This removes the exact-divisor requirement without physically padding or copying the input operands.

## Testing

- Uneven-K 1CTA and true-2CTA partial correctness.
- Flattened workspace layout.
- Complete partial-plus-reduction plan correctness.

## Known dependency

The multi-gigabyte production shapes still require the separate per-descriptor local-int32 TMA indexing work. That lower compiler change is intentionally not hidden in this review stack; the focused template and subgraph tests pass directly on `main`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>