### PR TITLE
[PrivateUse1][dynamo] torch._dynamo.reset() should support external reset callbacks for OOT backend caches

### DIFF
--- a/test/dynamo/test_callback.py
+++ b/test/dynamo/test_callback.py
@@ -4,8 +4,10 @@ import unittest
 from unittest.mock import Mock
 
 import torch
+from torch._dynamo import convert_frame
 from torch._dynamo.callback import callback_handler, CallbackArgs, CallbackTrigger
 from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.utils import guard_failures
 from torch._guards import CompileId
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.testing._internal.triton_utils import HAS_CUDA_AND_TRITON
@@ -62,6 +64,23 @@ class CallbackTests(TestCase):
         self.assertEqual(
             callback_handler._CompilationCallbackHandler__pending_callbacks_counter, 0
         )
+
+    def test_reset_callback(self) -> None:
+        calls = []
+
+        def callback():
+            calls.append((len(guard_failures), convert_frame.compile_lock._is_owned()))
+
+        self.assertIs(torch._dynamo.on_reset(callback), callback)
+        try:
+            guard_failures[object()].append(object())
+            torch._dynamo.reset()
+            guard_failures[object()].append(object())
+            torch._dynamo.reset()
+        finally:
+            callback_handler.remove_reset_callback(callback)
+
+        self.assertEqual(calls, [(0, True), (0, True)])
 
     @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
     @torch._inductor.config.patch(force_disable_caches=True)

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -20,7 +20,7 @@ from . import (
     resume_execution,
 )
 from .backends.registry import list_backends, lookup_backend, register_backend
-from .callback import callback_handler, on_compile_end, on_compile_start
+from .callback import callback_handler, on_compile_end, on_compile_start, on_reset
 from .code_context import code_context
 from .convert_frame import replay
 from .decorators import (
@@ -193,6 +193,8 @@ def reset() -> None:
             from torch._inductor.cudagraph_trees import reset_cudagraph_trees
 
             reset_cudagraph_trees()
+
+        callback_handler.run_reset_callbacks()
 
 
 def reset_code_caches() -> None:

--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -54,9 +54,13 @@ class CallbackArgs:
 class CompilationCallbackHandler:
     start_callbacks: list[Callable[[CallbackArgs], None]] = field(default_factory=list)
     end_callbacks: list[Callable[[CallbackArgs], None]] = field(default_factory=list)
+    reset_callbacks: list[Callable[[], None]] = field(default_factory=list)
 
     __pending_callbacks_counter: int = field(default=0, init=False, repr=False)
     __pending_callbacks_counter_lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
+    __reset_callbacks_lock: threading.Lock = field(
         default_factory=threading.Lock, init=False, repr=False
     )
 
@@ -102,6 +106,17 @@ class CompilationCallbackHandler:
         """
         self.end_callbacks.remove(callback)
 
+    def register_reset_callback(
+        self, callback: Callable[[], None]
+    ) -> Callable[[], None]:
+        with self.__reset_callbacks_lock:
+            self.reset_callbacks.append(callback)
+        return callback
+
+    def remove_reset_callback(self, callback: Callable[[], None]) -> None:
+        with self.__reset_callbacks_lock:
+            self.reset_callbacks.remove(callback)
+
     def run_start_callbacks(self, args: CallbackArgs) -> None:
         """
         Execute all registered start callbacks.
@@ -115,6 +130,12 @@ class CompilationCallbackHandler:
         """
         for callback in self.end_callbacks:
             callback(args)
+
+    def run_reset_callbacks(self) -> None:
+        with self.__reset_callbacks_lock:
+            callbacks = self.reset_callbacks.copy()
+        for callback in callbacks:
+            callback()
 
     @contextmanager
     def install_callbacks(
@@ -142,7 +163,7 @@ class CompilationCallbackHandler:
 
     def clear(self) -> None:
         """
-        Clear all registered callbacks.
+        Clear all registered compilation callbacks.
         """
         self.start_callbacks.clear()
         self.end_callbacks.clear()
@@ -173,3 +194,10 @@ def on_compile_end(
     """
     callback_handler.register_end_callback(callback)
     return callback
+
+
+def on_reset(callback: Callable[[], None]) -> Callable[[], None]:
+    """
+    Decorator to register a callback function to run after each Dynamo reset.
+    """
+    return callback_handler.register_reset_callback(callback)


### PR DESCRIPTION
## Issue

Fixes #194770

## Summary

Providing an official reset hook can eliminate the need for external backends to monkey-patch `reset()` for cache cleanup and reduce errors caused by stale caches.

> The following technical summary was prepared with OpenAI Codex:
>
> This change adds `torch._dynamo.on_reset`, backed by a thread-safe
> callback registry that persists across reset calls. Reset callbacks run
> in registration order after Dynamo's internal cleanup completes and
> while `compile_lock` remains held.
>
> The test verifies that registration returns the original callback,
> callbacks observe cleared internal state, execute under `compile_lock`,
> and remain registered across consecutive resets.
>
> The contributor reviewed and approved the AI-assisted implementation
> and this technical summary.

## Test Plan

> ```shell
> source .venv/bin/activate && spin lint -- torch/_dynamo/callback.py torch/_dynamo/__init__.py test/dynamo/test_callback.py
> source .venv/bin/activate && spin fixlint -- torch/_dynamo/callback.py torch/_dynamo/__init__.py test/dynamo/test_callback.py
> .venv/bin/python -m py_compile torch/_dynamo/callback.py torch/_dynamo/__init__.py test/dynamo/test_callback.py
> cd agent_space && ../.venv/bin/python test_reset_callback.py
> ```
>
> The targeted test passed against the installed PyTorch nightly binary.
> A full source-built test run was not performed because this checkout
> does not contain build artifacts.

## Checklist

> - [x] Passes lint (`spin fixlint`)
> - [x] Added/updated tests
> - [x] Documentation not required for this focused internal API
> - [x] Benchmarks not applicable

## BC-breaking?

> AI-assisted assessment: No.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98