### PR TITLE
[ROCm][FlexAttention] Enable TLX backward template choices

### DIFF
--- a/test/inductor/test_choices_composition.py
+++ b/test/inductor/test_choices_composition.py
@@ -201,6 +201,160 @@ class ChoicesCompositionTest(TestCase):
         self.assertEqual(second.calls, 0)
         self.assertIn("customize_fused_kernel_name", "\n".join(logs.output))
 
+    def test_flex_attention_backward_skips_forward_only_override(self) -> None:
+        class ForwardOnlyChoices(InductorChoices):
+            def __init__(self) -> None:
+                super().__init__()
+                self.calls = 0
+
+            def uuid(self) -> str:
+                return "forward-only"
+
+            def append_flex_attention_choices(
+                self,
+                choices,
+                configs,
+                input_nodes,
+                subgraphs,
+                layout,
+                kernel_options,
+                sparse_q_block_size,
+                sparse_kv_block_size,
+            ):
+                self.calls += 1
+                return choices
+
+        class BackwardChoices(InductorChoices):
+            def __init__(self) -> None:
+                super().__init__()
+                self.mutated_inputs: list[Any] | None = None
+
+            def uuid(self) -> str:
+                return "backward"
+
+            def append_flex_attention_choices(
+                self,
+                choices,
+                configs,
+                input_nodes,
+                subgraphs,
+                layout,
+                kernel_options,
+                sparse_q_block_size,
+                sparse_kv_block_size,
+                *,
+                mutated_inputs=None,
+            ):
+                self.mutated_inputs = mutated_inputs
+                return choices
+
+        forward = ForwardOnlyChoices()
+        backward = BackwardChoices()
+        register_inductor_choices("forward", lambda: forward)
+        register_inductor_choices("backward", lambda: backward)
+        mutated_inputs = [object()]
+
+        result = V.choices.append_flex_attention_backward_choices(
+            [], [], [], [], None, {}, 1, 1, mutated_inputs
+        )
+
+        self.assertEqual(result, [])
+        self.assertEqual(forward.calls, 0)
+        self.assertIs(backward.mutated_inputs, mutated_inputs)
+
+    def test_flex_attention_backward_conflict_warns_once(self) -> None:
+        class FirstBackwardChoices(InductorChoices):
+            def __init__(self) -> None:
+                super().__init__()
+                self.calls = 0
+
+            def uuid(self) -> str:
+                return "first-backward"
+
+            def append_flex_attention_choices(self, *args, **kwargs):
+                self.calls += 1
+                return args[0]
+
+        class SecondBackwardChoices(FirstBackwardChoices):
+            def uuid(self) -> str:
+                return "second-backward"
+
+        first = FirstBackwardChoices()
+        second = SecondBackwardChoices()
+        register_inductor_choices("first", lambda: first)
+        register_inductor_choices("second", lambda: second)
+        handler = V.choices
+
+        with self.assertLogs("torch._inductor.choices", level="WARNING") as logs:
+            for _ in range(2):
+                result = handler.append_flex_attention_backward_choices(
+                    [], [], [], [], None, {}, 1, 1, []
+                )
+                self.assertEqual(result, [])
+
+        self.assertEqual(first.calls, 2)
+        self.assertEqual(second.calls, 0)
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("append_flex_attention_choices", logs.output[0])
+
+    def test_flex_attention_backward_skips_uninspectable_override(self) -> None:
+        choices = InductorChoices()
+        expected = []
+
+        def append_choices(*args, **kwargs):
+            return args[0]
+
+        append_choices.__dict__["__signature__"] = object()
+        choices.__dict__["append_flex_attention_choices"] = append_choices
+
+        result = None
+        try:
+            result = choices.append_flex_attention_backward_choices(
+                expected, [], [], [], None, {}, 1, 1, []
+            )
+        except (TypeError, ValueError):
+            pass
+
+        self.assertIs(result, expected)
+
+    def test_explicit_flex_attention_backward_override_takes_precedence(self) -> None:
+        class CompatibleChoices(InductorChoices):
+            def __init__(self) -> None:
+                super().__init__()
+                self.calls = 0
+
+            def uuid(self) -> str:
+                return "compatible"
+
+            def append_flex_attention_choices(self, *args, **kwargs):
+                self.calls += 1
+                return args[0]
+
+        class ExplicitBackwardChoices(InductorChoices):
+            def __init__(self) -> None:
+                super().__init__()
+                self.calls = 0
+
+            def uuid(self) -> str:
+                return "explicit-backward"
+
+            def append_flex_attention_backward_choices(self, *args, **kwargs):
+                self.calls += 1
+                return args[0]
+
+        compatible = CompatibleChoices()
+        explicit = ExplicitBackwardChoices()
+        register_inductor_choices("compatible", lambda: compatible)
+        register_inductor_choices("explicit", lambda: explicit)
+
+        result = V.choices.append_flex_attention_backward_choices(
+            [], [], [], [], None, {}, 1, 1, []
+        )
+
+        self.assertEqual(result, [])
+        self.assertEqual(compatible.calls, 0)
+        self.assertEqual(explicit.calls, 1)
+
     def test_staticmethod_conflict_warns_once(self) -> None:
         register_inductor_choices("false", StaticFalseChoices)
         register_inductor_choices("true", StaticTrueChoices)

--- a/test/inductor/test_choices_composition.py
+++ b/test/inductor/test_choices_composition.py
@@ -65,6 +65,34 @@ class SecondNameChoices(InductorChoices):
         return f"{fused_name}_second"
 
 
+class ForwardFlexChoices(InductorChoices):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def uuid(self) -> str:
+        return "forward-flex"
+
+    def append_flex_attention_choices(self, choices, *args, **kwargs):
+        self.calls += 1
+        return choices
+
+
+class BackwardFlexChoices(InductorChoices):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mutated_inputs: list[Any] | None = None
+
+    def uuid(self) -> str:
+        return "backward-flex"
+
+    def append_flex_attention_backward_choices(
+        self, choices, *args, mutated_inputs: list[Any], **kwargs
+    ):
+        self.mutated_inputs = mutated_inputs
+        return choices
+
+
 class UUIDChoices(InductorChoices):
     def __init__(self, value: str) -> None:
         super().__init__()
@@ -201,159 +229,59 @@ class ChoicesCompositionTest(TestCase):
         self.assertEqual(second.calls, 0)
         self.assertIn("customize_fused_kernel_name", "\n".join(logs.output))
 
-    def test_flex_attention_backward_skips_forward_only_override(self) -> None:
-        class ForwardOnlyChoices(InductorChoices):
-            def __init__(self) -> None:
-                super().__init__()
-                self.calls = 0
+    def test_flex_attention_forward_override_is_not_used_for_backward(self) -> None:
+        handler = ForwardFlexChoices()
+        forward_choices = [object()]
+        backward_choices = [object()]
+        args = ([], [], [], None, {}, 1, 1)
 
-            def uuid(self) -> str:
-                return "forward-only"
+        self.assertIs(
+            handler.append_flex_attention_choices(forward_choices, *args),
+            forward_choices,
+        )
+        self.assertIs(
+            handler.append_flex_attention_backward_choices(
+                backward_choices,
+                *args,
+                mutated_inputs=[],
+            ),
+            backward_choices,
+        )
+        self.assertEqual(handler.calls, 1)
 
-            def append_flex_attention_choices(
-                self,
-                choices,
-                configs,
-                input_nodes,
-                subgraphs,
-                layout,
-                kernel_options,
-                sparse_q_block_size,
-                sparse_kv_block_size,
-            ):
-                self.calls += 1
-                return choices
-
-        class BackwardChoices(InductorChoices):
-            def __init__(self) -> None:
-                super().__init__()
-                self.mutated_inputs: list[Any] | None = None
-
-            def uuid(self) -> str:
-                return "backward"
-
-            def append_flex_attention_choices(
-                self,
-                choices,
-                configs,
-                input_nodes,
-                subgraphs,
-                layout,
-                kernel_options,
-                sparse_q_block_size,
-                sparse_kv_block_size,
-                *,
-                mutated_inputs=None,
-            ):
-                self.mutated_inputs = mutated_inputs
-                return choices
-
-        forward = ForwardOnlyChoices()
-        backward = BackwardChoices()
+    def test_flex_attention_hooks_compose_independently(self) -> None:
+        forward = ForwardFlexChoices()
+        backward = BackwardFlexChoices()
         register_inductor_choices("forward", lambda: forward)
         register_inductor_choices("backward", lambda: backward)
         mutated_inputs = [object()]
-
-        result = V.choices.append_flex_attention_backward_choices(
-            [], [], [], [], None, {}, 1, 1, mutated_inputs
-        )
-
-        self.assertEqual(result, [])
-        self.assertEqual(forward.calls, 0)
-        self.assertIs(backward.mutated_inputs, mutated_inputs)
-
-    def test_flex_attention_backward_conflict_warns_once(self) -> None:
-        class FirstBackwardChoices(InductorChoices):
-            def __init__(self) -> None:
-                super().__init__()
-                self.calls = 0
-
-            def uuid(self) -> str:
-                return "first-backward"
-
-            def append_flex_attention_choices(self, *args, **kwargs):
-                self.calls += 1
-                return args[0]
-
-        class SecondBackwardChoices(FirstBackwardChoices):
-            def uuid(self) -> str:
-                return "second-backward"
-
-        first = FirstBackwardChoices()
-        second = SecondBackwardChoices()
-        register_inductor_choices("first", lambda: first)
-        register_inductor_choices("second", lambda: second)
         handler = V.choices
 
