### PR TITLE
Replace dummy-array evaluation-order tricks with fold expressions

### DIFF
--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -132,8 +132,7 @@ template <typename... Types>
 inline void pop(Stack& stack, Types&... args) {
   size_t i = 0;
   constexpr size_t N = sizeof...(args);
-  (void)std::initializer_list<int>{
-      (args = std::move(peek(stack, i++, N)).template to<Types>(), 0)...};
+  ((args = std::move(peek(stack, i++, N)).template to<Types>()), ...);
   drop(stack, N);
 }
 template <typename... Types>
@@ -181,7 +180,7 @@ inline void push_one(Stack& stack, c10::TensorOptions options) {
 
 template <typename... Types>
 inline void push(Stack& stack, Types&&... args) {
-  (void)std::initializer_list<int>{(push_one(stack, std::forward<Types>(args)), 0)...};
+  (push_one(stack, std::forward<Types>(args)), ...);
 }
 template <typename... Types>
 inline void push(Stack* stack, Types&&... args) {

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -6,7 +6,6 @@
 #include <ATen/core/Tensor.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/python_headers.h>
-#include <initializer_list>
 #include <tuple>
 
 #include <torch/csrc/Dtype.h>
@@ -111,7 +110,7 @@ void apply_with_idx_impl(
     const F& f,
     Tuple& t,
     std::index_sequence<Is...> /*indices*/) {
-  (void)std::initializer_list<int>{(f(std::get<Is>(t), Is), 0)...};
+  (f(std::get<Is>(t), Is), ...);
 }
 
 // For tuple(a, b, c), calls f(a, 0), f(b, 1), f(c, 2)


### PR DESCRIPTION
`push()`/`pop()` in `aten/src/ATen/core/stack.h` and `apply_with_idx_impl()` in `torch/csrc/autograd/utils/wrap_outputs.h` each used a `std::initializer_list<int>{(expr, 0)...}` trick to force left-to-right evaluation of a variadic pack. The repo's floor is C++20, so both become comma fold expressions, which give the same evaluation-order guarantee without building an unused array. Dropped `wrap_outputs.h`'s now-unused `<initializer_list>` include.

This change was authored with the assistance of an AI coding agent and reviewed before submission.
