### PR TITLE
Fix fast symbolizer on aarch64 and for DWARF 2/3 and clang DWARF 5

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3048,6 +3048,7 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
 instantiate_device_type_tests(TestProfilerDevice, globals())
 
 
+@instantiate_parametrized_tests
 class TestExperimentalUtils(TestCase):
     def make_tree(self) -> list[MockNode]:
         tree = {
@@ -3145,6 +3146,44 @@ class TestExperimentalUtils(TestCase):
         addr2line = torch._C._profiler.symbolize_addresses(addrs, "addr2line")
         self.assertEqual(len(fast), len(addrs))
         self.assertEqual(len(addr2line), len(fast))
+
+    @unittest.skipIf(
+        not IS_LINUX or not (IS_X86 or IS_ARM64), "linux x86/aarch64 only cpp unwinding"
+    )
+    @parametrize("dwarf_version", [2, 3, 4, 5])
+    def test_fast_symbolize_dwarf_versions(self, dwarf_version):
+        import _ctypes
+        import ctypes
+        import shutil
+
+        cc = shutil.which("gcc") or shutil.which("clang") or shutil.which("cc")
+        if cc is None:
+            self.skipTest("no C compiler available")
+        src = "int square(int x) {\n  int y = x * x;\n  return y + 1;\n}\n"
+        with tempfile.TemporaryDirectory() as d:
+            c_file = os.path.join(d, "square.c")
+            so_file = os.path.join(d, "libsquare.so")
+            with open(c_file, "w") as f:
+                f.write(src)
+            flags = ["-shared", "-fPIC", "-O0", f"-gdwarf-{dwarf_version}"]
+            cmd = [cc, *flags, "-o", so_file, c_file]
+            r = subprocess.run(cmd, capture_output=True, text=True)
+            if r.returncode != 0:
+                self.skipTest(f"{cc} does not support {flags[-1]}: {r.stderr}")
+            lib = ctypes.CDLL(so_file)
+            try:
+                addr = ctypes.cast(lib.square, ctypes.c_void_p).value
+                # symbolize treats addresses as return addresses (pc - 1), so
+                # step a few bytes into the function body
+                frames = torch._C._profiler.symbolize_addresses([addr + 8], "fast")
+                filename, lineno, funcname = frames[0]
+            finally:
+                # unmap before the directory is deleted so later tests that
+                # walk /proc/self/maps do not see a deleted file
+                _ctypes.dlclose(lib._handle)
+            self.assertEqual(funcname, "square")
+            self.assertEqual(os.path.basename(filename), "square.c")
+            self.assertTrue(1 <= lineno <= 4, f"unexpected line {lineno}")
 
     def test_profiler_overload_names(self):
         from torch.library import _scoped_library, fallthrough_kernel

--- a/torch/csrc/profiler/unwind/debug_info.h
+++ b/torch/csrc/profiler/unwind/debug_info.h
@@ -33,12 +33,16 @@ struct DebugInfo {
         auto read = readSegmentOffset(L);
         offset = *rnglists_base_ + read;
       }
-      return version_ == 4 ? readRanges4(offset) : readRanges5(offset);
+      return version_ <= 4 ? readRanges4(offset) : readRanges5(offset);
     }
     if (!highpc_) {
       return {};
     }
