### PR TITLE
Align LSTM PackedSequence argument validation with dense inputs

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2687,6 +2687,39 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                                                 [2.42240309, 0.0354595, -0.60659063, -0.05378816]]]))
             torch.testing.assert_close(result, ref_output, rtol=1e-5, atol=0)
 
+    @parametrize_test("packed", [False, True])
+    @parametrize_test(
+        "invalid_arg,error_type,error_regex",
+        [
+            ("input_size", RuntimeError, r"input.size\(-1\) must be equal to input_size"),
+            ("input_dtype", ValueError, "RNN input dtype"),
+            ("hidden_layers", RuntimeError, r"Expected hidden\[0\] size"),
+            ("hidden_batch", RuntimeError, r"Expected hidden\[0\] size"),
+            ("hidden_size", RuntimeError, r"Expected hidden\[0\] size"),
+            ("cell_size", RuntimeError, r"Expected hidden\[1\] size"),
+        ],
+    )
+    def test_lstm_forward_args_check(self, packed, invalid_arg, error_type, error_regex):
+        feature_size = 5 if invalid_arg == "input_size" else 4
+        dtype = torch.double if invalid_arg == "input_dtype" else torch.float
+        input = torch.randn(5, 3, feature_size, dtype=dtype)
+        if packed:
+            input = rnn_utils.pack_padded_sequence(input, [5, 3, 2])
+
+        hx = None
+        if invalid_arg == "hidden_layers":
+            hx = (torch.zeros(3, 3, 3), torch.zeros(3, 3, 3))
+        elif invalid_arg == "hidden_batch":
+            hx = (torch.zeros(2, 2, 3), torch.zeros(2, 2, 3))
+        elif invalid_arg == "hidden_size":
+            hx = (torch.zeros(2, 3, 4), torch.zeros(2, 3, 3))
+        elif invalid_arg == "cell_size":
+            hx = (torch.zeros(2, 3, 3), torch.zeros(2, 3, 4))
+
+        lstm = nn.LSTM(4, 3, num_layers=2)
+        with self.assertRaisesRegex(error_type, error_regex):
+            lstm(input, hx)
+
     def test_cudnn_forward_exception(self):
         rnns = [
             (nn.LSTM(10, 20, batch_first=True), (torch.zeros(1, 2, 19), torch.zeros(1, 2, 19))),

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1105,9 +1105,11 @@ class LSTM(RNNBase):
                     device=input.device,
                 )
                 hx = (h_zeros, c_zeros)
+                self.check_forward_args(input, hx, batch_sizes)
             else:
                 # Each batch of the hidden state should match the input sequence that
                 # the user believes he/she is passing in.
+                self.check_forward_args(input, hx, batch_sizes)
                 hx = self.permute_hidden(hx, sorted_indices)
         else:
             if input.dim() not in (2, 3):


### PR DESCRIPTION
Fixes #195803.

### Summary

`LSTM.forward` validates dense inputs with `check_forward_args`, but skips this check for `PackedSequence` inputs. An incorrect hidden-state shape consequently produces backend errors about RNN parameters or input contiguity instead of the expected hidden-state size.

Restore the existing validator in both packed-input paths: after initializing the default hidden state, and before permuting a supplied hidden state. Add regression tests for incorrect input feature size, input dtype, and hidden/cell-state shapes, with dense and packed inputs.

This complements the dense-input validation fix in #115542. The earlier branch restructuring is visible in #92970.

### Testing

Previously run with Python 3.12 and the official `2.15.0.dev20260828+cu132` wheel using this branch's `rnn.py`, rather than a full source build:

- `python test/test_nn.py -k lstm_forward_args_check -v`: 12 CPU tests passed.
- `python test/test_nn.py TestNN.test_cudnn_forward_exception -v`: 1 CPU test passed.
- `python test/test_nn.py TestNNDeviceTypeCUDA -k test_variable_sequence -v`: 3 CUDA tests passed, covering float16, float32, and float64 forward/backward results.

An A/B comparison removing only the two new checks confirmed that the six packed-input cases matched the expected frontend exceptions after the change. The six dense-input cases passed with either version. Separate CUDA checks confirmed the frontend exception types and messages for the same six invalid cases.

JIT tracing and ONNX dynamic-shape export have not been verified for this change.

### Compatibility

Invalid packed inputs fail earlier, and exception messages and check ordering can change. In the tested dtype-mismatch case, the frontend raises `ValueError` instead of the previous backend `RuntimeError`.