### PR TITLE
Fix flaky test_stream_with_mutation by synchronizing cross-stream read

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -523,6 +523,9 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         def fn(x, y, s1, s2):
             with s1:
                 z1 = torch.add(x, y)
+            # z1 is produced on s1 and read below on s2; without this wait
+            # that read is unordered.
+            s2.wait_stream(s1)
             with s2:
                 z = torch.add(x, y)
                 y = z + 2 + z1
@@ -535,6 +538,10 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             torch.Stream(device=device),
             torch.Stream(device=device),
         )
+        # Inputs are built on the ambient stream and first read inside a stream
+        # context. torch.Stream.__enter__/__exit__ only swap the current stream
+        # and insert no synchronization, so nothing orders that read.
+        torch.accelerator.synchronize()
         expected = fn(*inp)
         (
             actual,
@@ -542,6 +549,7 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             fw_graphs,
             _,
         ) = extract_graph(fn, *inp)
+        torch.accelerator.synchronize()
         self.assertEqual(len(fw_graphs), 1)
         self.assertEqual(expected, actual)
         self.assertExpectedInline(
@@ -552,13 +560,28 @@ class <lambda>(torch.nn.Module):
         # Annotation: {'stream': 1}
         add: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, arg1_1)
 
+        # No stacktrace found for following nodes
+        subgraph_wait_stream = self.subgraph_wait_stream
+        control_deps = torch.ops.higher_order.control_deps((add, arg0_1, arg1_1), subgraph_wait_stream, add, arg0_1, arg1_1);  add = arg0_1 = arg1_1 = subgraph_wait_stream = None
+        getitem_2: "f32[2, 2]" = control_deps[3]
+        getitem_1: "f32[2, 2]" = control_deps[2]
+
+        # Annotation: {'stream': 1}
+        getitem: "f32[2, 2]" = control_deps[1];  control_deps = None
+
         # Annotation: {'stream': 2}
-        add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
+        add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(getitem_1, getitem_2);  getitem_1 = getitem_2 = None
 
         # Annotation: {'stream': 2}
         add_2: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_1, 2);  add_1 = None
-        add_3: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_2, add);  add_2 = add = None
+        add_3: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_2, getitem);  add_2 = getitem = None
         return (add_3,)
+
+    class subgraph_wait_stream(torch.nn.Module):
+        def forward(self, dep_0: "f32[2, 2]", dep_1: "f32[2, 2]", dep_2: "f32[2, 2]"):
+            #
+            wait_stream_default = torch.ops.streams.wait_stream.default(2, 1)
+            return (wait_stream_default, dep_0, dep_1, dep_2)
 """,
         )
 
@@ -813,19 +836,30 @@ class <lambda>(torch.nn.Module):
             with s0:
                 z1 = torch.add(y, y)
                 z0 = torch.add(z1, y)
+                # z1 is produced on s0 and read below on s2; without this wait
+                # that read is unordered.
+                s2.wait_stream(s0)
                 with s2:
                     y = 2 + z1
 
             return z0, y
 
         inp = (torch.ones(2, 2, device=device) + 1, torch.ones(2, 2, device=device))
+        # Inputs are built on the ambient stream and first read inside a stream
+        # context. torch.Stream.__enter__/__exit__ only swap the current stream
+        # and insert no synchronization, so nothing orders that read.
+        torch.accelerator.synchronize()
         expected = fn(*inp)
+        # fn mutates x in place and the compiled run below reuses the same inp,
+        # so the two in-place adds must not overlap.
+        torch.accelerator.synchronize()
         (
             actual,
             _,
             fw_graphs,
             _,
         ) = extract_graph(fn, *inp)
+        torch.accelerator.synchronize()
         self.assertEqual(len(fw_graphs), 1)
         self.assertEqual(expected, actual)
         self.assertExpectedInline(
@@ -839,15 +873,31 @@ class <lambda>(torch.nn.Module):
         # Annotation: {'stream': 3}
         add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg1_1, arg1_1)
 
+        # Annotation: {'stream': 3}
+        add_2: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_1, arg1_1);  arg1_1 = None
+
+        # No stacktrace found for following nodes
+        subgraph_wait_stream = self.subgraph_wait_stream
+        control_deps = torch.ops.higher_order.control_deps((add_1, add_2, add), subgraph_wait_stream, add_1, add);  add_1 = add = subgraph_wait_stream = None
+
         # Annotation: {'stream': 1}
-        add_2: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_1, 2)
+        getitem_1: "f32[2, 2]" = control_deps[2]
 
         # Annotation: {'stream': 3}
-        add_3: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_1, arg1_1);  add_1 = arg1_1 = None
+        getitem: "f32[2, 2]" = control_deps[1];  control_deps = None
 
         # Annotation: {'stream': 1}
-        copy_: "f32[2, 2]" = torch.ops.aten.copy_.default(arg0_1, add);  arg0_1 = add = copy_ = None
-        return (add_3, add_2)
+        add_3: "f32[2, 2]" = torch.ops.aten.add.Tensor(getitem, 2);  getitem = None
+
+        # Annotation: {'stream': 1}
+        copy_: "f32[2, 2]" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = getitem_1 = copy_ = None
+        return (add_2, add_3)
+
+    class subgraph_wait_stream(torch.nn.Module):
+        def forward(self, dep_0: "f32[2, 2]", dep_1: "f32[2, 2]"):
+            # Annotation: {'stream': 3}
+            wait_stream_default = torch.ops.streams.wait_stream.default(1, 3)
+            return (wait_stream_default, dep_0, dep_1)
 """,
         )
 


### PR DESCRIPTION
test_stream_with_mutation and test_stream_enter_exit are racy: both build a
value on one stream and read it on another with nothing establishing an
ordering between them. torch.Stream.__enter__ and __exit__ (THPStream_enter /
THPStream_exit, torch/csrc/Stream.cpp) only call
at::accelerator::setCurrentStream to swap the current stream; neither inserts
any synchronization. A read on the new stream can therefore observe a buffer
before the producing stream has written it.

There are two distinct unordered hops per test, and both have to be closed:

Inside the traced function, test_stream_with_mutation produces z1 under
`with s0:` and reads it under `with s2:`; test_stream_enter_exit produces z1
under `with s1:` and reads it under `with s2:`. Add the missing wait_stream in
each so the consuming stream waits on the producing one.

Around the runs, the inputs are built on the ambient stream and first read
inside a stream context, and the returned tensors are produced on side streams
but compared by assertEqual on the ambient stream. The comparison path
(isclose -> all -> .item()) is only ordered against the current stream, and
neither extract_graph nor the test harness performs a device-wide wait. Add
torch.accelerator.synchronize() before the eager run and after extract_graph,
matching the placement already used by test_stream_backward_sync.

The in-function wait cannot be replaced by the host-side synchronize: a wait
after the function returns cannot repair a value that was already computed from
a stale buffer. The two fixes address different races.

The expected graphs are updated accordingly; both now carry the wait_stream op
wrapped in control_deps.

Fixes #195001
Fixes #194837

Test Plan:

Both tests are disabled on trunk, and CI re-enables a disabled test when the PR
declares it fixes the disabling issue. With Fixes #195001 present,
test_stream_with_mutation_cuda ran and passed on the trunk workflow:

```
PASS  TestStreamsCUDA.test_stream_with_mutation_cuda
```

Adding Fixes #194837 does the same for test_stream_enter_exit_cuda, so both
regenerated goldens are exercised on real accelerator hardware rather than
resting on the MPS regeneration alone.

The tests are CUDA/XPU-only (instantiate_device_type_tests(..., except_for=
("cpu",))), so they could not be executed locally on an Apple Silicon machine.
The expected graphs were regenerated on MPS and validated by first reproducing
each pre-change golden byte-for-byte, which establishes that these graphs are
device-independent and that the regenerated text is therefore correct for the
target devices. Regeneration used torch._dynamo.config.patch(
canonicalize_output_graph_node_order=True), matching what
torch/_dynamo/test_case.py sets for dynamo tests.

Lint:

```
lintrunner --paths-cmd 'git diff --name-only HEAD'
```

This change was authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98

https://claude.ai/code/session_01S1oKxkDjeWvPQZCJJETqEQ
