### PR TITLE
inductor: offer bounded Blackwell BMM and decompose-K choices

### DIFF
--- a/test/inductor/test_blackwell_bmm.py
+++ b/test/inductor/test_blackwell_bmm.py
@@ -143,6 +143,23 @@ class TestBlackwellBMM(TestCase):
         self.assertIn("ctas_per_cga=(2, 1, 1)", codes[0])
         self.assertIn("make_tensor_descriptor(out_ptr0", codes[0])
 
+    def test_tuned_bmm_choice_smoke(self):
+        bsz, m, k, n = 3, 256, 8193, 128
+        a_storage = torch.randn(bsz, k, m, device="cuda", dtype=torch.bfloat16)
+        a = a_storage.transpose(1, 2)
+        b = torch.randn(bsz, k, n, device="cuda", dtype=torch.bfloat16)
+        with config.patch(
+            max_autotune=True,
+            max_autotune_gemm_backends="ATEN,TRITON",
+            compile_threads=1,
+            **{
+                "triton.enable_persistent_tma_matmul": True,
+                "triton.enable_blackwell_bmm_template": True,
+            },
+        ):
+            actual = torch.compile(torch.bmm, fullgraph=True)(a, b)
+        torch.testing.assert_close(actual, torch.bmm(a, b), atol=16.0, rtol=1e-1)
+
 
 if __name__ == "__main__":
     if HAS_GPU and HAS_CPU:

--- a/test/inductor/test_blackwell_decompose_k_partial.py
+++ b/test/inductor/test_blackwell_decompose_k_partial.py
@@ -128,6 +128,30 @@ class TestBlackwellDecomposeKPartial(TestCase):
     def test_2cta(self):
         self._run(True)
 
+    def test_tuned_mm_choice_smoke(self):
+        m, k, n = 256, 8193, 128
+        a_storage = torch.randn(k, m, device="cuda", dtype=torch.bfloat16)
+        a = a_storage.T
+        b = torch.randn(k, n, device="cuda", dtype=torch.bfloat16)
+
+        with config.patch(
+            max_autotune=True,
+            max_autotune_gemm_backends="ATEN,TRITON",
+            compile_threads=1,
+            assume_aligned_inputs=True,
+            **{
+                "triton.enable_template_tma_store": True,
+                "triton.enable_persistent_tma_matmul": True,
+                "triton.enable_blackwell_decompose_k_partial": True,
+                "triton.num_decompose_k_splits": 4,
+                "triton.use_tensor_descriptor": True,
+                "triton.disallow_failing_autotune_kernels_TESTING_ONLY": True,
+            },
+        ):
+            actual = torch.compile(lambda x, y: x @ y, fullgraph=True)(a, b)
+
+        torch.testing.assert_close(actual, a @ b, atol=16.0, rtol=1e-1)
+
     def test_complete_plan_direct(self):
         m, k, n = 256, 8193, 128
         a_storage = torch.randn(k, m, device="cuda", dtype=torch.bfloat16)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2269,6 +2269,19 @@ class triton:
         os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32")
     )
 
+    # Experimental Blackwell partial template with divisor-free aligned K
+    # partitions.  Kept opt-in until complete-plan coverage is broader.
+    enable_blackwell_decompose_k_partial = (
+        os.environ.get("TORCHINDUCTOR_ENABLE_BLACKWELL_DECOMPOSE_K_PARTIAL", "0")
+        == "1"
+    )
+
+    # Experimental logical rank-3 Blackwell BMM template.  The initial route
+    # offers only one 1CTA plan; 2CTA uses a flattened-output subgraph adapter.
+    enable_blackwell_bmm_template = (
+        os.environ.get("TORCHINDUCTOR_ENABLE_BLACKWELL_BMM_TEMPLATE", "0") == "1"
+    )
+
     # Programmatic Dependent Launch improves launch latency on Nvidia Hopper+ devices
     # If set to true, will generate PDL code on devices that support it.
     # If set to false, will never generate PDL code.

--- a/torch/_inductor/heuristics/template/decompose_k.py
+++ b/torch/_inductor/heuristics/template/decompose_k.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import math
 from typing import Any, TYPE_CHECKING
 
 import sympy
 
+from torch._inductor import config
 from torch._inductor.heuristics.registry import register_template_heuristic
 
 from ...ir import get_free_symbols
-from ...kernel.mm import decompose_k_subgraph_template
+from ...kernel.decompose_k import BLACKWELL_DECOMPOSE_K_PARTIAL_CONFIGS
+from ...kernel.mm import (
+    blackwell_decompose_k_subgraph_template,
+    decompose_k_subgraph_template,
+)
 from ...kernel_inputs import KernelInputs, MMKernelInputs
+from ...runtime.hints import DeviceProperties
 from ...utils import get_k_splits
 from ...virtualized import V
 from .base import TemplateConfigHeuristics
@@ -70,3 +77,73 @@ class DecomposeKConfigHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
             ):
                 continue
             yield {"k_split": k_split}
