### PR TITLE
Dispatch `index_put_` to `index_fill_.Scalar` when possible

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -686,6 +686,41 @@ inline bool try_dispatch_masked_fill_(
   return false;
 }
 
+inline bool try_dispatch_index_fill_(
+    Tensor& self,
+    const std::vector<Tensor>& indices,
+    const Scalar& value) {
+  const auto self_dtype = self.scalar_type();
+  if (isQIntType(self_dtype) || isFloat8Type(self_dtype)) {
+    return false;
+  }
+
+  // index_fill_ only supports advanced indexing with a single index tensor.
+  std::optional<int64_t> index_dim;
+  for (const auto i : c10::irange(indices.size())) {
+    if (!indices[i].defined()) {
+      continue;
+    }
+    if (index_dim.has_value()) {
+      return false;
+    }
+    index_dim = static_cast<int64_t>(i);
+  }
+
+  if (!index_dim.has_value()) {
+    return false;
+  }
+  const auto dim = *index_dim;
+  const Tensor& index = indices[dim];
+  if (index.scalar_type() != kLong || index.device() != self.device() ||
+      (index.dim() > 1 && !index.is_contiguous_or_false())) {
+    return false;
+  }
+
+  self.index_fill_(dim, index.dim() > 1 ? index.view({-1}) : index, value);
+  return true;
+}
+
 // NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing
 // functions from Python ]
 //
