### PR TITLE
Make the in-process fast symbolizer the default for C++ stack traces

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3185,6 +3185,36 @@ class TestExperimentalUtils(TestCase):
             self.assertEqual(os.path.basename(filename), "square.c")
             self.assertTrue(1 <= lineno <= 4, f"unexpected line {lineno}")
 
+    @unittest.skipIf(
+        not IS_LINUX or not (IS_X86 or IS_ARM64), "linux x86/aarch64 only cpp unwinding"
+    )
+    @parametrize(
+        "env, expected",
+        [
+            ({}, "fast"),
+            ({"TORCH_DISABLE_ADDR2LINE": "1"}, "dladdr"),
+            ({"TORCH_DISABLE_ADDR2LINE": "0"}, "addr2line"),
+            (
+                {"TORCH_SYMBOLIZE_MODE": "addr2line", "TORCH_DISABLE_ADDR2LINE": "1"},
+                "addr2line",
+            ),
+            ({"TORCH_SYMBOLIZE_MODE": "dladdr"}, "dladdr"),
+        ],
+        name_fn=lambda env, expected: expected + "_" + "_".join(sorted(env)),
+    )
+    def test_default_symbolize_mode(self, env, expected):
+        child_env = {k: v for k, v in os.environ.items() if not k.startswith("TORCH_")}
+        child_env.update(env)
+        code = "import torch; print(torch._C._profiler._get_symbolize_mode())"
+        r = subprocess.run(
+            [sys.executable, "-c", code],
+            env=child_env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(r.stdout.strip(), expected)
+
     def test_profiler_overload_names(self):
         from torch.library import _scoped_library, fallthrough_kernel
 

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/profiler/cupti/monitor_python.h>
 #include <torch/csrc/profiler/python/combined_traceback.h>
 #include <torch/csrc/profiler/standalone/execution_trace_observer.h>
+#include <torch/csrc/utils/cpp_stacktraces.h>
 #include <torch/csrc/utils/pybind.h>
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
@@ -755,6 +756,18 @@ void initPythonBindings(PyObject* module) {
       tb_ptrs.emplace_back(((THPCapturedTraceback*)tb.ptr())->data.get());
     }
     return py_symbolize(tb_ptrs);
+  });
+  // effective TORCH_SYMBOLIZE_MODE / TORCH_DISABLE_ADDR2LINE choice, for tests
+  m.def("_get_symbolize_mode", []() -> std::string {
+    switch (torch::get_symbolize_mode()) {
+      case torch::unwind::Mode::addr2line:
+        return "addr2line";
+      case torch::unwind::Mode::fast:
+        return "fast";
+      case torch::unwind::Mode::dladdr:
+        return "dladdr";
+    }
+    TORCH_CHECK(false, "unknown symbolize mode");
   });
   // directly convert address pointers to frames, used for testing symbolize
   m.def(

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -767,7 +767,7 @@ void initPythonBindings(PyObject* module) {
       case torch::unwind::Mode::dladdr:
         return "dladdr";
     }
-    TORCH_CHECK(false, "unknown symbolize mode");
+    TORCH_CHECK_VALUE(false, "unknown symbolize mode");
   });
   // directly convert address pointers to frames, used for testing symbolize
   m.def(

--- a/torch/csrc/profiler/unwind/unwind.h
+++ b/torch/csrc/profiler/unwind/unwind.h
@@ -18,9 +18,9 @@ struct Frame {
 
 enum class Mode { addr2line, fast, dladdr };
 
-// note: symbolize is really slow
-// it will launch an addr2line process that has to parse dwarf
-// information from the libraries that frames point into.
+// note: symbolize can be slow. Mode::fast parses the dwarf information
+// of the libraries in-process; Mode::addr2line launches an addr2line
+// process per library, which can take minutes on some binutils versions.
 // Callers should first batch up all the unique void* pointers
 // across a number of unwind states and make a single call to
 // symbolize.

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -9,9 +9,6 @@ bool compute_cpp_stack_traces_enabled() {
   return c10::utils::check_env("TORCH_SHOW_CPP_STACKTRACES") == true;
 }
 
-bool compute_disable_addr2line() {
-  return c10::utils::check_env("TORCH_DISABLE_ADDR2LINE") == true;
-}
 } // namespace
 
 bool get_cpp_stacktraces_enabled() {
@@ -34,10 +31,17 @@ static torch::unwind::Mode compute_symbolize_mode() {
           "expected {dladdr, addr2line, fast} for TORCH_SYMBOLIZE_MODE, got ",
           envar_c.value());
     }
-  } else {
-    return compute_disable_addr2line() ? unwind::Mode::dladdr
-                                       : unwind::Mode::addr2line;
   }
+  // The in-process symbolizer is the default. TORCH_DISABLE_ADDR2LINE is kept
+  // for backwards compatibility: =1 falls back to dladdr, =0 opts into the
+  // external addr2line process (previously the default).
+  auto disable_addr2line = c10::utils::check_env("TORCH_DISABLE_ADDR2LINE");
+  if (disable_addr2line == true) {
+    return unwind::Mode::dladdr;
+  } else if (disable_addr2line == false) {
+    return unwind::Mode::addr2line;
+  }
+  return unwind::Mode::fast;
 }
 
 unwind::Mode get_symbolize_mode() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195800

Supersedes #195462, which proposed defaulting to dladdr because addr2line
symbolization is slow. Investigating that slowness (see the previous commit
in this stack), the cost turned out to be a fixed ~150 s DWARF parse inside
some binutils addr2line builds for LTO libraries such as the uv-shipped
python-build-standalone libpython, which no amount of PyTorch-side batching
can avoid. With the previous commit's fixes, the in-tree FastSymbolizer
(TORCH_SYMBOLIZE_MODE=fast, #123966) handles the same workloads in about a
second with the same file:line coverage as addr2line, so it is a much
better default than dladdr, which drops file:line entirely.

Behavior when TORCH_SYMBOLIZE_MODE is unset:

- default: fast (was addr2line)
- TORCH_DISABLE_ADDR2LINE=1: dladdr (unchanged)
- TORCH_DISABLE_ADDR2LINE=0: addr2line (explicit opt-in to the old default)

TORCH_SYMBOLIZE_MODE continues to take precedence. The effective mode is
exposed as torch._C._profiler._get_symbolize_mode() so the environment
handling can be tested from Python subprocesses.

Fidelity difference vs addr2line: fast takes function names from .symtab
rather than DWARF, so frames inside inlined callees are attributed to the
enclosing function (95.4% vs 96.6% of frames named on a CUDA memory snapshot
workload), and a binary stripped of .symtab but not of DWARF loses names.
file:line is identical wherever both produce it.

Test Plan:

```
python test/profiler/test_profiler.py -k test_default_symbolize_mode -k test_fast_symbolize_dwarf_versions -k test_fuzz_symbolize
python test/test_utils.py TestTraceback
python test/inductor/test_cudagraph_trees.py -k test_workspace_allocation_error
```

Authored with an AI assistant.