+
+
+@register_template_heuristic(
+    blackwell_decompose_k_subgraph_template.uid,
+    None,
+    op_name="mm",
+)
+class EmptyBlackwellDecomposeKConfigHeuristics(TemplateConfigHeuristics):
+    """Skip the experimental partial template outside NVIDIA CUDA."""
+
+
+@register_template_heuristic(
+    blackwell_decompose_k_subgraph_template.uid,
+    "cuda",
+    op_name="mm",
+)
+class BlackwellDecomposeKConfigHeuristics(TemplateConfigHeuristics):
+    """Generate one bounded 1CTA and one bounded 2CTA complete-plan seed."""
+
+    def _get_template_configs_impl(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        if not config.triton.enable_blackwell_decompose_k_partial:
+            return
+        if not isinstance(kernel_inputs, MMKernelInputs):
+            raise AssertionError(f"{self.__class__.__name__} requires MMKernelInputs")
+        if any(
+            len(get_free_symbols(value, unbacked_only=True)) > 0
+            for value in (
+                *kernel_inputs.shapes_symbolic(),
+                *kernel_inputs.strides_symbolic(),
+            )
+        ):
+            return
+
+        device = DeviceProperties.create(kernel_inputs.device())
+        if device.type != "cuda" or device.major != 10:
+            return
+        m_sym, n_sym, k_sym = kernel_inputs.mnk_symbolic()
+        m, n, k = int(m_sym), int(n_sym), int(k_sym)
+
+        config_indices = [0]
+        if m > 128:
+            config_indices.append(1 if n <= 128 else 2)
+
+        for config_index in config_indices:
+            partial_config = BLACKWELL_DECOMPOSE_K_PARTIAL_CONFIGS[config_index]
+            m_tiles = math.ceil(m / partial_config.block_m)
+            if partial_config.two_ctas:
+                m_tiles = math.ceil(m_tiles / 2) * 2
+            output_tiles = m_tiles * math.ceil(n / partial_config.block_n)
+            waves = 1 if partial_config.two_ctas else 2
+            k_split = max(
+                2,
+                round(waves * device.multi_processor_count / output_tiles),
+            )
+            k_split = min(k_split, k // partial_config.block_k)
+            while k_split >= 2:
+                k_part = (
+                    math.ceil(math.ceil(k / k_split) / partial_config.block_k)
+                    * partial_config.block_k
+                )
+                workspace_bytes = k_split * m_tiles * partial_config.block_m * n * 4
+                if (k_split - 1) * k_part < k and workspace_bytes <= 128 * 1024**2:
+                    break
+                k_split -= 1
+            if k_split >= 2:
+                yield {"k_split": k_split, "config_index": config_index}

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -177,6 +177,24 @@ def append_blackwell_bmm_choice(
     if error is not None:
         raise error
 
+
+def can_use_blackwell_bmm_template(mat1, mat2, layout) -> bool:
+    if not (
+        inductor_config.triton.enable_blackwell_bmm_template
+        and inductor_config.triton.enable_persistent_tma_matmul
+        and has_triton_stable_tma_api()
+        and mat1.get_dtype() in (torch.float16, torch.bfloat16)
+        and mat1.get_dtype() == mat2.get_dtype() == layout.dtype
+    ):
+        return False
+    try:
+        tuple(map(int, (*mat1.get_size(), *mat2.get_size(), *layout.size)))
+    except (TypeError, ValueError):
+        return False
+    from ..codegen.cuda.cuda_env import is_datacenter_blackwell_arch
+
+    return is_datacenter_blackwell_arch()
+
 aten_bmm = ExternKernelChoice(torch.bmm, "at::bmm_out", op_overload=aten.bmm.out)
 aten_bmm_dtype = ExternKernelChoice(
     torch.bmm,
@@ -352,6 +370,21 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
             kwarg_overrides=kwarg_overrides,
         )
     )
+    if can_use_blackwell_bmm_template(mat1, mat2, layout):
+        # Keep candidate growth bounded while the generic template's cost model
+        # is being validated.  2CTA is a separate flattened-output subgraph
+        # choice and is not silently mixed into this direct rank-3 route.
+        append_blackwell_bmm_choice(
+            choices,
+            (mat1, mat2),
+            layout,
+            config=BlackwellBMMConfig(
+                block_m=128,
+                block_n=128,
+                block_k=128,
+                num_stages=3,
+            ),
+        )
     _, is_nonzero = _is_static_problem(layout)
     batch_stride_largest_or_zero = is_batch_stride_largest_or_zero(mat1, mat2, layout)
     if (

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -496,6 +496,13 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
     ):
         if use_decompose_k_choice(m, n, k):
             templates_to_use.append(decompose_k_subgraph_template)
+            if (
+                inductor_config.triton.enable_blackwell_decompose_k_partial
+                and use_triton_blackwell_tma_template(
+                    mat1, mat2, output_layout=layout, add_guards=True
+                )
+            ):
+                templates_to_use.append(blackwell_decompose_k_subgraph_template)
         # Triton Templates typically perform very poorly for large K.
         # Its highly unlikely that if we want to use decompose_k, then
         # Triton will ever win.


### PR DESCRIPTION
## Summary

Adds opt-in bounded selection for the Blackwell BMM and aligned decompose-K plans.

- Offers the generic Blackwell BMM through `tuned_bmm`.
- Offers one bounded 1CTA and, when applicable, one bounded 2CTA decompose-K plan through `tuned_mm`.
- Selects split counts from output-tile occupancy and workspace constraints.
- Benchmarks complete partial-plus-reduction plans.
- Retains ATen and existing Triton choices as fallbacks.

The feature remains disabled by default while performance coverage is expanded.

## Testing

- End-to-end `tuned_bmm` choice smoke test.
- End-to-end `tuned_mm` decompose-K choice smoke test.
- Combined focused suite: 8 tests passing on B200.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>