### PR TITLE
[releng] Keep the plain source archive out of the PEP 517 sdist, and gate on release-asset size

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -68,21 +68,46 @@ jobs:
           cp .ci/docker/requirements-docs.txt docs/requirements.txt
       - name: Create source distribution
         run: |
+          # Staged entirely under /tmp. Anything this step leaves in the working
+          # tree is picked up by the PEP 517 sdist below, whose file walk uses
+          # gitignore semantics and so has no allowlist to exclude it: in 2.14.0
+          # the copy and the archive added ~1.55 GB and pushed the sdist over
+          # GitHub's release-asset cap.
           # Create new folder with specified name so extracting the archive yields that
           rm -rf "/tmp/$PT_RELEASE_NAME"
           cp -r "$PWD" "/tmp/$PT_RELEASE_NAME"
-          mv "/tmp/$PT_RELEASE_NAME" .
           # Cleanup
-          rm -rf "$PT_RELEASE_NAME"/.ci
-          find "$PT_RELEASE_NAME" -name '.git*' -exec rm -rv {} \; || true
+          rm -rf "/tmp/$PT_RELEASE_NAME/.ci"
+          find "/tmp/$PT_RELEASE_NAME" -name '.git*' -exec rm -rv {} \; || true
           # Create archive
-          tar -czf "$PT_RELEASE_FILE" "$PT_RELEASE_NAME"
-          echo "Created source archive $PT_RELEASE_FILE with content: $(ls -a "$PT_RELEASE_NAME")"
+          tar -czf "/tmp/$PT_RELEASE_FILE" -C /tmp "$PT_RELEASE_NAME"
+          echo "Created source archive $PT_RELEASE_FILE with content: $(ls -a "/tmp/$PT_RELEASE_NAME")"
+          rm -rf "/tmp/$PT_RELEASE_NAME"
       - name: Create PEP 517 compatible source distribution
         run: |
           pip install build==1.2.2.post1 || exit 1
           python -m build --sdist || exit 1
-          mv dist/$PT_PEP517_RELEASE_FILE . || exit 1
+          mv "dist/$PT_PEP517_RELEASE_FILE" . || exit 1
+          # Only now that the sdist walk is done does the plain archive enter the
+          # working tree.
+          mv "/tmp/$PT_RELEASE_FILE" . || exit 1
+      - name: Check release assets against GitHub's size cap
+        run: |
+          # GitHub rejects release assets of 2 GiB or more. This runs on every
+          # tag, so an rc trips it weeks ahead; the upload step that enforces it
+          # today is gated on `release: published` and fires once, too late to
+          # do anything about.
+          cap=2147483648
+          status=0
+          for f in "$PT_RELEASE_FILE" "$PT_PEP517_RELEASE_FILE"; do
+            sz=$(stat -c%s "$f")
+            echo "$f: $sz bytes"
+            if [ "$sz" -ge "$cap" ]; then
+              echo "::error::$f is $sz bytes, at or over GitHub's $cap-byte release-asset cap"
+              status=1
+            fi
+          done
+          exit "$status"
       - name: Upload source distribution for release
         if: ${{ github.event_name == 'release' }}
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2


### PR DESCRIPTION
Fixes# meta-pytorch/pytorch-gha-infra#1467.

## What happened

`v2.14.0` shipped without its PEP 517 source distribution. The `release: published` run failed at `Upload source distribution for release`:

```
Validation Failed: {"resource":"ReleaseAsset","field":"size","message":"size must be less than 2147483648"}
```

The sdist was **2,316,868,676 B** against GitHub's 2,147,483,648 B release-asset cap, so the release carries only `pytorch-v2.14.0.tar.gz`. The equivalent 2.13.0 asset (466,957,017 B) has 270 downloads.

## Root cause

`Create source distribution` leaves two large untracked objects in the working tree — the full `cp -r "$PWD"` copy and the ~792 MB archive built from it — and `python -m build --sdist` then runs in that same tree.

Under 2.13 this was harmless: the backend was `setuptools.build_meta` with a `MANIFEST.in` allowlist, so build leftovers could never be picked up. 2.14 moved to `scikit_build_core.build`, whose sdist walk uses gitignore semantics, and neither object is in `.gitignore` or in `[tool.scikit-build.sdist].exclude`.

Confirmed empirically: building the sdist from a clean checkout of `v2.14.0` gives **774,964,070 B**, and `tar -tzf … | grep -c '^torch-2.14.0/pytorch-v2.14.0'` returns `0`. The leftovers accounted for ~1.54 GB of the 2.32 GB.

## Changes

**1. Stage the plain archive under `/tmp`.** It moves into the working tree only after the sdist is built, so the sdist walk never sees it.

Reordering the two steps — the other obvious fix — would just reverse the problem: `python -m build` ends with `mv dist/$PT_PEP517_RELEASE_FILE .`, and the following `cp -r "$PWD"` would sweep the ~775 MB sdist into the plain archive. That stays under the cap, so it would fail silently rather than loudly.

**2. Add a size check on both assets.** Today the only enforcement is GitHub rejecting the upload, and that step is gated `github.event_name == 'release'` — it runs once per release, after the tag is cut and the release is published. rc tags upload to GHA artifacts instead, which have no per-file cap, which is why `v2.14.0-rc2` … `-rc10` were all green with the sdist already ~8% over. Checking in the build step means an rc fails three weeks earlier.

## Test plan

- `bash -n` on all three changed `run` blocks.
- Simulated the staging logic on a scratch tree: the archive keeps the same top-level `$PT_RELEASE_NAME/` directory, `.ci` and `.git*` are still stripped, and the working tree is left with no copy or archive in it.
- Verified against the real thing: a clean-checkout sdist of `v2.14.0` is 774,964,070 B with no self-inclusion, i.e. comfortably under the cap once the leftovers are gone.
- This workflow has `pull_request: paths: [.github/workflows/create_release.yml]`, so this PR exercises the build path itself.

## Follow-up, not in this PR

At 774,964,070 B the clean sdist is still **1.66x** the 2.13.0 sdist, so the backend migration did add real content beyond the pollution. Worth auditing the blanket `third_party/**` include in `[tool.scikit-build.sdist]` separately.
