### PR TITLE
Fix default_backend set error when backend is "cpu:gloo,mcu:mccl"

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2002,7 +2002,7 @@ def _new_process_group_helper(
             pg._set_default_backend(ProcessGroup.BackendType.NCCL)
         elif Backend._plugins.keys():
             custom_backend = next(iter(Backend._plugins.keys()))
-            if custom_backend in backend_config.device_backend_map.values():
+            if custom_backend.lower() in backend_config.device_backend_map.values():
                 pg._set_default_backend(ProcessGroup.BackendType.CUSTOM)
         else:
             pg._set_default_backend(ProcessGroup.BackendType.GLOO)


### PR DESCRIPTION
The custom backend is stored in `Backend._plugins` with uppercase letters:
https://github.com/pytorch/pytorch/blob/0fabc3ba44823f257e70ce397d989c8de5e362c1/torch/distributed/distributed_c10d.py#L357-L363


Custom backend exists in lowercase letters：
https://github.com/pytorch/pytorch/blob/0fabc3ba44823f257e70ce397d989c8de5e362c1/torch/distributed/distributed_c10d.py#L335-L339

All the backends in `backend_config.device_backend_map.values()` exist in lowercase letter form. However, 'custom_backend ' is composed of uppercase letters, so it needs to be converted to lowercase letters
https://github.com/pytorch/pytorch/blob/0fabc3ba44823f257e70ce397d989c8de5e362c1/torch/distributed/distributed_c10d.py#L1956-L1960