### PR TITLE
[TLX][Inductor] Prototype generic cross-phase LDS retention

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -28,6 +28,7 @@ from torch._inductor.codegen.triton import (
     TritonCSEVariable,
     TritonKernel,
     TritonKernelOverrides,
+    TritonScheduling,
     TritonSymbols,
 )
 from torch._inductor.codegen.wrapper import _escape_triton_kernel_source_for_wrapper
@@ -343,6 +344,73 @@ def helper(x):
 
         self.assertFalse(kernel.persistent_reduction)
         self.assertEqual(seen_scores, [tiling_scores])
+
+    def test_extra_kernel_choices_follow_multi_kernel_contract(self):
+        features = SimpleNamespace(
+            contains_op=lambda name: False,
+            scheduler_nodes=lambda: (),
+            reduction_numel=sympy.Integer(1),
+        )
+
+        class FakeKernel:
+            @classmethod
+            def apply_feature_required_overrides(cls, features, kwargs):
+                pass
+
+            def __init__(self, *args, **kwargs):
+                self.persistent_reduction = kwargs.get(
+                    "override_persistent_reduction", True
+                )
+                self.cooperative_reduction = False
+                self.must_keep_buffers = set()
+                self.features = features
+
+            def python_argdefs(self):
+                return tuple(sorted(self.must_keep_buffers))
+
+        class ExtraKernelChoices(InductorChoices):
+            def __init__(self):
+                self.calls = 0
+
+            def get_extra_triton_kernel_choices(
+                self, kernel_cls, kernel_features, kernel_args, kernel_kwargs
+            ):
+                self.calls += 1
+                return [
+                    kernel_cls(
+                        *kernel_args,
+                        **kernel_kwargs,
+                        override_persistent_reduction=False,
+                    )
+                ]
+
+        scheduling = object.__new__(TritonScheduling)
+        scheduling.kernel_type = FakeKernel
+        choices = ExtraKernelChoices()
+        with V.set_choices_handler(choices), inductor_config.patch(
+            "triton.multi_kernel", 1
+        ):
+            kernels = scheduling.create_kernel_choices(features, [], {})
+
+        self.assertEqual(choices.calls, 1)
+        self.assertEqual(
+            [kernel.persistent_reduction for kernel in kernels],
+            [False, False, True],
+        )
+        kernels[0].must_keep_buffers.add("workspace")
+        self.assertEqual(
+            [kernel.python_argdefs() for kernel in kernels],
+            [("workspace",)] * 3,
+        )
+
+        choices.calls = 0
+        with V.set_choices_handler(choices), inductor_config.patch(
+            "triton.multi_kernel", 0
+        ):
+            kernels = scheduling.create_kernel_choices(features, [], {})
+
+        self.assertEqual(choices.calls, 0)
+        self.assertEqual(len(kernels), 1)
 
     def test_reduction_invariant_load_indexing(self):
         self._stack.enter_context(self._graph.set_current_device(torch.device("cuda")))

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -423,6 +423,21 @@ class InductorChoices:
         """Hook to change the kwargs passed to TritonKernel, used to apply fixed configurations"""
         return kernel_kwargs
 
+    def get_extra_triton_kernel_choices(
+        self,
+        kernel_cls: type[TritonKernel],
+        features: SIMDKernelFeatures,
+        kernel_args: list[Any],
+        kernel_kwargs: dict[str, Any],
+    ) -> list[TritonKernel]:
+        """Return extra candidates for multi-kernel benchmarking.
+
+        This is called only when multi-kernel generation is enabled.  Returned
+        kernels participate in the same argument sharing and ordering as the
+        built-in persistent and cooperative reduction candidates.
+        """
+        return []
+
     def override_best_choice(
         self,
         best_choice: ChoiceCaller,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6903,6 +6903,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.prologue.clear()
         self.prologue_cache.clear()
 
+    def reduction_loop_range(self, prefix: str, loop_start: str, loop_end: str) -> str:
+        """Return the reduction iterator expression used by generated kernels.
+
+        Backends may override this to select a different loop primitive while
+        preserving the scheduler-provided bounds and reduction block size.
+        """
+        # Conditionalize pipelining on HIP for Triton due to reports of
+        # numerical inaccuracies on older Triton.
+        if torch.version.hip and get_triton_version() > (3, 2):
+            num_stages = ", num_stages = 2"
+        else:
+            num_stages = ""
+        return f"tl.range({loop_start}, {loop_end}, {prefix.upper()}BLOCK{num_stages})"
+
     def codegen_body(self):
         """
         Concat output code from index_code, loads, compute, stores,
@@ -7008,15 +7022,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     loop_end = (
                         "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
                     )
-                    # Conditionalize pipelining on HIP for Triton due to
-                    # reports of numerical inaccuracies on older Triton
-                    if torch.version.hip and get_triton_version() > (3, 2):
-                        num_stages = ", num_stages = 2"
-                    else:
-                        num_stages = ""
-                    self.body.writeline(
-                        f"for {prefix}offset in tl.range({loop_start}, {loop_end}, {prefix.upper()}BLOCK{num_stages}):"
-                    )
+                    loop = self.reduction_loop_range(prefix, loop_start, loop_end)
+                    self.body.writeline(f"for {prefix}offset in {loop}:")
                 with self.body.indent(offset=level + 1):
                     self.iteration_ranges_codegen_header(tree, self.body)
 
@@ -8767,13 +8774,23 @@ class TritonScheduling(SIMDScheduling):
             kernel_type, kernel_features, kernel_args, kernel_kwargs
         )
         kernel = kernel_type(*kernel_args, **kernel_kwargs)
-        return self.add_multi_kernel_choices(kernel, kernel_args, kernel_kwargs)
+        if not config.triton.multi_kernel:
+            return [kernel]
+        return self.add_multi_kernel_choices(
+            kernel,
+            kernel_args,
+            kernel_kwargs,
+            V.choices.get_extra_triton_kernel_choices(
+                kernel_type, kernel_features, kernel_args, kernel_kwargs
+            ),
+        )
 
     def add_multi_kernel_choices(
         self,
         kernel: TritonKernel,
         kernel_args: list[Any],
         kernel_kwargs: dict[str, Any],
+        extra_kernels: list[TritonKernel] | None = None,
     ) -> list[TritonKernel]:
         kernels: list[TritonKernel] = [kernel]
         if not config.triton.multi_kernel:
@@ -8814,6 +8831,7 @@ class TritonScheduling(SIMDScheduling):
                         )
                     )
 
+        kernels.extend(extra_kernels or ())
         if len(kernels) > 1:
             for kernel2 in kernels[1:]:
                 # Keep buffers needed by the non-persistent reduction so both kernels have the same arguments


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/triton/pull/3447

Add an opt-in scheduler/codegen prototype that retains materialized values in TLX local memory across reduction phases on AMD. Candidate discovery is dataflow-based: it finds a direct contiguous store followed by a matching later load owned by the same program.

The scheduler sends a structured buffer/phase/storage plan to Triton codegen. Codegen allocates LDS, redirects only the selected store/load interval, preserves the original storage-dtype rounding, emits the required barrier, and statically unrolls the retained reduction tiles. The ordinary Triton kernel remains a sibling MultiKernel choice so runtime benchmarking can reject an unprofitable LDS candidate.

The initial legality envelope is intentionally conservative: AMD with Triton beta, one reduction dimension, one row per CTA, static contiguous access, fp16/bf16/fp32 storage, and at most 32 KiB of retained data per CTA. This covers the production double-LayerNorm case while defining a reusable mechanism for other non-templated reduction pipelines.

The diff retains the hand-written double-LayerNorm kernel as a performance-ceiling reference and adds an Inductor A/B benchmark with configurable hidden width.

Test Plan:
## Unit + codegen tests (real gfx950 hardware)

There is no MI350X GPU RE, so this runs locally on a devgpu via `buck run` rather than `buck test`:

```
buck2 run mode/opt-amd-gpu -m ovr_config//triton:beta \
  fbcode//caffe2/test/inductor/fb/tlx:test_templates -- -v
```

All 9 `TestLocalBufferRetention` tests pass, including `test_inductor_codegen` against real hardware (`devgpu048`, 8x gfx950 / MI350X).

- Complete buck run log: P2497418257
- Generated kernel from `test_inductor_codegen`: P2497418490

Use `mode/opt-amd-gpu`, not `mode/opt`. The latter builds a CUDA torch, so `torch.version.hip` is `None`, `current_target()` reports no device, and `test_inductor_codegen` silently skips.

The retention path also requires `triton.multi_kernel` (default `0`), since the retained kernel is offered as a MultiKernel choice. The test and the Inductor benchmark both enable it explicitly.

The generated kernel confirms the retained interval:

```
tl.static_assert(XBLOCK == 1)
tlx_local_0_storage = tlx.local_alloc((1, 8192,), tl.float16, 1)
tlx_local_0 = tlx.local_view(tlx_local_0_storage, 0)
...
for r0_offset in tl.static_range(0, 6144, R0_BLOCK):
    tlx.local_store(tlx.local_slice(tlx_local_0, [0, r0_offset], [1, R0_BLOCK]), tmp26.to(tl.float16))
...
tl.debug_barrier()
for r0_offset in tl.static_range(0, 6144, R0_BLOCK):
    tmp35 = tlx.local_load(tlx.local_slice(tlx_local_0, [0, r0_offset], [1, R0_BLOCK]), relaxed=True)
```

The baseline's `tl.store(in_out_ptr0 + (r0_1 + 6144*x0), tmp26, ...)` at the end of the second reduction loop is gone: the intermediate stays in LDS and never round-trips HBM. `tl.debug_barrier()` is emitted exactly once, after the welford finalize and before the load loop.

## Performance

**Inductor A/B** -- `fbcode//ads_mkl/ops/tlx/benchmark:tlx_inductor_local_buffer_retention_gfx950`, 1024x6144 fp16. This is the end-to-end Inductor path this diff ships:

```
correctness_vs_baseline max_abs=0.007812 mean_abs=0.000122
FINAL baseline=19.944us local_buffer_retention=18.854us speedup=1.058x
```

**19.944us -> 18.854us, i.e. 5.8% lower latency.** Measured with `--samples 1 --warmup 25 --rep 100`; a full-default run would tighten the interval.

Performance ceiling reference, for context:

- Standalone hand-written retained kernel: 25.75 -> 21.39 us, 16.9% lower latency.
- E2E gain: T1 OC_HIM 1091651359 `mts_gpu_bench`: 34.1 -> 27.6 ms (19.1% improvement)


## Lint

`arc f` and `arc lint --never-apply-patches` clean on all changed files.

Reviewed By: dshi7, htyu

Differential Revision: D117433340


