### PR TITLE
[MPSInductor] Make MetalKernel launch device overridable via a class attribute

### DIFF
--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 
 import torch
+from torch._inductor.codegen.mps import MetalKernel
 from torch.testing import FileCheck, make_tensor
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.testing._internal.common_utils import (
@@ -353,6 +354,9 @@ class MPSBasicTests(TestCase):
                 torch.randn(1, na, 1, 1, 2, device="mps"),
             ),
         )
+
+    def test_metal_kernel_device_type(self):
+        self.assertEqual(MetalKernel.device_type, "mps")
 
 
 @unittest.skipUnless(torch.backends.mps.is_available(), "MPS not available")

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -558,6 +558,13 @@ class MetalKernel(SIMDKernel):
     newvar_prefix = "auto "
     max_threadgroup_size = 1024
     simd_group_size = 32
+    # Device that generated kernels are launched on. Subclasses reusing the
+    # Metal-style call plumbing for another device can override this instead of
+    # copying call_kernel(). A retarget is not usable on its own yet: the
+    # non-triton branch of PythonWrapperCodegen._generate_kernel_call_helper()
+    # raises "device ... nyi" for device types other than cpu/cuda/xpu/mps, so
+    # subclasses need the wrapper-side follow-up noted in the PR description.
+    device_type = "mps"
     pexpr = PythonPrinter().doprint
     cexpr = CppPrinter().doprint
     sexpr = MetalExprPrinter().doprint
@@ -1158,7 +1165,7 @@ class MetalKernel(SIMDKernel):
         wrapper.generate_kernel_call(
             name,
             args,
-            device=torch.device("mps"),
+            device=torch.device(self.device_type),
             triton=False,
             arg_types=arg_types,
         )


### PR DESCRIPTION
## Motivation

`MetalKernel.call_kernel()` is the only kernel-call site across the in-tree Inductor codegen backends that pins a device literal: it unconditionally passes `device=torch.device("mps")` to `generate_kernel_call()`. For comparison, Triton and Cpp rely on the graph's current device (the wrapper default), and Halide passes a computed device value.

An out-of-tree backend that reuses the Metal-style kernel plumbing (subclassing `MetalKernel` for a device that follows the same one-thread-per-element launch convention) currently has to copy the whole `call_kernel()` body just to retarget the launch device.

This is one of the small patches that remove device hardcodings from codegen so out-of-tree backends need fewer monkey-patches.

## Changes

- Add a `device_type = "mps"` class attribute to `MetalKernel`, next to the existing class-level knobs (`max_threadgroup_size`, `simd_group_size`, ...).
- `call_kernel()` derives the launch device from `self.device_type` instead of the literal.
- Test: a single assertion on `test/inductor/test_mps_basic.py`'s existing MPS-gated `MPSBasicTests` class (`assertEqual(MetalKernel.device_type, "mps")`). An earlier version of this PR shipped a larger test block that drove `call_kernel()` with a stubbed kernel state and a mocked wrapper; the review correctly found that it does not run in the Linux CI shards this file targets, and that its two behavioral assertions were a tautology and an assertion of a `meta`-device retarget the real wrapper rejects. Those were dropped; the existing end-to-end MPS tests already drive `call_kernel()`, so the only genuinely new thing to pin is the class attribute default, which is one line.

An alternative considered was to drop the `device=` kwarg and let the wrapper default to `V.graph.get_current_device_or_throw()`, like Triton (`wrapper.py` already does `device = device or V.graph.get_current_device_or_throw()`). I did not take that path: it changes the source of truth for the launch device from the kernel that emitted the call to whatever the graph's current device happens to be at wrapper time, and with it the failure mode for an unimplemented device type, which is a behavior question rather than a decoupling one. The kernel-side class attribute keeps the value sourced from the kernel and gives subclasses a single explicit knob.

## Behavior

No change for in-tree backends. The default attribute value yields the exact same `torch.device("mps")` object as before, and the MPS branch of `PythonWrapperCodegen._generate_kernel_call_helper()` only dispatches on `device.type` (it never consumes the value or the index for `mps`). No other backend references the touched symbols, and the change adds no import-time device probing.

## Test Plan

```
cd /tmp && unset PYTHONPATH
python -m pytest <repo>/test/inductor/test_mps_basic.py -q
# 60 collected, 60 skipped (torch 2.15.0.dev20260819+cpu wheel, changed mps.py overlaid)
# base commit 00ea4089 on the same command: 59 collected, 59 skipped
# (the +1 is the single new MPS-gated assertion; on Linux it is skipped like the
#  other 59 cases and runs on the macOS --mps shards, where MPSBasicTests is
#  gated by torch.backends.mps.is_available())
python -m pytest <repo>/test/inductor/test_mps_basic.py --collect-only -k metal_kernel
# test_mps_basic.py::MPSBasicTests::test_metal_kernel_device_type
lintrunner -a --take PYFMT,RUFF torch/_inductor/codegen/mps.py test/inductor/test_mps_basic.py
# ok No lint issues.
```

PYREFLY note: on this unbuilt source tree it emits ~20k missing-attribute errors against unmodified lines on both the base commit and this diff, so it cannot discriminate locally; CI's pyrefly job covers `torch/`, where the only functional lines changed live. No NPU-side verification is claimed: `torch_npu` does not reference this file, and the diff does not change generated code for any in-tree backend.

## Notes

`MetalOverrides._initialize_pointwise_overrides("mps")` is intentionally left unchanged: every backend passes its codegen backend name there (`"cpp"`, `"cppvec"`, `"halide"`, `"triton"`, `"mps"`), so it is a table key, not a device hardcoding.

A subclass retargeting `device_type` is not usable end-to-end on its own yet: `PythonWrapperCodegen._generate_kernel_call_helper()` dispatches on `device.type not in ("cuda", "xpu")` and raises for unknown types, and `CppWrapperMps._generate_kernel_call_helper()` asserts `device.type == "mps"` while its shader-library pass skips non-mps `KernelCallLine`s. This PR is deliberately kernel-side only to keep the diff reviewable in isolation; the wrapper-side change (a negated dispatch like the merged #187939 used for ShardedTensor, plus the `CppWrapperMps` assert) touches the cpu/cuda/xpu paths and deserves its own PR. This is noted in the code comment above `device_type` as well. If you would rather the attribute land after that wrapper-side change so it is exercisable, I am glad to restack this on top of it.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo