### PR TITLE
Add __init__.pyi.in to XPU merge rule patterns

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -517,6 +517,7 @@
   - '**XPU**'
   - '**sycl**'
   - '**SYCL**'
+  - torch/_C/__init__.pyi.in
   approved_by:
   - EikanWang
   - jgong5


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #195826

# Motivation
Add `__init__.pyi.in` to the XPU merge rule patterns. This will reduce the maintenance effort for maintainers, improving the efficiency of ongoing XPU feature development and alignment.