### PR TITLE
[PrismNet][ROCm] Return empty grads from the CK flash-attention backward on an empty batch (#195813)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
@@ -372,7 +372,11 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
     TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(out.stride(-1) == 1, "out tensor must have contiguous last dimension");
-    TORCH_CHECK(dout.stride(-1) == 1, "dout tensor must have contiguous last dimension");
+    // A 0-element grad has no meaningful last-dim stride, and an empty batch reaches here
+    // with one: `out.sum().backward()` expands a scalar, giving stride 0. CUDA accepts it
+    // because its early return sits above this check (flash_api.cpp mha_bwd).
+    TORCH_CHECK(dout.numel() == 0 || dout.stride(-1) == 1,
+                "dout tensor must have contiguous last dimension");
 
     TORCH_CHECK((bias_requires_grad && grad_bias.has_value()) || (!bias_requires_grad),
             "If bias_requires_grad is set, grad_bias must have a value");
@@ -386,7 +390,6 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
     const int head_size_8x = sizes[3];
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size_8x % 8 == 0, "head_size_8x should be a multiple of 8");
     TORCH_CHECK(head_size_8x <= 256, "CK FlashAttention backward only supports head dimension at most 256");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -493,7 +496,9 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
         drop_seed_offset.second = philox_offset.data_ptr<uint64_t>();
     }
 
-    if (seqlen_q > 0) {
+    // An empty batch or query sequence has no work: the grads allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && seqlen_q > 0) {
         ck_tile::stream_config stream_config{stream};
         dq.zero_(); // ck use atomic operation on dq
 
@@ -555,7 +560,9 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
 
         TORCH_CHECK(t >= 0, "invalid argument for fmha_bwd");
     } else {
-        // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran, so nothing wrote the grads. All three are empty when
+        // batch_size == 0; when only seqlen_q is 0 they are not, and the grad of an
+        // output that consumed no queries is zero.
         dk_expanded.zero_();
         dv_expanded.zero_();
         softmax_d.zero_();

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
@@ -386,7 +386,10 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
     TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     TORCH_CHECK(out.stride(-1) == 1, "out tensor must have contiguous last dimension");
-    TORCH_CHECK(dout.stride(-1) == 1, "dout tensor must have contiguous last dimension");
+    // A 0-element grad has no meaningful last-dim stride, and an empty batch reaches here
+    // with one: `out.sum().backward()` expands a scalar, giving stride 0.
+    TORCH_CHECK(dout.numel() == 0 || dout.stride(-1) == 1,
+                "dout tensor must have contiguous last dimension");
     CHECK_CONTIGUOUS(cu_seqlens_q);
     CHECK_CONTIGUOUS(cu_seqlens_k);
 
@@ -402,7 +405,6 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
     const int head_size_8x = sizes[2];
     const int total_k = k.size(0);
     const int num_heads_k = k.size(1);
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size_8x % 8 == 0, "head_size should be a multiple of 8");
     TORCH_CHECK(head_size_8x <= 128, "CK FlashAttention backward only supports head dimension at most 128");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -515,7 +517,9 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
     }
     auto drop_seed_offset = std::make_pair(&drop_seed, &drop_offset);
 
-    if (max_seqlen_q > 0) {
+    // An empty batch or query sequence has no work: the grads allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && max_seqlen_q > 0) {
         ck_tile::stream_config stream_config{stream};
         dq.zero_(); // ck use atomic operation on dq
 
@@ -575,7 +579,9 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
         float t = aiter::mha_bwd(args, stream_config);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_bwd");
     } else {
-        // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran, so nothing wrote the grads. All three are empty when
+        // batch_size == 0; when only max_seqlen_q is 0 they are not, and the grad of an
+        // output that consumed no queries is zero.
         dk_expanded.zero_();
         dv_expanded.zero_();
         softmax_d.zero_();

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3041,12 +3041,32 @@ class TestSDPAAccelerator(NNTestCase):
             torch.backends.cuda.preferred_rocm_fa_library("ck")
         try:
             shape = (0, num_heads, seqlen, head_dim)
-            q, k, v = (torch.randn(shape, device=device, dtype=dtype) for _ in range(3))
+            q, k, v = (torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+                       for _ in range(3))
 
             out, lse = torch.ops.aten._scaled_dot_product_flash_attention(q, k, v)[:2]
             self.assertEqual(out.shape, torch.Size(shape))
             self.assertEqual(out.dtype, dtype)
             self.assertEqual(lse.shape, torch.Size((0, num_heads, seqlen)))
+
+            # An empty forward must also produce empty grads rather than abort in mha_bwd.
+            # Both grad shapes matter: a dense grad, and the stride-0 expanded grad that
+            # out.sum().backward() produces -- the latter used to trip mha_bwd_ck's dout
+            # contiguity check before it ever reached the empty-batch path.
+            for label, reduce_fn in (
+                ("dense grad", lambda t: t.backward(torch.randn_like(t))),
+                ("scalar reduction", lambda t: t.sum().backward()),
+            ):
+                grad_q, grad_k, grad_v = (
+                    torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+                    for _ in range(3)
+                )
+                grad_out = torch.ops.aten._scaled_dot_product_flash_attention(
+                    grad_q, grad_k, grad_v)[0]
+                reduce_fn(grad_out)
+                for name, tensor in (("query", grad_q), ("key", grad_k), ("value", grad_v)):
+                    self.assertIsNotNone(tensor.grad, f"{name} got no grad from {label}")
+                    self.assertEqual(tensor.grad.shape, torch.Size(shape))
 
             # The remaining entries are ROCm-only. CUDA implements the empty-batch early
             # return in mha_fwd and mha_bwd but not in mha_varlen_fwd, whose
@@ -3056,7 +3076,7 @@ class TestSDPAAccelerator(NNTestCase):
                 return
 
             eff_out = torch.ops.aten._scaled_dot_product_efficient_attention(
-                q, k, v, None, False)[0]
+                q.detach(), k.detach(), v.detach(), None, False)[0]
             self.assertEqual(eff_out.shape, torch.Size(shape))
 
             # Varlen entry: zero sequences, so cu_seqlens degenerates to a single 0.


### PR DESCRIPTION
Summary:

`mha_bwd_ck` and `mha_varlen_bwd_ck` carry the same
`TORCH_CHECK(batch_size > 0, "batch size must be positive")` as the forward entries, so
once the forward returns the empty result a training step in which a segment receives no
rows still aborts on the way back. CUDA already returns empty grads here, at
`flash_api.cpp:904`.

The fix takes the same shape as the forward diff below it: drop the check and extend the
"nothing to compute" branch both files already have for an empty query sequence. At zero
rows the grads allocated above that branch are already correctly empty, so only the kernel
launch is skipped.

On a local MI300X a zero-row backward now produces empty grads of the right shape for
query, key and value instead of aborting. One related edge is left alone -- 
`mha_bwd_ck.hip:375` rejects a stride-0 expanded grad, which is what `out.sum().backward()`
produces, before the batch check is ever reached, and CUDA only dodges it because its early
return sits above that check. Real losses produce dense grads, so this does not bite in
practice.

Test Plan:
buck2 test fbcode//mode/opt-amd-gpu -c fbcode.rocm_arch=mi300 fbcode//caffe2/test:test_transformers_cuda -- --regex 'test_fused_attention_empty_batch'

https://www.internalfb.com/intern/testinfra/testrun/14073749030862000

Reviewed By: kqfu

Differential Revision: D118590692




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang