### PR TITLE
Back out D118342273: "[ROCm][BE] Remove outdated version conditions (#193927)" (#195788)

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -252,6 +252,15 @@ using detail::CuBlasLtGroupedMatrixLayout;
 
 template <typename Dtype, typename C_Dtype = Dtype>
 static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
+#if defined(USE_ROCM) && ROCM_VERSION == 60400
+  // regression in ROCm 6.4, planned fixed in 6.4.1, hipblaslt TT fp32 calculation errors
+  // best to disallow hipblaslt for this specific case
+  if constexpr (std::is_same_v<Dtype, float>) {
+    if (detail::cublasOpFromChar(transa) == CUBLAS_OP_T && detail::cublasOpFromChar(transb) == CUBLAS_OP_T) {
+        return false;
+    }
+  }
+#endif
   const auto type_info = detail::getCublasLtTypeInfo<Dtype, C_Dtype>();
   const cudaDataType_t abType = type_info.ab_type;
   const cudaDataType_t cType = type_info.c_type;
@@ -1928,16 +1937,18 @@ void scaled_gemm(
     matmulDescB = HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT;
   }
   else if (mat1_scale_dtype == kFloat8_e8m0fnu && mat2_scale_dtype == kFloat8_e8m0fnu) {
-    std::vector<std::string> mx_archs{"gfx950"};
-#if ROCM_VERSION >= 71400
-    mx_archs.push_back("gfx1250");
-#endif
-    if (at::detail::getCUDAHooks().isGPUArch(mx_archs)) {
-      // TODO: add constraints based on hipblaslt internals
-      TORCH_CHECK((m % 16 == 0) && (n % 16 == 0) && (k % 128 == 0),
-                 "M, N must be multiples of 16 and K should be multiple of 128 for MX format. "
-                 "Got m=", m, ", n=", n, ", k=", k);
-    }
+  #if ROCM_VERSION >= 70000
+            std::vector<std::string> mx_archs{"gfx950"};
+  #if ROCM_VERSION >= 71400
+            mx_archs.push_back("gfx1250");
+  #endif
+            if (at::detail::getCUDAHooks().isGPUArch(mx_archs)) {
+                // TODO: add constraints based on hipblaslt internals
+                TORCH_CHECK((m % 16 == 0) && (n % 16 == 0) && (k % 128 == 0),
+                           "M, N must be multiples of 16 and K should be multiple of 128 for MX format. "
+                           "Got m=", m, ", n=", n, ", k=", k);
+            }
+  #endif
   }
 #elif (CUDA_VERSION < 12090) && !defined(USE_ROCM)
   // hipblaslt supported row-wise before cublas, and did so their own way (via

--- a/aten/src/ATen/cuda/CUDADataType.h
+++ b/aten/src/ATen/cuda/CUDADataType.h
@@ -81,17 +81,19 @@ inline cudaDataType ScalarTypeToCudaDataType(const c10::ScalarType& scalar_type)
       return CUDA_R_64I;
     case c10::ScalarType::BFloat16:
       return CUDA_R_16BF;
+#if !defined(USE_ROCM) || ROCM_VERSION >= 60300
     case c10::ScalarType::Float8_e4m3fn:
       return CUDA_R_8F_E4M3;
     case c10::ScalarType::Float8_e5m2:
       return CUDA_R_8F_E5M2;
+#endif
 #if defined(USE_ROCM)
     case c10::ScalarType::Float8_e4m3fnuz:
       return HIP_R_8F_E4M3_FNUZ;
     case c10::ScalarType::Float8_e5m2fnuz:
       return HIP_R_8F_E5M2_FNUZ;
 #endif
-#if (defined(CUDA_VERSION) && CUDA_VERSION >= 12080) || defined(USE_ROCM)
+#if (defined(CUDA_VERSION) && CUDA_VERSION >= 12080) || (defined(USE_ROCM) && ROCM_VERSION >= 70000)
     case c10::ScalarType::Float4_e2m1fn_x2:
       return CUDA_R_4F_E2M1;
 #endif

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -546,8 +546,12 @@ bool CUDAHooks::isGPUArch(const std::vector<std::string>& archs, DeviceIndex dev
 const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
   static const std::vector<std::string> archs = {
     "gfx90a", "gfx942",
+#if ROCM_VERSION >= 60400
     "gfx1200", "gfx1201",
+#endif
+#if ROCM_VERSION >= 70000
     "gfx950",
+#endif
 #if ROCM_VERSION >= 71300
     "gfx1100", "gfx1101", "gfx1151",
 #endif
@@ -561,8 +565,12 @@ const std::vector<std::string>& CUDAHooks::getHipblasltPreferredArchs() const {
 const std::vector<std::string>& CUDAHooks::getHipblasltSupportedArchs() const {
   static const std::vector<std::string> archs = {
     "gfx90a", "gfx942",
+#if ROCM_VERSION >= 60300
     "gfx1100", "gfx1101", "gfx1103", "gfx1200", "gfx1201", "gfx908",
+#endif
+#if ROCM_VERSION >= 70000
     "gfx950", "gfx1150", "gfx1151",
+#endif
 #if ROCM_VERSION >= 71400
     "gfx1250"
 #endif

--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -176,7 +176,7 @@ inline int cublasLtMatmulScaleMode(
   switch (scaling_type) {
     case at::blas::ScalingType::BlockWise1x32:
       TORCH_CHECK(scale_dtype == kFloat8_e8m0fnu);
-#if CUDA_VERSION >= 12080 || defined(USE_ROCM)
+#if CUDA_VERSION >= 12080 || (defined(USE_ROCM) && ROCM_VERSION >= 70000)
       return CUBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
 #else
       TORCH_CHECK(

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -64,14 +64,23 @@ constexpr hipDataType HipDataTypeFor<c10::Float8_e5m2fnuz>() {
 }
 
 // This code is instantiated regardless of ROCm version.
+// Prior to ROCm 6.3, we hard-code the known enum values.
 template <>
 constexpr hipDataType HipDataTypeFor<c10::Float8_e4m3fn>() {
+#if ROCM_VERSION >= 60300
   return HIP_R_8F_E4M3;
+#else
+  return static_cast<hipDataType>(28);
+#endif
 }
 
 template <>
 constexpr hipDataType HipDataTypeFor<c10::Float8_e5m2>() {
+#if ROCM_VERSION >= 60300
   return HIP_R_8F_E5M2;
+#else
+  return static_cast<hipDataType>(29);
+#endif
 }
 
 // This type is not intended for matrix types but rather a scale factor.
@@ -83,7 +92,11 @@ constexpr hipDataType HipDataTypeFor<c10::Float8_e8m0fnu>() {
 
 template <>
 constexpr hipDataType HipDataTypeFor<c10::Float4_e2m1fn_x2>() {
+#if ROCM_VERSION >= 70000
   return HIP_R_4F_E2M1;
+#else
+  return static_cast<hipDataType>(33);
+#endif
 }
 
 template <typename T>
@@ -627,6 +640,14 @@ auto GetHipBlasLtTypeStringAndOps() {
   auto b_datatype = HipDataTypeFor<BT>();
   auto in_out_datatype = HipDataTypeFor<CT>();
   std::vector<hipblasLtMatmulHeuristicResult_t> heuristic_result;
+#if ROCM_VERSION == 60400
+  // hipblaslt TT fp32 regression on ROCm 6.4, cannot use
+  if ((a_datatype == HIP_R_32F || b_datatype == HIP_R_32F || in_out_datatype == HIP_R_32F)
+          && (transa_outer == HIPBLAS_OP_T && transb_outer == HIPBLAS_OP_T)) {
+    std::vector<std::pair<std::string, std::unique_ptr<Callable<ParamsT>>>> ignore;
+    return ignore;
+  }
+#endif
 
   hipblasComputeType_t computeType = HipBlasComputeTypeFor<CT>();
   if constexpr (std::is_same_v<CT, float>) {

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -168,6 +168,14 @@ static bool isInputCompliesAddmmCudaLt(
   }
   #endif
 
+  #if defined(USE_ROCM) && ROCM_VERSION == 60400
+  // hipblaslt TT fp32 regression on ROCm 6.4, cannot use
+  const auto args = cublasCommonArgs(mat1, mat2, result);
+  if (args.transa == 't' && args.transb == 't') {
+    return false;
+  }
+  #endif
+
   const auto mat1_sizes = mat1.sizes();
   const auto mat2_sizes = mat2.sizes();
   const auto scalar_type = mat1.scalar_type();

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -71,6 +71,7 @@ bool _scaled_mm_is_fnuz() {
     return at::detail::getCUDAHooks().isGPUArch({"gfx942"});
 }
 
+#if ROCM_VERSION >= 70000
 static void check_blockwise_e8m0fnu_arch_supported() {
   std::vector<std::string> mx_archs{"gfx950"};
 #if ROCM_VERSION >= 71400
@@ -81,6 +82,7 @@ static void check_blockwise_e8m0fnu_arch_supported() {
       "Block-wise scaling for Float8_e8m0fnu is only supported on ",
       c10::Join(",", mx_archs));
 }
+#endif
 #endif
 
 /*
@@ -539,6 +541,17 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   if (use_fast_accum) {
     TORCH_CHECK(mat1.scalar_type() != ScalarType::Float4_e2m1fn_x2 && mat2.scalar_type() != ScalarType::Float4_e2m1fn_x2, "`use_fast_accum` is not supported when `mat1` or `mat2` tensors have the `Float4_e2m1fn_x2` dtype.");
   }
+#ifdef USE_ROCM
+  if (mat1.scalar_type() == ScalarType::Float4_e2m1fn_x2 || mat2.scalar_type() == ScalarType::Float4_e2m1fn_x2) {
+    TORCH_CHECK(ROCM_VERSION >= 70000, "Float4_e2m1fn_x2 is only supported for ROCm 7.0 and above");
+  }
+  if (mat1.scalar_type() == ScalarType::Float8_e5m2 || mat2.scalar_type() == ScalarType::Float8_e5m2) {
+    TORCH_CHECK(ROCM_VERSION >= 60500, "Float8_e5m2 is only supported for ROCm 6.5 and above");
+  }
+  if (mat1.scalar_type() == ScalarType::Float8_e4m3fn || mat2.scalar_type() == ScalarType::Float8_e4m3fn) {
+    TORCH_CHECK(ROCM_VERSION >= 60500, "Float8_e4m3fn is only supported for ROCm 6.5 and above");
+  }
+#endif
   if (bias) {
     TORCH_CHECK(out.scalar_type() != kFloat,
         "Bias is not supported when out_dtype is set to Float32");
@@ -627,6 +640,7 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   }
   else if (scaling_choice_a == ScalingType::BlockWise1x32 && scaling_choice_b == ScalingType::BlockWise1x32) {
 #ifdef USE_ROCM
+#if ROCM_VERSION >= 70000
     check_blockwise_e8m0fnu_arch_supported();
 
     int packed_factor = 1;
@@ -642,6 +656,9 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
     TORCH_CHECK_VALUE(out.scalar_type() == ScalarType::BFloat16 ||
                 out.scalar_type() == ScalarType::Half,
                 "Block-wise scaling only supports BFloat16 or Half output types");
+#else
+    TORCH_CHECK_NOT_IMPLEMENTED(false, "Block-wise scaling for Float8_e8m0fnu requires ROCm 7.0 or later");
+#endif
 #endif
   }
 
@@ -1066,6 +1083,7 @@ _scaled_mxfp8_mxfp8(
   auto scaling_choice_b = ScalingType::BlockWise1x32;
 
 #ifdef USE_ROCM
+#if ROCM_VERSION >= 70000
   check_blockwise_e8m0fnu_arch_supported();
 
   TORCH_CHECK_VALUE(mat_a.size(0) % 32 == 0 && mat_a.size(1) % 32 == 0 &&
@@ -1076,6 +1094,9 @@ _scaled_mxfp8_mxfp8(
               out.scalar_type() == ScalarType::Half,
               "Block-wise scaling only supports BFloat16 or Half output types");
   return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out);
+#else
+    TORCH_CHECK_NOT_IMPLEMENTED(false, "Block-wise scaling for Float8_e8m0fnu requires ROCm 7.0 or later");
+#endif
 #else
   return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out);
 #endif
@@ -1148,6 +1169,7 @@ _scaled_mxfp4_mxfp4(
   auto scaling_choice_a = ScalingType::BlockWise1x32;
   auto scaling_choice_b = ScalingType::BlockWise1x32;
 
+#if ROCM_VERSION >= 70000
   check_blockwise_e8m0fnu_arch_supported();
 
   TORCH_CHECK_VALUE(mat_a.size(0) % 32 == 0 && mat_a.size(1) % 32 == 0 &&
@@ -1157,6 +1179,7 @@ _scaled_mxfp4_mxfp4(
   TORCH_CHECK_VALUE(out.scalar_type() == ScalarType::BFloat16 ||
               out.scalar_type() == ScalarType::Half,
               "Block-wise scaling only supports BFloat16 or Half output types");
+#endif
 
   return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out);
 #else
@@ -1348,6 +1371,20 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
   if (use_fast_accum) {
     TORCH_CHECK_VALUE(mat_a.scalar_type() != ScalarType::Float4_e2m1fn_x2 && mat_b.scalar_type() != ScalarType::Float4_e2m1fn_x2, "`use_fast_accum` is not supported when `mat_a` or `mat_b` tensors have the `Float4_e2m1fn_x2` dtype.");
   }
+#ifdef USE_ROCM
+  if (mat_a.scalar_type() == ScalarType::Float4_e2m1fn_x2 || mat_b.scalar_type() == ScalarType::Float4_e2m1fn_x2) {
+    TORCH_CHECK_NOT_IMPLEMENTED(ROCM_VERSION >= 70000,
+        "Float4_e2m1fn_x2 is only supported for ROCm 7.0 and above");
+  }
+  if (mat_a.scalar_type() == ScalarType::Float8_e5m2 || mat_b.scalar_type() == ScalarType::Float8_e5m2) {
+    TORCH_CHECK_NOT_IMPLEMENTED(ROCM_VERSION >= 60500,
+        "Float8_e5m2 is only supported for ROCm 6.5 and above");
+  }
+  if (mat_a.scalar_type() == ScalarType::Float8_e4m3fn || mat_b.scalar_type() == ScalarType::Float8_e4m3fn) {
+    TORCH_CHECK_NOT_IMPLEMENTED(ROCM_VERSION >= 60500,
+        "Float8_e4m3fn is only supported for ROCm 6.5 and above");
+  }
+#endif
   if (bias.has_value()) {
     TORCH_CHECK_VALUE(out.scalar_type() != kFloat,
         "Bias is not supported when out_dtype is set to Float32");

--- a/aten/src/ATen/native/cuda/ScaledBlasDeviceUtils.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlasDeviceUtils.cpp
@@ -12,8 +12,12 @@ namespace at::native::scaled {
 bool scaled_mm_arch_allowed(bool /*sm90_only*/, bool /*sm100_only*/) {
   static const std::vector<std::string> archs = {
       "gfx942",
+#if ROCM_VERSION >= 60300
       "gfx1200", "gfx1201",
+#endif
+#if ROCM_VERSION >= 60500
       "gfx950",
+#endif
 #if ROCM_VERSION >= 71400
       "gfx1250",
 #endif

--- a/aten/src/ATen/native/cuda/SortUtils.cuh
+++ b/aten/src/ATen/native/cuda/SortUtils.cuh
@@ -10,8 +10,9 @@
 #include <ATen/native/StridedRandomAccessor.h>
 
 #if defined(USE_ROCM)
-// ROCm: WarpMergeSort available and tested on every supported ROCm
-#define HAS_WARP_MERGE_SORT() (1)
+// ROCm: WarpMergeSort available and tested on ROCm 7.0+
+// ROCM_VERSION encoding: MAJOR*10000 + MINOR*100 + PATCH
+#define HAS_WARP_MERGE_SORT() (ROCM_VERSION >= 70000)
 #else
 // CUDA: WarpMergeSort available since CUDA 11.6
 #define HAS_WARP_MERGE_SORT() (CUDA_VERSION >= 11060)

--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -16,7 +16,8 @@ namespace c10::cuda::CUDACachingAllocator {
 bool CUDAAllocatorConfig::expandable_segments() {
   bool enabled = c10::CachingAllocator::AcceleratorAllocatorConfig::
       use_expandable_segments();
-#if !defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && !defined(USE_ROCM)
+#if !defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
+    (!defined(USE_ROCM) || (ROCM_VERSION < 70000))
   if (enabled) {
     TORCH_WARN_ONCE("expandable_segments not supported on this platform")
   }

--- a/c10/cuda/CUDAEvent.h
+++ b/c10/cuda/CUDAEvent.h
@@ -141,14 +141,18 @@ struct CUDAEvent {
         ".");
     CUDAGuard guard(device_index_);
 
+#if !defined(USE_ROCM) || ROCM_VERSION >= 70000
     // it is an error to use cudaEventRecordExternal when not doing stream
-    // capture (same applies to hipEventRecordExternal)
+    // capture (same applies to hipEventRecordExternal on ROCm 7.0+)
     unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
                               c10::cuda::CaptureStatus::None &&
                           external_)
         ? cudaEventRecordExternal
         : cudaEventRecordDefault;
     C10_CUDA_CHECK(cudaEventRecordWithFlags(event_, stream, flags));
+#else
+    C10_CUDA_CHECK(cudaEventRecord(event_, stream));
+#endif
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
     if (C10_UNLIKELY(interp)) {
       (*interp)->trace_gpu_event_record(
@@ -164,14 +168,18 @@ struct CUDAEvent {
   void block(const CUDAStream& stream) {
     if (is_created_) {
       CUDAGuard guard(stream.device_index());
+#if !defined(USE_ROCM) || ROCM_VERSION >= 70000
       // it is an error to use cudaEventWaitExternal when not doing stream
-      // capture (same applies to hipEventWaitExternal)
+      // capture (same applies to hipEventWaitExternal on ROCm 7.0+)
       unsigned int flags = (c10::cuda::currentStreamCaptureStatusMayInitCtx() !=
                                 c10::cuda::CaptureStatus::None &&
                             external_)
           ? cudaEventWaitExternal
           : cudaEventWaitDefault;
       C10_CUDA_CHECK(cudaStreamWaitEvent(stream, event_, flags));
+#else
+      C10_CUDA_CHECK(cudaStreamWaitEvent(stream, event_));
+#endif
       const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
       if (C10_UNLIKELY(interp)) {
         (*interp)->trace_gpu_event_wait(
@@ -244,6 +252,10 @@ struct CUDAEvent {
 
   void createEvent(DeviceIndex device_index) {
     external_ = (flags_ & cudaEventExternal) != 0;
+#if defined(USE_ROCM) && ROCM_VERSION < 70000
+    TORCH_CHECK(
+        !external_, "External CUDA-graph events on ROCm require ROCm 7.0+");
+#endif
     flags_ &= ~cudaEventExternal;
     device_index_ = device_index;
     CUDAGuard guard(device_index_);

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -880,7 +880,11 @@ print(t.is_pinned())
                 # ROCm logic is less so, it's cublaslt for some Instinct, cublas for all else
                 # Mirror CUDAHooks::getHipblasltPreferredArchs in CUDAHooks.cpp
                 ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split(".")[:2])
-                archs = ["gfx90a", "gfx942", "gfx1200", "gfx1201", "gfx950"]
+                archs = ["gfx90a", "gfx942"]
+                if ROCM_VERSION >= (6, 4):
+                    archs.extend(["gfx1200", "gfx1201"])
+                if ROCM_VERSION >= (7, 0):
+                    archs.append("gfx950")
                 if ROCM_VERSION >= (7, 13):
                     archs.extend(["gfx1100", "gfx1101", "gfx1151"])
                 if ROCM_VERSION >= (7, 14):

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -46,6 +46,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     MI200_ARCH,
     NAVI_ARCH,
+    getRocmVersion,
     isRocmArchAnyOf,
     parametrize,
     random_matrix_with_scaled_reduction_dim,
@@ -577,6 +578,9 @@ class TestMatmulCuda(InductorTestCase):
     @parametrize("backend", ["cublas", "cublaslt"])
     def test_cublas_addmm(self, size: int, dtype: torch.dtype, backend):
         with blas_library_context(backend):
+            if (TEST_WITH_ROCM and backend == "cublas" and isRocmArchAnyOf(NAVI_ARCH) and
+                    getRocmVersion() < (6, 4) and dtype == torch.float16 and size >= 10000):
+                self.skipTest(f"failed on Navi for ROCm6.3 due to hipblas backend, dtype={dtype} and size={size}")
             self.cublas_addmm(size, dtype, False)
 
     @onlyCUDA

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -289,9 +289,12 @@ PLATFORM_SUPPORTS_WORKQUEUE_CONFIG: bool = LazyVal(lambda: evaluate_platform_sup
 def evaluate_platform_supports_fp8():
     if torch.cuda.is_available():
         if torch.version.hip:
-            # gfx120 and gfx95 only support OCP fp8 (e4m3fn/e5m2), which every
-            # supported ROCm provides.
-            archs = ['gfx94', 'gfx95', 'gfx120']
+            archs = ['gfx94']
+            if ROCM_VERSION >= (6, 5):
+                # OCP fp8 (e4m3fn/e5m2) in scaled_mm requires ROCm 6.5+; see
+                # the ROCM_VERSION checks in aten/src/ATen/native/cuda/ScaledBlas.cpp.
+                # gfx120 and gfx95 only support OCP, so gate them on 6.5.
+                archs.extend(['gfx95', 'gfx120'])
             if ROCM_VERSION >= (7, 14):
                 archs.append('gfx1250')
             for arch in archs:


### PR DESCRIPTION
Summary:

D118342273 (diff-train import of pytorch/pytorch#193927) drops every `ROCM_VERSION >= 60300/60400/60500/70000` guard in caffe2, on the premise that "ROCm minimum supported version is now 7.0". That premise holds for OSS PyTorch but not for fbcode, which still pins ROCm 6.2.1 and 6.4.0 -- see the live `select()` arms and their `TODO(T256598044)` in `fbcode/caffe2/fb/fbcode/defs_hip.bzl`.

**Trunk break in `c10/cuda/CUDAEvent.h`.** With the guard gone, `record()` and `block()` reference the external-event flags unconditionally. The HIP headers added the two pairs in different releases:

- ROCm 6.2.1: neither pair exists
- ROCm 6.4.0: `hipEventRecordDefault`/`hipEventRecordExternal` exist, `hipEventWaitDefault`/`hipEventWaitExternal` do NOT
- ROCm 6.4.2 and later: all four exist

So on 6.4.0 the record pair resolves and only the wait pair fails:

```
c10/hip/HIPEvent.h:173:13: error: use of undeclared identifier 'hipEventWaitExternal'
c10/hip/HIPEvent.h:174:13: error: use of undeclared identifier 'hipEventWaitDefault'
```

That takes out `fbcode//caffe2:ATen-hip` and everything downstream of it. It was reported against `fbcode//sigrid/predictor/utils:event_pool` (Sigrid predictor AMD), one of the targets the 6.4.0 pin exists for.

**`ATen/cuda/tunable/GemmHipblaslt.h` is the same hazard one step behind.** The diff also removes the `ROCM_VERSION >= 70000` guard around `HIP_R_4F_E2M1`, which only exists in ROCm 7.0's `hipblaslt.h` and previously fell back to `static_cast<hipDataType>(33)`. Those are the guards D111505147 added in July for exactly this reason.

Backing out the whole commit rather than patching the two files, since the remaining hunks carry the same latent hazard. This should re-land once fbcode's 6.2.1 and 6.4.0 ROCm pins are retired (T256598044).

 ---

bypass-github-export-checks

This is an internal-only backout of a landed diff-train import, taken as the immediate stop-gap for a live trunk break, so there is no PR to link. Per the GitHub-first hotfix path, the upstream side still needs handling: pytorch/pytorch#193927 must be reverted or fixed on GitHub (restoring the guards for ROCm < 7.0), otherwise the next diff train re-imports it and re-breaks the 6.2.1/6.4.0 builds.

Test Plan:
Repro at the culprit commit (`6160cf8408fd`, which contains D118342273), ROCm 6.4.0:

```
buck2 build --flagfile fbcode//mode/opt-amd-gpu \
  -m ovr_config//third-party/rocm/constraints:6.4.0 \
  fbcode//sigrid/predictor/utils:event_pool
```

EXIT=3, `use of undeclared identifier 'hipEventWaitExternal'` / `'hipEventWaitDefault'` at `c10/hip/HIPEvent.h:173`/`174` -- byte-identical to the reported failure.

With this backout applied, all three ROCm versions fbcode still builds are green:

```
# 6.4.0 -- previously failing
buck2 build --flagfile fbcode//mode/opt-amd-gpu -m ovr_config//third-party/rocm/constraints:6.4.0 \
  fbcode//sigrid/predictor/utils:event_pool fbcode//caffe2:ATen-hip    -> EXIT=0

# 7.0 (default) -- no regression on the path the original diff targeted
buck2 build --flagfile fbcode//mode/opt-amd-gpu \
  fbcode//sigrid/predictor/utils:event_pool fbcode//caffe2:ATen-hip    -> EXIT=0

# 6.2.1
buck2 build --flagfile fbcode//mode/opt-amd-gpu -m ovr_config//third-party/rocm/constraints:6.2.1 \
  fbcode//sigrid/predictor/utils:event_pool                            -> EXIT=0
```

`arc f`: no changes. `arc lint --rev .^`: no lint issues.

Differential Revision: D118535204