@@ -847,7 +882,8 @@ inline void set_item(
   }
 
   if constexpr (std::is_same_v<T, Scalar>) {
-    if (try_dispatch_masked_fill_(sliced, tensorIndices, value)) {
+    if (try_dispatch_masked_fill_(sliced, tensorIndices, value) ||
+        try_dispatch_index_fill_(sliced, tensorIndices, value)) {
       return;
     }
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2180,6 +2180,7 @@ class TestTorchDeviceType(TestCase):
         x = torch.rand(size, device=device)
         y = torch.rand((), device=device)
         ind = torch.randint(size, (3,), device=device)
+        ind_2d = torch.randint(size, (2, 3), device=device)
         ind_cpu = ind.cpu()
         repeats = torch.full((1,), 2, device=device)
         mask = torch.randint(2, (size,), device=device, dtype=bool)
@@ -2188,6 +2189,7 @@ class TestTorchDeviceType(TestCase):
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),
                           lambda: _ind_put_fn(x, ind, 1.),
+                          lambda: _ind_put_fn(x, ind_2d, 1.),
                           lambda: _ind_put_fn(x, 0, 5.),
                           lambda: _ind_put_fn(x, slice(0, 1), 5.),
                           lambda: _ind_get_fn(x, mask_cpu),

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -597,6 +597,8 @@ static int THPVariable_setitem_impl(
     pybind11::gil_scoped_release no_gil;
     if constexpr (std::is_same_v<T, Scalar>) {
       if (at::indexing::try_dispatch_masked_fill_(
+              sliced, variableIndices, value) ||
+          at::indexing::try_dispatch_index_fill_(
               sliced, variableIndices, value)) {
         return 0;
       }


### PR DESCRIPTION
This is a followup on #188330 and tries to dispatch `index_put_` to `index_fill_.Scalar` where possible - e.g. `gpu_tensor[indices] = 1.0` - instead of converting the scalar to a tensor first and dispatching to `index_put_`.

Compared to #188330 the current code already doesn't do a GPU/CPU sync, however I think it's still a good idea to remove the unneeded tensor creation.

/cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @ngimel @atalman

I benchmarked this on a A100 with the following small script:
```python
import torch
from torch.utils.benchmark import Compare, Timer

results = []
for device in ["cuda", "cpu"]:
    if device == "cuda" and not torch.cuda.is_available():
        continue
    for dtype in [torch.float32]:
        for tensor_size in [100_000, 500_000, 1_000_000, 5_000_000]:
            shapes = [(tensor_size,), (1000, tensor_size // 1000)]
            for shape in shapes:
                indexed_dim_size = shape[0]
                permutation = torch.randperm(indexed_dim_size, device=device)
                for index_ratio in [0, 0.25, 0.5, 0.75, 1.0]:
                    num_indices = round(indexed_dim_size * index_ratio)
                    index = permutation[:num_indices]
                    indices = [("1-D index", index), ("2-D contiguous index", index.reshape(1, -1))]
                    for index_description, shaped_index in indices:
                        a = torch.rand(shape, dtype=dtype, device=device)
                        flat_index = shaped_index.view(-1)
                        sub_label = (f"{shape}, {index_description}, selected {index_ratio}")
                        statements = ("a[shaped_index] = val", "a.index_fill_(0, flat_index, val)")
                        descriptions = (f"index, {device}", f"index_fill, {device}")
                        timers = [
                            Timer(
                                stmt=statement,
                                num_threads=10,
                                sub_label=sub_label,
                                label="Fill",
                                description=description,
                                globals={"a": a, "shaped_index": shaped_index, "flat_index": flat_index, "val": 1.0},
                            )
                            for statement, description in zip(statements, descriptions)
                        ]
                        for timer in timers:
                            results.append(timer.blocked_autorange())

Compare(results).print()
```

**Before:**

On GPU `index_fill` tends to have much lower overhead since we don't need create a new GPU tensor. However, on CPU the the `index_put_` path is sometimes faster for smaller or sparse workloads. My guess is that this is due to the [smaller tuned grain size](https://github.com/pytorch/pytorch/blob/d31de0a6ee94769b1eec66bc3c81dfe1cf5c2d5b/aten/src/ATen/native/cpu/IndexKernelUtils.h#L70-L73) allowing for more parallelism for smaller indexing whereas `index_fill` uses the much larger default grain size. Let me know if you think this is worth re-tuning, though I guess that might need a few more benchmarks.
```
[------------------------------------------------------------ Fill ------------------------------------------------------------]
                                                          |  index, cuda  |  index_fill, cuda  |  index, cpu  |  index_fill, cpu
10 threads: --------------------------------------------------------------------------------------------------------------------
      (100000,), 1-D index, selected 0                    |      11.8     |         2.5        |       2.8    |          1.9
      (100000,), 1-D index, selected 0.25                 |      17.3     |         7.0        |      61.3    |        104.8
      (100000,), 1-D index, selected 0.5                  |      17.5     |         6.9        |     104.6    |        123.6
      (100000,), 1-D index, selected 0.75                 |      17.3     |         6.9        |     156.3    |        134.8
      (100000,), 1-D index, selected 1.0                  |      17.4     |         6.7        |     212.4    |        143.2
      (1000, 100), 1-D index, selected 0                  |      12.8     |         2.7        |       3.2    |          2.0
      (1000, 100), 1-D index, selected 0.25               |      18.4     |         6.9        |      11.1    |         19.2
      (1000, 100), 1-D index, selected 0.5                |      18.4     |         7.0        |      15.8    |         39.8
      (1000, 100), 1-D index, selected 0.75               |      17.5     |         7.0        |      20.1    |         42.1
      (1000, 100), 1-D index, selected 1.0                |      18.1     |         6.9        |      25.3    |         49.0
      (500000,), 1-D index, selected 0                    |      12.0     |         2.5        |       3.0    |          1.9
      (500000,), 1-D index, selected 0.25                 |      17.1     |         6.9        |     251.1    |        152.2
      (500000,), 1-D index, selected 0.5                  |      17.7     |         9.5        |     493.8    |        174.3
      (500000,), 1-D index, selected 0.75                 |      17.7     |        12.1        |     739.5    |        257.2
      (500000,), 1-D index, selected 1.0                  |      18.9     |        15.4        |     981.5    |        341.0
      (1000, 500), 1-D index, selected 0                  |      13.0     |         2.7        |       3.1    |          2.1
      (1000, 500), 1-D index, selected 0.25               |      18.0     |         7.2        |      16.4    |         31.6
      (1000, 500), 1-D index, selected 0.5                |      17.6     |         6.7        |      27.3    |         36.0
      (1000, 500), 1-D index, selected 0.75               |      17.6     |         6.9        |      44.5    |         45.4
      (1000, 500), 1-D index, selected 1.0                |      18.6     |         7.2        |      63.7    |         66.1
      (1000000,), 1-D index, selected 0                   |      12.6     |         2.5        |       3.0    |          1.8
      (1000000,), 1-D index, selected 0.25                |      17.9     |         9.4        |     485.4    |        169.9
      (1000000,), 1-D index, selected 0.5                 |      18.9     |        15.3        |     960.8    |        333.8
      (1000000,), 1-D index, selected 0.75                |      30.0     |        21.2        |    1460.1    |        504.7
      (1000000,), 1-D index, selected 1.0                 |      31.2     |        27.5        |    1913.0    |        672.0
      (1000, 1000), 1-D index, selected 0                 |      11.8     |         2.6        |       3.3    |          2.0
      (1000, 1000), 1-D index, selected 0.25              |      18.5     |         7.0        |      22.6    |         30.3
      (1000, 1000), 1-D index, selected 0.5               |      18.1     |         7.0        |      41.5    |         49.4
      (1000, 1000), 1-D index, selected 0.75              |      18.7     |         7.2        |      73.1    |         80.3
      (1000, 1000), 1-D index, selected 1.0               |      18.5     |         7.7        |     103.5    |        111.3
      (5000000,), 1-D index, selected 0                   |      12.0     |         2.5        |       3.0    |          1.9
      (5000000,), 1-D index, selected 0.25                |      37.0     |        33.3        |    2739.9    |        852.2
      (5000000,), 1-D index, selected 0.5                 |      66.2     |        62.7        |    4653.4    |       1638.7
      (5000000,), 1-D index, selected 0.75                |      94.2     |        90.9        |    6834.9    |       2492.9
      (5000000,), 1-D index, selected 1.0                 |     122.7     |       119.2        |   10806.9    |       3407.6
      (1000, 5000), 1-D index, selected 0                 |      12.8     |         2.7        |       3.3    |          2.0
      (1000, 5000), 1-D index, selected 0.25              |      18.1     |         8.6        |      62.3    |         93.2
      (1000, 5000), 1-D index, selected 0.5               |      19.9     |        13.9        |     118.9    |        182.0
      (1000, 5000), 1-D index, selected 0.75              |      26.6     |        19.4        |     178.3    |        272.2
      (1000, 5000), 1-D index, selected 1.0               |      33.4     |        24.6        |     246.5    |        367.9

Times are in microseconds (us).
```

**After:**
After this PR, performance of `index_put_` and `index_fill_` is identical.
```
[------------------------------------------------------------ Fill ------------------------------------------------------------]
                                                          |  index, cuda  |  index_fill, cuda  |  index, cpu  |  index_fill, cpu
10 threads: --------------------------------------------------------------------------------------------------------------------
      (100000,), 1-D index, selected 0                    |       2.5     |         2.5        |       1.8    |          1.9
      (100000,), 1-D index, selected 0.25                 |       6.5     |         6.5        |      99.0    |        114.0
      (100000,), 1-D index, selected 0.5                  |       6.7     |         6.5        |     122.3    |        122.6
      (100000,), 1-D index, selected 0.75                 |       6.5     |         6.6        |     135.9    |        136.2
      (100000,), 1-D index, selected 1.0                  |       6.9     |         7.1        |     143.0    |        144.0
      (1000, 100), 1-D index, selected 0                  |       2.8     |         2.7        |       1.9    |          2.0
      (1000, 100), 1-D index, selected 0.25               |       6.8     |         6.7        |      11.8    |         11.9
      (1000, 100), 1-D index, selected 0.5                |       6.9     |         6.8        |      36.9    |         37.1
      (1000, 100), 1-D index, selected 0.75               |       6.8     |         6.7        |      44.8    |         45.4
      (1000, 100), 1-D index, selected 1.0                |       7.0     |         7.2        |      47.5    |         47.9
      (500000,), 1-D index, selected 0                    |       2.4     |         2.5        |       1.8    |          1.8
      (500000,), 1-D index, selected 0.25                 |       7.1     |         7.1        |     151.7    |        152.2
      (500000,), 1-D index, selected 0.5                  |       9.5     |         9.5        |     175.2    |        174.9
      (500000,), 1-D index, selected 0.75                 |      12.2     |        12.2        |     254.6    |        254.9
      (500000,), 1-D index, selected 1.0                  |      15.6     |        15.6        |     337.2    |        337.5
      (1000, 500), 1-D index, selected 0                  |       2.5     |         2.7        |       1.9    |          2.1
      (1000, 500), 1-D index, selected 0.25               |       6.7     |         7.0        |      21.5    |         22.4
      (1000, 500), 1-D index, selected 0.5                |       7.1     |         6.7        |      27.2    |         28.8
      (1000, 500), 1-D index, selected 0.75               |       6.7     |         7.0        |      39.2    |         40.0
      (1000, 500), 1-D index, selected 1.0                |       6.7     |         7.3        |      64.8    |         64.9
      (1000000,), 1-D index, selected 0                   |       2.4     |         2.4        |       1.7    |          1.9
      (1000000,), 1-D index, selected 0.25                |       9.4     |         9.4        |     168.6    |        170.2
      (1000000,), 1-D index, selected 0.5                 |      15.4     |        15.4        |     331.5    |        331.5
      (1000000,), 1-D index, selected 0.75                |      21.3     |        21.3        |     501.3    |        501.9
      (1000000,), 1-D index, selected 1.0                 |      27.6     |        27.5        |     667.7    |        667.2
      (1000, 1000), 1-D index, selected 0                 |       2.7     |         2.7        |       1.9    |          2.1
      (1000, 1000), 1-D index, selected 0.25              |       6.8     |         7.1        |      23.1    |         23.2
      (1000, 1000), 1-D index, selected 0.5               |       6.7     |         6.9        |      39.8    |         40.1
      (1000, 1000), 1-D index, selected 0.75              |       7.0     |         7.2        |      64.7    |         65.5
      (1000, 1000), 1-D index, selected 1.0               |       7.8     |         7.8        |     101.8    |        102.2
      (5000000,), 1-D index, selected 0                   |       2.5     |         2.4        |       1.8    |          1.9
      (5000000,), 1-D index, selected 0.25                |      33.3     |        33.3        |     902.9    |        903.1
      (5000000,), 1-D index, selected 0.5                 |      62.7     |        62.7        |    1643.2    |       1639.5
      (5000000,), 1-D index, selected 0.75                |      91.0     |        91.0        |    2514.0    |       2498.7
      (5000000,), 1-D index, selected 1.0                 |     119.2     |       119.2        |    3591.1    |       3570.7
      (1000, 5000), 1-D index, selected 0                 |       2.7     |         2.6        |       1.8    |          2.0
      (1000, 5000), 1-D index, selected 0.25              |       8.8     |         8.8        |      51.2    |         51.6
      (1000, 5000), 1-D index, selected 0.5               |      13.9     |        13.9        |     101.9    |        102.5
      (1000, 5000), 1-D index, selected 0.75              |      19.5     |        19.5        |     161.9    |        163.1
      (1000, 5000), 1-D index, selected 1.0               |      24.7     |        24.7        |     216.0    |        217.6

Times are in microseconds (us).
```