-        with self.assertLogs("torch._inductor.choices", level="WARNING") as logs:
-            for _ in range(2):
-                result = handler.append_flex_attention_backward_choices(
-                    [], [], [], [], None, {}, 1, 1, []
-                )
-                self.assertEqual(result, [])
-
-        self.assertEqual(first.calls, 2)
-        self.assertEqual(second.calls, 0)
-        self.assertEqual(len(logs.output), 1)
-        self.assertIn("append_flex_attention_choices", logs.output[0])
-
-    def test_flex_attention_backward_skips_uninspectable_override(self) -> None:
-        choices = InductorChoices()
-        expected = []
-
-        def append_choices(*args, **kwargs):
-            return args[0]
-
-        append_choices.__dict__["__signature__"] = object()
-        choices.__dict__["append_flex_attention_choices"] = append_choices
-
-        result = None
-        try:
-            result = choices.append_flex_attention_backward_choices(
-                expected, [], [], [], None, {}, 1, 1, []
-            )
-        except (TypeError, ValueError):
-            pass
-
-        self.assertIs(result, expected)
-
-    def test_explicit_flex_attention_backward_override_takes_precedence(self) -> None:
-        class CompatibleChoices(InductorChoices):
-            def __init__(self) -> None:
-                super().__init__()
-                self.calls = 0
-
-            def uuid(self) -> str:
-                return "compatible"
-
-            def append_flex_attention_choices(self, *args, **kwargs):
-                self.calls += 1
-                return args[0]
-
-        class ExplicitBackwardChoices(InductorChoices):
-            def __init__(self) -> None:
-                super().__init__()
-                self.calls = 0
-
-            def uuid(self) -> str:
-                return "explicit-backward"
-
-            def append_flex_attention_backward_choices(self, *args, **kwargs):
-                self.calls += 1
-                return args[0]
-
-        compatible = CompatibleChoices()
-        explicit = ExplicitBackwardChoices()
-        register_inductor_choices("compatible", lambda: compatible)
-        register_inductor_choices("explicit", lambda: explicit)
-
-        result = V.choices.append_flex_attention_backward_choices(
-            [], [], [], [], None, {}, 1, 1, []
+        forward_choices = [object()]
+        backward_choices = [object()]
+        args = ([], [], [], None, {}, 1, 1)
+        self.assertIs(
+            handler.append_flex_attention_choices(forward_choices, *args),
+            forward_choices,
+        )
+        self.assertIs(
+            handler.append_flex_attention_backward_choices(
+                backward_choices,
+                *args,
+                mutated_inputs=mutated_inputs,
+            ),
+            backward_choices,
         )
 
-        self.assertEqual(result, [])
-        self.assertEqual(compatible.calls, 0)
-        self.assertEqual(explicit.calls, 1)
+        self.assertEqual(forward.calls, 1)
+        self.assertIs(backward.mutated_inputs, mutated_inputs)
+
+    def test_flex_attention_backward_mutated_inputs_is_keyword_only(self) -> None:
+        choices = InductorChoices()
+        with self.assertRaises(TypeError):
+            choices.append_flex_attention_backward_choices(
+                [], [], [], [], None, {}, 1, 1, []
+            )
 
     def test_staticmethod_conflict_warns_once(self) -> None:
         register_inductor_choices("false", StaticFalseChoices)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -6087,11 +6087,11 @@ class GraphModule(torch.nn.Module):
     @supported_platform
     @skip_on_cpu
     @expected_not_implemented_on_mps  # backward path; NIE on MPS via _validate_device
-    def test_backward_calls_flex_attention_choices_hook(self, device):
+    def test_backward_calls_flex_attention_backward_choices_hook(self, device):
         from torch._inductor.choices import InductorChoices
         from torch._inductor.virtualized import V
 
-        class LegacyChoices(InductorChoices):
+        class ForwardChoices(InductorChoices):
             def __init__(self):
                 self.calls = 0
 
@@ -6128,7 +6128,7 @@ class GraphModule(torch.nn.Module):
                 self.stock_input_nodes = None
                 self.stock_mutated_inputs = None
 
-            def append_flex_attention_choices(
+            def append_flex_attention_backward_choices(
                 self,
                 choices,
                 configs,
@@ -6138,7 +6138,8 @@ class GraphModule(torch.nn.Module):
                 kernel_options,
                 sparse_q_block_size,
                 sparse_kv_block_size,
-                mutated_inputs=None,
+                *,
+                mutated_inputs,
             ):
                 self.calls.append((input_nodes, subgraphs, mutated_inputs))
                 stock_choice = choices[0]
@@ -6148,20 +6149,12 @@ class GraphModule(torch.nn.Module):
                 choices.append(SelectedChoice(stock_choice, self))
                 return choices
 
-        class VariadicChoices(InductorChoices):
-            def __init__(self):
-                self.calls = []
-
-            def append_flex_attention_choices(self, *args, **kwargs):
-                self.calls.append((args[2], args[3], kwargs["mutated_inputs"]))
-                return args[0]
-
         class MutatingChoices(InductorChoices):
             def __init__(self):
                 self.stock_input_node_count = None
                 self.stock_mutated_input_count = None
 
-            def append_flex_attention_choices(
+            def append_flex_attention_backward_choices(
                 self,
                 choices,
                 configs,
@@ -6171,7 +6164,8 @@ class GraphModule(torch.nn.Module):
                 kernel_options,
                 sparse_q_block_size,
                 sparse_kv_block_size,
-                mutated_inputs=None,
+                *,
+                mutated_inputs,
             ):
                 input_nodes.clear()
                 subgraphs.clear()
@@ -6225,16 +6219,16 @@ class GraphModule(torch.nn.Module):
                     query, key, value, out, logsumexp, grad_out
                 )
 
-        legacy_choices = LegacyChoices()
-        legacy_result = run_with_choices(legacy_choices)
-        self.assertEqual(legacy_choices.calls, 0)
+        forward_choices = ForwardChoices()
+        stock_result = run_with_choices(forward_choices)
+        self.assertEqual(forward_choices.calls, 0)
 
         recording_choices = RecordingChoices()
         recording_result = run_with_choices(recording_choices)
 
         self.assertEqual(len(recording_choices.calls), 1)
         self.assertTrue(recording_choices.selected)
-        self.assertEqual(recording_result, legacy_result)
+        self.assertEqual(recording_result, stock_result)
         input_nodes, subgraphs, mutated_inputs = recording_choices.calls[0]
         self.assertEqual(len(input_nodes), 16)
         self.assertEqual(len(subgraphs), 4)
@@ -6256,20 +6250,9 @@ class GraphModule(torch.nn.Module):
 
         mutating_choices = MutatingChoices()
         mutating_result = run_with_choices(mutating_choices)
-        self.assertEqual(mutating_result, legacy_result)
+        self.assertEqual(mutating_result, stock_result)
         self.assertEqual(mutating_choices.stock_input_node_count, 16)
         self.assertEqual(mutating_choices.stock_mutated_input_count, 2)
-
-        variadic_choices = VariadicChoices()
-        run_with_choices(variadic_choices)
-
-        self.assertEqual(len(variadic_choices.calls), 1)
-        input_nodes, subgraphs, mutated_inputs = variadic_choices.calls[0]
-        self.assertEqual(len(input_nodes), 16)
-        self.assertEqual(len(subgraphs), 4)
-        self.assertEqual(len(mutated_inputs), 2)
-        self.assertIs(mutated_inputs[0], input_nodes[6])
-        self.assertIs(mutated_inputs[1], input_nodes[7])
 
     @supported_platform
     @skip_on_cpu
@@ -6285,7 +6268,7 @@ class GraphModule(torch.nn.Module):
             def uuid(self):
                 return "captured_grad_mutation_test"
 
-            def append_flex_attention_choices(
+            def append_flex_attention_backward_choices(
                 self,
                 choices,
                 configs,
@@ -6295,7 +6278,8 @@ class GraphModule(torch.nn.Module):
                 kernel_options,
                 sparse_q_block_size,
                 sparse_kv_block_size,
-                mutated_inputs=None,
+                *,
+                mutated_inputs,
             ):
                 self.calls.append((input_nodes, subgraphs, mutated_inputs))
                 return choices

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -6087,6 +6087,262 @@ class GraphModule(torch.nn.Module):
     @supported_platform
     @skip_on_cpu
     @expected_not_implemented_on_mps  # backward path; NIE on MPS via _validate_device
+    def test_backward_calls_flex_attention_choices_hook(self, device):
+        from torch._inductor.choices import InductorChoices
+        from torch._inductor.virtualized import V
+
+        class LegacyChoices(InductorChoices):
+            def __init__(self):
+                self.calls = 0
+
+            def append_flex_attention_choices(
+                self,
+                choices,
+                configs,
+                input_nodes,
+                subgraphs,
+                layout,
+                kernel_options,
+                sparse_q_block_size,
+                sparse_kv_block_size,
+            ):
+                self.calls += 1
+                return choices
+
+        class SelectedChoice:
+            def __init__(self, choice, owner):
+                self.choice = choice
+                self.owner = owner
+
+            def __getattr__(self, name):
+                return getattr(self.choice, name)
+
+            def output_node(self):
+                self.owner.selected = True
+                return self.choice.output_node()
+
+        class RecordingChoices(InductorChoices):
+            def __init__(self):
+                self.calls = []
+                self.selected = False
+                self.stock_input_nodes = None
+                self.stock_mutated_inputs = None
+
+            def append_flex_attention_choices(
+                self,
+                choices,
+                configs,
+                input_nodes,
+                subgraphs,
+                layout,
+                kernel_options,
+                sparse_q_block_size,
+                sparse_kv_block_size,
+                mutated_inputs=None,
+            ):
+                self.calls.append((input_nodes, subgraphs, mutated_inputs))
+                stock_choice = choices[0]
+                self.stock_input_nodes = stock_choice.input_nodes
+                self.stock_mutated_inputs = stock_choice.mutated_inputs
+                choices.clear()
+                choices.append(SelectedChoice(stock_choice, self))
+                return choices
+
+        class VariadicChoices(InductorChoices):
+            def __init__(self):
+                self.calls = []
+
+            def append_flex_attention_choices(self, *args, **kwargs):
+                self.calls.append((args[2], args[3], kwargs["mutated_inputs"]))
+                return args[0]
+
+        class MutatingChoices(InductorChoices):
+            def __init__(self):
+                self.stock_input_node_count = None
+                self.stock_mutated_input_count = None
+
+            def append_flex_attention_choices(
+                self,
+                choices,
+                configs,
+                input_nodes,
+                subgraphs,
+                layout,
+                kernel_options,
+                sparse_q_block_size,
+                sparse_kv_block_size,
+                mutated_inputs=None,
+            ):
+                input_nodes.clear()
+                subgraphs.clear()
+                mutated_inputs.clear()
+                self.stock_input_node_count = len(choices[0].input_nodes)
+                self.stock_mutated_input_count = len(choices[0].mutated_inputs)
+                return choices
+
+        shape = (1, 1, 128, 16)
+        query = torch.randn(shape, device=device)
+        key = torch.randn(shape, device=device)
+        value = torch.randn(shape, device=device)
+        block_mask = _create_empty_block_mask(query, key)
+        scale = 1.0 / shape[-1] ** 0.5
+        out, logsumexp = flex_attention_fwd(
+            query,
+            key,
+            value,
+            _identity,
+            block_mask,
+            scale,
+        )
+        grad_out = torch.randn_like(out)
+
+        def compiled_bw(query, key, value, out, logsumexp, grad_out):
+            return torch.ops.higher_order.flex_attention_backward(
+                query,
+                key,
+                value,
+                out,
+                logsumexp,
+                grad_out,
+                None,
+                _identity,
+                None,
+                block_mask.as_tuple(),
+                scale,
+                {"BACKEND": "TRITON"},
+                (),
+                (),
+            )
+
+        def run_with_choices(choices):
+            torch._dynamo.reset()
+            with (
+                config.patch(force_disable_caches=True),
+                V.set_choices_handler(choices),
+                torch.no_grad(),
+            ):
+                return torch.compile(compiled_bw, fullgraph=True)(
+                    query, key, value, out, logsumexp, grad_out
+                )
+
+        legacy_choices = LegacyChoices()
+        legacy_result = run_with_choices(legacy_choices)
+        self.assertEqual(legacy_choices.calls, 0)
+
+        recording_choices = RecordingChoices()
+        recording_result = run_with_choices(recording_choices)
+
+        self.assertEqual(len(recording_choices.calls), 1)
+        self.assertTrue(recording_choices.selected)
+        self.assertEqual(recording_result, legacy_result)
+        input_nodes, subgraphs, mutated_inputs = recording_choices.calls[0]
+        self.assertEqual(len(input_nodes), 16)
+        self.assertEqual(len(subgraphs), 4)
+        self.assertEqual(len(mutated_inputs), 2)
+        self.assertEqual(len(recording_choices.stock_input_nodes), len(input_nodes))
+        for stock_node, hook_node in zip(
+            recording_choices.stock_input_nodes, input_nodes
+        ):
+            self.assertIs(hook_node, stock_node)
+        self.assertEqual(
+            len(recording_choices.stock_mutated_inputs), len(mutated_inputs)
+        )
+        for stock_node, hook_node in zip(
+            recording_choices.stock_mutated_inputs, mutated_inputs
+        ):
+            self.assertIs(hook_node, stock_node)
+        self.assertIs(mutated_inputs[0], input_nodes[6])
+        self.assertIs(mutated_inputs[1], input_nodes[7])
+
+        mutating_choices = MutatingChoices()
+        mutating_result = run_with_choices(mutating_choices)
+        self.assertEqual(mutating_result, legacy_result)
+        self.assertEqual(mutating_choices.stock_input_node_count, 16)
+        self.assertEqual(mutating_choices.stock_mutated_input_count, 2)
+
+        variadic_choices = VariadicChoices()
+        run_with_choices(variadic_choices)
+
+        self.assertEqual(len(variadic_choices.calls), 1)
+        input_nodes, subgraphs, mutated_inputs = variadic_choices.calls[0]
+        self.assertEqual(len(input_nodes), 16)
+        self.assertEqual(len(subgraphs), 4)
+        self.assertEqual(len(mutated_inputs), 2)
+        self.assertIs(mutated_inputs[0], input_nodes[6])
+        self.assertIs(mutated_inputs[1], input_nodes[7])
+
+    @supported_platform
+    @skip_on_cpu
+    @expected_not_implemented_on_mps  # backward path; NIE on MPS via _validate_device
+    def test_backward_choices_hook_preserves_captured_grad_mutations(self, device):
+        from torch._inductor.choices import InductorChoices
+        from torch._inductor.virtualized import V
+
+        class RecordingChoices(InductorChoices):
+            def __init__(self):
+                self.calls = []
+
+            def uuid(self):
+                return "captured_grad_mutation_test"
+
+            def append_flex_attention_choices(
+                self,
+                choices,
+                configs,
+                input_nodes,
+                subgraphs,
+                layout,
+                kernel_options,
+                sparse_q_block_size,
+                sparse_kv_block_size,
+                mutated_inputs=None,
+            ):
+                self.calls.append((input_nodes, subgraphs, mutated_inputs))
+                return choices
+
+        shape = (1, 1, 128, 16)
+        query = torch.randn(shape, device=device, requires_grad=True)
+        key = torch.randn(shape, device=device, requires_grad=True)
+        value = torch.randn(shape, device=device, requires_grad=True)
+        score_bias = torch.randn((1,), device=device, requires_grad=True)
+
+        def compiled_attention(query, key, value, bias):
+            def score_mod(score, b, h, m, n):
+                return score * bias[0]
+
+            return flex_attention(
+                query,
+                key,
+                value,
+                score_mod=score_mod,
+                kernel_options={"BACKEND": "TRITON"},
+            )
+
+        choices = RecordingChoices()
+        torch._dynamo.reset()
+        with (
+            config.patch(
+                force_disable_caches=True,
+                inductor_choices_class=lambda: choices,
+            ),
+            V.set_choices_handler(choices),
+        ):
+            torch.compile(compiled_attention, fullgraph=True)(
+                query, key, value, score_bias
+            ).sum().backward()
+
+        backward_calls = [call for call in choices.calls if len(call[0]) == 16]
+        self.assertEqual(len(backward_calls), 1)
+        input_nodes, subgraphs, mutated_inputs = backward_calls[0]
+        self.assertEqual(len(subgraphs), 4)
+        self.assertEqual(len(mutated_inputs), 3)
+        self.assertIs(mutated_inputs[0], input_nodes[6])
+        self.assertIs(mutated_inputs[1], input_nodes[7])
+        self.assertEqual(mutated_inputs[2].get_size(), [1])
+
+    @supported_platform
+    @skip_on_cpu
+    @expected_not_implemented_on_mps  # backward path; NIE on MPS via _validate_device
     def test_direct_backward_preserves_explicit_buffers(self, device):
         mask_buffer = torch.full((), 128, device=device, dtype=torch.int32)
 

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -1266,6 +1266,44 @@ class TestTemplateRender(TestCase):
             for kernel in template_kernels
         )
 
+    @requires_triton()
+    def test_jit_lines_preserves_hip_options(self):
+        kernel = unittest.mock.MagicMock()
+        kernel.use_jit = False
+        kernel.args.python_argdefs.return_value = ([], [], [], [])
+        kernel.index_dtype = "tl.int32"
+        kernel.output_node.get_device.return_value = torch.device("cuda")
+        kernel.meta = {
+            "matrix_instr_nonkdim": 16,
+            "waves_per_eu": 0,
+            "kpack": 1,
+        }
+        kernel.triton_meta = None
+        kernel.inductor_meta_common.return_value = {}
+        kernel.num_stages = 1
+        kernel.num_warps = 4
+        kernel.num_consumer_groups = 0
+        kernel.num_buffers_warp_spec = 0
+
+        with patch.object(
+            select_algorithm.DeviceProperties,
+            "create",
+            return_value=unittest.mock.MagicMock(),
+        ):
+            TritonTemplateKernel.jit_lines(kernel)
+
+        self.assertEqual(
+            {
+                key: kernel.triton_meta[key]
+                for key in ("matrix_instr_nonkdim", "waves_per_eu", "kpack")
+            },
+            {
+                "matrix_instr_nonkdim": 16,
+                "waves_per_eu": 0,
+                "kpack": 1,
+            },
+        )
+
     @requires_gpu()
     @requires_triton()
     @config.patch(cuda_backend="triton")

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -504,6 +504,48 @@ class TestTritonHeuristics(TestCase):
             self.assertEqual(configs[0].num_consumer_groups, num_consumer_groups)
             self.assertEqual(configs[0].num_buffers_warp_spec, num_buffers_warp_spec)
 
+    @parametrize(
+        "hip_version, expected_kwargs",
+        [
+            (
+                "7.2",
+                {
+                    "matrix_instr_nonkdim": 16,
+                    "waves_per_eu": 0,
+                    "kpack": 1,
+                },
+            ),
+            (None, {}),
+        ],
+    )
+    def test_template_function_preserves_hip_options(
+        self, hip_version, expected_kwargs
+    ):
+        triton_meta = {
+            "device": MagicMock(),
+            "matrix_instr_nonkdim": 16,
+            "waves_per_eu": 0,
+            "kpack": 1,
+        }
+
+        def capture_configs(_size_hints, configs, **_kwargs):
+            return configs
+
+        with (
+            patch.object(torch.version, "hip", hip_version),
+            patch(
+                "torch._inductor.runtime.triton_heuristics.cached_autotune",
+                side_effect=capture_configs,
+            ),
+        ):
+            configs = template(
+                num_stages=1,
+                num_warps=4,
+                triton_meta=triton_meta,
+            )
+
+        self.assertEqual(configs[0].kwargs, expected_kwargs)
+
     @runOnRocm
     def test_amd_special_config_args(self):
         """

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -505,21 +505,27 @@ class TestTritonHeuristics(TestCase):
             self.assertEqual(configs[0].num_buffers_warp_spec, num_buffers_warp_spec)
 
     @parametrize(
-        "hip_version, expected_kwargs",
+        "hip_version, tlx_options, expected_kwargs",
         [
             (
                 "7.2",
+                ("matrix_instr_nonkdim", "waves_per_eu", "kpack"),
                 {
                     "matrix_instr_nonkdim": 16,
                     "waves_per_eu": 0,
                     "kpack": 1,
                 },
             ),
-            (None, {}),
+            ("7.2", (), {}),
+            (
+                None,
+                ("matrix_instr_nonkdim", "waves_per_eu", "kpack"),
+                {},
+            ),
         ],
     )
-    def test_template_function_preserves_hip_options(
-        self, hip_version, expected_kwargs
+    def test_template_function_preserves_tlx_hip_options(
+        self, hip_version, tlx_options, expected_kwargs
     ):
         triton_meta = {
             "device": MagicMock(),
@@ -533,6 +539,10 @@ class TestTritonHeuristics(TestCase):
 
         with (
             patch.object(torch.version, "hip", hip_version),
+            patch(
+                "torch._inductor.runtime.triton_heuristics.tlx_only_hip_options",
+                return_value=tlx_options,
+            ),
             patch(
                 "torch._inductor.runtime.triton_heuristics.cached_autotune",
                 side_effect=capture_configs,

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -54,24 +54,6 @@ if TYPE_CHECKING:
 log: logging.Logger = logging.getLogger(__name__)
 
 
-def _accepts_flex_attention_mutated_inputs(
-    append_choices: typing.Callable[..., Any],
-) -> bool:
-    try:
-        parameters = inspect.signature(append_choices).parameters
-    except (TypeError, ValueError):
-        return False
-    mutated_inputs = parameters.get("mutated_inputs")
-    return (
-        mutated_inputs is not None
-        and mutated_inputs.kind
-        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
-    ) or any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD
-        for parameter in parameters.values()
-    )
-
-
 if TYPE_CHECKING or not config.is_fbcode():
 
     def _maybe_log_inductor_mm_shape(
@@ -214,16 +196,11 @@ class InductorChoices:
         kernel_options: dict[str, Any],
         sparse_q_block_size: int,
         sparse_kv_block_size: int,
-        mutated_inputs: list[Any] | None = None,
     ) -> list[Any]:
-        """Append backend-specific flex-attention template choices.
+        """Append backend-specific forward flex-attention template choices.
 
         Default is a no-op. Subclasses may override to inject additional
         autotuning candidates (e.g. TLX templates in fbcode).
-
-        Forward calls provide nine input nodes and two subgraphs. Backward calls
-        provide sixteen input nodes, four subgraphs, and the output buffers in
-        ``mutated_inputs``.
         """
         return choices
 
@@ -237,27 +214,16 @@ class InductorChoices:
         kernel_options: dict[str, Any],
         sparse_q_block_size: int,
         sparse_kv_block_size: int,
+        *,
         mutated_inputs: list[Any],
     ) -> list[Any]:
-        """Append backend-specific backward flex-attention choices."""
-        append_choices = self.append_flex_attention_choices
-        if (
-            getattr(append_choices, "__func__", None)
-            is InductorChoices.append_flex_attention_choices
-            or not _accepts_flex_attention_mutated_inputs(append_choices)
-        ):
-            return choices
-        return append_choices(
-            choices,
-            configs,
-            input_nodes,
-            subgraphs,
-            layout,
-            kernel_options,
-            sparse_q_block_size,
-            sparse_kv_block_size,
-            mutated_inputs=mutated_inputs,
-        )
+        """Append backend-specific backward flex-attention template choices.
+
+        Default is a no-op. Subclasses may override to inject additional
+        autotuning candidates. Backward calls provide sixteen input nodes, four
+        subgraphs, and the output buffers in ``mutated_inputs``.
+        """
+        return choices
 
     def _logging_context(self) -> dict[str, Any]:
         """Extra fields for the per-shape log row. Subclasses may override."""
@@ -886,10 +852,6 @@ class _ComposedInductorChoices(InductorChoices):
         super().__init__()
         self._choices = tuple(choices)
         self._dispatchers: dict[str, typing.Callable[..., Any] | None] = {}
-        self._flex_attention_backward_dispatcher: typing.Callable[..., Any] | None = (
-            None
-        )
-        self._flex_attention_backward_dispatcher_initialized = False
 
     def __getattribute__(self, name: str) -> Any:
         try:
@@ -938,64 +900,6 @@ class _ComposedInductorChoices(InductorChoices):
         if dispatcher is None:
             return object.__getattribute__(self, name)
         return dispatcher
-
-    def append_flex_attention_backward_choices(
-        self,
-        choices: list[Any],
-        configs: list[Any],
-        input_nodes: list[Any],
-        subgraphs: list[Any],
-        layout: Any,
-        kernel_options: dict[str, Any],
-        sparse_q_block_size: int,
-        sparse_kv_block_size: int,
-        mutated_inputs: list[Any],
-    ) -> list[Any]:
-        if not self._flex_attention_backward_dispatcher_initialized:
-            default = inspect.getattr_static(
-                InductorChoices, "append_flex_attention_choices"
-            )
-            dispatcher = None
-            owner = ""
-            for choice in self._choices:
-                choice_impl = inspect.getattr_static(
-                    choice, "append_flex_attention_choices"
-                )
-                if choice_impl is default:
-                    continue
-                append_choices = choice.append_flex_attention_choices
-                if not _accepts_flex_attention_mutated_inputs(append_choices):
-                    continue
-                if dispatcher is not None:
-                    log.warning(
-                        "InductorChoices hook %r accepts backward inputs in both %s and %s; "
-                        "list order selects %s",
-                        "append_flex_attention_choices",
-                        owner,
-                        type(choice).__name__,
-                        owner,
-                    )
-                    continue
-                dispatcher = append_choices
-                owner = type(choice).__name__
-
-            self._flex_attention_backward_dispatcher = dispatcher
-            self._flex_attention_backward_dispatcher_initialized = True
-
-        dispatcher = self._flex_attention_backward_dispatcher
-        if dispatcher is None:
-            return choices
-        return dispatcher(
-            choices,
-            configs,
-            input_nodes,
-            subgraphs,
-            layout,
-            kernel_options,
-            sparse_q_block_size,
-            sparse_kv_block_size,
-            mutated_inputs=mutated_inputs,
-        )
 
     def uuid(self) -> tuple[str, tuple[Any, ...]]:
         return (

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -54,6 +54,24 @@ if TYPE_CHECKING:
 log: logging.Logger = logging.getLogger(__name__)
 
 
+def _accepts_flex_attention_mutated_inputs(
+    append_choices: typing.Callable[..., Any],
+) -> bool:
+    try:
+        parameters = inspect.signature(append_choices).parameters
+    except (TypeError, ValueError):
+        return False
+    mutated_inputs = parameters.get("mutated_inputs")
+    return (
+        mutated_inputs is not None
+        and mutated_inputs.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    ) or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+
+
 if TYPE_CHECKING or not config.is_fbcode():
 
     def _maybe_log_inductor_mm_shape(
@@ -196,13 +214,50 @@ class InductorChoices:
         kernel_options: dict[str, Any],
         sparse_q_block_size: int,
         sparse_kv_block_size: int,
+        mutated_inputs: list[Any] | None = None,
     ) -> list[Any]:
         """Append backend-specific flex-attention template choices.
 
         Default is a no-op. Subclasses may override to inject additional
         autotuning candidates (e.g. TLX templates in fbcode).
+
+        Forward calls provide nine input nodes and two subgraphs. Backward calls
+        provide sixteen input nodes, four subgraphs, and the output buffers in
+        ``mutated_inputs``.
         """
         return choices
+
+    def append_flex_attention_backward_choices(
+        self,
+        choices: list[Any],
+        configs: list[Any],
+        input_nodes: list[Any],
+        subgraphs: list[Any],
+        layout: Any,
+        kernel_options: dict[str, Any],
+        sparse_q_block_size: int,
+        sparse_kv_block_size: int,
+        mutated_inputs: list[Any],
+    ) -> list[Any]:
+        """Append backend-specific backward flex-attention choices."""
+        append_choices = self.append_flex_attention_choices
+        if (
+            getattr(append_choices, "__func__", None)
+            is InductorChoices.append_flex_attention_choices
+            or not _accepts_flex_attention_mutated_inputs(append_choices)
+        ):
+            return choices
+        return append_choices(
+            choices,
+            configs,
+            input_nodes,
+            subgraphs,
+            layout,
+            kernel_options,
+            sparse_q_block_size,
+            sparse_kv_block_size,
+            mutated_inputs=mutated_inputs,
+        )
 
     def _logging_context(self) -> dict[str, Any]:
         """Extra fields for the per-shape log row. Subclasses may override."""
@@ -831,6 +886,10 @@ class _ComposedInductorChoices(InductorChoices):
         super().__init__()
         self._choices = tuple(choices)
         self._dispatchers: dict[str, typing.Callable[..., Any] | None] = {}
+        self._flex_attention_backward_dispatcher: typing.Callable[..., Any] | None = (
+            None
+        )
+        self._flex_attention_backward_dispatcher_initialized = False
 
     def __getattribute__(self, name: str) -> Any:
         try:
@@ -879,6 +938,64 @@ class _ComposedInductorChoices(InductorChoices):
         if dispatcher is None:
             return object.__getattribute__(self, name)
         return dispatcher
+
+    def append_flex_attention_backward_choices(
+        self,
+        choices: list[Any],
+        configs: list[Any],
+        input_nodes: list[Any],
+        subgraphs: list[Any],
+        layout: Any,
+        kernel_options: dict[str, Any],
+        sparse_q_block_size: int,
+        sparse_kv_block_size: int,
+        mutated_inputs: list[Any],
+    ) -> list[Any]:
+        if not self._flex_attention_backward_dispatcher_initialized:
+            default = inspect.getattr_static(
+                InductorChoices, "append_flex_attention_choices"
+            )
+            dispatcher = None
+            owner = ""
+            for choice in self._choices:
+                choice_impl = inspect.getattr_static(
+                    choice, "append_flex_attention_choices"
+                )
+                if choice_impl is default:
+                    continue
+                append_choices = choice.append_flex_attention_choices
+                if not _accepts_flex_attention_mutated_inputs(append_choices):
+                    continue
+                if dispatcher is not None:
+                    log.warning(
+                        "InductorChoices hook %r accepts backward inputs in both %s and %s; "
+                        "list order selects %s",
+                        "append_flex_attention_choices",
+                        owner,
+                        type(choice).__name__,
+                        owner,
+                    )
+                    continue
+                dispatcher = append_choices
+                owner = type(choice).__name__
+
+            self._flex_attention_backward_dispatcher = dispatcher
+            self._flex_attention_backward_dispatcher_initialized = True
+
+        dispatcher = self._flex_attention_backward_dispatcher
+        if dispatcher is None:
+            return choices
+        return dispatcher(
+            choices,
+            configs,
+            input_nodes,
+            subgraphs,
+            layout,
+            kernel_options,
+            sparse_q_block_size,
+            sparse_kv_block_size,
+            mutated_inputs=mutated_inputs,
+        )
 
     def uuid(self) -> tuple[str, tuple[Any, ...]]:
         return (

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -999,6 +999,35 @@ def flex_attention_backward(*args, **kwargs):
     invalid_block_options: dict[str, Any] | None = None
 
     original_kernel_options = kernel_options.copy()
+    bwd_input_nodes = [
+        query,
+        key,
+        value,
+        logsumexp,
+        delta,
+        grad_out,
+        grad_query,
+        broadcasted_grad_value,
+        kv_num_blocks,
+        kv_indices,
+        q_num_blocks,
+        q_indices,
+        full_kv_num_blocks,
+        full_kv_indices,
+        full_q_num_blocks,
+        full_q_indices,
+    ]
+    bwd_subgraphs = [
+        fw_subgraph_buffer,
+        joint_outputs.grad_input,
+        mask_graph_buffer,
+        joint_outputs.captured_grads_compute,
+    ]
+    bwd_mutated_inputs = [
+        grad_query,
+        broadcasted_grad_value,
+        *joint_outputs.mutated_grads,
+    ]
 
     for conf in configs:
         # Performance tuning
@@ -1084,39 +1113,25 @@ def flex_attention_backward(*args, **kwargs):
 
         flex_attention_backward_template.maybe_append_choice(
             choices=choices,
-            input_nodes=[
-                query,
-                key,
-                value,
-                logsumexp,
-                delta,
-                grad_out,
-                grad_query,
-                broadcasted_grad_value,
-                kv_num_blocks,
-                kv_indices,
-                q_num_blocks,
-                q_indices,
-                full_kv_num_blocks,
-                full_kv_indices,
-                full_q_num_blocks,
-                full_q_indices,
-            ],
+            input_nodes=bwd_input_nodes,
             layout=layout_broadcasted_k,  # We use store_output only for grad_key
-            subgraphs=[
-                fw_subgraph_buffer,
-                joint_outputs.grad_input,
-                mask_graph_buffer,
-                joint_outputs.captured_grads_compute,
-            ],
-            mutated_inputs=[
-                grad_query,
-                broadcasted_grad_value,
-                *joint_outputs.mutated_grads,
-            ],
+            subgraphs=bwd_subgraphs,
+            mutated_inputs=bwd_mutated_inputs,
             call_sizes=query.get_size() + key.get_size()[1:3],
             **cur_kernel_options,
         )
+
+    choices = V.choices.append_flex_attention_backward_choices(
+        choices,
+        configs,
+        list(bwd_input_nodes),
+        list(bwd_subgraphs),
+        layout_broadcasted_k,
+        original_kernel_options,
+        SPARSE_Q_BLOCK_SIZE,
+        SPARSE_KV_BLOCK_SIZE,
+        mutated_inputs=list(bwd_mutated_inputs),
+    )
 
     if not choices and invalid_block_options is not None:
         raise_flex_kernel_options_error(
@@ -1131,24 +1146,7 @@ def flex_attention_backward(*args, **kwargs):
     mask_mod_other_buffers = maybe_realize(mask_mod_other_buffers)
 
     inputs_for_autotuning = (
-        [
-            query,
-            key,
-            value,
-            logsumexp,
-            delta,
-            grad_out,
-            grad_query,
-            broadcasted_grad_value,
-            kv_num_blocks,
-            kv_indices,
-            q_num_blocks,
-            q_indices,
-            full_kv_num_blocks,
-            full_kv_indices,
-            full_q_num_blocks,
-            full_q_indices,
-        ]
+        bwd_input_nodes
         + list(score_mod_other_buffers)
         + list(mask_mod_other_buffers)
         + joint_outputs.mutated_grads

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -5086,6 +5086,7 @@ def template(
         "num_stages": num_stages,
         "num_warps": num_warps,
     }
+    config_kwargs = {}
 
     # Conditionally add arguments based on HAS_WARP_SPEC
     if HAS_WARP_SPEC:
@@ -5096,13 +5097,18 @@ def template(
             }
         )
 
+    if torch.version.hip:
+        for k in ("matrix_instr_nonkdim", "waves_per_eu", "kpack"):
+            if k in triton_meta:
+                config_kwargs[k] = triton_meta[k]
+
     for k in tlx_only_cuda_options():
         if v := triton_meta.get(k, None):
             config_args[k] = v
 
     return cached_autotune(
         None,
-        [triton.Config({}, **config_args)],
+        [triton.Config(config_kwargs, **config_args)],
         triton_meta=triton_meta,
         inductor_meta=inductor_meta,
         heuristic_type=HeuristicType.TEMPLATE,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -47,6 +47,7 @@ from ..utils import (
     GPU_KERNEL_BIN_EXTS,
     prefix_is_reduction,
     tlx_only_cuda_options,
+    tlx_only_hip_options,
     TMA_ALIGNMENT,
     triton_version_uses_attrs_dict,
     XPU_KERNEL_FORMAT,
@@ -5098,7 +5099,7 @@ def template(
         )
 
     if torch.version.hip:
-        for k in ("matrix_instr_nonkdim", "waves_per_eu", "kpack"):
+        for k in tlx_only_hip_options():
             if k in triton_meta:
                 config_kwargs[k] = triton_meta[k]
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -916,11 +916,11 @@ class TritonTemplateKernel(TritonKernel):
         matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", None)
         waves_per_eu = self.meta.get("waves_per_eu", None)
         kpack = self.meta.get("kpack", None)
-        if matrix_instr_nonkdim:
+        if matrix_instr_nonkdim is not None:
             triton_meta["matrix_instr_nonkdim"] = matrix_instr_nonkdim
-        if waves_per_eu:
+        if waves_per_eu is not None:
             triton_meta["waves_per_eu"] = waves_per_eu
-        if kpack:
+        if kpack is not None:
             triton_meta["kpack"] = kpack
 
         # tlx options carry dynamic string keys outside the TritonMeta schema.

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -5095,6 +5095,18 @@ def tlx_only_cuda_options() -> list[str]:
         return []
 
 
+@lru_cache
+def tlx_only_hip_options() -> list[str]:
+    try:
+        # Succeeds only when fbtriton (a Triton fork) is installed
+        from triton.language.extra.tlx.inductor.registry import tlx_only_hip_options
+
+        return tlx_only_hip_options
+
+    except ImportError:
+        return []
+
+
 def _round_up(x: int, y: int) -> int:
     """Round x up to the nearest multiple of y."""
     return ((x + y - 1) // y) * y


### PR DESCRIPTION
Enable out-of-tree Inductor backends such as TLX to register FlexAttention backward candidates and receive the complete mutation contract.

This adds backward-compatible choice dispatch, caches composed-hook resolution, protects the stock payload from handler mutation, and preserves zero-valued ROCm Triton options.

## Related PR

 Companion TLX implementation: facebookexperimental/triton#3255 (https://github.com/facebookexperimental/triton/pull/3255). This PR provides the PyTorch backward-choice hook and ROCm configuration propagation required to activate that kernel.
 
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben