### PR TITLE
[inductor] Reject underfilled decompose-K split choices

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2913,7 +2913,7 @@ class TestMaxAutotune(TestCase):
         )
         self.assertEqual(
             candidates,
-            [18, 16, 36, 33, 72, 66, 144, 159],
+            [22, 24, 36, 33, 72, 66, 144, 159],
         )
         self.assertLessEqual(len(candidates), config.triton.num_decompose_k_splits)
         self.assertLessEqual(len(candidates), 8)
@@ -2943,7 +2943,7 @@ class TestMaxAutotune(TestCase):
         )
         self.assertEqual(
             one_cta_candidates,
-            [36, 33, 72, 66, 144, 159, 288, 318],
+            [44, 48, 72, 66, 144, 159, 288, 318],
         )
 
         get_k_splits.cache_clear()
@@ -2957,12 +2957,13 @@ class TestMaxAutotune(TestCase):
         )
         self.assertEqual(
             irregular_candidates,
-            [64, 89, 128, 178, 256, 356, 712, 104],
+            [89, 104, 128, 178, 256, 356, 712, 1157],
         )
         self.assertLessEqual(len(irregular_candidates), 8)
 
-        # When the legal set is already smaller than the tuning budget, retain
-        # every candidate rather than trying to predict the vendor BMM winner.
+        # Mathematical divisibility alone is insufficient.  This small shape
+        # cannot produce one GPU wave even at its largest useful exact split,
+        # so do not compile known-underfilled BMM plans.
         get_k_splits.cache_clear()
         small_candidates = get_k_splits(
             64,
@@ -2972,9 +2973,53 @@ class TestMaxAutotune(TestCase):
             ctas_per_tile=2,
             max_workspace_bytes=128 * 1024 * 1024,
         )
-        self.assertEqual(small_candidates, [2, 4, 8, 16, 32, 41])
+        self.assertEqual(small_candidates, [])
         self.assertLessEqual(
             len(small_candidates), config.triton.num_decompose_k_splits
+        )
+
+        # Sparse factorization must not force a bad choice.  split=7 cannot
+        # fill a wave for this semiprime production K, while the other exact
+        # divisors make Kpart too small or violate the workspace limit.
+        get_k_splits.cache_clear()
+        sparse_candidates = get_k_splits(
+            256,
+            128,
+            11_091_857,
+            num_sms=148,
+            ctas_per_tile=2,
+            max_workspace_bytes=128 * 1024 * 1024,
+        )
+        self.assertEqual(sparse_candidates, [])
+
+        # Sparse does not automatically mean bad: this dynamic production K
+        # has a split that fills the GPU and leaves a still-K-dominant BMM.
+        get_k_splits.cache_clear()
+        useful_sparse_candidates = get_k_splits(
+            256,
+            128,
+            10_954_007,
+            num_sms=148,
+            ctas_per_tile=2,
+            max_workspace_bytes=128 * 1024 * 1024,
+        )
+        self.assertEqual(useful_sparse_candidates, [587])
+
+        # If filtering takes an over-budget divisor set below the configured
+        # limit, it must remain ranked rather than expanding from eight
+        # candidates to every survivor.
+        get_k_splits.cache_clear()
+        filtered_ranked_candidates = get_k_splits(
+            256,
+            256,
+            9_216,
+            num_sms=148,
+            ctas_per_tile=2,
+            max_workspace_bytes=128 * 1024 * 1024,
+        )
+        self.assertEqual(
+            filtered_ranked_candidates,
+            [6, 8, 9, 18, 16, 36, 32],
         )
 
     @unittest.skipIf(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2834,6 +2834,7 @@ def get_k_splits(
         return pow_of_2_divisors + mul_of_32_divisors + rest_of_splits
 
     legacy_splits = pow_of_2_divisors + mul_of_32_divisors + rest_of_splits
+    needs_bounded_ranking = len(valid_divisors) > k_splits_limit
 
     # On Blackwell the partial BMM can use a 2CTA kernel.  Ranking solely by
     # K-part alignment can then badly over-split a skinny GEMM: once there are
@@ -2853,16 +2854,37 @@ def get_k_splits(
         and (not isinstance(n, sympy.Expr) or n.is_number)
     ):
         m_hint, n_hint = int(m), int(n)
+        output_tiles = ((m_hint + 63) // 64) * ((n_hint + 63) // 64)
+        output_ctas_per_split = output_tiles * ctas_per_tile
+
+        # Reject exact divisors that cannot fill one physical output-CTA wave
+        # before ranking them.  Divisibility by itself does not make a split a
+        # useful autotuning candidate (for example, split=2 on a skinny
+        # semiprime K).  Do not impose a Kpart upper-cost cutoff here: useful
+        # vendor BMM plans have a much broader Kpart range than a single
+        # K-dominance threshold predicts.  Workspace and the bounded ranking
+        # below control excessive splitting.
+        min_occupancy_split = max(
+            2,
+            math.ceil(num_sms / output_ctas_per_split),
+        )
+        valid_divisors = [
+            split
+            for split in valid_divisors
+            if split >= min_occupancy_split
+        ]
         if max_workspace_bytes is not None:
             valid_divisors = [
                 split
                 for split in valid_divisors
                 if split * m_hint * n_hint * 4 <= max_workspace_bytes
             ]
-        if len(valid_divisors) <= k_splits_limit:
+        # Filtering must not accidentally expand the tuning set.  If the
+        # unfiltered set required ranking, keep ranking even when the occupancy
+        # cutoff leaves ten or fewer candidates.
+        if not needs_bounded_ranking:
             return valid_divisors
 
-        output_tiles = ((m_hint + 63) // 64) * ((n_hint + 63) // 64)
         wave_targets = [
             max(
                 2.0,
@@ -2909,6 +2931,7 @@ def get_k_splits(
             )
             occupancy_splits.append(aligned_fallback)
         best_splits = list(dict.fromkeys(occupancy_splits))
+        return best_splits[:k_splits_limit]
     else:
         best_splits = legacy_splits
 


### PR DESCRIPTION
Stacked on the device-aware decompose-K split-ranking prerequisite.

This filters exact decompose-K split choices that cannot populate one physical output-CTA wave before compiling them. It deliberately adds no upper K-part/traffic cutoff and retains the existing workspace cap, bounded ranking, and ATen whole-plan fallback.

The filter also preserves the original need-for-ranking decision, so pruning cannot accidentally expand a previously bounded candidate set.

Validation:
- focused sparse-divisor, useful-split, and no-candidate unit cases
- 118-shape BF16 oracle sweep: no measured direct-ATen-winning plan removed
- captured IGR LSR census: 521 -> 204 candidate plans across 86 eligible sites
- representative cold compile: 26.34 -> 21.06 s and 37.46 -> 21.82 s in two fresh-cache pairs
- selected winner unchanged on graph-16/206 representative families and exhaustive graph-213/220 huge-K shortlists

Test Plan:
- python test/inductor/test_max_autotune.py TestMaxAutotune.test_decompose_k_blackwell_split_candidates
- representative B200 compile/cache probe and complete-plan oracle sweeps

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo