### PR TITLE
[NativeRT] Support optional Triton profile scratch argument (#195811)

### DIFF
--- a/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
@@ -51,8 +51,13 @@ class CudaKernelInputs final : public KernelInputs {
   CudaKernelInputs(size_t num_args, size_t num_attrs)
       : KernelInputs(num_args, num_attrs),
         arg_ptrs_(num_args),
-        global_scratch_(0) {
+        global_scratch_(0),
+        profile_scratch_(0) {
     inputs_.push_back(&global_scratch_);
+    // Some Triton kernel ABIs include profile scratch after global scratch.
+    // Kernels without it ignore this trailing parameter because the compiled
+    // kernel signature determines how many entries the runtime reads.
+    inputs_.push_back(&profile_scratch_);
   }
   ~CudaKernelInputs() final = default;
 
@@ -72,6 +77,7 @@ class CudaKernelInputs final : public KernelInputs {
  private:
   std::vector<void*> arg_ptrs_;
   CUdeviceptr global_scratch_;
+  CUdeviceptr profile_scratch_;
 };
 
 class CudaTritonKernelManager final : public TritonKernelManager {


### PR DESCRIPTION
Summary:

Pass a trailing null `profile_scratch` pointer after `global_scratch` in the CUDA/HIP NativeRT launcher. The cubin signature makes the slot optional for older Triton kernels.