-    return {{lowpc_, lowpc_ + *highpc_}};
+    auto lowpc = resolveAddr(lowpc_, lowpc_form_);
+    auto highpc = resolveAddr(*highpc_, highpc_form_);
+    bool absolute =
+        highpc_form_ == DW_FORM_addr || highpc_form_ == DW_FORM_addrx;
+    return {{lowpc, absolute ? highpc : lowpc + highpc}};
   }
 
   bool is64bit() {
@@ -54,7 +58,7 @@ struct DebugInfo {
     end_ = (const char*)L.loc() + length_;
     version_ = L.read<uint16_t>();
     UNWIND_CHECK(
-        version_ == 5 || version_ == 4,
+        version_ >= 2 && version_ <= 5,
         "unexpected dwarf version {}",
         version_);
     uint8_t address_size = 0;
@@ -85,6 +89,16 @@ struct DebugInfo {
     return s_.readSegmentOffset(L, is_64bit_);
   }
 
+  // DW_AT_addr_base may appear after DW_AT_low_pc in the CU DIE, so addrx
+  // indices are kept raw during parsing and resolved lazily in ranges()
+  uint64_t resolveAddr(uint64_t value, uint64_t form) {
+    if (form != DW_FORM_addrx) {
+      return value;
+    }
+    return s_.debug_addr.lexer(address_base_ + sizeof(uint64_t) * value)
+        .read<uint64_t>();
+  }
+
   uint64_t readEncoded(CheckedLexer& L, uint64_t encoding) {
     switch (encoding) {
       case DW_FORM_data8:
@@ -93,9 +107,7 @@ struct DebugInfo {
       case DW_FORM_data4:
         return L.read<uint32_t>();
       case DW_FORM_addrx: {
-        auto idx = L.readULEB128();
-        return s_.debug_addr.lexer(address_base_ + sizeof(uint64_t) * idx)
-            .read<uint64_t>();
+        return L.readULEB128();
       }
       case DW_FORM_sec_offset:
         return readSegmentOffset(L);
@@ -121,9 +133,13 @@ struct DebugInfo {
       }
       if (attr == DW_AT_low_pc) {
         lowpc_ = readEncoded(L, form);
+        lowpc_form_ = form;
         LOG_INFO("  lowpc {:x}\n", lowpc_);
       } else if (attr == DW_AT_high_pc) {
+        // DWARF 2/3 (and optionally later) encode high_pc as an absolute
+        // address rather than an offset from low_pc; see ranges()
         highpc_ = readEncoded(L, form);
+        highpc_form_ = form;
         range_ptr_ = std::nullopt;
         LOG_INFO("  highpc {:x}\n", *highpc_);
       } else if (attr == DW_AT_addr_base) {
@@ -138,9 +154,13 @@ struct DebugInfo {
       } else if (form == DW_FORM_string) {
         L.readCString();
       } else if (attr == DW_AT_stmt_list) {
-        UNWIND_CHECK(form == DW_FORM_sec_offset, "unexpected stmt_list form");
+        // DWARF 2/3 use data4/data8 here; DWARF 4+ use sec_offset
+        UNWIND_CHECK(
+            form == DW_FORM_sec_offset || form == DW_FORM_data4 ||
+                form == DW_FORM_data8,
+            "unexpected stmt_list form");
+        line_number_program_offset_ = readEncoded(L, form);
         LOG_INFO("  program table offset {:x}\n", *line_number_program_offset_);
-        line_number_program_offset_ = readSegmentOffset(L);
       } else if (form == DW_FORM_exprloc) {
         auto sz = L.readULEB128();
         L.skip(int64_t(sz));
@@ -197,11 +217,11 @@ struct DebugInfo {
           LOG_INFO("END RANGES\n");
           return ranges;
         case DW_RLE_base_addressx: {
-          base = readEncoded(L, DW_FORM_addrx);
+          base = resolveAddr(readEncoded(L, DW_FORM_addrx), DW_FORM_addrx);
           LOG_INFO("BASE ADDRX {:x}\n", base);
         } break;
         case DW_RLE_startx_length: {
-          auto s = readEncoded(L, DW_FORM_addrx);
+          auto s = resolveAddr(readEncoded(L, DW_FORM_addrx), DW_FORM_addrx);
           auto e = L.readULEB128();
           LOG_INFO("startx_length {:x} {:x}\n", s, e);
           ranges.emplace_back(s, s + e);
@@ -271,7 +291,9 @@ struct DebugInfo {
 
   std::optional<std::pair<uint64_t, uint8_t>> range_ptr_;
   uint64_t lowpc_ = 0;
+  uint64_t lowpc_form_ = DW_FORM_addr;
   std::optional<uint64_t> highpc_;
+  uint64_t highpc_form_ = DW_FORM_data8;
   uint16_t version_ = 0;
   uint64_t address_base_ = 0;
   std::optional<uint64_t> rnglists_base_;

--- a/torch/csrc/profiler/unwind/line_number_program.h
+++ b/torch/csrc/profiler/unwind/line_number_program.h
@@ -25,8 +25,8 @@ struct LineNumberProgram {
     program_end_ = (char*)L.loc() + length_;
     auto version = L.read<uint16_t>();
     UNWIND_CHECK(
-        version == 5 || version == 4,
-        "expected version 4 or 5 but found {}",
+        version >= 2 && version <= 5,
+        "expected version 2-5 but found {}",
         version);
     if (version == 5) {
       auto address_size = L.read<uint8_t>();
@@ -40,7 +40,8 @@ struct LineNumberProgram {
     program_ = L;
     program_.skip(int64_t(header_length_));
     minimum_instruction_length_ = L.read<uint8_t>();
-    maximum_operations_per_instruction_ = L.read<uint8_t>();
+    // maximum_operations_per_instruction was added in DWARF 4
+    maximum_operations_per_instruction_ = version >= 4 ? L.read<uint8_t>() : 1;
     default_is_stmt_ = L.read<uint8_t>();
     line_base_ = L.read<int8_t>();
     line_range_ = L.read<uint8_t>();
@@ -53,9 +54,8 @@ struct LineNumberProgram {
     // fmt::print("{:x} {:x} {} {} {} {} {}\n", offset_, header_length_,
     // minimum_instruction_length_, maximum_operations_per_instruction_,
     // line_base_, line_range_, opcode_base_);
-    uint8_t directory_entry_format_count = L.read<uint8_t>();
-
     if (version == 5) {
+      uint8_t directory_entry_format_count = L.read<uint8_t>();
       struct Member {
         uint64_t content_type;
         uint64_t form;
@@ -141,8 +141,8 @@ struct LineNumberProgram {
         maximum_operations_per_instruction_ == 1,
         "maximum_operations_per_instruction_ must be 1");
     UNWIND_CHECK(
-        minimum_instruction_length_ == 1,
-        "minimum_instruction_length_ must be 1");
+        minimum_instruction_length_ != 0,
+        "minimum_instruction_length_ must be non-zero");
     readProgram();
   }
   struct Entry {
@@ -220,7 +220,7 @@ struct LineNumberProgram {
       uint8_t op = program_.read<uint8_t>();
       if (op >= opcode_base_) {
         auto op2 = int64_t(op - opcode_base_);
-        address_ += op2 / line_range_;
+        address_ += minimum_instruction_length_ * (op2 / line_range_);
         entry_.line += line_base_ + (op2 % line_range_);
         PRINT_INST(
             "address += {}, line += {}\n",
@@ -261,7 +261,7 @@ struct LineNumberProgram {
           } break;
           case DW_LNS_advance_pc: {
             PRINT_INST("advance pc\n");
-            address_ += program_.readULEB128();
+            address_ += minimum_instruction_length_ * program_.readULEB128();
           } break;
           case DW_LNS_advance_line: {
             entry_.line += program_.readSLEB128();
@@ -274,7 +274,8 @@ struct LineNumberProgram {
           } break;
           case DW_LNS_const_add_pc: {
             PRINT_INST("const add pc\n");
-            address_ += (255 - opcode_base_) / line_range_;
+            address_ += minimum_instruction_length_ *
+                ((255 - opcode_base_) / line_range_);
           } break;
           case DW_LNS_fixed_advance_pc: {
             PRINT_INST("fixed advance pc\n");

--- a/torch/csrc/profiler/unwind/mem_file.h
+++ b/torch/csrc/profiler/unwind/mem_file.h
@@ -76,7 +76,7 @@ struct MemFile {
     ELF_CHECK(ehdr_->e_ident[EI_CLASS] == ELFCLASS64);
     ELF_CHECK(ehdr_->e_ident[EI_VERSION] == EV_CURRENT);
     ELF_CHECK(ehdr_->e_version == EV_CURRENT);
-    ELF_CHECK(ehdr_->e_machine == EM_X86_64);
+    ELF_CHECK(ehdr_->e_machine == EM_X86_64 || ehdr_->e_machine == EM_AARCH64);
 #undef ELF_CHECK
     UNWIND_CHECK(
         ehdr_->e_shoff + sizeof(Elf64_Shdr) * ehdr_->e_shnum <= n_bytes_,

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -366,6 +366,9 @@ struct Symbolizer {
       return;
     }
     has_pending_results_ = true;
+    // placeholder so repeated addresses in this batch are not re-queried
+    // before the pending results have been read back
+    frame_map_[addr] = Frame{"??", "??", 0};
     auto& entry = getOrCreate(maybe_library->first);
     entry.queried.push_back(addr);
     auto libaddress = maybe_library->second - 1;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195800
* __->__ #195799

Motivation: #195462 proposes disabling addr2line symbolization by default
because it is slow. Investigating on an aarch64 devserver, the slowness
reproduced (156 s to symbolize 2000 tracebacks, 158-403 s for a CUDA
memory snapshot) and was entirely one addr2line child process: the
binutils 2.37 addr2line on PATH spends ~150 s parsing the DWARF of the
uv-shipped python-build-standalone libpython, which is an LTO build with a
single giant compile unit. The cost is fixed per DSO, so deduplicating or
parallelizing queries on the PyTorch side would not help. binutils 2.35.2
does the same lookup in 0.15 s.

The in-tree FastSymbolizer (TORCH_SYMBOLIZE_MODE=fast, #123966) was added
for exactly this situation, but on this machine it produced no file:line
for anything. It turned out to have never worked on aarch64, and to have a
few DWARF coverage gaps:

- mem_file.h rejected any ELF with e_machine != EM_X86_64 as "not an ELF
  file". The aarch64 unwinder was added later without relaxing this.
- Line tables: DWARF 2/3 headers (no maximum_operations_per_instruction
  field) were rejected, minimum_instruction_length (4 on aarch64) was
  asserted to be 1 instead of applied to address advances, and the v5-only
  directory_entry_format_count byte was read unconditionally, mis-parsing
  v4 tables.
- CU DIEs: DWARF 2/3 encode DW_AT_stmt_list as data4/data8 rather than
  sec_offset, and DW_AT_high_pc with DW_FORM_addr is an absolute address
  rather than an offset from low_pc.
- clang DWARF 5 emits DW_AT_low_pc as DW_FORM_addrx before DW_AT_addr_base
  in the same DIE, so resolving the index eagerly used a zero base. The
  index is now kept raw and resolved lazily in ranges().

Also the addr2line Symbolizer now inserts a placeholder when it queues an
address, so duplicates within a batch are not resubmitted before results
are read back.

With these fixes, fast mode on the workloads above takes 1.4 s and 1.5 s,
returns file:line for the same 34.4% of frames as addr2line (identical on
all 4942 shared frames), and function names for 95.4% vs 96.6%. The
difference is inlined-callee names, which come from DWARF in addr2line and
from the symbol table here. This PR does not change the default mode; it
makes fast mode a credible candidate for that discussion.

Test Plan:

New test compiles a tiny C library with -gdwarf-{2,3,4,5}, loads it via
ctypes and checks fast-mode symbolization returns the right function, file
and line.

```
python test/profiler/test_profiler.py -k test_fast_symbolize_dwarf_versions -k test_fuzz_symbolize
python test/test_utils.py TestTraceback
```

Torture-tested with a standalone harness against /usr/bin/addr2line on
every 4-byte offset of every function in small libraries built with gcc 11
and clang 15 at DWARF 2/3/4/5, -O0, -O2, -O2 -flto and -gsplit-dwarf: zero
line mismatches wherever addr2line has a line, except line-0 entries at
clang -O2 where addr2line prints `?`. Fuzzed with 30k random addresses
across all mapped DSOs with no crashes.

Authored with an AI assistant.