### PR TITLE
[Inductor] Decompose functional wrappers with E8M0 inputs

### DIFF
--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -59,6 +59,34 @@ class AutoFunctionalizeTests(torch._inductor.test_case.TestCase):
 
             f(x, out)
 
+    def _test_auto_functionalize_e8m0_input(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::foo",
+                "(Tensor(a!) x) -> ()",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl("mylib::foo", "cpu", lib=lib)
+            @torch._dynamo.disable
+            def foo_impl(x):
+                pass
+
+            def f(x):
+                torch.ops.mylib.foo(x)
+
+            x = torch.full((2,), 127, dtype=torch.uint8).view(torch.float8_e8m0fnu)
+            torch.compile(f, backend="inductor", fullgraph=True)(x)
+
+    @torch._inductor.config.patch(enable_auto_functionalized_v2=False)
+    def test_auto_functionalize_e8m0_input(self):
+        self._test_auto_functionalize_e8m0_input()
+
+    @torch._inductor.config.patch(enable_auto_functionalized_v2=True)
+    def test_auto_functionalize_v2_e8m0_input(self):
+        self._test_auto_functionalize_e8m0_input()
+
     def test_auto_functionalize_self_as_mutate_arg(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
             lib.define("foo(Tensor(a!) self) -> None")

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -497,6 +497,46 @@ class KernelTests(torch._inductor.test_case.TestCase):
         # Make sure it is NOT modified
         self.assertEqual(output, torch.zeros_like(t1))
 
+    @requires_cuda_and_triton
+    def test_triton_kernel_functional_e8m0_arg(self):
+        from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
+        from torch._inductor.fx_passes.post_grad import (
+            decompose_triton_kernel_wrapper_functional,
+        )
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        kernel_side_table.reset_table()
+        kernel_idx = kernel_side_table.add_kernel(add_kernel_with_optional_param)
+        constant_args_idx = kernel_side_table.add_constant_args(
+            {"n_elements": 16, "ARGS_PASSED": "one", "BLOCK_SIZE": 16}
+        )
+
+        def copy_e8m0(scale, output):
+            out = triton_kernel_wrapper_functional(
+                kernel_idx=kernel_idx,
+                constant_args_idx=constant_args_idx,
+                grid=[(1,)],
+                tma_descriptor_metadata={},
+                kwargs={
+                    "in_ptr0": scale,
+                    "in_ptr1": scale,
+                    "out_ptr": output,
+                },
+                tensors_to_clone=["out_ptr"],
+            )
+            return out["out_ptr"]
+
+        raw_scale = torch.arange(16, dtype=torch.uint8, device=GPU_TYPE)
+        scale_e8m0 = raw_scale.view(torch.float8_e8m0fnu)
+        output = torch.zeros_like(raw_scale)
+        gm = make_fx(copy_e8m0, tracing_mode="fake")(scale_e8m0, output)
+        decompose_triton_kernel_wrapper_functional(gm.graph)
+        functional_nodes = gm.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.higher_order.triton_kernel_wrapper_functional,
+        )
+        self.assertEqual(len(functional_nodes), 0)
+
     @requires_gpu
     def test_triton_kernel_functionalize(self):
         from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2833,6 +2833,17 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
         if not node:
             return True
 
+        # These HOPs are structural wrappers that must be decomposed before
+        # lowering. Allowing their decomposition does not imply arithmetic
+        # support for float8_e8m0fnu; the decomposed operations are checked
+        # independently.
+        if node.target in (
+            torch.ops.higher_order.auto_functionalized,
+            torch.ops.higher_order.auto_functionalized_v2,
+            torch.ops.higher_order.triton_kernel_wrapper_functional,
+        ):
+            return False
+
         # Allow bitcasts, views, memory movement, and supported conversions,
         # but not arithmetic.
         # TODO: delete once triton adds native support


### PR DESCRIPTION
## Summary

Fixes #189522.

`fallback_node_due_to_unsupported_type` treats `float8_e8m0fnu` as unsupported except for a small set of view and memory operations. This also caused the following structural higher-order operators to be skipped by their decomposition passes:

- `auto_functionalized`
- `auto_functionalized_v2`
- `triton_kernel_wrapper_functional`

These wrappers are not lowered directly and must be decomposed. Skipping them leaves the wrapper in the graph and triggers assertions such as:

```text
auto_functionalized_v2 was not removed
```

This change allows these structural wrappers through the E8M0-specific check. It does not enable E8M0 arithmetic: operations produced by decomposition are still checked independently during lowering.

## Tests

Added regression coverage for:

- `auto_functionalized` with an E8M0 mutable custom-op argument.
- `auto_functionalized_v2` with an E8M0 mutable custom-op argument.
- `triton_kernel_wrapper_functional` with an E8M0 input using an existing pass-through Triton kernel.

@eellison @jansel @zou3519 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo