### PR TITLE
[Inductor] Add Blackwell persistent TMA BMM template

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -48,6 +48,7 @@ from torch._inductor.heuristics.template.triton import (
     CUDAAddmmPersistentTMATemplateConfigHeuristic,
     CUDAAddMMTemplateConfigHeuristic,
     CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic,
+    CUDABlackwellBMMTemplateConfigHeuristic,
     CUDABlackwellPersistentTMATemplateConfigHeuristic,
     CUDAMMTemplateConfigHeuristic,
     CUDAPersistentTMATemplateConfigHeuristic,
@@ -58,6 +59,9 @@ from torch._inductor.heuristics.template.triton import (
     XPUPersistentTMATemplateConfigHeuristic,
 )
 from torch._inductor.ir import Buffer, ChoiceCaller, FixedLayout, FlexibleLayout
+from torch._inductor.kernel.bmm import blackwell_ws_persistent_tma_bmm_template
+from torch._inductor.kernel_inputs import MMKernelInputs
+from torch._inductor.lowering import lowerings
 from torch._inductor.kernel.mm_plus_mm import aten_mm_plus_mm
 from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.runtime.triton_heuristics import CachingAutotuner, pointwise
@@ -74,7 +78,11 @@ from torch._inductor.select_algorithm import (
     TritonTemplate,
     TritonTemplateCaller,
 )
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
+from torch.testing._internal.common_cuda import (
+    PLATFORM_SUPPORTS_FP8,
+    SM100OrLater,
+    SM90OrLater,
+)
 from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -148,6 +156,15 @@ _DECOMPOSE_K_PATCH_ROCM = (
     {"triton.num_decompose_k_splits": 10} if torch.version.hip else {}
 )
 
+@torch.library.custom_op("inductor_test::blackwell_bmm", mutates_args={})
+def blackwell_bmm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return torch.bmm(a, b)
+
+
+@blackwell_bmm.register_fake
+def _(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return a.new_empty((a.shape[0], a.shape[1], b.shape[2]))
+
 
 def benchmark_choice(choice, args, out, expected_out, timings):
     result = choice.benchmark(*args, out=out)
@@ -178,6 +195,83 @@ class TestMaxAutotune(TestCase):
         a = make_matrix(M, K, *batch_dims, reduction_dim=-1)
         b = make_matrix(K, N, *batch_dims, reduction_dim=-2)
         return a, b
+
+    def _run_blackwell_bmm_template(
+        self, broadcast_b: bool, epilogue_subtile: int
+    ) -> None:
+        bsz, m, k, n = 3, 256, 8193, 128
+        a_storage = torch.randn(bsz, k, m, device=GPU_TYPE, dtype=torch.bfloat16)
+        a = a_storage.transpose(1, 2)
+        if broadcast_b:
+            b = torch.randn(k, n, device=GPU_TYPE, dtype=torch.bfloat16)
+            b = b.unsqueeze(0).expand(bsz, -1, -1)
+        else:
+            b = torch.randn(bsz, k, n, device=GPU_TYPE, dtype=torch.bfloat16)
+
+        class TestBlackwellBMMHeuristic(CUDABlackwellBMMTemplateConfigHeuristic):
+            def _get_template_configs_impl(self, kernel_inputs, op_name):
+                for template_config in super()._get_template_configs_impl(
+                    kernel_inputs, op_name
+                ):
+                    if (
+                        template_config["BLOCK_M"] == 128
+                        and template_config["BLOCK_N"] == 128
+                    ):
+                        yield {
+                            **template_config,
+                            "EPILOGUE_SUBTILE": epilogue_subtile,
+                        }
+                        return
+
+        def lowering(a_node, b_node):
+            choices = V.choices.get_template_configs(
+                MMKernelInputs([a_node, b_node]),
+                [blackwell_ws_persistent_tma_bmm_template],
+                "bmm",
+            )
+            return choices[0].output_node()
+
+        with (
+            override_template_heuristics(
+                device_type=GPU_TYPE,
+                template_op_pairs=[
+                    (blackwell_ws_persistent_tma_bmm_template.uid, "bmm")
+                ],
+                override_heuristic_class=TestBlackwellBMMHeuristic,
+            ),
+            mock.patch.dict(
+                lowerings,
+                {torch.ops.inductor_test.blackwell_bmm.default: lowering},
+            ),
+            config.patch(compile_threads=1),
+        ):
+            actual, codes = run_and_get_code(
+                torch.compile(lambda x, y: blackwell_bmm(x, y), fullgraph=True),
+                a,
+                b,
+            )
+
+        torch.testing.assert_close(actual, torch.bmm(a, b), atol=1e-2, rtol=1e-2)
+        self.assertIn("make_tensor_descriptor", codes[0])
+        self.assertNotIn("two_ctas=True", codes[0])
+        self.assertIn(
+            f"EPILOGUE_SUBTILE : tl.constexpr = {epilogue_subtile}", codes[0]
+        )
+
+    @unittest.skipIf(not SM100OrLater, "Blackwell BMM template requires SM100+")
+    @parametrize("epilogue_subtile", (1, 2, 4))
+    def test_blackwell_bmm_template(self, epilogue_subtile: int) -> None:
+        self._run_blackwell_bmm_template(
+            broadcast_b=False,
+            epilogue_subtile=epilogue_subtile,
+        )
+
+    @unittest.skipIf(not SM100OrLater, "Blackwell BMM template requires SM100+")
+    def test_blackwell_bmm_template_broadcast_b(self) -> None:
+        self._run_blackwell_bmm_template(
+            broadcast_b=True,
+            epilogue_subtile=1,
+        )
 
     @parametrize("dynamic", (False, True))
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -19,7 +19,11 @@ from torch.utils._triton import has_triton_stable_tma_api
 
 from ... import config
 from ...autows_utils import meta_ws_enabled
-from ...kernel.bmm import bmm_template
+from ...kernel.bmm import (
+    BLACKWELL_BMM_MAX_AUTOTUNE_CONFIGS,
+    blackwell_ws_persistent_tma_bmm_template,
+    bmm_template,
+)
 from ...kernel.mm import (
     blackwell_ws_persistent_device_tma_mm_template,
     get_scaling_options,
@@ -44,6 +48,7 @@ from ...utils import (
     using_rocm_rdna3,
 )
 from ...virtualized import V
+from .base import TemplateConfigHeuristics
 from .gemm import GemmMaxAutotuneTemplateConfigHeuristics
 from .triton_addmm import AddMMConfigMixin
 
@@ -3075,6 +3080,77 @@ class ScaledBlackwellTMAConfigMixin(
 )
 class CUDAMMTemplateConfigHeuristic(MMTemplateConfigMixin, CUDAConfigHeuristic):
     """Standard MM template heuristic for CUDA"""
+
+
+@register_template_heuristic(
+    blackwell_ws_persistent_tma_bmm_template.uid,
+    "cuda",
+    register=torch.version.hip is None,
+    op_name="bmm",
+)
+class CUDABlackwellBMMTemplateConfigHeuristic(TemplateConfigHeuristics):
+    """Bounded configs for the Blackwell persistent-TMA BMM template."""
+
+    def _get_template_configs_impl(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        if not isinstance(kernel_inputs, MMKernelInputs):
+            raise AssertionError(
+                f"{self.__class__.__name__} requires MMKernelInputs"
+            )
+
+        mat1, mat2 = kernel_inputs.mat1mat2()
+        if len(mat1.get_size()) != 3 or len(mat2.get_size()) != 3:
+            raise NotImplementedError("Blackwell BMM requires rank-3 operands")
+
+        batch, _, k = map(int, mat1.get_size())
+        batch_b, k_b, _ = map(int, mat2.get_size())
+        if batch != batch_b or k != k_b:
+            raise NotImplementedError(
+                "Blackwell BMM does not broadcast logical batches"
+            )
+
+        a_row_major = mat1.get_stride()[2] == 1
+        a_col_major = mat1.get_stride()[1] == 1
+
+        b_row_major = mat2.get_stride()[2] == 1
+        b_col_major = mat2.get_stride()[1] == 1
+
+        if not (a_row_major or a_col_major) or not (
+            b_row_major or b_col_major
+        ):
+            raise NotImplementedError(
+                "Blackwell BMM requires one contiguous matrix dimension"
+            )
+
+        tma_options = {
+            "NUM_SMS": get_num_sms(),
+            "A_ROW_MAJOR": a_row_major,
+            "B_ROW_MAJOR": b_row_major,
+            "tma_store": False,
+        }
+        for candidate in BLACKWELL_BMM_MAX_AUTOTUNE_CONFIGS:
+            yield {
+                "BLOCK_M": candidate.block_m,
+                "BLOCK_N": candidate.block_n,
+                "BLOCK_K": candidate.block_k,
+                "GROUP_M": 8,
+                "num_stages": candidate.num_stages,
+                "num_warps": candidate.num_warps,
+                "EPILOGUE_SUBTILE": candidate.epilogue_subtile,
+                "WARP_SPECIALIZE": True,
+                "FLATTEN": True,
+                **tma_options,
+            }
+
+    def get_extra_kwargs(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> dict[str, Any]:
+        return {"ALLOW_TF32": False}
 
 
 @register_template_heuristic(

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import dataclasses
 import logging
 from typing import TYPE_CHECKING
 
@@ -62,6 +63,42 @@ bmm_template = TritonTemplate(
     grid=bmm_grid,
     source=load_kernel_template("triton_bmm"),
     cache_codegen_enabled_for_template=True,
+)
+
+
+@SymbolicGridFn
+def blackwell_bmm_grid(b, m, n, meta, *, cdiv, max, min):
+    grid_m = cdiv(m, meta["BLOCK_M"])
+    tiles = grid_m * cdiv(n, meta["BLOCK_N"])
+    grid_x = min(meta["NUM_SMS"], tiles)
+    max_y_grid = get_max_y_grid()
+    grid_z = max(cdiv(b, max_y_grid), 1)
+    return (grid_x, cdiv(b, grid_z), grid_z)
+
+
+blackwell_ws_persistent_tma_bmm_template = TritonTemplate(
+    name="blackwell_bmm",
+    grid=blackwell_bmm_grid,
+    source=load_kernel_template("triton_blackwell_ws_persistent_device_tma_bmm"),
+    cache_codegen_enabled_for_template=True,
+    prologue_loads_all_inputs=True,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class BlackwellBMMConfig:
+    block_m: int
+    block_n: int
+    block_k: int
+    num_stages: int
+    num_warps: int
+    epilogue_subtile: int = 1
+
+
+BLACKWELL_BMM_MAX_AUTOTUNE_CONFIGS = (
+    BlackwellBMMConfig(64, 64, 128, 5, 4),
+    BlackwellBMMConfig(128, 128, 128, 3, 8),
+    BlackwellBMMConfig(128, 256, 64, 4, 8),
 )
 
 aten_bmm = ExternKernelChoice(torch.bmm, "at::bmm_out", op_overload=aten.bmm.out)

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
@@ -1,0 +1,131 @@
+{{def_kernel("A", "B")}}
+    BATCH = {{size("A", 0)}}
+    M = {{size("A", 1)}}
+    N = {{size("B", 2)}}
+    K = {{size("A", 2)}}
+    batch = (tl.program_id(1) + tl.program_id(2) * tl.num_programs(1)).to(tl.int32)
+    if batch >= BATCH or M * N == 0:
+        return
+
+    stride_ab = {{stride("A", 0)}}
+    stride_bb = {{stride("B", 0)}}
+
+    stride_am = {{stride("A", 1)}}
+    stride_ak = {{stride("A", 2)}}
+    stride_bk = {{stride("B", 1)}}
+    stride_bn = {{stride("B", 2)}}
+
+    a_base = A + batch * stride_ab
+    b_base = B + batch * stride_bb
+
+    # A logical rank-3 BMM is represented by one rank-2 descriptor per batch.
+    # This supports arbitrary/zero batch strides and keeps the descriptor-load
+    # shape compatible with today's rank-2 Transform2CTALoads implementation.
+    a_desc = triton.language.make_tensor_descriptor(
+        base=a_base,
+        shape=[M, K] if A_ROW_MAJOR else [K, M],
+        strides=[stride_am, 1] if A_ROW_MAJOR else [stride_ak, 1],
+        block_shape=[BLOCK_M, BLOCK_K] if A_ROW_MAJOR else [BLOCK_K, BLOCK_M],
+    )
+    b_desc = triton.language.make_tensor_descriptor(
+        base=b_base,
+        shape=[K, N] if B_ROW_MAJOR else [N, K],
+        strides=[stride_bk, 1] if B_ROW_MAJOR else [stride_bn, 1],
+        block_shape=[BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
+    )
+
+    start_pid = tl.program_id(0)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    num_tiles = grid_m * grid_n
+    num_pid_in_group = GROUP_M * grid_n
+    k_tiles = tl.cdiv(K, BLOCK_K)
+    tile_id_c = start_pid - NUM_SMS
+
+    for tile_id in tl.range(
+        start_pid,
+        num_tiles,
+        NUM_SMS,
+        flatten=FLATTEN,
+        warp_specialize=WARP_SPECIALIZE,
+    ):
+        pid_m, pid_n = _blackwell_bmm_pid(
+            tile_id, num_pid_in_group, grid_m, GROUP_M
+        )
+        offs_am = (pid_m * BLOCK_M).to(tl.int32)
+        offs_bn = (pid_n * BLOCK_N).to(tl.int32)
+        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = (ki * BLOCK_K).to(tl.int32)
+            a = a_desc.load(
+                [offs_am, offs_k] if A_ROW_MAJOR else [offs_k, offs_am],
+            )
+            b = b_desc.load(
+                [offs_k, offs_bn] if B_ROW_MAJOR else [offs_bn, offs_k],
+            )
+            accumulator += tl.dot(
+                a if A_ROW_MAJOR else a.T,
+                b if B_ROW_MAJOR else b.T,
+                allow_tf32=ALLOW_TF32,
+            )
+
+        tile_id_c += NUM_SMS
+        pid_m, pid_n = _blackwell_bmm_pid(
+            tile_id_c, num_pid_in_group, grid_m, GROUP_M
+        )
+        offs_cm = pid_m * BLOCK_M
+        offs_cn = pid_n * BLOCK_N
+        subtiles = _subtile_accumulator(
+            accumulator, BLOCK_M, BLOCK_N, EPILOGUE_SUBTILE
+        )
+        for i in tl.static_range(EPILOGUE_SUBTILE):
+            offs_cn_i = offs_cn + i * (BLOCK_N // EPILOGUE_SUBTILE)
+            rm = offs_cm + tl.arange(0, BLOCK_M)[:, None]
+            rn = offs_cn_i + tl.arange(0, BLOCK_N // EPILOGUE_SUBTILE)[None, :]
+            mask = (rm < M) & (rn < N)
+            {{store_output(
+                ("batch", "rm", "rn"),
+                "subtiles[i]",
+                "mask",
+                indent_width=12,
+                val_shape=("BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE")
+            )}}
+
+
+@triton.jit
+def _blackwell_bmm_pid(tile_id, num_pid_in_group, grid_m, GROUP_M: tl.constexpr):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_M
+    group_m = min(grid_m - first_pid_m, GROUP_M)
+    pid_m = first_pid_m + tile_id % group_m
+    pid_n = (tile_id % num_pid_in_group) // group_m
+    return pid_m, pid_n
+
+
+@triton.jit
+def _subtile_accumulator(
+    acc,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SUBTILE_FACTOR: tl.constexpr,
+):
+    tl.static_assert(SUBTILE_FACTOR > 0, "SUBTILE_FACTOR must be positive")
+    tl.static_assert(
+        (SUBTILE_FACTOR & (SUBTILE_FACTOR - 1)) == 0,
+        "SUBTILE_FACTOR must be a power of 2",
+    )
+
+    if SUBTILE_FACTOR == 1:
+        return (acc,)
+    else:
+        tl.static_assert(BLOCK_N % 2 == 0)
+        acc = tl.reshape(acc, (BLOCK_M, 2, BLOCK_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        left, right = tl.split(acc)
+        left_subtiles = _subtile_accumulator(
+            left, BLOCK_M, BLOCK_N // 2, SUBTILE_FACTOR // 2
+        )
+        right_subtiles = _subtile_accumulator(
+            right, BLOCK_M, BLOCK_N // 2, SUBTILE_FACTOR // 2
+        )
+        return left_subtiles + right_subtiles


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Add a config-gated Blackwell persistent TMA BMM template with bounded autotuning choices for rank-3 BMM operands. Use per-batch rank-2 TMA descriptors and integrate the template with the existing BMM selection path.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo