### PR TITLE
[ROCm] Skip amd-smi tests for DPX runners

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7494,7 +7494,7 @@ print(value, end="")
             self.assertTrue(torch.cuda._get_amdsmi_handler() is not None)
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
-    @unittest.skipIf(TEST_WITH_ROCM, "AMD SMI is flaky on ROCm DPX runners")
+    @skipIfRocmArch(MI350_ARCH)
     def test_temperature(self):
         self.assertTrue(0 <= torch.cuda.temperature() <= 150)
 
@@ -7536,7 +7536,7 @@ print(value, end="")
         self.assertTrue(torch.cuda.power_draw() >= 0)
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
-    @unittest.skipIf(TEST_WITH_ROCM, "AMD SMI is flaky on ROCm DPX runners")
+    @skipIfRocmArch(MI350_ARCH)
     def test_clock_speed(self):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7494,6 +7494,7 @@ print(value, end="")
             self.assertTrue(torch.cuda._get_amdsmi_handler() is not None)
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
+    @unittest.skipIf(TEST_WITH_ROCM, "AMD SMI is flaky on ROCm DPX runners")
     def test_temperature(self):
         self.assertTrue(0 <= torch.cuda.temperature() <= 150)
 
@@ -7535,6 +7536,7 @@ print(value, end="")
         self.assertTrue(torch.cuda.power_draw() >= 0)
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
+    @unittest.skipIf(TEST_WITH_ROCM, "AMD SMI is flaky on ROCm DPX runners")
     def test_clock_speed(self):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 


### PR DESCRIPTION
Example: https://github.com/pytorch/pytorch/actions/runs/33665382613/job/100377537652
amd-smi is flaky on DPX runners:
```
______________________ TestCudaAllocator.test_temperature ______________________
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/test/test_cuda.py", line 7494, in test_temperature
    self.assertTrue(0 <= torch.cuda.temperature() <= 150)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/cuda/__init__.py", line 1692, in temperature
    return _get_amdsmi_temperature(device)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/cuda/__init__.py", line 1581, in _get_amdsmi_temperature
    return amdsmi.amdsmi_get_temp_metric(
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/_rocm_sdk_devel/share/amd_smi/amdsmi/amdsmi_interface.py", line 5348, in amdsmi_get_temp_metric
    _check_res(
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/_rocm_sdk_devel/share/amd_smi/amdsmi/amdsmi_interface_utils.py", line 97, in _check_res
    raise AmdSmiLibraryException(ret_code)
amdsmi.amdsmi_exception.AmdSmiLibraryException: Error code:
	2 | AMDSMI_STATUS_NOT_SUPPORTED - Feature not supported
```

amd-smi team is notified about this failure (ROCM-30477)

Coauthored with @pelumi1163. Changes come from @pelumi1163 and committed by me to work around CLA sign.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang