### PR TITLE
Capture Python launch stacks for CUDA graph nodes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -603,6 +603,7 @@
 # /test/test_cuda_compatibility.py
 # /test/test_cuda_expandable_segments.py
 # /test/test_cuda_graph_debug.py
+# /test/test_cuda_graph_py_stacks.py
 # /test/test_cuda_graph_utils.py
 # /test/test_cuda_multigpu.py
 # /test/test_cuda_nvml_based_avail.py

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -231,6 +231,45 @@ can equally be saved next to a trace and joined offline.
 .. currentmodule:: torch.cuda
 ```
 
+## Graph Python Launch Stacks (prototype)
+
+`torch.cuda.graph_py_stacks` records the Python launch stack for each top-level
+CUDA graph node. Enable it on an annotation-enabled capture, then retrieve the
+stacks after the graph has been instantiated:
+
+```python
+import torch
+from torch.cuda.graph_py_stacks import take_stacks
+
+g = torch.cuda.CUDAGraph()
+with torch.autograd.grad_mode.set_multithreading_enabled(False):
+    with torch.cuda.graph(
+        g,
+        enable_annotations=True,
+        annotation_config={"capture_py_stacks": True},
+    ):
+        output = workload(input)
+
+stacks_by_graph_node_id = take_stacks(g)
+```
+
+Stack capture requires `cupti-python`, `enable_annotations=True`, and
+single-threaded autograd. It forces the CUPTI callback path; if no CUPTI
+subscriber is already active, this prevents {class}`torch.profiler.profile`
+from initializing later in the same process.
+
+```{eval-rst}
+.. currentmodule:: torch.cuda.graph_py_stacks
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    take_stacks
+    clear_stacks
+
+.. currentmodule:: torch.cuda
+```
+
 (cuda-memory-management-api)=
 
 ```{eval-rst}
@@ -462,6 +501,10 @@ deprecated compatibility APIs.
 
 ```{eval-rst}
 .. py:module:: torch.cuda.graph_annotations
+```
+
+```{eval-rst}
+.. py:module:: torch.cuda.graph_py_stacks
 ```
 
 ```{eval-rst}

--- a/test/test_cuda_graph_py_stacks.py
+++ b/test/test_cuda_graph_py_stacks.py
@@ -1,0 +1,512 @@
+# Owner(s): ["module: cuda graphs"]
+
+import os
+import sys
+import unittest
+import warnings
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+from torch.cuda import (
+    _graph_annotations,
+    _graph_node_callbacks,
+    _graph_py_stacks,
+    graph_py_stacks,
+)
+from torch.cuda.graph_annotations import (
+    clear_kernel_annotations,
+    get_kernel_annotations,
+    mark_kernels,
+)
+from torch.cuda.graphs import _parse_annotation_config
+from torch.testing._internal.common_cuda import (
+    TEST_CUDA_GRAPH_TOOLS_ID,
+    TEST_CUPTI_V13_3,
+)
+from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TestCase
+
+
+class _FakeTrace:
+    def __init__(self):
+        self.cleaned = False
+
+    def cleanup(self):
+        self.cleaned = True
+
+
+class TestGraphPyStacks(TestCase):
+    def tearDown(self):
+        graph = _graph_py_stacks._active_graph
+        if graph is not None:
+            _graph_py_stacks._end_capture(graph)
+        super().tearDown()
+
+    @staticmethod
+    def _graph():
+        return SimpleNamespace(
+            _py_stack_traces={}, _py_stack_dropped=0, _remapped_exec_id=None
+        )
+
+    def test_format_stack_filters_only_pytorch_sources(self):
+        internal = os.path.join(_graph_py_stacks._TORCH_ROOT, "cuda", "graphs.py")
+        user = "/home/user/project/torch/model.py"
+        stack = _graph_py_stacks._format_stack(
+            [
+                f'  File "{user}", line 12, in launch_site\n',
+                f'  File "{internal}", line 34, in capture\n',
+            ]
+        )
+
+        self.assertEqual(stack, "model.py:12:launch_site")
+        self.assertNotIn("/home/user", stack)
+
+    def test_format_filename_ignores_root_base(self):
+        with patch.object(_graph_py_stacks, "_CWD", "/"):
+            filename = _graph_py_stacks._format_filename("/workspace/project/model.py")
+
+        self.assertEqual(filename, "model.py")
+
+    def test_capture_is_graph_owned_and_bounded(self):
+        first = self._graph()
+        second = self._graph()
+        traces = [_FakeTrace(), _FakeTrace(), _FakeTrace()]
+        with (
+            patch.object(_graph_py_stacks, "_MAX_STACKS_PER_GRAPH", 2),
+            patch.object(
+                _graph_py_stacks.CapturedTraceback,
+                "extract",
+                side_effect=traces,
+            ),
+        ):
+            _graph_py_stacks._begin_capture(first)
+            _graph_py_stacks._record(1)
+            _graph_py_stacks._record(2)
+            _graph_py_stacks._record(3)
+            _graph_py_stacks._end_capture(first)
+            _graph_py_stacks._begin_capture(second)
+            _graph_py_stacks._record(4)
+            _graph_py_stacks._end_capture(second)
+
+        self.assertEqual(set(first._py_stack_traces), {1, 2})
+        self.assertEqual(first._py_stack_dropped, 1)
+        self.assertEqual(set(second._py_stack_traces), {4})
+        first._remapped_exec_id = 1
+        with (
+            patch.object(
+                _graph_py_stacks.CapturedTraceback,
+                "format_all",
+                return_value=[[], []],
+            ),
+            self.assertWarnsRegex(UserWarning, "1 node") as warning,
+        ):
+            self.assertEqual(set(graph_py_stacks.take_stacks(first)), {1, 2})
+        self.assertEqual(os.path.realpath(warning.filename), os.path.realpath(__file__))
+
+    def test_concurrent_capture_is_rejected(self):
+        first = self._graph()
+        second = self._graph()
+        _graph_py_stacks._begin_capture(first)
+        with self.assertRaisesRegex(RuntimeError, "already active"):
+            _graph_py_stacks._begin_capture(second)
+
+    def test_remap_and_take_stacks(self):
+        graph = self._graph()
+        graph._capture_graph_id = 1
+        graph.raw_cuda_graph_exec = lambda: 123
+        trace = _FakeTrace()
+        graph._py_stack_traces[(1 << 32) | 5] = trace
+
+        runtime = SimpleNamespace(cudaGraphExecGetId=lambda _graph: (0, 0))
+        with (
+            patch.object(_graph_annotations, "_cuda_runtime", runtime),
+            patch.object(
+                _graph_annotations, "_check_cuda_bindings", side_effect=[2, 3]
+            ),
+            patch.object(_graph_annotations, "_kernel_annotations", {}),
+            patch.object(
+                _graph_py_stacks.CapturedTraceback,
+                "format_all",
+                return_value=[
+                    ['  File "/home/user/project/model.py", line 7, in launch\n']
+                ],
+            ) as format_all,
+        ):
+            _graph_annotations.remap_to_exec_graph(graph)
+            _graph_annotations.remap_to_exec_graph(graph)
+            stacks = graph_py_stacks.take_stacks(graph)
+
+        format_all.assert_called_once_with([trace])
+        self.assertEqual(stacks, {(3 << 32) | 5: "model.py:7:launch"})
+        self.assertEqual(graph._remapped_exec_id, 3)
+        self.assertEqual(graph._py_stack_traces, {})
+        self.assertTrue(trace.cleaned)
+
+    def test_take_requires_instantiated_graph(self):
+        graph = self._graph()
+        graph._py_stack_traces[1] = _FakeTrace()
+
+        with self.assertRaisesRegex(RuntimeError, "instantiate"):
+            graph_py_stacks.take_stacks(graph)
+        self.assertEqual(set(graph._py_stack_traces), {1})
+
+    def test_public_module_owns_api(self):
+        self.assertEqual(
+            graph_py_stacks.take_stacks.__module__, "torch.cuda.graph_py_stacks"
+        )
+
+    def test_public_clear_stacks(self):
+        graph = self._graph()
+        trace = _FakeTrace()
+        graph._py_stack_traces[1] = trace
+        graph._py_stack_dropped = 2
+
+        graph_py_stacks.clear_stacks(graph)
+
+        self.assertEqual(graph._py_stack_traces, {})
+        self.assertEqual(graph._py_stack_dropped, 0)
+        self.assertTrue(trace.cleaned)
+
+    def test_annotation_config_accepts_capture_py_stacks(self):
+        config = _parse_annotation_config({"capture_py_stacks": True})
+        self.assertTrue(config["capture_py_stacks"])
+
+    def test_capture_py_stacks_requires_annotations(self):
+        with self.assertRaisesRegex(ValueError, "requires enable_annotations=True"):
+            torch.cuda.graph(
+                self._graph(), annotation_config={"capture_py_stacks": True}
+            )
+
+    def test_callback_rejects_unexpected_domain_before_cast(self):
+        handler = SimpleNamespace(domain=1, cbid=2)
+        with (
+            patch.object(_graph_node_callbacks, "_handler", handler),
+            patch.object(_graph_py_stacks, "_record") as record,
+        ):
+            _graph_node_callbacks._on_graph_node_created(9, 2, object())  # type: ignore[arg-type]
+        record.assert_not_called()
+
+    def test_disarm_is_finally_safe(self):
+        handler = SimpleNamespace(domain=1, cbid=2)
+        monitor = SimpleNamespace(
+            disarm_callback=Mock(side_effect=RuntimeError("disarm failed")),
+            unregister_callback_handler=Mock(
+                side_effect=RuntimeError("unregister failed")
+            ),
+        )
+        monitor_module = SimpleNamespace(CuptiMonitor=lambda: monitor)
+        warn = Mock(side_effect=RuntimeError("warning failed"))
+        with (
+            patch.object(_graph_node_callbacks, "_handler", handler),
+            patch.object(_graph_node_callbacks, "_dropped_body_nodes", 1),
+            patch.dict(sys.modules, {"torch.profiler._cupti.monitor": monitor_module}),
+            patch.object(_graph_node_callbacks, "warnings", SimpleNamespace(warn=warn)),
+            self.assertLogs(_graph_node_callbacks.logger, level="ERROR"),
+        ):
+            _graph_node_callbacks.disarm()
+            self.assertIsNone(_graph_node_callbacks._handler)
+            self.assertEqual(_graph_node_callbacks._dropped_body_nodes, 0)
+        monitor.disarm_callback.assert_called_once_with(1, 2)
+        monitor.unregister_callback_handler.assert_called_once_with(handler)
+        warn.assert_called_once()
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+class TestGraphPyStacksCUDAConfig(TestCase):
+    def test_auto_falls_back_when_multithreaded(self):
+        x = torch.ones(1, device="cuda")
+        graph = torch.cuda.CUDAGraph()
+        with (
+            torch.autograd.grad_mode.set_multithreading_enabled(True),
+            patch.object(_graph_node_callbacks, "register") as register,
+        ):
+            with torch.cuda.graph(graph, enable_annotations=True):
+                output = x + 1
+
+        register.assert_not_called()
+        graph.replay()
+        self.assertEqual(output, x + 1)
+
+    def test_default_config_requires_single_threaded_autograd(self):
+        graph = torch.cuda.CUDAGraph()
+        with torch.autograd.grad_mode.set_multithreading_enabled(True):
+            with self.assertRaisesRegex(
+                RuntimeError, "capture_py_stacks.*single-threaded"
+            ):
+                with torch.cuda.graph(
+                    graph,
+                    enable_annotations=True,
+                    annotation_config={"capture_py_stacks": True},
+                ):
+                    pass
+
+    def test_registration_failure_is_actionable(self):
+        graph = torch.cuda.CUDAGraph()
+        with (
+            torch.autograd.grad_mode.set_multithreading_enabled(False),
+            patch.object(_graph_node_callbacks, "register", return_value=False),
+            self.assertRaisesRegex(
+                RuntimeError, "capture_py_stacks.*could not register"
+            ),
+        ):
+            with torch.cuda.graph(
+                graph,
+                enable_annotations=True,
+                annotation_config={"capture_py_stacks": True},
+            ):
+                pass
+        self.assertFalse(_graph_py_stacks._is_capturing())
+
+    def test_reservation_failure_precedes_capture(self):
+        graph = torch.cuda.CUDAGraph()
+        with (
+            torch.autograd.grad_mode.set_multithreading_enabled(False),
+            patch.object(_graph_node_callbacks, "register", return_value=True),
+            patch.object(
+                _graph_py_stacks, "_begin_capture", side_effect=RuntimeError("busy")
+            ),
+            patch.object(_graph_node_callbacks, "disarm") as disarm,
+            self.assertRaisesRegex(RuntimeError, "busy"),
+        ):
+            with torch.cuda.graph(
+                graph,
+                enable_annotations=True,
+                annotation_config={"capture_py_stacks": True},
+            ):
+                pass
+        self.assertFalse(torch.cuda.is_current_stream_capturing())
+        disarm.assert_called_once_with()
+
+    def test_post_capture_begin_failure_cleans_up(self):
+        graph = torch.cuda.CUDAGraph()
+        hooks = []
+        graph.register_capture_end_hook(lambda _: hooks.append("capture_end"))
+        graph.register_post_instantiate_hook(lambda _: hooks.append("instantiate"))
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="The CUDA Graph is empty")
+            with (
+                torch.autograd.grad_mode.set_multithreading_enabled(False),
+                patch.object(_graph_node_callbacks, "register", return_value=True),
+                patch.object(_graph_node_callbacks, "disarm") as disarm,
+                patch.object(
+                    _graph_annotations,
+                    "maybe_stamp_capture_root",
+                    side_effect=RuntimeError("stamp failed"),
+                ),
+                self.assertRaisesRegex(RuntimeError, "stamp failed"),
+            ):
+                with torch.cuda.graph(
+                    graph,
+                    enable_annotations=True,
+                    annotation_config={"capture_py_stacks": True},
+                ):
+                    pass
+        self.assertFalse(_graph_py_stacks._is_capturing())
+        self.assertFalse(torch.cuda.is_current_stream_capturing())
+        self.assertEqual(hooks, [])
+        with self.assertRaisesRegex(
+            RuntimeError, r"capture_end\(\) must have been called"
+        ):
+            graph.replay()
+        disarm.assert_called_once_with()
+
+    def test_observer_disarms_between_capture_and_finalize(self):
+        x = torch.ones(1, device="cuda")
+        graph = torch.cuda.CUDAGraph()
+        self.addCleanup(graph.reset)
+        events = []
+        capture_end_pre = graph.capture_end_pre
+        capture_end_after_pre = graph._capture_end_after_pre
+
+        def end_capture():
+            capture_end_pre()
+            events.append("capture_end")
+
+        def finalize_capture():
+            events.append("finalize")
+            capture_end_after_pre()
+
+        with (
+            patch.object(graph, "capture_end_pre", side_effect=end_capture),
+            patch.object(graph, "_capture_end_after_pre", side_effect=finalize_capture),
+            patch.object(
+                _graph_node_callbacks,
+                "disarm",
+                side_effect=lambda: events.append("disarm"),
+            ),
+        ):
+            with torch.cuda.graph(
+                graph,
+                enable_annotations=True,
+                annotation_config={"backend": "edge_walk"},
+            ):
+                output = x + 1
+
+        self.assertEqual(events[:3], ["capture_end", "disarm", "finalize"])
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(output, x + 1)
+
+    def test_finalize_failure_restores_stream(self):
+        original_stream = torch.cuda.current_stream()
+        capture_stream = torch.cuda.Stream()
+        graph = torch.cuda.CUDAGraph()
+        self.addCleanup(graph.reset)
+
+        with (
+            patch.object(
+                graph,
+                "_capture_end_after_pre",
+                side_effect=RuntimeError("finalize failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "finalize failed"),
+        ):
+            with torch.cuda.graph(graph, stream=capture_stream):
+                torch.ones(1, device="cuda") + 1
+
+        self.assertEqual(torch.cuda.current_stream(), original_stream)
+
+    def test_arm_failure_warns_and_cleans_up(self):
+        x = torch.ones(1, device="cuda")
+        graph = torch.cuda.CUDAGraph()
+        with (
+            torch.autograd.grad_mode.set_multithreading_enabled(False),
+            patch.object(_graph_node_callbacks, "register", return_value=True),
+            patch.object(_graph_node_callbacks, "arm", return_value=False),
+            patch.object(_graph_node_callbacks, "disarm") as disarm,
+            self.assertWarnsRegex(UserWarning, "could not arm"),
+        ):
+            with torch.cuda.graph(
+                graph,
+                enable_annotations=True,
+                annotation_config={"capture_py_stacks": True},
+            ):
+                output = x + 1
+
+        graph.replay()
+        self.assertEqual(output, x + 1)
+        self.assertFalse(_graph_py_stacks._is_capturing())
+        self.assertEqual(graph_py_stacks.take_stacks(graph), {})
+        self.assertGreaterEqual(disarm.call_count, 1)
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA required")
+@unittest.skipUnless(TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+@unittest.skipUnless(
+    TEST_CUDA_GRAPH_TOOLS_ID,
+    "requires cudaGraphNodeGetToolsId (cuda-bindings and driver >= 13.1)",
+)
+class TestGraphPyStacksCUDA(TestCase):
+    def setUp(self):
+        super().setUp()
+        clear_kernel_annotations()
+        self.addCleanup(clear_kernel_annotations)
+        ctx = torch.autograd.grad_mode.set_multithreading_enabled(False)
+        ctx.__enter__()
+        self.addCleanup(ctx.__exit__, None, None, None)
+
+    @staticmethod
+    def _warm(x):
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                x = x.sin()
+        torch.cuda.current_stream().wait_stream(stream)
+        return x
+
+    def test_stacks_match_annotations_and_graph_nodes(self):
+        def launch_site(x):
+            return x.sin()
+
+        x = self._warm(torch.randn(64, device="cuda"))
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with torch.cuda.graph(
+            graph,
+            enable_annotations=True,
+            annotation_config={"backend": "cupti", "capture_py_stacks": True},
+        ):
+            with mark_kernels("phase"):
+                output = launch_site(x)
+
+        graph.instantiate()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertIsNone(_graph_node_callbacks._handler)
+        stacks = graph_py_stacks.take_stacks(graph)
+        self.assertEqual(set(stacks), set(get_kernel_annotations()))
+        self.assertGreater(len(stacks), 0)
+        graph_data = graph.get_graph_data()
+        node_tools_ids = {node["tools_id"] for node in graph_data["nodes"]}
+        self.assertTrue(set(stacks).issubset(node_tools_ids))
+        self.assertEqual(
+            {tools_id >> 32 for tools_id in stacks}, {graph_data["exec_graph_id"]}
+        )
+        self.assertTrue(any(":launch_site" in stack for stack in stacks.values()))
+        self.assertEqual(output, x.sin())
+
+    def test_default_instantiation_remaps_stacks(self):
+        x = self._warm(torch.randn(64, device="cuda"))
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph,
+            enable_annotations=True,
+            annotation_config={"capture_py_stacks": True},
+        ):
+            output = x.cos()
+
+        self.assertIsNone(_graph_node_callbacks._handler)
+        stacks = graph_py_stacks.take_stacks(graph)
+        self.assertGreater(len(stacks), 0)
+        self.assertEqual(
+            {tools_id >> 32 for tools_id in stacks}, {graph._remapped_exec_id}
+        )
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(output, x.cos())
+
+    def test_edge_walk_annotations_with_stacks(self):
+        x = self._warm(torch.randn(64, device="cuda"))
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph,
+            enable_annotations=True,
+            annotation_config={"backend": "edge_walk", "capture_py_stacks": True},
+        ):
+            with mark_kernels("phase"):
+                output = x.exp()
+
+        stacks = graph_py_stacks.take_stacks(graph)
+        self.assertEqual(set(stacks), set(get_kernel_annotations()))
+        self.assertGreater(len(stacks), 0)
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(output, x.exp())
+
+    def test_stack_capture_counts_conditional_body_nodes(self):
+        from torch._higher_order_ops.cudagraph_conditional_nodes import _if_body
+
+        x = torch.ones(2048, device="cuda")
+        pred = torch.tensor(True, device="cuda")
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with self.assertWarnsRegex(UserWarning, "node observation skipped") as warning:
+            with torch.cuda.graph(
+                graph,
+                enable_annotations=True,
+                annotation_config={"backend": "edge_walk", "capture_py_stacks": True},
+            ):
+                y = x + 1
+                with _if_body(pred):
+                    _ = y.sqrt()
+
+        self.assertEqual(os.path.realpath(warning.filename), os.path.realpath(__file__))
+        graph.instantiate()
+        stacks = graph_py_stacks.take_stacks(graph)
+        self.assertGreater(len(stacks), 0)
+        exec_graph_id = graph.get_graph_data()["exec_graph_id"]
+        self.assertEqual({tools_id >> 32 for tools_id in stacks}, {exec_graph_id})
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -2151,7 +2151,7 @@ class TestCuptiAnnotationBackend(TestCase):
         x = torch.ones([2048], device="cuda")
         pred = torch.tensor(True, device="cuda")
         g = torch.cuda.CUDAGraph(keep_graph=True)
-        with self.assertWarnsRegex(UserWarning, "were not annotated"):
+        with self.assertWarnsRegex(UserWarning, "node observation skipped"):
             with torch.cuda.graph(
                 g, enable_annotations=True, annotation_config={"backend": "cupti"}
             ):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,6 +14,7 @@ import types
 import unittest
 import warnings
 from typing import Any, cast
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -1074,11 +1075,19 @@ def f(x):
         )
 
     def test_captured_traceback_format_all(self):
-        rs = CapturedTraceback.format_all(
-            [CapturedTraceback.extract(), CapturedTraceback.extract()]
-        )
+        import torch._C._profiler
+
+        traces = [CapturedTraceback.extract(), CapturedTraceback.extract()]
+        symbolize_tracebacks = torch._C._profiler.symbolize_tracebacks
+        with patch.object(
+            torch._C._profiler,
+            "symbolize_tracebacks",
+            wraps=symbolize_tracebacks,
+        ) as symbolize:
+            rs = CapturedTraceback.format_all(traces)
         self.assertEqual(len(rs), 2)
         self.assertIn("test_captured_traceback_format_all", "".join(rs[0]))
+        symbolize.assert_called_once_with([trace.tb for trace in traces])
 
     def test_captured_traceback_format_all_cached(self):
         tb = CapturedTraceback.extract()

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -2103,7 +2103,16 @@ def _compile_kernel(
         return getattr(result, mangled_name)
 
 
-from . import amp, graph_annotations, jiterator, nvtx, profiler, sparse, tunable
+from . import (
+    amp,
+    graph_annotations,
+    graph_py_stacks,
+    jiterator,
+    nvtx,
+    profiler,
+    sparse,
+    tunable,
+)
 
 
 _POOL_HANDLE = NewType("_POOL_HANDLE", tuple[int, int])
@@ -2188,6 +2197,7 @@ __all__ = [
     "get_sync_debug_mode",
     "graph",
     "graph_annotations",
+    "graph_py_stacks",
     "graph_pool_handle",
     "graphs",
     "has_half",

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -49,7 +49,7 @@ import warnings
 from collections.abc import Mapping
 from contextlib import contextmanager
 from logging import getLogger
-from typing import Any, NamedTuple, TYPE_CHECKING, TypeAlias
+from typing import Any, NamedTuple, TYPE_CHECKING, TypeAlias, TypeVar
 
 
 if TYPE_CHECKING:
@@ -78,6 +78,7 @@ logger = getLogger(__name__)
 
 _CaptureState: TypeAlias = tuple[Any, list[Any]]
 _ExistingDirectDependents: TypeAlias = dict[int, set[int]]
+_T = TypeVar("_T")
 
 
 # Tri-state: None = not probed, True = available, False = unavailable.
@@ -944,11 +945,11 @@ def resolve_pending_annotations() -> None:
 
 
 def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
-    """Remap annotation keys from capture graph ID to exec graph ID.
+    """Remap recorded graph metadata from capture graph ID to exec graph ID.
 
     During capture, toolsId encodes the capture graph's ID in the upper
     32 bits. After instantiation, the profiler uses the exec graph's ID.
-    This function rewrites the keys so annotations match the trace.
+    This function rewrites annotation and Python-stack keys so they match the trace.
 
     The graph's capture id is read from the ``_capture_graph_id`` stamped on it
     by ``maybe_stamp_capture_root`` at capture_begin, so only the annotations
@@ -967,7 +968,7 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     matches the live exec id (e.g. replay after instantiate) this is a no-op.
     """
     capture_graph_id = torch_cuda_graph._capture_graph_id
-    if not _kernel_annotations or capture_graph_id is None:
+    if capture_graph_id is None:
         return
 
     exec_graph_id = _check_cuda_bindings(
@@ -984,6 +985,11 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     if current_key_id == exec_graph_id:
         return
 
+    from torch.cuda import _graph_py_stacks
+
+    _graph_py_stacks._remap_to_exec_graph(
+        torch_cuda_graph, current_key_id, exec_graph_id
+    )
     remapped = _rekey_annotations(_kernel_annotations, current_key_id, exec_graph_id)
     _kernel_annotations.clear()
     _kernel_annotations.update(remapped)
@@ -991,10 +997,10 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
 
 
 def _rekey_annotations(
-    annotations: dict[int, dict[str, Any]],
+    annotations: dict[int, _T],
     capture_graph_id: int,
     exec_graph_id: int,
-) -> dict[int, dict[str, Any]]:
+) -> dict[int, _T]:
     """Rekey one graph's annotations from its capture id to its exec id.
 
     A toolsId packs the graph id in the upper 32 bits and the node id in the
@@ -1005,7 +1011,7 @@ def _rekey_annotations(
     differ in node id, and the driver mints graph and exec ids from one counter
     that it does not reuse, so no other entry is keyed on a freshly minted exec id.
     """
-    remapped: dict[int, dict[str, Any]] = {}
+    remapped: dict[int, _T] = {}
     for tools_id, annotation in annotations.items():
         if tools_id >> 32 != capture_graph_id:
             remapped[tools_id] = annotation

--- a/torch/cuda/_graph_node_callbacks.py
+++ b/torch/cuda/_graph_node_callbacks.py
@@ -1,4 +1,4 @@
-"""Attribute CUDA-graph nodes as CUPTI reports their creation.
+r"""Observe CUDA-graph nodes as CUPTI reports their creation.
 
 The CUPTI-backed discovery half of :mod:`torch.cuda._graph_annotations`. Where the
 edge-walk backend infers a ``mark_kernels`` scope's membership from graph topology after
@@ -8,23 +8,23 @@ CUPTI announces it. A scope entered while the *current* stream is not yet captur
 nothing at all under the walk; CUPTI correctly attributes kernels. The walk rescans a nested
 scope's nodes once per enclosing scope; CUPTI visits each node once.
 
-Both backends key annotations by the node's capture-side ``toolsId`` and are remapped to
-exec-graph ids by ``remap_to_exec_graph`` identically, so downstream consumers cannot tell
-them apart.
+The same handler also records Python launch stacks when requested, so both consumers share
+the node-type filter, child/body-node rejection, and capture-side ``toolsId`` lookup.
 
 Needs a CUPTI subscription, but does not require one to already exist:
 ``annotation_backend="auto"`` picks this backend only when the monitor is already holding
 one (see ``torch.profiler._cupti.monitor.has_live_subscription``), while
 ``annotation_backend="cupti"`` brings the monitor up to take one. The handler runs
-synchronously on the capturing thread inside the CUDA call, so it stays as short as it can
-and never raises (the monitor's switchboard swallows exceptions, but a raise would still
-cost a traceback per node).
+synchronously on the capturing thread inside the CUDA call, so it stays as short as it can.
+The monitor's switchboard logs and suppresses exceptions before they reach CUPTI's C
+dispatch.
 """
 
 from __future__ import annotations
 
 import warnings
 from logging import getLogger
+from threading import Lock
 from typing import Any
 
 
@@ -34,23 +34,30 @@ logger = getLogger(__name__)
 # The handler token from the monitor. Carries the (domain, cbid) it was registered for, so
 # it is also what arm/disarm address the callback by; kept so disarm can unregister it.
 _handler: Any = None
+_handler_lock = Lock()
 
 # Nodes dropped during the armed capture for belonging to a child-graph or conditional
 # body. Counted rather than warned about on the spot: warnings.warn can be configured to
 # raise, and that must not happen inside CUPTI's C dispatch. disarm() reports the total.
 _dropped_body_nodes: int = 0
+_dropped_body_nodes_lock = Lock()
 
 
-def _on_graph_node_created(_domain: int, _cbid: int, cbdata: int) -> None:
-    """Record the ambient ``mark_kernels`` annotation for a freshly created graph node.
+def _on_graph_node_created(domain: int, cbid: int, cbdata: int) -> None:
+    """Record metadata for a freshly created graph node.
 
     Runs on the capturing thread inside the CUDA call. ``cbdata`` is a raw
     ``CUpti_ResourceData*``; its ``resource_descriptor`` is the ``CUpti_GraphData`` carrying
     the node handle and type.
     """
+    handler = _handler
+    if handler is None or domain != handler.domain or cbid != handler.cbid:
+        return
+
     from cuda.bindings import runtime  # pyrefly: ignore[missing-import]
     from cupti import cupti as _cupti  # pyrefly: ignore[missing-import]
 
+    from torch.cuda import _graph_py_stacks
     from torch.cuda._graph_annotations import (
         _get_annotatable_type_values,
         capture_root_graph_id,
@@ -59,29 +66,32 @@ def _on_graph_node_created(_domain: int, _cbid: int, cbdata: int) -> None:
     )
     from torch.cuda._utils import _check_cuda_bindings
 
-    # Cheapest rejection first: the node type is already in hand, the annotation costs a
-    # merge when scopes are nested, and the toolsId lookup is a driver call.
+    annotation = current_annotation()
+    capture_stack = _graph_py_stacks._is_capturing()
+    if annotation is None and not capture_stack:
+        return
+
     graph_data = _cupti.GraphData.from_ptr(
         _cupti.ResourceData.from_ptr(cbdata).resource_descriptor
     )
     if int(graph_data.node_type) not in _get_annotatable_type_values():
         return
-    annotation = current_annotation()
-    if annotation is None:
-        return
-    # toolsId is the value CUPTI later reports as "graph node id". mark_kernels gates on
-    # _is_tools_id_unavailable, so a driver without this API leaves no scope open and we
-    # returned above -- an error here is genuinely unexpected, and the monitor's switchboard
-    # logs it rather than letting it reach CUPTI's C dispatch.
+    # toolsId is the value CUPTI later reports as "graph node id". The graph context probes
+    # this API before arming the callback, so an error here is genuinely unexpected and the
+    # monitor's switchboard logs it rather than letting it reach CUPTI's C dispatch.
     tools_id = _check_cuda_bindings(runtime.cudaGraphNodeGetToolsId(graph_data.node))
     # Nodes reported for any other graph belong to a child-graph or conditional body, whose
     # ids live in that body graph's space and are renumbered again in the exec graph -- so
     # recording them would produce keys matching nothing. disarm() warns about the total.
     if tools_id >> 32 != capture_root_graph_id():
         global _dropped_body_nodes
-        _dropped_body_nodes += 1
+        with _dropped_body_nodes_lock:
+            _dropped_body_nodes += 1
         return
-    record_node_annotation(tools_id, annotation)
+    if annotation is not None:
+        record_node_annotation(tools_id, annotation)
+    if capture_stack:
+        _graph_py_stacks._record(tools_id)
 
 
 def is_available() -> bool:
@@ -109,37 +119,39 @@ def register(*, force: bool = False) -> bool:
 
     ``force`` brings the CUPTI monitor up instead of requiring a live subscription. That is a
     deliberate, opt-in cost: once we hold a CUPTI subscription, kineto's one-shot init fails
-    permanently, so a later ``torch.profiler`` run records no GPU activity. Only
-    ``annotation_backend="cupti"`` asks for it.
+    permanently, so a later ``torch.profiler`` run records no GPU activity. The CUPTI
+    annotation backend and Python stack capture ask for it.
     """
     global _handler
-    if _handler is not None:
-        raise RuntimeError("graph-node callbacks are already registered")
-    if not force and not is_available():
-        return False
-    # force=True skips the is_available() check above, so cupti-python may still be missing
-    # here; report that as "unavailable" and let the caller raise something actionable.
-    try:
-        from cupti import cupti as _cupti  # pyrefly: ignore[missing-import]
+    with _handler_lock:
+        if _handler is not None:
+            raise RuntimeError("graph-node callbacks are already registered")
+        if not force and not is_available():
+            return False
+        # force=True skips the is_available() check above, so cupti-python may still be
+        # missing here; report that as "unavailable" and let the caller raise something
+        # actionable.
+        try:
+            from cupti import cupti as _cupti  # pyrefly: ignore[missing-import]
 
-        from torch.profiler._cupti.monitor import CuptiMonitor
-    except ImportError:
-        return False
+            from torch.profiler._cupti.monitor import CuptiMonitor
+        except ImportError:
+            return False
 
-    # Importing the monitor requires cupti-python, so its enums are available too -- there is
-    # no case where a hardcoded (domain, cbid) fallback would be reachable.
-    try:
-        _handler = CuptiMonitor().register_callback_handler(
-            int(_cupti.CallbackDomain.RESOURCE),
-            int(_cupti.CallbackIdResource.GRAPHNODE_CREATED),
-            _on_graph_node_created,
-        )
-    except Exception:
-        # Subscribing can fail outright -- e.g. another CUPTI consumer already holds a
-        # subscription it did not offer to share. Fall back rather than fail the capture.
-        logger.debug("graph-node callback registration failed", exc_info=True)
-        return False
-    return True
+        # Importing the monitor requires cupti-python, so its enums are available too --
+        # there is no case where a hardcoded (domain, cbid) fallback would be reachable.
+        try:
+            _handler = CuptiMonitor().register_callback_handler(
+                int(_cupti.CallbackDomain.RESOURCE),
+                int(_cupti.CallbackIdResource.GRAPHNODE_CREATED),
+                _on_graph_node_created,
+            )
+        except Exception:
+            # Subscribing can fail outright -- e.g. another CUPTI consumer already holds a
+            # subscription it did not offer to share. Fall back rather than fail the capture.
+            logger.debug("graph-node callback registration failed", exc_info=True)
+            return False
+        return True
 
 
 def arm() -> bool:
@@ -150,42 +162,62 @@ def arm() -> bool:
     every node would be dropped and the caller should fall back to the edge walk.
     """
     global _dropped_body_nodes
-    if _handler is None:
-        return False
-    from torch.cuda._graph_annotations import capture_root_graph_id
-    from torch.profiler._cupti.monitor import CuptiMonitor
+    with _handler_lock:
+        if _handler is None:
+            return False
+        from torch.cuda._graph_annotations import capture_root_graph_id
+        from torch.profiler._cupti.monitor import CuptiMonitor
 
-    if capture_root_graph_id() is None:
-        return False
-    _dropped_body_nodes = 0
-    CuptiMonitor().arm_callback(_handler.domain, _handler.cbid)
-    return True
+        if capture_root_graph_id() is None:
+            return False
+        with _dropped_body_nodes_lock:
+            _dropped_body_nodes = 0
+        try:
+            CuptiMonitor().arm_callback(_handler.domain, _handler.cbid)
+        except Exception:
+            logger.debug("graph-node callback arm failed", exc_info=True)
+            return False
+        return True
 
 
 def disarm() -> None:
-    """Disable and unregister the node-creation callback, and report any work that went
-    unannotated. Idempotent, so it is safe in a ``finally`` for a capture that raised."""
-    global _handler
-    if _handler is None:
-        return
-    from torch.profiler._cupti.monitor import CuptiMonitor
+    r"""Disable and unregister the node-creation callback, and report skipped body nodes.
 
-    monitor = CuptiMonitor()
-    try:
-        monitor.disarm_callback(_handler.domain, _handler.cbid)
-        monitor.unregister_callback_handler(_handler)
-    finally:
+    Idempotent and non-throwing, so it is safe in a ``finally`` for a capture that raised.
+    """
+    global _dropped_body_nodes, _handler
+    with _handler_lock:
+        handler = _handler
         _handler = None
-    # Warn here rather than from the handler: this runs on the normal path, where a
-    # warnings filter promoting warnings to errors is harmless. The edge walk reports the
-    # same situation at scope entry; reporting it on the drop instead covers both a scope
-    # inside a body and a scope containing one, and says how much was actually lost.
-    if _dropped_body_nodes:
-        warnings.warn(
-            f"mark_kernels: {_dropped_body_nodes} node(s) created inside a CUDA graph "
-            "child-graph or conditional-node body (torch.cond / torch.while_loop) were "
-            "not annotated -- such a body is captured into a separate cudaGraph_t whose "
-            "node ids are never remapped to the exec graph, so an annotation there would "
-            "match nothing in a profiler trace",
-            stacklevel=2,
-        )
+        if handler is not None:
+            try:
+                from torch.profiler._cupti.monitor import CuptiMonitor
+
+                monitor = CuptiMonitor()
+                try:
+                    monitor.disarm_callback(handler.domain, handler.cbid)
+                except Exception:
+                    logger.exception("graph-node callback disarm failed")
+                try:
+                    monitor.unregister_callback_handler(handler)
+                except Exception:
+                    logger.exception("graph-node callback unregister failed")
+            except Exception:
+                logger.exception("graph-node callback monitor teardown failed")
+    with _dropped_body_nodes_lock:
+        dropped_body_nodes = _dropped_body_nodes
+        _dropped_body_nodes = 0
+    # Report after teardown rather than running Python warning machinery in CUPTI's C
+    # dispatch. If a warning filter raises, log it to preserve disarm's non-throwing contract.
+    if dropped_body_nodes:
+        try:
+            warnings.warn(
+                f"CUDA graph node observation skipped {dropped_body_nodes} node(s) inside a "
+                "child-graph or conditional-node body (torch.cond / torch.while_loop). "
+                "Such a body is captured into a separate cudaGraph_t whose node ids are "
+                "never remapped to the exec graph, so its annotations or Python launch "
+                "stacks would match nothing in a profiler trace.",
+                stacklevel=3,
+            )
+        except Exception:
+            logger.exception("graph-node callback drop warning failed")

--- a/torch/cuda/_graph_py_stacks.py
+++ b/torch/cuda/_graph_py_stacks.py
@@ -1,0 +1,163 @@
+"""Capture Python launch stacks for CUDA graph nodes."""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+import warnings
+from functools import lru_cache
+from typing import Any
+
+from torch.utils._traceback import CapturedTraceback, shorten_filename
+
+
+_MAX_STACKS_PER_GRAPH = 100_000
+_TORCH_ROOT = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
+_CWD = os.path.realpath(os.getcwd())
+_HOME = os.path.realpath(os.path.expanduser("~"))
+_FRAME_PATTERN = re.compile(r'^\s*File "(.*)", line ([0-9]+), in (.*)$')
+
+_active_graph: Any = None
+_state_lock = threading.RLock()
+
+
+def _begin_capture(graph: Any) -> None:
+    """Attach a bounded stack store to the graph for the active capture."""
+    global _active_graph
+
+    with _state_lock:
+        if _active_graph is not None:
+            raise RuntimeError("CUDA graph Python stack capture is already active")
+        clear_stacks(graph)
+        graph._py_stack_dropped = 0
+        _active_graph = graph
+
+
+def _end_capture(graph: Any) -> None:
+    """Stop recording stacks for ``graph``. Idempotent for error cleanup."""
+    global _active_graph
+
+    with _state_lock:
+        if _active_graph is graph:
+            _active_graph = None
+
+
+def _is_capturing() -> bool:
+    with _state_lock:
+        return _active_graph is not None
+
+
+def _record(tools_id: int) -> None:
+    """Record a node stack from the shared CUPTI graph-node callback."""
+    with _state_lock:
+        graph = _active_graph
+        if graph is None or tools_id in graph._py_stack_traces:
+            return
+        if len(graph._py_stack_traces) >= _MAX_STACKS_PER_GRAPH:
+            graph._py_stack_dropped += 1
+            return
+        graph._py_stack_traces[tools_id] = CapturedTraceback.extract(skip=1)
+
+
+@lru_cache(maxsize=4096)
+def _format_filename(filename: str) -> str | None:
+    real_filename = os.path.realpath(filename)
+    try:
+        if os.path.commonpath((real_filename, _TORCH_ROOT)) == _TORCH_ROOT:
+            return None
+    except ValueError:
+        pass
+    for base in (_CWD, _HOME):
+        if os.path.dirname(base) == base:
+            continue
+        try:
+            if os.path.commonpath((real_filename, base)) == base:
+                return shorten_filename(real_filename, base=base)
+        except ValueError:
+            pass
+    return os.path.basename(filename)
+
+
+def _format_stack(frames: list[str]) -> str:
+    stack: list[str] = []
+    for frame in reversed(frames):
+        lines = frame.splitlines()
+        if not lines:
+            continue
+        match = _FRAME_PATTERN.match(lines[0])
+        if match is None:
+            continue
+        filename, lineno, name = match.groups()
+        filename = _format_filename(filename)
+        if filename is not None:
+            stack.append(f"{filename}:{lineno}:{name}")
+    return "\n".join(stack) or "<no Python frames outside PyTorch>"
+
+
+def take_stacks(graph: Any) -> dict[int, str]:
+    r"""take_stacks(graph) -> dict[int, str]
+
+    Return and clear the Python launch stacks recorded for a CUDA graph.
+
+    Keys are exec-graph ``toolsId`` values after the graph has been instantiated.
+    Formatting and path shortening happen here, outside the capture callback.
+
+    Args:
+        graph (torch.cuda.CUDAGraph): the graph whose captured stacks are returned.
+
+    Returns:
+        dict[int, str]: A mapping from graph-node ``toolsId`` to its Python stack.
+    """
+    with _state_lock:
+        if graph._py_stack_traces and graph._remapped_exec_id is None:
+            raise RuntimeError("instantiate the CUDA graph before taking Python stacks")
+        traces = graph._py_stack_traces
+        graph._py_stack_traces = {}
+        dropped = graph._py_stack_dropped
+        graph._py_stack_dropped = 0
+
+    cache: dict[str, str] = {}
+    stacks: dict[int, str] = {}
+    try:
+        formatted = CapturedTraceback.format_all(list(traces.values()))
+        for tools_id, frames in zip(traces, formatted):
+            stack = _format_stack(frames)
+            stacks[tools_id] = cache.setdefault(stack, stack)
+    finally:
+        for trace in traces.values():
+            trace.cleanup()
+    if dropped:
+        warnings.warn(
+            f"CUDA graph Python stack capture dropped {dropped} node(s) after its "
+            f"{_MAX_STACKS_PER_GRAPH}-node limit",
+            stacklevel=3,
+        )
+    return stacks
+
+
+def clear_stacks(graph: Any) -> None:
+    r"""clear_stacks(graph) -> None
+
+    Discard Python launch stacks recorded for a CUDA graph.
+
+    Args:
+        graph (torch.cuda.CUDAGraph): the graph whose captured stacks are discarded.
+    """
+    with _state_lock:
+        for trace in graph._py_stack_traces.values():
+            trace.cleanup()
+        graph._py_stack_traces.clear()
+        graph._py_stack_dropped = 0
+
+
+def _remap_to_exec_graph(graph: Any, capture_graph_id: int, exec_graph_id: int) -> None:
+    from torch.cuda._graph_annotations import _rekey_annotations
+
+    with _state_lock:
+        graph._py_stack_traces = _rekey_annotations(
+            graph._py_stack_traces, capture_graph_id, exec_graph_id
+        )
+
+
+__all__ = ["clear_stacks", "take_stacks"]

--- a/torch/cuda/graph_py_stacks.py
+++ b/torch/cuda/graph_py_stacks.py
@@ -1,0 +1,67 @@
+r"""Capture Python launch stacks for CUDA graph nodes.
+
+Enable stack capture through :class:`torch.cuda.graph` and retrieve the result after
+the graph has been instantiated::
+
+    import torch
+    from torch.cuda.graph_py_stacks import take_stacks
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.autograd.grad_mode.set_multithreading_enabled(False):
+        with torch.cuda.graph(
+            graph,
+            enable_annotations=True,
+            annotation_config={"capture_py_stacks": True},
+        ):
+            output = workload(input)
+
+    stacks = take_stacks(graph)
+
+The mapping keys are the same ``graph node id`` values emitted by CUPTI-based profilers.
+
+.. warning::
+    Stack capture requires ``cupti-python`` and enables a CUPTI subscriber. If no subscriber
+    is already active, this prevents :class:`torch.profiler.profile` from initializing later
+    in the same process.
+
+.. warning::
+    This API is in prototype and may change in future releases.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def take_stacks(graph: Any) -> dict[int, str]:
+    r"""take_stacks(graph) -> dict[int, str]
+
+    Return and clear the Python launch stacks recorded for a CUDA graph.
+
+    Keys are exec-graph ``toolsId`` values after the graph has been instantiated.
+
+    Args:
+        graph (torch.cuda.CUDAGraph): the graph whose captured stacks are returned.
+
+    Returns:
+        dict[int, str]: A mapping from graph-node ``toolsId`` to its Python stack.
+    """
+    from torch.cuda._graph_py_stacks import take_stacks as _take_stacks
+
+    return _take_stacks(graph)
+
+
+def clear_stacks(graph: Any) -> None:
+    r"""clear_stacks(graph) -> None
+
+    Discard Python launch stacks recorded for a CUDA graph.
+
+    Args:
+        graph (torch.cuda.CUDAGraph): the graph whose captured stacks are discarded.
+    """
+    from torch.cuda._graph_py_stacks import clear_stacks as _clear_stacks
+
+    _clear_stacks(graph)
+
+
+__all__ = ["clear_stacks", "take_stacks"]

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -1,6 +1,7 @@
 # pylint: disable=useless-parent-delegation
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import gc
 import typing
@@ -335,6 +336,10 @@ class CUDAGraph(_CUDAGraph):
     # instantiate). Handed to the graph-destroy hooks on destruction so consumers
     # can purge that state and their maps do not grow across the run.
     _recorded_exec_ids: set[int]
+    # Compact, unsymbolized Python traces keyed by graph-node toolsId. Populated only when
+    # capture_py_stacks is requested and bounded by _graph_py_stacks.
+    _py_stack_traces: dict[int, typing.Any]
+    _py_stack_dropped: int
     _keep_graph: bool
     # User hooks fired by capture_begin / capture_end / instantiate (see register_*_hook).
     _capture_start_hooks: dict[int, Callable[[CUDAGraph], None]]
@@ -363,6 +368,8 @@ class CUDAGraph(_CUDAGraph):
         instance._capture_graph_id = None
         instance._remapped_exec_id = None
         instance._recorded_exec_ids = set()
+        instance._py_stack_traces = {}
+        instance._py_stack_dropped = 0
         instance._keep_graph = keep_graph
         # OrderedDict (not dict): RemovableHandle weak-references the mapping.
         instance._capture_start_hooks = OrderedDict()
@@ -540,8 +547,8 @@ class CUDAGraph(_CUDAGraph):
         return handle
 
     def _maybe_remap_annotations(self) -> None:
-        # Remap recorded kernel annotations to the current exec graph id. No-op
-        # unless a capture id was stamped (annotations enabled). Called from
+        # Remap recorded kernel annotations and Python stacks to the current exec graph id.
+        # No-op unless a capture id was stamped (annotations enabled). Called from
         # instantiate() -- which replay() routes through for keep_graph=True --
         # so every fresh exec graph (each instantiate() produces a new exec id)
         # rekeys the annotations; remap_to_exec_graph self-skips when the exec id
@@ -566,6 +573,10 @@ class CUDAGraph(_CUDAGraph):
         tracker, self._tracker = self._tracker, None
         if tracker is not None:
             tracker.stop()
+        if self._py_stack_traces:
+            from torch.cuda._graph_py_stacks import clear_stacks
+
+            clear_stacks(self)
 
     def __del__(self) -> None:
         try:
@@ -647,6 +658,9 @@ class CUDAGraph(_CUDAGraph):
         which call ``capture_end`` internally.
         """
         self.capture_end_pre()
+        self._capture_end_after_pre()
+
+    def _capture_end_after_pre(self) -> None:
         # Run the capture-end hooks while the template is live (both keep_graph modes). The
         # capture graph id is NOT read here: maybe_stamp_capture_root already stamped it at
         # capture_begin, and the template keeps that id for its whole life. Errors are user
@@ -1087,6 +1101,7 @@ def export_graph_data(path: str) -> Callable[[CUDAGraph], None]:
 # Recognized keys of graph()'s annotation_config, each mapped to (default, allowed values).
 _ANNOTATION_CONFIG_KEYS: dict[str, tuple[typing.Any, tuple[typing.Any, ...]]] = {
     "backend": ("auto", ("auto", "cupti", "edge_walk")),
+    "capture_py_stacks": (False, (False, True)),
 }
 
 
@@ -1150,7 +1165,12 @@ class graph:
             needed -- which prevents kineto from initializing, so a later
             :class:`torch.profiler.profile` records no GPU activity; ``"edge_walk"`` forces
             the walk, which cannot see nodes created while the current stream was not yet
-            capturing.
+            capturing. ``"capture_py_stacks"`` records the Python launch stack for each
+            top-level graph node. It requires ``enable_annotations=True`` and
+            single-threaded autograd. Retrieve and drain the stacks with
+            :func:`torch.cuda.graph_py_stacks.take_stacks` after instantiation. This option
+            forces the CUPTI path; bringing up its subscriber prevents
+            :class:`torch.profiler.profile` from initializing later in the same process.
         check_input_liveness (bool, optional): If ``True``, tracks external tensor inputs during graph capture and
             raises an error if any are deallocated before replay. This helps debug "use after free" errors
             where input tensors are garbage collected between capture and replay. Default: ``False``.
@@ -1183,6 +1203,13 @@ class graph:
         check_input_liveness: bool = False,
     ):
         self._annotation_config = _parse_annotation_config(annotation_config)
+        self._capture_py_stacks = self._annotation_config["capture_py_stacks"]
+        if self._capture_py_stacks and not enable_annotations:
+            raise ValueError(
+                "annotation_config={'capture_py_stacks': True} requires "
+                "enable_annotations=True"
+            )
+        self._capture_py_stacks_active = False
         # Lazy-init of default_capture_stream helps avoid circular-import errors.
         # Not thread safe, but graphs already have the general (explicitly documented)
         # restriction that only one capture may be underway at a time in the process.
@@ -1222,7 +1249,7 @@ class graph:
 
         # Pick the annotation backend before capture_begin, so that failing to obtain CUPTI
         # raises without a capture already underway.
-        from torch.cuda import _graph_node_callbacks
+        from torch.cuda import _graph_node_callbacks, _graph_py_stacks
         from torch.cuda._graph_annotations import (
             _set_annotation_backend,
             _set_annotations_enabled,
@@ -1230,26 +1257,42 @@ class graph:
         )
 
         backend = "edge_walk"
+        node_callbacks_registered = False
         requested = self._annotation_config["backend"]
-        if self._enable_annotations and requested != "edge_walk":
-            force = requested == "cupti"
+        if self._enable_annotations and (
+            requested != "edge_walk" or self._capture_py_stacks
+        ):
+            force = requested == "cupti" or self._capture_py_stacks
             # The CUPTI backend attributes each node to the mark_kernels scope open on the
             # thread that created it, so multithreaded autograd would mis-attribute the nodes
             # its engine worker threads create -- their scope state is not the capturing
             # thread's. (capture_error_mode is NOT the gate: it scopes capture's safety
             # checks, not which threads contribute nodes.) The edge walk reads no ambient
             # scope, so it is unaffected and remains the fallback.
-            if torch._C._is_multithreading_enabled():
-                if force:
-                    raise RuntimeError(
-                        "annotation_config={'backend': 'cupti'} requires single-threaded "
-                        "autograd, so that graph nodes are created on the capturing thread and "
-                        "attributed to the right mark_kernels scope. Wrap the capture in "
-                        "torch.autograd.grad_mode.set_multithreading_enabled(False)."
-                    )
-            elif _graph_node_callbacks.register(force=force):
-                backend = "cupti"
+            multithreaded = torch._C._is_multithreading_enabled()
+            if multithreaded and (requested == "cupti" or self._capture_py_stacks):
+                option = (
+                    "'capture_py_stacks': True"
+                    if self._capture_py_stacks
+                    else "'backend': 'cupti'"
+                )
+                raise RuntimeError(
+                    f"annotation_config={{{option}}} requires single-threaded "
+                    "autograd, so that graph nodes are created on the capturing thread and "
+                    "have the expected Python stack. Wrap the capture in "
+                    "torch.autograd.grad_mode.set_multithreading_enabled(False)."
+                )
+            if not multithreaded and _graph_node_callbacks.register(force=force):
+                node_callbacks_registered = True
+                if requested != "edge_walk":
+                    backend = "cupti"
             elif force:
+                if self._capture_py_stacks:
+                    raise RuntimeError(
+                        "annotation_config={'capture_py_stacks': True} could not register "
+                        "CUPTI node-creation callbacks. This needs the cupti-python package "
+                        "and a CUPTI monitor able to subscribe."
+                    )
                 raise RuntimeError(
                     "annotation_config={'backend': 'cupti'} could not register CUPTI "
                     "node-creation callbacks. This needs the cupti-python package and a "
@@ -1257,64 +1300,117 @@ class graph:
                     "dependent-edge walk instead."
                 )
 
-        # Scope annotation recording to this capture: the capture-root stamp and
-        # mark_kernels both gate on this flag, and __exit__ always clears it. It has to be
-        # set before capture_begin so maybe_stamp_capture_root below is not a no-op.
-        _set_annotations_enabled(self._enable_annotations)
+        if self._capture_py_stacks:
+            try:
+                _graph_py_stacks._begin_capture(self.cuda_graph)
+            except Exception:
+                _graph_node_callbacks.disarm()
+                raise
+            self._capture_py_stacks_active = True
 
-        # Stackoverflow seems comfortable with this pattern
-        # https://stackoverflow.com/questions/26635684/calling-enter-and-exit-manually#39172487
-        self.stream_ctx.__enter__()
+        stream_entered = False
+        capture_started = False
+        try:
+            # Scope annotation recording to this capture: the capture-root stamp and
+            # mark_kernels both gate on this flag, and __exit__ always clears it. It has to
+            # be set before capture_begin so maybe_stamp_capture_root below is not a no-op.
+            _set_annotations_enabled(self._enable_annotations)
 
-        self.cuda_graph.capture_begin(
-            # type: ignore[misc]
-            *self.pool,
-            # pyrefly: ignore [bad-keyword-argument]
-            capture_error_mode=self.capture_error_mode,
-            # pyrefly: ignore [bad-keyword-argument]
-            check_input_liveness=self.check_input_liveness,
-        )
-        # The capture stream is now capturing into the top-level graph, and this is the only
-        # point where its id is readable (the cudaGraph_t itself does not exist until
-        # capture_end). One read serves everything downstream: mark_kernels telling a
-        # conditional-node body apart from this graph, the CUPTI backend's body-node filter,
-        # and the stamp remap_to_exec_graph later rekeys from.
-        maybe_stamp_capture_root(self.cuda_graph)
+            # Stackoverflow seems comfortable with this pattern
+            # https://stackoverflow.com/questions/26635684/calling-enter-and-exit-manually#39172487
+            self.stream_ctx.__enter__()
+            stream_entered = True
+            self.cuda_graph.capture_begin(
+                # type: ignore[misc]
+                *self.pool,
+                # pyrefly: ignore [bad-keyword-argument]
+                capture_error_mode=self.capture_error_mode,
+                # pyrefly: ignore [bad-keyword-argument]
+                check_input_liveness=self.check_input_liveness,
+            )
+            capture_started = True
 
-        # Arming needs the capture live. If it does not work out, settle on the edge walk
-        # before any mark_kernels scope runs rather than recording keys that would match
-        # nothing -- which is why the backend is published only now.
-        if backend == "cupti" and not _graph_node_callbacks.arm():
-            _graph_node_callbacks.disarm()
-            backend = "edge_walk"
-        _set_annotation_backend(backend)
+            # The capture stream is now capturing into the top-level graph, and this is the
+            # only point where its id is readable (the cudaGraph_t itself does not exist until
+            # capture_end). One read serves everything downstream: mark_kernels telling a
+            # conditional-node body apart from this graph and the CUPTI callback's body-node
+            # filter, while the graph stamp is used to remap recorded metadata after
+            # instantiate.
+            maybe_stamp_capture_root(self.cuda_graph)
+
+            # Arming needs the capture live. If it does not work out, settle on the edge walk
+            # before any mark_kernels scope runs rather than recording keys that would match
+            # nothing -- which is why the backend is published only now.
+            if node_callbacks_registered and not _graph_node_callbacks.arm():
+                _graph_node_callbacks.disarm()
+                backend = "edge_walk"
+                if self._capture_py_stacks_active:
+                    _graph_py_stacks._end_capture(self.cuda_graph)
+                    _graph_py_stacks.clear_stacks(self.cuda_graph)
+                    self._capture_py_stacks_active = False
+                    warnings.warn(
+                        "annotation_config={'capture_py_stacks': True} could not arm CUPTI "
+                        "node-creation callbacks; no Python launch stacks will be recorded",
+                        stacklevel=2,
+                    )
+            _set_annotation_backend(backend)
+        except BaseException as error:
+            with contextlib.suppress(Exception):
+                _graph_node_callbacks.disarm()
+            if self._capture_py_stacks_active:
+                _graph_py_stacks._end_capture(self.cuda_graph)
+                self._capture_py_stacks_active = False
+                with contextlib.suppress(Exception):
+                    _graph_py_stacks.clear_stacks(self.cuda_graph)
+            if capture_started:
+                with contextlib.suppress(Exception):
+                    try:
+                        self.cuda_graph.capture_end_pre()
+                    finally:
+                        self.cuda_graph.reset()
+            if stream_entered:
+                with contextlib.suppress(Exception):
+                    self.stream_ctx.__exit__(type(error), error, error.__traceback__)
+            _set_annotations_enabled(False)
+            raise
 
     def __exit__(self, *args: object) -> None:
-        from torch.cuda import _graph_node_callbacks
+        from torch.cuda import _graph_node_callbacks, _graph_py_stacks
         from torch.cuda._graph_annotations import (
             _set_annotations_enabled,
             resolve_pending_annotations,
         )
 
+        capture_completed = False
         try:
-            # Stop recording before capture_end: the CUPTI backend has already attributed
-            # every node as it was created, and leaving the callback enabled would also pick
-            # up nodes created while instantiating.
-            _graph_node_callbacks.disarm()
             if self._enable_annotations:
                 resolve_pending_annotations()
 
-            # capture_end stamps the capture id and, for keep_graph=False,
-            # instantiates (which remaps annotations to the exec id). For
-            # keep_graph=True the remap is owned by the later instantiate()/replay().
-            self.cuda_graph.capture_end()
-            self.stream_ctx.__exit__(*args)
-        finally:
-            # Annotation recording is capture-scoped; clear it unconditionally. disarm() is
-            # idempotent, so repeating it here just covers a capture that raised before the
-            # call above (it must not stay armed past this context either way).
+            # cudaStreamEndCapture is not expected to create graph nodes; the stack/annotation
+            # parity tests rely on that. Keeping the synchronous CUPTI callback armed through
+            # capture_end_pre is defensive. Disarm immediately after, before hooks or
+            # instantiation can create unrelated nodes.
+            self.cuda_graph.capture_end_pre()
             _graph_node_callbacks.disarm()
-            _set_annotations_enabled(False)
+            if self._capture_py_stacks_active:
+                _graph_py_stacks._end_capture(self.cuda_graph)
+                self._capture_py_stacks_active = False
+            self.cuda_graph._capture_end_after_pre()
+            capture_completed = True
+        finally:
+            try:
+                # Annotation recording is capture-scoped; clear it unconditionally. disarm()
+                # is idempotent, so repeating it here covers a capture that raised before the
+                # call above.
+                _graph_node_callbacks.disarm()
+                if self._capture_py_stacks_active:
+                    _graph_py_stacks._end_capture(self.cuda_graph)
+                    self._capture_py_stacks_active = False
+                if self._capture_py_stacks and not capture_completed:
+                    _graph_py_stacks.clear_stacks(self.cuda_graph)
+                _set_annotations_enabled(False)
+            finally:
+                self.stream_ctx.__exit__(*args)
         # returning None should propagate exceptions from either capture_end or stream_ctx.__exit__()
 
 

--- a/torch/utils/_traceback.py
+++ b/torch/utils/_traceback.py
@@ -242,9 +242,11 @@ class CapturedTraceback:
                 rs.append(None)
                 delayed_idxs.append(i)
 
-        torch._C._profiler.symbolize_tracebacks([tbs[i].tb for i in delayed_idxs])
-        for i in delayed_idxs:
-            rs[i] = traceback.format_list(tbs[i].summary())
+        symbolized = torch._C._profiler.symbolize_tracebacks(
+            [tbs[i].tb for i in delayed_idxs]
+        )
+        for i, tb in zip(delayed_idxs, symbolized):
+            rs[i] = traceback.format_list(_extract_symbolized_tb(tb, tbs[i].skip))
 
         return rs
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195785

Add opt-in Python launch-stack capture to torch.cuda.graph using the existing CUPTI graph-node callback. Keep unsymbolized traces in bounded per-graph storage, filter unsupported body nodes with the annotation path, and remap tools IDs when the graph is instantiated so they join directly to profiler events.

Require single-threaded autograd because callback attribution is thread-local, and preserve the existing edge-walk fallback for multithreaded auto selection. Synchronize callback state and expose stack retrieval through torch.cuda.graph_py_stacks.

Failed capture setup ends and resets the template directly because the public capture_end path runs success hooks and instantiates a replayable graph. End capture is not expected to create nodes, as enforced by stack/annotation parity tests; the synchronous CUPTI observer remains armed through it defensively, then disarms before hooks and instantiation can create unrelated nodes. Teardown failures are logged rather than escaping disarm, and stream restoration runs unconditionally.

Path formatting ignores filesystem roots, warning locations point to user call sites, and CapturedTraceback.format_all consumes its batched result instead of symbolizing every trace again.

Test Plan:

```
MAX_JOBS=36 BUILD_IGNORE_SVE_UNAVAILABLE=1 pip install -e . -v --no-build-isolation
python test/test_cuda_graph_py_stacks.py -v
python test/test_cuda_graph_utils.py -v
python test/test_utils.py TestTraceback.test_captured_traceback_format_all TestTraceback.test_captured_traceback_format_all_cached -v
python test/test_public_bindings.py TestPublicBindings.test_correct_module_names -v
spin quicklint
lintrunner -a
```

Authored with assistance from Codex.