### PR TITLE
Fix double-counting under TorchDispatchMode (#195746)

### DIFF
--- a/aten/src/ATen/core/PythonFallbackKernel.cpp
+++ b/aten/src/ATen/core/PythonFallbackKernel.cpp
@@ -62,6 +62,13 @@ void pythonFallback(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_
   const auto mode_stack_len = c10::impl::TorchDispatchModeTLS::stack_len();
   if (mode_stack_len > 0) {
     RECORD_FUNCTION("PythonDispatchMode", torch::jit::last(*stack, num_arguments));
+    // A user TorchDispatchMode can call the underlying op again while handling the
+    // current one (for example, a pass-through mode calls func(*args, **kwargs)).
+    // If we allow RecordFunction callbacks to stay active here, the nested op will be
+    // profiled as a second operator event even though the kernel timing is only
+    // generated once. We still want the explicit mode event, but suppress the re-entrant
+    // profiler record for the underlying call.
+    at::DisableRecordFunctionGuard no_record_function;
     const auto& cur_torch_dispatch_mode_state = c10::impl::TorchDispatchModeTLS::get_stack_at(mode_stack_len - 1);
     cur_torch_dispatch_mode_state->pyinterpreter()->dispatch(op, stack);
     return;

--- a/test/profiler/test_record_function.py
+++ b/test/profiler/test_record_function.py
@@ -179,6 +179,28 @@ class TestRecordFunction(TestCase):
             "PythonDispatchMode record function not found in profiler events",
         )
 
+    def test_python_dispatch_mode_does_not_double_count_ops(self):
+        from torch.utils._python_dispatch import TorchDispatchMode
+
+        class PassThrough(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+                return func(*args, **kwargs)
+
+        x = torch.randn(4)
+        with _profile() as prof:
+            with enable_python_dispatcher():
+                with PassThrough():
+                    for _ in range(3):
+                        torch.sin(x)
+
+        count = 0
+        for e in prof.function_events:
+            if e.name == "aten::sin":
+                count += 1
+        self.assertEqual(count, 3, prof.function_events)
+
     def test_python_subclass_record_function(self):
         class TestTensorSubclass(torch.Tensor):
             @staticmethod


### PR DESCRIPTION
Fix profiler double-counting when a TorchDispatchMode is active

Summary

This change fixes a profiler bug where operator events were counted twice when a "TorchDispatchMode" re-entered Python dispatch. The underlying op executed only once, but the profiler recorded it twice because the nested dispatch path still allowed "RecordFunction" callbacks to fire.

Root cause

When a dispatch mode is active, Python fallback dispatch calls the mode interpreter. During this re-entrant path, the profiler callback remained enabled and recorded the same op a second time when the user mode passed the call through.

As a result, "key_averages()" reported an exact 2× count, while "self_device_time_total" remained correct.

Fix

Suppress the nested "RecordFunction" during mode re-entry while preserving the explicit "PythonDispatchMode" profiler event indicating that the dispatch mode was active.

Tests

Added a regression test ensuring that a pass-through "TorchDispatchMode" does not double-count profiled ops:

"test_python_dispatch_mode_does_not_double_count_ops"

Fixes #195746