### PR TITLE
Update native_functions.yaml for register linalg.cholesky for XPU

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14249,7 +14249,7 @@
   python_module: linalg
   structured: True
   dispatch:
-    CPU, CUDA, MPS: linalg_cholesky_ex_out
+    CPU, CUDA, MPS, XPU: linalg_cholesky_ex_out
 
 - func: linalg_cholesky(Tensor self, *, bool upper=False) -> Tensor
   python_module: linalg


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/1936
Added support for XPU linalg cholesky, It's needed for pytorch to see operator defined for torch-xpu-ops.
Implementation will come in separate PR.
 