### PR TITLE
[PrismNet][ROCm] Return the empty result from CK flash attention on an empty batch (#195812)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -277,7 +277,6 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     const int head_size = sizes[3];
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size <= 256, "CK only supports head dimension at most 256");
     TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -412,9 +411,13 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     {
       attn_bias = attn_bias_;
     }
-    if (seqlen_k > 0) {
-        drop_seed_offset.first = rng_state[0].data_ptr<uint64_t>();
-        drop_seed_offset.second = rng_state[1].data_ptr<uint64_t>();
+    // Read below by the p_dropout > 0 epilogue, which runs whether or not the kernel does.
+    drop_seed_offset.first = rng_state[0].data_ptr<uint64_t>();
+    drop_seed_offset.second = rng_state[1].data_ptr<uint64_t>();
+
+    // An empty batch or key sequence has no work: the tensors allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && seqlen_k > 0) {
         auto stream = at::cuda::getCurrentHIPStream().stream();
         ck_tile::stream_config stream_config{stream};
 
@@ -452,7 +455,8 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
     }
     else {
-        // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran. Both are empty when batch_size == 0; when only seqlen_k is 0
+        // they are not, and attention over no keys is defined as zeros with an lse of inf.
         out.zero_();
         softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -243,7 +243,8 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
     const int total_q = q.size(0);
     const int total_k = k.size(0);
 
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
+    // batch_size is cu_seqlens_q.numel() - 1, so an empty cu_seqlens makes it negative.
+    TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least one element");
     TORCH_CHECK(head_size_og <= 256, "CK only supports head dimension at most 256");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
@@ -348,7 +349,9 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
     }
 
 
-    if (max_seqlen_k > 0) {
+    // An empty batch or key sequence has no work: the tensors allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && max_seqlen_k > 0) {
         auto drop_seed_offset = std::make_pair(rng_state_ptr, rng_state_ptr + 1);
         auto stream = at::cuda::getCurrentCUDAStream().stream();
         ck_tile::stream_config stream_config{stream};
@@ -382,7 +385,8 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
     }
     else {
-        // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran. Both are empty when batch_size == 0; when only max_seqlen_k is 0
+        // they are not, and attention over no keys is defined as zeros with an lse of inf.
         out.zero_();
         softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3024,6 +3024,52 @@ class TestSDPAAccelerator(NNTestCase):
     _do_cuda_non_default_stream = True
     hw_classification = HardwareClassification.ACCELERATOR
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention is not supported on this system")
+    def test_fused_attention_empty_batch(self, device):
+        # Attention over zero rows is an empty result, not an error. The composite
+        # scaled_dot_product_attention short-circuits an empty input before dispatching,
+        # so only a caller that reaches the backend op directly -- as a compiled graph
+        # does -- exercises this. ROCm used to abort here with "batch size must be
+        # positive" while CUDA returned the empty result.
+        dtype = torch.bfloat16
+        num_heads, seqlen, head_dim = 4, 8, 64
+
+        prev_fa_library = None
+        if TEST_WITH_ROCM:
+            # The internal build ships composable kernels, not AOTriton.
+            prev_fa_library = torch.backends.cuda.preferred_rocm_fa_library()
+            torch.backends.cuda.preferred_rocm_fa_library("ck")
+        try:
+            shape = (0, num_heads, seqlen, head_dim)
+            q, k, v = (torch.randn(shape, device=device, dtype=dtype) for _ in range(3))
+
+            out, lse = torch.ops.aten._scaled_dot_product_flash_attention(q, k, v)[:2]
+            self.assertEqual(out.shape, torch.Size(shape))
+            self.assertEqual(out.dtype, dtype)
+            self.assertEqual(lse.shape, torch.Size((0, num_heads, seqlen)))
+
+            # The remaining entries are ROCm-only. CUDA implements the empty-batch early
+            # return in mha_fwd and mha_bwd but not in mha_varlen_fwd, whose
+            # TORCH_CHECK(batch_size > 0) still aborts (flash_api.cpp), and its
+            # mem-efficient path is separate code that makes no such guarantee.
+            if not TEST_WITH_ROCM:
+                return
+
+            eff_out = torch.ops.aten._scaled_dot_product_efficient_attention(
+                q, k, v, None, False)[0]
+            self.assertEqual(eff_out.shape, torch.Size(shape))
+
+            # Varlen entry: zero sequences, so cu_seqlens degenerates to a single 0.
+            varlen_shape = (0, num_heads, head_dim)
+            qv = torch.randn(varlen_shape, device=device, dtype=dtype)
+            cu_seqlens = torch.zeros(1, device=device, dtype=torch.int32)
+            varlen_out = torch.ops.aten._flash_attention_forward(
+                qv, qv, qv, cu_seqlens, cu_seqlens, 0, 0, 0.0, False, False, scale=None)[0]
+            self.assertEqual(varlen_out.shape, torch.Size(varlen_shape))
+        finally:
+            if prev_fa_library is not None:
+                torch.backends.cuda.preferred_rocm_fa_library(prev_fa_library)
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
     def test_cudnn_attention_decode_disabled_on_affected_blackwell(self, device):
         # See #193893 and #194927 for reasoning


### PR DESCRIPTION
Summary:

Attention over zero rows is an empty result, not an error, and CUDA returns it. The ROCm
CK entries instead abort with "batch size must be positive" (`mha_fwd_ck.hip:280`,
`mha_varlen_fwd_ck.hip:246`), so the same graph serves fine on CUDA and dies on AMD. Eager
code rarely notices, because the composite `scaled_dot_product_attention` guards
`numel == 0` and returns zeros; a compiled graph does not get that guard, since the sizes
are symbolic at trace time and it is traced away, leaving AOTI to call the backend op
directly. PrismNet hits this whenever no request routes to a segment and its attention
tower is handed zero rows -- normal at serving, and every other op in the graph absorbs it.

Both files already have a "nothing to compute" branch for `seqlen_k == 0`, so rather than
add a hand-written empty tuple this drops the check and extends that branch to an empty
batch. At zero rows the allocations above it are already the correct empty result, which
means only the kernel launch is skipped and the empty and non-empty paths cannot drift
apart in shape or dtype. While in `mha_fwd_ck`, the two `drop_seed_offset` assignments move
above the branch as well: they were set only on the launching path, but the
`p_dropout > 0` epilogue below dereferences them unconditionally.

Measured on a local MI300X, zero-row `_scaled_dot_product_flash_attention`,
`_scaled_dot_product_efficient_attention` and `_flash_attention_forward` now all return the
empty result instead of aborting. Probing the rest of the DHEN op mix at zero rows found
nothing else to fix -- linear, addmm, matmul, layer_norm, softmax, bmm, baddbmm, cat and sum
all already absorb an empty batch -- so attention was the only gap.

Test Plan:
buck2 test fbcode//mode/opt-amd-gpu -c fbcode.rocm_arch=mi300 fbcode//caffe2/test:test_transformers_cuda -- --regex 'test_fused_attention_empty_batch'

https://www.internalfb.com/intern/testinfra/testrun/22236523204207138

Reviewed By: kqfu

Differential Revision: D118577322




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang