### PR TITLE
[PrismNet][ROCm] Mirror the empty-batch skip in the AOTriton flash-attention forward (#195814)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -185,7 +185,6 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   const int head_size_og = sizes[3];
   const int seqlen_k = k.size(1);
   const int num_heads_k = k.size(2);
-  TORCH_CHECK(batch_size > 0, "batch size must be positive");
   TORCH_CHECK(head_size_og % 8 == 0, "head_size must be a multiple of 8, this is ensured by padding!");
   TORCH_CHECK(head_size_og <= 512, "FlashAttention on ROCm forward only supports head dimension at most 512");
   TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -254,6 +253,13 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   at::Tensor atomic_counter;
   if (is_causal) {
     atomic_counter = at::zeros({1}, opts.dtype(at::kInt));
+  }
+
+  // An empty batch has no work: the tensors allocated above are already the correct
+  // empty result, so skip the launch rather than reject it.
+  if (batch_size == 0) {
+    return {out, q_padded, k_padded, v_padded,
+            M.view({batch_size, num_heads, seqlen_q}), seed_t, offset_t, softmax_fa_t};
   }
 
   hipError_t err; // TODO: Error handling

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_bwd_ck.hip
@@ -386,7 +386,6 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
     const int head_size_8x = sizes[3];
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size_8x % 8 == 0, "head_size_8x should be a multiple of 8");
     TORCH_CHECK(head_size_8x <= 256, "CK FlashAttention backward only supports head dimension at most 256");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -493,7 +492,9 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
         drop_seed_offset.second = philox_offset.data_ptr<uint64_t>();
     }
 
-    if (seqlen_q > 0) {
+    // An empty batch or query sequence has no work: the grads allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && seqlen_q > 0) {
         ck_tile::stream_config stream_config{stream};
         dq.zero_(); // ck use atomic operation on dq
 
@@ -555,7 +556,9 @@ mha_bwd_ck(const at::Tensor &dout,                   // batch_size x seqlen_q x 
 
         TORCH_CHECK(t >= 0, "invalid argument for fmha_bwd");
     } else {
-        // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran, so nothing wrote the grads. All three are empty when
+        // batch_size == 0; when only seqlen_q is 0 they are not, and the grad of an
+        // output that consumed no queries is zero.
         dk_expanded.zero_();
         dv_expanded.zero_();
         softmax_d.zero_();

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -277,7 +277,6 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     const int head_size = sizes[3];
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size <= 256, "CK only supports head dimension at most 256");
     TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -412,9 +411,13 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     {
       attn_bias = attn_bias_;
     }
-    if (seqlen_k > 0) {
-        drop_seed_offset.first = rng_state[0].data_ptr<uint64_t>();
-        drop_seed_offset.second = rng_state[1].data_ptr<uint64_t>();
+    // Read below by the p_dropout > 0 epilogue, which runs whether or not the kernel does.
+    drop_seed_offset.first = rng_state[0].data_ptr<uint64_t>();
+    drop_seed_offset.second = rng_state[1].data_ptr<uint64_t>();
+
+    // An empty batch or key sequence has no work: the tensors allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && seqlen_k > 0) {
         auto stream = at::cuda::getCurrentHIPStream().stream();
         ck_tile::stream_config stream_config{stream};
 
@@ -452,7 +455,8 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
     }
     else {
-        // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran. Both are empty when batch_size == 0; when only seqlen_k is 0
+        // they are not, and attention over no keys is defined as zeros with an lse of inf.
         out.zero_();
         softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_bwd_ck.hip
@@ -402,7 +402,6 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
     const int head_size_8x = sizes[2];
     const int total_k = k.size(0);
     const int num_heads_k = k.size(1);
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size_8x % 8 == 0, "head_size should be a multiple of 8");
     TORCH_CHECK(head_size_8x <= 128, "CK FlashAttention backward only supports head dimension at most 128");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -515,7 +514,9 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
     }
     auto drop_seed_offset = std::make_pair(&drop_seed, &drop_offset);
 
-    if (max_seqlen_q > 0) {
+    // An empty batch or query sequence has no work: the grads allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && max_seqlen_q > 0) {
         ck_tile::stream_config stream_config{stream};
         dq.zero_(); // ck use atomic operation on dq
 
@@ -575,7 +576,9 @@ mha_varlen_bwd_ck(const at::Tensor &dout,                   // total_q x num_hea
         float t = aiter::mha_bwd(args, stream_config);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_bwd");
     } else {
-        // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran, so nothing wrote the grads. All three are empty when
+        // batch_size == 0; when only max_seqlen_q is 0 they are not, and the grad of an
+        // output that consumed no queries is zero.
         dk_expanded.zero_();
         dv_expanded.zero_();
         softmax_d.zero_();

--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_varlen_fwd_ck.hip
@@ -243,7 +243,8 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
     const int total_q = q.size(0);
     const int total_k = k.size(0);
 
-    TORCH_CHECK(batch_size > 0, "batch size must be positive");
+    // batch_size is cu_seqlens_q.numel() - 1, so an empty cu_seqlens makes it negative.
+    TORCH_CHECK(batch_size >= 0, "cu_seqlens_q must have at least one element");
     TORCH_CHECK(head_size_og <= 256, "CK only supports head dimension at most 256");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
@@ -348,7 +349,9 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
     }
 
 
-    if (max_seqlen_k > 0) {
+    // An empty batch or key sequence has no work: the tensors allocated above are
+    // already the correct empty result, so skip the launch rather than reject it.
+    if (batch_size > 0 && max_seqlen_k > 0) {
         auto drop_seed_offset = std::make_pair(rng_state_ptr, rng_state_ptr + 1);
         auto stream = at::cuda::getCurrentCUDAStream().stream();
         ck_tile::stream_config stream_config{stream};
@@ -382,7 +385,8 @@ mha_varlen_fwd_ck(const at::Tensor &q,                   // total_q x num_heads 
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
     }
     else {
-        // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
+        // No kernel ran. Both are empty when batch_size == 0; when only max_seqlen_k is 0
+        // they are not, and attention over no keys is defined as zeros with an lse of inf.
         out.zero_();
         softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2983,15 +2983,29 @@ class TestSDPACudaOnly(NNTestCase):
             torch.backends.cuda.preferred_rocm_fa_library("ck")
         try:
             shape = (0, num_heads, seqlen, head_dim)
-            q, k, v = (torch.randn(shape, device=device, dtype=dtype) for _ in range(3))
+            q, k, v = (torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+                       for _ in range(3))
 
             out, lse = torch.ops.aten._scaled_dot_product_flash_attention(q, k, v)[:2]
             self.assertEqual(out.shape, torch.Size(shape))
             self.assertEqual(out.dtype, dtype)
             self.assertEqual(lse.shape, torch.Size((0, num_heads, seqlen)))
 
+            # An empty forward must also produce empty grads rather than abort in mha_bwd.
+            out.backward(torch.randn_like(out))
+            for name, tensor in (("query", q), ("key", k), ("value", v)):
+                self.assertIsNotNone(tensor.grad, f"{name} received no grad")
+                self.assertEqual(tensor.grad.shape, torch.Size(shape))
+
+            # The remaining entries are ROCm-only. CUDA implements the empty-batch early
+            # return in mha_fwd and mha_bwd but not in mha_varlen_fwd, whose
+            # TORCH_CHECK(batch_size > 0) still aborts (flash_api.cpp), and its
+            # mem-efficient path is separate code that makes no such guarantee.
+            if not TEST_WITH_ROCM:
+                return
+
             eff_out = torch.ops.aten._scaled_dot_product_efficient_attention(
-                q, k, v, None, False)[0]
+                q.detach(), k.detach(), v.detach(), None, False)[0]
             self.assertEqual(eff_out.shape, torch.Size(shape))
 
             # Varlen entry: zero sequences, so cu_seqlens degenerates to a single 0.

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2966,6 +2966,45 @@ class TestSDPACudaOnly(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention is not supported on this system")
+    def test_fused_attention_empty_batch(self, device):
+        # Attention over zero rows is an empty result, not an error. The composite
+        # scaled_dot_product_attention short-circuits an empty input before dispatching,
+        # so only a caller that reaches the backend op directly -- as a compiled graph
+        # does -- exercises this. ROCm used to abort here with "batch size must be
+        # positive" while CUDA returned the empty result.
+        dtype = torch.bfloat16
+        num_heads, seqlen, head_dim = 4, 8, 64
+
+        prev_fa_library = None
+        if TEST_WITH_ROCM:
+            # The internal build ships composable kernels, not AOTriton.
+            prev_fa_library = torch.backends.cuda.preferred_rocm_fa_library()
+            torch.backends.cuda.preferred_rocm_fa_library("ck")
+        try:
+            shape = (0, num_heads, seqlen, head_dim)
+            q, k, v = (torch.randn(shape, device=device, dtype=dtype) for _ in range(3))
+
+            out, lse = torch.ops.aten._scaled_dot_product_flash_attention(q, k, v)[:2]
+            self.assertEqual(out.shape, torch.Size(shape))
+            self.assertEqual(out.dtype, dtype)
+            self.assertEqual(lse.shape, torch.Size((0, num_heads, seqlen)))
+
+            eff_out = torch.ops.aten._scaled_dot_product_efficient_attention(
+                q, k, v, None, False)[0]
+            self.assertEqual(eff_out.shape, torch.Size(shape))
+
+            # Varlen entry: zero sequences, so cu_seqlens degenerates to a single 0.
+            varlen_shape = (0, num_heads, head_dim)
+            qv = torch.randn(varlen_shape, device=device, dtype=dtype)
+            cu_seqlens = torch.zeros(1, device=device, dtype=torch.int32)
+            varlen_out = torch.ops.aten._flash_attention_forward(
+                qv, qv, qv, cu_seqlens, cu_seqlens, 0, 0, 0.0, False, False, scale=None)[0]
+            self.assertEqual(varlen_out.shape, torch.Size(varlen_shape))
+        finally:
+            if prev_fa_library is not None:
+                torch.backends.cuda.preferred_rocm_fa_library(prev_fa_library)
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
     def test_cudnn_attention_decode_disabled_on_affected_blackwell(self, device):
         # See #193893 and #194927 for reasoning


### PR DESCRIPTION
Summary:

`mha_fwd_aot` carries the same `TORCH_CHECK(batch_size > 0, ...)` as the CK entries, so an
OSS ROCm build, which selects AOTriton by default, still aborts on an empty batch even with
the two CK diffs below applied. The fix returns the tensors already allocated above the
launch -- at zero rows they are the correct empty result -- instead of rejecting the call.

There is no internal result to report, and that is why this is a separate diff.
`hip/flash_attn/fb/aotriton.cpp` replaces all four `*_aot` entries with stubs that raise
"AOTriton is not supported in the internal stack", and the internal build links those stubs
rather than this file: `mha_all_aot.hip` appears only in the `caffe2:torch_sources` and
`caffe2:src-files` source lists, with no compile rule of its own, unlike its CK sibling
which is additionally owned by `caffe2:ATen-hip-ck`. So no internal test can reach the
changed line. Upstream ROCm CI covers it after the ShipIt sync. Keeping it out of the CK
diffs means their hardware-verified claim stays clean.

Test Plan:
Not testable internally. `hip/flash_attn/fb/aotriton.cpp` replaces all four `*_aot`
entries with stubs that raise "AOTriton is not supported in the internal stack", so no
fbcode target compiles this file. Covered by upstream ROCm CI after the ShipIt sync.

The two CK diffs below carry the hardware-verified coverage:
https://www.internalfb.com/intern/testinfra/testrun/22236523204207138

Reviewed By: kqfu

Differential Revision: D118590695




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang