### PR TITLE
torch/_native: one CuTeDSL kernel for the chunked linear_cross_entropy backward

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -513,8 +513,15 @@ test_python_smoke_b200() {
   # The CuTeDSL linear_cross_entropy overrides: the routing test, and the OpInfo
   # variants that only exist where the CuTeDSL runtime does, so they are
   # collected nowhere else.
-  time python test/run_test.py --include python_native/test_linear_cross_entropy_override $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include \
+    python_native/test_linear_cross_entropy_override \
+    python_native/test_lce_fused_grad_logits_kernel \
+    $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time env OPINFO_RESTRICT_TO_DSL=cutedsl python test/run_test.py --include test_ops -k linear_cross_entropy $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  # The op's own accuracy harness: fp16/bf16 against an fp64 reference with
+  # calibrated tolerances. It runs in every CUDA job, but only here is the DSL
+  # installed, so only here does it measure the override rather than eager.
+  time python test/run_test.py --include test_nn -k linear_cross_entropy $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
 
   time python test/run_test.py --include test_linalg -k "mm or addmv" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty

--- a/test/python_native/test_lce_fused_grad_logits_kernel.py
+++ b/test/python_native/test_lce_fused_grad_logits_kernel.py
@@ -1,0 +1,281 @@
+# Owner(s): ["module: dsl-native-ops"]
+#
+# Numerics for the CuTeDSL kernel that computes the row statistics and the
+# softmax-gradient transform together, used by the `fused` variant of the
+# chunked linear_cross_entropy overrides. Checked on its own, against a torch
+# expression of the same contract, before anything routes through it.
+
+import unittest
+
+import torch
+from torch._native import cutedsl_utils as cu
+from torch.testing._internal.common_cuda import SM80OrLater, TEST_CUDA
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+def _reference(logits, row_scale, target, out_dtype):
+    # The kernel widens every element it loads, so the reference reads the
+    # same values in fp32: what is compared is the kernel, not the buffer's
+    # rounding.
+    logits = logits.float()
+    row_max = logits.amax(dim=1, keepdim=True)
+    e = (logits - row_max).exp()
+    row_sum = e.sum(dim=1)
+    g = e * (row_scale / row_sum).unsqueeze(1)
+    rows = torch.arange(logits.shape[0], device=logits.device)
+    g[rows, target] -= row_scale
+    return (
+        g.to(out_dtype),
+        row_max.squeeze(1) + row_sum.log(),
+        logits[rows, target],
+    )
+
+
+def _outputs(num_rows, V, dtype, device="cuda", row_stride=None):
+    if row_stride is None:
+        g = torch.empty(num_rows, V, device=device, dtype=dtype)
+    else:
+        # A wider row stride than V: the kernel indexes through the tensor's
+        # own strides, so this must work as well as the packed case.
+        g = torch.empty(num_rows, row_stride, device=device, dtype=dtype)[:, :V]
+    lse = torch.empty(num_rows, device=device, dtype=torch.float32)
+    target_logit = torch.empty(num_rows, device=device, dtype=torch.float32)
+    return g, lse, target_logit
+
+
+def _inputs(num_rows, V, device="cuda", logits_dtype=torch.float32):
+    logits = torch.randn(num_rows, V, device=device, dtype=torch.float32).to(
+        logits_dtype
+    )
+    row_scale = torch.rand(num_rows, device=device, dtype=torch.float32) + 0.5
+    target = torch.randint(0, V, (num_rows,), device=device)
+    return logits, row_scale, target
+
+
+# `skipIfNoCuteDSL` and `runtime_available()` only say the package is
+# installed. These tests call the kernel entry points DIRECTLY, with no `cond`
+# in front to decline an unsupported device, so they need the DSL's executable
+# floor -- documented as Ampere and later. (The kernel's own eligibility is a
+# validated-set membership instead, since capability is not an ordering.)
+@unittest.skipIf(not TEST_CUDA, "CuTeDSL kernels are CUDA-only")
+@unittest.skipIf(not SM80OrLater, "the CuTeDSL runtime requires sm_80 or later")
+class TestFusedGradLogitsKernel(TestCase):
+    def setUp(self):
+        super().setUp()
+        if not cu.runtime_available() or cu.check_native_jit_disabled():
+            self.skipTest("CuTeDSL runtime unavailable or native DSL disabled")
+        from torch._native.ops.linear_cross_entropy import fused_grad_logits_kernel
+
+        self.kernel = fused_grad_logits_kernel
+
+    def _run(self, logits, row_scale, target, dtype, row_stride=None):
+        g, lse, target_logit = _outputs(*logits.shape, dtype, row_stride=row_stride)
+        self.kernel.fused_grad_logits_into(
+            g, lse, target_logit, logits, row_scale, target
+        )
+        return g, lse, target_logit
+
+    def _check(self, logits, row_scale, target, dtype, row_stride=None):
+        g, lse, target_logit = self._run(
+            logits, row_scale, target, dtype, row_stride=row_stride
+        )
+        want_g, want_lse, want_target_logit = _reference(
+            logits, row_scale, target, dtype
+        )
+        if dtype is torch.float32:
+            # The kernel's exponential is the hardware approximation and its
+            # row sum reduces in a different order than torch's.
+            self.assertEqual(g, want_g, atol=1e-6, rtol=1e-5)
+        else:
+            self.assertEqual(g, want_g)
+        self.assertEqual(lse, want_lse, atol=1e-4, rtol=1e-5)
+        # A copy, not a computation.
+        self.assertEqual(target_logit, want_target_logit)
+
+    @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize(
+        "num_rows, V",
+        [
+            (1, 7),  # V far below the block width: most threads see nothing
+            (4, 512),  # exactly the block width
+            (4, 513),  # one column past it
+            (37, 4097),  # neither dimension a multiple of the block width
+            (128, 32000),  # a realistic chunk
+        ],
+    )
+    def test_matches_reference(self, dtype, num_rows, V):
+        logits, row_scale, target = _inputs(num_rows, V)
+        self._check(logits, row_scale, target, dtype)
+
+    @parametrize("logits_dtype", [torch.bfloat16, torch.float16])
+    @parametrize("num_rows, V", [(4, 513), (128, 32000)])
+    def test_low_precision_logits_buffer(self, logits_dtype, num_rows, V):
+        """The buffer dtype is a compile-key axis: the kernel widens each
+        element on load, so the result must match the same values read in
+        fp32."""
+        logits, row_scale, target = _inputs(num_rows, V, logits_dtype=logits_dtype)
+        self._check(logits, row_scale, target, torch.bfloat16)
+
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @parametrize(
+        "num_rows, V",
+        [
+            (1, 7),  # below one tile
+            (4, 513),  # crosses the block width
+            (8, 2049),  # one column past a full staging group
+            (37, 4097),
+            (128, 32000),  # a realistic chunk, many staging groups
+        ],
+    )
+    def test_aliased_g_shares_the_logits_storage(self, dtype, num_rows, V):
+        """`g` written into the logits' own bytes, which is what makes a chunk
+        cost one buffer instead of two. `g[n, j]` occupies `z[n, j // 2]`, so
+        the kernel must order its writes against its reads; a stale read shows
+        up as a wrong value here. An element left unwritten would hold
+        reinterpreted fp32 bytes, so matching the reference everywhere also
+        proves full coverage -- the aliased buffer is its own sentinel.
+
+        The kernel takes `g`'s layout from the caller and orders its writes
+        either way, so this and the separate-buffer tests above exercise one
+        compiled mode."""
+        logits, row_scale, target = _inputs(num_rows, V)
+        source = logits.clone()
+        g, lse, target_logit = _outputs(num_rows, V, dtype)
+        g = logits.view(dtype).narrow(1, 0, V)
+        self.kernel.fused_grad_logits_into(
+            g, lse, target_logit, logits, row_scale, target
+        )
+        want_g, want_lse, want_target_logit = _reference(
+            source, row_scale, target, dtype
+        )
+        self.assertEqual(g, want_g)
+        self.assertEqual(lse, want_lse, atol=1e-4, rtol=1e-5)
+        # Read before any write could occupy its bytes.
+        self.assertEqual(target_logit, want_target_logit)
+
+    def test_monotonic_rows_rescale_every_element(self):
+        """Worst case for the online statistics: each thread walks its columns
+        in increasing order, so every element raises its running maximum and
+        rescales its running sum."""
+        num_rows, V = 8, 4096
+        logits = (
+            torch.arange(V, device="cuda", dtype=torch.float32)
+            .div(64.0)
+            .expand(num_rows, V)
+            .contiguous()
+        )
+        _, row_scale, target = _inputs(num_rows, V)
+        self._check(logits, row_scale, target, torch.float32)
+
+    def test_large_magnitudes_do_not_overflow(self):
+        """The row maximum is what keeps the exponentials finite; without the
+        shift these logits would give inf."""
+        num_rows, V = 8, 1024
+        logits, row_scale, target = _inputs(num_rows, V)
+        logits = logits + 10000.0
+        g, lse, _ = self._run(logits, row_scale, target, torch.float32)
+        self.assertTrue(torch.isfinite(g).all())
+        self.assertEqual(lse, _reference(logits, row_scale, target, torch.float32)[1])
+
+    def test_uniform_row_sums_to_the_class_count(self):
+        num_rows, V = 4, 2048
+        logits = torch.full((num_rows, V), 3.5, device="cuda", dtype=torch.float32)
+        _, row_scale, target = _inputs(num_rows, V)
+        _, lse, target_logit = self._run(logits, row_scale, target, torch.float32)
+        want = torch.full_like(lse, 3.5 + torch.tensor(float(V)).log().item())
+        self.assertEqual(lse, want, atol=1e-4, rtol=1e-6)
+        self.assertEqual(target_logit, torch.full_like(target_logit, 3.5))
+
+    def test_target_column_is_the_shifted_probability(self):
+        """The one-hot subtract is what replaces eager's index_add_, so the
+        target column is checked explicitly rather than only in aggregate."""
+        num_rows, V = 16, 512
+        logits, row_scale, target = _inputs(num_rows, V)
+        g, lse, _ = self._run(logits, row_scale, target, torch.float32)
+        rows = torch.arange(num_rows, device=g.device)
+        p_target = (logits[rows, target] - lse).exp()
+        self.assertEqual(
+            g[rows, target], (p_target - 1.0) * row_scale, atol=1e-6, rtol=1e-5
+        )
+        # Rows sum to ~0 for unit scale: sum_v p = 1 and one 1.0 is removed.
+        self.assertEqual(
+            (g / row_scale.unsqueeze(1)).sum(dim=1),
+            torch.zeros(num_rows, device=g.device),
+            atol=1e-4,
+            rtol=0,
+        )
+
+    def test_zero_row_scale_gives_a_zero_gradient(self):
+        """An ignored row carries scale 0, and its whole gradient row -- target
+        column included -- must be exactly zero."""
+        num_rows, V = 6, 300
+        logits, row_scale, target = _inputs(num_rows, V)
+        row_scale = torch.zeros_like(row_scale)
+        g, _, _ = self._run(logits, row_scale, target, torch.bfloat16)
+        self.assertEqual(g, torch.zeros_like(g))
+
+    def test_wider_row_stride(self):
+        logits, row_scale, target = _inputs(24, 100)
+        self._check(logits, row_scale, target, torch.bfloat16, row_stride=128)
+
+    @parametrize(
+        "meta",
+        [
+            {},
+            {"threads_per_block": 128},
+            {"tiles_per_stage": 1},
+            {"threads_per_block": 1024, "tiles_per_stage": 8},
+        ],
+    )
+    def test_shape_knobs_do_not_change_the_result(self, meta):
+        """`threads_per_block` and `tiles_per_stage` pick the block width and how
+        many column tiles pass 2 stages per barrier. They exist for tuning, so
+        every legal combination has to compute the same thing -- including the
+        write ordering, whose safety argument holds for any staging depth."""
+        logits, row_scale, target = _inputs(24, 4097)
+        g, lse, target_logit = _outputs(24, 4097, torch.bfloat16)
+        self.kernel.fused_grad_logits_into(
+            g, lse, target_logit, logits, row_scale, target, **meta
+        )
+        want_g, want_lse, _ = _reference(logits, row_scale, target, torch.bfloat16)
+        self.assertEqual(g, want_g)
+        self.assertEqual(lse, want_lse, atol=1e-4, rtol=1e-5)
+
+    @parametrize(
+        "meta, message",
+        [
+            ({"threads_per_block": 100}, "multiple of 32"),
+            ({"threads_per_block": 2048}, "multiple of 32"),
+            ({"tiles_per_stage": 0}, "at least 1"),
+            ({"tiles_pre_stage": 4}, "unknown meta parameters"),
+        ],
+    )
+    def test_illegal_shape_knobs_raise(self, meta, message):
+        """A typo or an out-of-range value must fail loudly rather than compile
+        something that silently drops per-warp partials (above 32 warps) or
+        never runs (a zero-tile stage)."""
+        logits, row_scale, target = _inputs(4, 64)
+        g, lse, target_logit = _outputs(4, 64, torch.bfloat16)
+        with self.assertRaisesRegex(ValueError, message):
+            self.kernel.fused_grad_logits_into(
+                g, lse, target_logit, logits, row_scale, target, **meta
+            )
+
+    def test_logits_are_not_modified(self):
+        """The buffer is read twice and never shifted in place, which is what
+        lets the caller skip eager's `sub_` and `exp_`."""
+        logits, row_scale, target = _inputs(16, 777)
+        before = logits.clone()
+        self._run(logits, row_scale, target, torch.bfloat16)
+        self.assertEqual(logits, before)
+
+
+instantiate_parametrized_tests(TestFusedGradLogitsKernel)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_linear_cross_entropy_override.py
+++ b/test/python_native/test_linear_cross_entropy_override.py
@@ -48,6 +48,10 @@ class TestLinearCrossEntropyOverride(TestCase):
             self.assertTrue(live, f"no live cutedsl override for {op_symbol}")
             self.assertIn(key, registry_module._override_libs)
 
+    @unittest.skipIf(
+        not TEST_CUDA or not cutedsl_impl._arch_supported(),
+        "the scalar op's kernel declines this device, so `mean` would not route",
+    )
     @parametrize("reduction", ["mean", "none"])
     def test_cutedsl_path_is_used(self, reduction):
         """A call must route to one of the registered overrides.
@@ -113,7 +117,13 @@ class TestLinearCrossEntropyOverride(TestCase):
 
         The shared accumulator is called if and only if a chunked op runs (the
         reference path uses linear + cross_entropy instead), so counting entries
-        into it is the same question the predicate answers.
+        into it is the same question the predicate answers -- but only while no
+        override REPLACES that call. The kernel, where it is eligible for the
+        sample, runs instead of the accumulator and makes the witness read
+        False for a sample that did reach the op, so the whole loop runs with
+        the cutedsl overrides disabled. That is also the honest scope: the predicate
+        describes the functional's gate, which is about whether a chunked op is
+        reached, not about which implementation answers.
 
         The predicate is evaluated in the same grad mode as the call it
         describes: one of its clauses reads ``torch.is_grad_enabled()``, so
@@ -131,11 +141,14 @@ class TestLinearCrossEntropyOverride(TestCase):
             if reduction == "none"
             else cmi.sample_inputs_linear_cross_entropy_chunked
         )
-        with unittest.mock.patch.object(
-            lce_module,
-            "_linear_cross_entropy_batch_chunked_accumulator",
-            wraps=lce_module._linear_cross_entropy_batch_chunked_accumulator,
-        ) as accumulator:
+        with (
+            torch.backends.python_native.cutedsl.disabled(),
+            unittest.mock.patch.object(
+                lce_module,
+                "_linear_cross_entropy_batch_chunked_accumulator",
+                wraps=lce_module._linear_cross_entropy_batch_chunked_accumulator,
+            ) as accumulator,
+        ):
             for i, sample in enumerate(
                 generator(None, "cuda", torch.float16, requires_grad), start=1
             ):
@@ -161,6 +174,75 @@ class TestLinearCrossEntropyOverride(TestCase):
                 0,
                 f"{generator.__name__} admits none of its samples",
             )
+
+    @unittest.skipIf(
+        not TEST_CUDA or not cutedsl_impl._arch_supported(),
+        "the kernel declines this device, so there is no kernel path to test "
+        "-- the call would fall back to eager",
+    )
+    def test_kernel_path_is_deterministic(self):
+        """Two identical calls must give bit-identical gradients.
+
+        The dense grad-logits formulation replaced eager's `index_add_` --
+        atomic on CUDA, and used there for both `grad_linear_weight` and
+        `grad_linear_bias` -- with a GEMM and a fixed-order column sum, so the
+        whole backward is deterministic. That is a user-visible property, and
+        the reason a bias-grad epilogue built on atomics was rejected, so it is
+        pinned here rather than left aspirational.
+        """
+        import torch.nn.modules.linear_cross_entropy as lce_module
+
+        torch.manual_seed(0)
+        num_batches, in_features, num_classes = 96, 64, 512
+        input = torch.randn(
+            num_batches, in_features, device="cuda", dtype=torch.bfloat16
+        )
+        linear_weight = (
+            torch.randn(num_classes, in_features, device="cuda", dtype=torch.bfloat16)
+            / in_features**0.5
+        )
+        linear_bias = torch.randn(num_classes, device="cuda", dtype=torch.bfloat16)
+        target = torch.randint(0, num_classes, (num_batches,), device="cuda")
+        options = LinearCrossEntropyOptions(
+            acc_policy="compact",
+            acc_dtype=torch.float32,
+            chunking_method=None,
+            batch_chunk_size=32,
+        )
+
+        def once():
+            leaves = [
+                t.detach().clone().requires_grad_()
+                for t in (input, linear_weight, linear_bias)
+            ]
+            loss = torch.nn.functional.linear_cross_entropy(
+                leaves[0], leaves[1], target, linear_bias=leaves[2], options=options
+            )
+            loss.backward()
+            return (loss.detach(), *(t.grad for t in leaves))
+
+        # The kernel replaces the accumulator, so any entry into it means the
+        # call fell back and this test never saw the kernel path.
+        with unittest.mock.patch.object(
+            lce_module,
+            "_linear_cross_entropy_batch_chunked_accumulator",
+            wraps=lce_module._linear_cross_entropy_batch_chunked_accumulator,
+        ) as accumulator:
+            first, second = once(), once()
+            self.assertEqual(
+                accumulator.call_count,
+                0,
+                "the call fell back to the accumulator, so this asserted "
+                "determinism of the eager path, not the kernel's",
+            )
+        names = ("loss", "grad_input", "grad_linear_weight", "grad_linear_bias")
+        for name, a, b in zip(names, first, second):
+            if not torch.equal(a, b):
+                self.fail(
+                    f"{name} differs between two identical runs (max abs diff "
+                    f"{(a - b).abs().max().item():.3e}), so the kernel path is "
+                    "not deterministic"
+                )
 
 
 instantiate_parametrized_tests(TestLinearCrossEntropyOverride)

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -421,6 +421,7 @@ class TestPublicBindings(TestCase):
             # runtime is missing, so it's safe to skip them here.
             cuda_dep_prefixes = (
                 "torch._native.ops.foreach_mm.",
+                "torch._native.ops.linear_cross_entropy.fused_grad_logits_kernel",
                 "torch._native.ops.polar.",
                 "torch._native.ops.reductions.inner_tree_kernel",
                 "torch._native.ops.scatter_add.",

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2809,6 +2809,7 @@ class TestImports(TestCase):
                            "torch._inductor.runtime.triton_helpers",  # depends on triton
                            "torch._native.ops.bmm_outer_product.triton_kernels",  # depends on triton
                            "torch._native.ops.foreach_mm",  # depends on nvmath-python, cuda-python
+                           "torch._native.ops.linear_cross_entropy.fused_grad_logits_kernel",  # depends on cutlass
                            "torch._native.ops.norm.flydsl_rmsnorm_fwd",  # depends on flydsl
                            "torch._native.ops.polar.nvmath_impl",  # depends on nvmath-python, cuda-python
                            "torch._native.ops.reductions.inner_tree_kernel",  # depends on cutlass

--- a/torch/_native/ops/linear_cross_entropy/cutedsl_impl.py
+++ b/torch/_native/ops/linear_cross_entropy/cutedsl_impl.py
@@ -13,6 +13,7 @@ read it again. Collapsing those passes is what a DSL kernel is for.
 registration loop and the tests both read it, so adding an override is one row.
 """
 
+import functools
 import importlib
 
 import torch
@@ -20,72 +21,8 @@ import torch
 from ... import cutedsl_utils as cu
 
 
-def _batch_chunked_cond(*args: object, **kwargs: object) -> bool:
-    # Where a kernel's eligibility gate goes: it returns True only for the
-    # shapes and dtypes that kernel implements, and the registry's router falls
-    # back to the op for everything else.
-    return True
-
-
-def _batch_chunked_impl(
-    input: torch.Tensor,
-    linear_weight: torch.Tensor,
-    target: torch.Tensor,
-    linear_bias: torch.Tensor | None,
-    weight: torch.Tensor | None,
-    reduction: str,
-    ignore_index: int,
-    label_smoothing: float,
-    batch_chunk_size: int,
-    acc_policy: str,
-    acc_dtype: torch.dtype,
-    allow_retain_graph: bool,
-    compute_input_grad: bool,
-    compute_linear_weight_grad: bool,
-    compute_linear_bias_grad: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    # Installing at a backend key means the op's body never runs, so its checks
-    # have to be run here. ``allow_retain_graph`` is a backward-only flag that
-    # neither the checks nor the accumulator take.
-    #
-    # A kernel replacing the accumulator call below also loses the checks
-    # *inside* it and must re-enforce those: the unresolved
-    # ``acc_policy`` / ``acc_dtype`` check, and ``_ChunkContext.build``'s
-    # ``linear_bias`` shape and ``acc_dtype`` compatibility checks.
-    from torch.nn.modules.linear_cross_entropy import (
-        _check_batch_chunked_grad_flags,
-        _linear_cross_entropy_batch_chunked_accumulator,
-    )
-
-    _check_batch_chunked_grad_flags(
-        input,
-        linear_weight,
-        target,
-        linear_bias,
-        compute_input_grad,
-        compute_linear_weight_grad,
-        compute_linear_bias_grad,
-    )
-    return _linear_cross_entropy_batch_chunked_accumulator(
-        input,
-        linear_weight,
-        target,
-        linear_bias,
-        weight,
-        reduction,
-        ignore_index,
-        label_smoothing,
-        batch_chunk_size,
-        acc_policy,
-        acc_dtype,
-        compute_input_grad,
-        compute_linear_weight_grad,
-        compute_linear_bias_grad,
-    )
-
-
 def _no_reduction_cond(*args: object, **kwargs: object) -> bool:
-    # As above: where this op's kernel gate goes.
+    # Where this op's kernel gate goes; nothing declines yet.
     return True
 
 
@@ -133,6 +70,283 @@ def _no_reduction_impl(
 # (op_symbol, cond, impl) for every override this module installs on the
 # `torch_nn` namespace. Single source of truth: the registration loop below and
 # test/python_native/test_linear_cross_entropy_override.py both read it.
+@functools.cache
+def _arch_supported(device_index: int = 0) -> bool:
+    """Whether the kernel can run on this device: the CuTeDSL runtime's floor.
+
+    8.0 is also where this path's own arithmetic becomes available -- the logits
+    matmul asks cuBLAS for an fp32 output from low-precision inputs, which is
+    rejected below it. A floor rather than a list of architectures this was
+    measured on is deliberate: waiting for a measurement on every capability,
+    minor revisions included, would keep the kernel off hardware it runs on
+    perfectly well. What is unmeasured below sm_90 is PERFORMANCE, not
+    correctness.
+
+    Called from `cond`, i.e. at dispatch and never at registration, so the
+    `cuInit` this performs cannot poison a fork before torch is used.
+    """
+    return torch.cuda.get_device_capability(device_index) >= (8, 0)
+
+
+def _kernel_eligible(
+    input: torch.Tensor,
+    linear_weight: torch.Tensor,
+    target: torch.Tensor,
+    linear_bias: torch.Tensor | None,
+    weight: torch.Tensor | None,
+    reduction: str,
+    ignore_index: int,
+    label_smoothing: float,
+    batch_chunk_size: int,
+    acc_policy: str,
+    acc_dtype: torch.dtype | None,
+    allow_retain_graph: bool,
+    compute_input_grad: bool,
+    compute_linear_weight_grad: bool,
+    compute_linear_bias_grad: bool,
+) -> bool:
+    """What the kernel implements. Shapes, dtypes and device only -- no data
+        reads, so this is safe under FakeTensor tracing.
+
+        Everything outside this set stays with the op: an ineligible input never
+        enters the override at all and the router falls back, which keeps "the
+        kernel ran" observable in a profile rather than hidden behind an internal
+        delegation.
+
+        The architecture condition is the DSL runtime's floor rather than a list of
+        architectures this was measured on -- see `_arch_supported`.
+
+    fp16 is eligible because eager keeps fp16 logits under `compact` (fp32
+        for bf16), so at fp16 a chunk is two bytes per element -- which this kernel
+        matches by aliasing `g` into the logits rather than allocating a second
+        buffer.
+    """
+    return (
+        input.device.type == "cuda"
+        and _arch_supported(input.device.index or 0)
+        and input.dtype in (torch.bfloat16, torch.float16)
+        and linear_weight.dtype is input.dtype
+        and acc_dtype is torch.float32
+        and acc_policy == "compact"
+        # Class-index targets; a probability target is (N, C) in the input
+        # dtype and a different algorithm.
+        and target.dtype is torch.int64
+        and target.dim() == 1
+        and reduction in ("mean", "sum")
+        and label_smoothing == 0.0
+        and input.dim() == 2
+        and linear_weight.dim() == 2
+    )
+
+
+def _batch_chunked_kernel(
+    input: torch.Tensor,
+    linear_weight: torch.Tensor,
+    target: torch.Tensor,
+    linear_bias: torch.Tensor | None,
+    weight: torch.Tensor | None,
+    reduction: str,
+    ignore_index: int,
+    label_smoothing: float,
+    batch_chunk_size: int,
+    acc_policy: str,
+    acc_dtype: torch.dtype,
+    allow_retain_graph: bool,
+    compute_input_grad: bool,
+    compute_linear_weight_grad: bool,
+    compute_linear_bias_grad: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Chunked loss and gradients with the softmax-gradient transform fused.
+
+    Same four outputs as the op, and the same chunking contract: the caller's
+    `batch_chunk_size` bounds the per-chunk footprint. What differs is the
+    middle of the loop. Eager walks the `(Bc, V)` logits buffer five more
+    times (row max, subtract, gather, `exp_`, row sum, scale) and then
+    scatters the one-hot correction into `grad_linear_weight` with
+    `index_add_`; here one kernel reads the logits once and writes the dense
+    gradient-of-logits `g`, which turns both parameter gradients into plain
+    GEMMs -- `grad_input = g @ W`, `grad_linear_weight = g^T @ X` -- and
+    removes the scatter entirely, so the result is also deterministic where
+    eager's was not.
+
+    The row statistics follow eager's buffer discipline rather than calling
+    `torch.logsumexp`: that is a composite which materializes `self - maxes`,
+    a full `(Bc, V)` fp32 temporary per chunk, which showed up as a peak-memory
+    regression against eager. Shifting and exponentiating in place costs the
+    same traffic and allocates nothing.
+
+    One launch computes the row statistics and `g` together from the raw
+    logits, so the shift, the `exp_` and the two reductions never run as
+    separate passes -- two reads of the logits buffer and one write of `g`,
+    against five more passes over it. The forward-only path (no gradient
+    requested) has no `g` to write, so it takes its statistics from eager ops;
+    fusing that path is B1's job, when its gate is met.
+
+    The logits buffer stays at `acc_dtype`, eager's parity. A low-precision
+    buffer was measured and dropped: it halves the buffer and the kernel's
+    reads of it, but bf16 stores the logits with absolute error ~|z| * 2^-9
+    while the softmax depends on their differences, so the gradients degrade
+    once |z| reaches the tens -- the regime a trained head operates in.
+
+    `g` is a view of the logits storage rather than a second buffer, which
+    reaches a low-precision buffer's footprint without its rounding: a chunk
+    costs one `(Bc, V)` buffer and no value loses precision. Only a kernel that
+    owns a whole row in one block can do this, since it has to order its writes
+    against its reads; a row split across blocks would need a grid-wide
+    barrier.
+
+    At fp16 the buffer follows eager down to two bytes per element, which makes
+    the aliasing overlap exact rather than half-offset, and is also why fp16 is
+    only offered where `inplace_g` is set: a separate `g` would double eager's
+    chunk footprint. The rounded fp16 logits carry eager's own accuracy
+    behaviour, measured and recorded in the plan -- what this path does not
+    inherit is the fp16 rounding of `exp()` and of the scaled gradient, which
+    stay in fp32 registers here.
+    """
+    from torch.nn.modules.linear_cross_entropy import (
+        _check_acc_dtype_compatible,
+        _check_batch_chunked_grad_flags,
+        _check_linear_bias_shape,
+        _check_resolved_acc,
+        _corrected_target,
+        _make_empty,
+        _make_zeros,
+        _neg_weight_target,
+    )
+
+    # Installed at a backend key, so the op's body never runs and its checks
+    # have to run here -- including the ones inside the accumulator this
+    # replaces.
+    _check_batch_chunked_grad_flags(
+        input,
+        linear_weight,
+        target,
+        linear_bias,
+        compute_input_grad,
+        compute_linear_weight_grad,
+        compute_linear_bias_grad,
+    )
+    _check_resolved_acc(acc_policy, acc_dtype)
+    _check_linear_bias_shape(linear_weight, linear_bias)
+    dtype = input.dtype
+    _check_acc_dtype_compatible(dtype, acc_dtype)
+
+    from .fused_grad_logits_kernel import fused_grad_logits_into
+
+    device = input.device
+    num_batches, _ = input.shape
+    num_classes = linear_weight.shape[0]
+
+    # Per-row prep from the op's own functions rather than a restatement of
+    # them: same clamped target, same class weight, mean divisor and ignored
+    # rows. The sign is the one difference -- the accumulator consumes
+    # `neg_weight_target * (onehot - softmax)` while the kernel writes
+    # `s * (softmax - onehot)` -- and the negation is in place on a tensor the
+    # function allocates fresh.
+    target_hat = _corrected_target(target, ignore_index, num_classes)
+    row_scale = _neg_weight_target(
+        target_hat, target == ignore_index, weight, acc_dtype, reduction
+    ).neg_()
+
+    loss = _make_zeros((), acc_dtype, device)
+    grad_input = _make_empty(input.shape, dtype, device, when=compute_input_grad)
+    grad_linear_weight = _make_zeros(
+        linear_weight.shape, dtype, device, when=compute_linear_weight_grad
+    )
+    grad_linear_bias = _make_zeros(
+        linear_weight.shape[:-1], dtype, device, when=compute_linear_bias_grad
+    )
+    bias_grad_acc = _make_zeros(
+        linear_weight.shape[:-1], acc_dtype, device, when=compute_linear_bias_grad
+    )
+    if num_batches == 0:
+        if reduction == "mean":
+            loss.fill_(torch.nan)
+        return (loss.to(dtype), grad_input, grad_linear_weight, grad_linear_bias)
+
+    compute_grads = (
+        compute_input_grad or compute_linear_weight_grad or compute_linear_bias_grad
+    )
+    chunk_rows = min(batch_chunk_size, num_batches)
+    # Eager's buffer dtype, verbatim: fp16 input under `compact` keeps its
+    # logits at fp16 (two bytes per element, and the softmax input rounded with
+    # it); everything else upcasts to acc_dtype for softmax stability.
+    logits_dtype = dtype if dtype is torch.float16 else acc_dtype
+    # Allocated once and reused: the peak is one chunk of each, which is what
+    # `batch_chunk_size` promises.
+    logits_buf = torch.empty(
+        (chunk_rows, num_classes), dtype=logits_dtype, device=device
+    )
+    # `g` shares the logits storage: row n's gradients occupy the first half
+    # of the bytes that held its logits, so a chunk is one buffer, not two. The
+    # kernel orders its writes against its reads, which is what makes that safe.
+    g_alias = logits_buf.view(dtype).narrow(1, 0, num_classes)
+    row_max_buf = torch.empty((chunk_rows, 1), dtype=logits_dtype, device=device)
+    # The fused kernel's two (Bc,) statistics outputs.
+    lse_buf = torch.empty(chunk_rows, dtype=acc_dtype, device=device)
+    target_logit_buf = torch.empty(chunk_rows, dtype=acc_dtype, device=device)
+    weight_t = linear_weight.t()
+
+    for start in range(0, num_batches, chunk_rows):
+        rows = min(chunk_rows, num_batches - start)
+        input_chunk = input.narrow(0, start, rows)
+        target_chunk = target_hat.narrow(0, start, rows)
+        scale_chunk = row_scale.narrow(0, start, rows)
+        logits = logits_buf.narrow(0, 0, rows)
+
+        if linear_bias is None:
+            torch.mm(input_chunk, weight_t, out_dtype=logits_dtype, out=logits)
+        else:
+            torch.addmm(
+                linear_bias, input_chunk, weight_t, out_dtype=logits_dtype, out=logits
+            )
+
+        g = g_alias.narrow(0, 0, rows) if compute_grads else None
+        if g is not None:
+            lse = lse_buf.narrow(0, 0, rows)
+            target_logit = target_logit_buf.narrow(0, 0, rows)
+            # This consumes `logits`: on return those bytes hold `g`. Nothing
+            # below reads them again, and the next chunk's matmul overwrites
+            # the buffer.
+            fused_grad_logits_into(
+                g, lse, target_logit, logits, scale_chunk, target_chunk
+            )
+            # `lse` and the target logit are both unshifted here, so the same
+            # shift invariance applies as below.
+            loss.add_((scale_chunk * (lse - target_logit)).sum())
+        else:
+            # Shift in place by the row max, then read the target logit BEFORE
+            # exponentiating -- `exp_` overwrites the shifted logits.
+            row_max = row_max_buf.narrow(0, 0, rows)
+            torch.amax(logits, dim=1, keepdim=True, out=row_max)
+            logits.sub_(row_max)
+            target_logit = logits.gather(1, target_chunk.unsqueeze(1)).squeeze(1)
+            logits.exp_()
+            row_sum = logits.sum(dim=1, dtype=acc_dtype)
+            # Shift-invariant: log(sum exp(z - m)) - (z_T - m) == lse - z_T.
+            loss.add_((scale_chunk * (row_sum.log() - target_logit)).sum())
+            continue
+
+        if compute_linear_bias_grad:
+            # Accumulated in acc_dtype like eager's bias-grad scratch, and
+            # committed once after the loop.
+            bias_grad_acc.add_(g.sum(dim=0, dtype=acc_dtype))
+        if compute_input_grad:
+            torch.mm(g, linear_weight, out=grad_input.narrow(0, start, rows))
+        if compute_linear_weight_grad:
+            grad_linear_weight.addmm_(g.t(), input_chunk)
+
+    if compute_linear_bias_grad:
+        grad_linear_bias.copy_(bias_grad_acc)
+
+    return (
+        loss.to(dtype),
+        grad_input,
+        grad_linear_weight,
+        grad_linear_bias,
+    )
+
+
 # Declaration read by both the registrar below and the drift-guard test in
 # test/python_native/test_override_declarations.py. `aten` ops exist by
 # construction, so a bad symbol there dies on any `import torch`; a
@@ -142,8 +356,10 @@ def _no_reduction_impl(
 # so drift cannot ship.
 _NAMESPACE = "torch_nn"
 _DEFINING_MODULE = "torch.nn.modules.linear_cross_entropy"
+
+
 _OVERRIDES = (
-    ("_linear_cross_entropy_batch_chunked", _batch_chunked_cond, _batch_chunked_impl),
+    ("_linear_cross_entropy_batch_chunked", _kernel_eligible, _batch_chunked_kernel),
     (
         "_linear_cross_entropy_batch_chunked_no_reduction",
         _no_reduction_cond,

--- a/torch/_native/ops/linear_cross_entropy/fused_grad_logits_kernel.py
+++ b/torch/_native/ops/linear_cross_entropy/fused_grad_logits_kernel.py
@@ -1,0 +1,324 @@
+"""Row statistics and the softmax-gradient transform in one kernel.
+
+Replaces the five eager passes the chunked loop makes over its ``(Bc, V)``
+logits buffer -- row max, subtract, gather, ``exp_``, row sum -- plus the
+separate gradient-transform kernel, with a single launch that reads the raw
+logits twice and writes the dense gradient-of-logits once.
+
+Contract, per row ``n`` of the chunk, with ``m_n = max_v z[n, v]`` and
+``l_n = sum_v exp(z[n, v] - m_n)``::
+
+    g[n, v] = exp(z[n, v] - m_n) * (s_n / l_n) - s_n * [v == T_hat_n]
+    lse[n] = m_n + log(l_n)
+    z_target[n] = z[n, T_hat_n]
+
+``g`` is what makes both parameter gradients plain GEMMs (see
+``grad_logits_kernel``); ``lse`` and ``z_target`` are the two ``(Bc,)``
+statistics the loss needs, and the caller forms ``s_n * (lse_n - z_target_n)``
+with the raw logits, not the shifted ones -- that difference is shift
+invariant.
+
+The logits stay raw: nothing here mutates them, so the eager loop's in-place
+shift and ``exp_`` disappear along with their traffic, and the buffer can be
+read a second time instead of being reconstructed.
+
+Geometry: one block per row, columns split across its threads. A row's own
+maximum and sum must be complete before any element of that row can be
+written, and a block is the largest unit that can share them without a
+grid-wide barrier -- which is why this cannot use the column-parallel grid of
+the unfused transform, whose statistics arrive precomputed. Parallelism is
+therefore the chunk's row count, not its element count, so blocks are wide by
+default to keep enough threads in flight per row.
+
+Pass 1 keeps a per-thread running maximum and the sum of ``exp(z - m)``
+against it, so each element costs one exponential and only a maximum update
+pays a rescale of the running sum. The per-thread pairs are then combined
+block-wide: maximum first, then the sums rescaled to it.
+
+Traffic on the ``(Bc, V)`` footprint: two fp32 reads and one output write,
+against roughly thirty bytes per element for the sequence this replaces.
+
+Numerics follow the unfused path: ``exp(z - m)`` in fp32, one fp32 divide per
+row for ``s / l``, and the one-hot term subtracted before the downcast so the
+target column rounds once, from ``(p - 1) * s``. The exponentials use the
+hardware approximation (``ex2.approx``), where the eager path used ``exp_``.
+
+The logits buffer's dtype is the caller's choice and is part of the compile
+key: fp32 is eager parity, and a low-precision buffer halves both reads at the
+cost of rounding the softmax input. Either way every element is widened to fp32
+on load and all arithmetic here is fp32.
+
+``g`` may share the logits buffer's storage: the same bytes hold fp32 logits
+on the way in and (half as many) low-precision gradients on the way out, so a
+chunk costs one buffer rather than two, with no value rounding anywhere. Pass 2
+is ordered for that case unconditionally -- it costs nothing measurable when the
+buffers are distinct, and one mode is one thing to reason about.
+
+Why the ordering is needed: ``g[n, j]`` occupies the bytes of ``z[n, j / 2]``,
+so an unsynchronized write would destroy a logit another thread has yet to read.
+Pass 2 therefore stages a group of column tiles in registers, synchronizes, and
+only then writes them. That is safe for any group size: a group's writes reach
+at most halfway into the columns it just read, so they can only land on logits
+this block has already consumed, and never on the columns a later group will
+read. The loop runs the same number of iterations in every thread --
+out-of-range lanes re-read column zero rather than exiting -- because a thread
+that left early would hang the others on the barrier.
+"""
+
+import operator
+
+import cuda.bindings.driver as cuda  # pyrefly: ignore[missing-import]
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import BFloat16, Float16, Float32, Int32, Int64
+
+import torch
+from torch._native.instrumentation import instrumented_cutedsl_cache
+from torch._vendor.quack.reduce import block_reduce
+
+
+# Defaults for the kernel's two shape knobs, which a caller may override (see
+# `fused_grad_logits_into`). Measured on H100 over threads x tiles in
+# {256, 512, 1024} x {1, 4, 8, 16, 32} at 20 (Bc, V) chunk shapes and both
+# buffer layouts: no setting wins everywhere. A wide block pays off only on
+# long rows (V >= 32000); staging peaks around 8 tiles there and degrades past
+# it, steeply on short rows. (512, 4) is the middle of both axes -- the worst
+# setting at no shape measured, at most 1.39x behind the per-shape best -- and
+# the stake is small either way: where the split can be measured cleanly the
+# chunked loop spends ~85% of its time in its three cuBLAS GEMMs and under 10%
+# here, so the best setting at the loop's own chunk shapes is worth under 2%
+# end to end.
+#
+# Legal ranges, as opposed to preferences: `threads_per_block` must be a
+# multiple of 32 and at most 1024, both because a CUDA block stops there and
+# because the cross-warp combine reads one warp's worth of per-warp partials, so
+# more than 32 warps per row would drop the surplus. `tiles_per_stage` may be
+# any positive integer -- the write-ordering argument below holds for every
+# group size.
+_DEFAULT_THREADS_PER_BLOCK = 512
+_DEFAULT_TILES_PER_STAGE = 4
+
+_TORCH_TO_CUTE = {
+    torch.float32: Float32,
+    torch.float16: Float16,
+    torch.bfloat16: BFloat16,
+}
+
+
+def _make_kernel(out_dtype, threads_per_block, tiles_per_stage):
+    warps_per_block = threads_per_block // 32
+
+    @cute.kernel
+    def _kernel(
+        mZ: cute.Tensor,
+        mS: cute.Tensor,
+        mTarget: cute.Tensor,
+        mG: cute.Tensor,
+        mLse: cute.Tensor,
+        mTargetLogit: cute.Tensor,
+        V: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        row, _, _ = cute.arch.block_idx()
+
+        smem = cutlass.utils.SmemAllocator()
+        # One slot per warp for each of the two block-wide combines; separate
+        # buffers so the second combine cannot overwrite what a warp still
+        # reads from the first.
+        buf_max = smem.allocate_tensor(
+            Float32, cute.make_layout((1, warps_per_block)), byte_alignment=4
+        )
+        buf_sum = smem.allocate_tensor(
+            Float32, cute.make_layout((1, warps_per_block)), byte_alignment=4
+        )
+
+        threads = Int32(threads_per_block)
+        target = Int32(mTarget[row])
+
+        m = Float32(-Float32.inf)
+        l = Float32(0.0)
+        col = tidx
+        while col < V:
+            z = Float32(mZ[row, col])
+            if z > m:
+                # Rescale the sum to the new maximum. A thread that has seen
+                # nothing yet has m = -inf and l = 0, so this yields l = 1.
+                l = l * cute.math.exp(m - z, fastmath=True) + Float32(1.0)
+                m = z
+            else:
+                l = l + cute.math.exp(z - m, fastmath=True)
+            col = col + threads
+
+        row_max = block_reduce(
+            cute.arch.warp_reduction_max(m),
+            cute.arch.fmax,
+            buf_max,
+            init_val=-Float32.inf,
+        )
+        l = l * cute.math.exp(m - row_max, fastmath=True)
+        row_sum = block_reduce(
+            cute.arch.warp_reduction_sum(l),
+            operator.add,
+            buf_sum,
+            init_val=Float32(0.0),
+        )
+
+        s = mS[row]
+        factor = s / row_sum
+        if tidx == 0:
+            mLse[row] = row_max + cute.math.log(row_sum, fastmath=True)
+            mTargetLogit[row] = Float32(mZ[row, target])
+
+        # This read of the target logit has to be ordered against the writes
+        # below, which may occupy its bytes.
+        cute.arch.barrier()
+        stage = Int32(tiles_per_stage)
+        tiles = (V + threads - Int32(1)) // threads
+        groups = (tiles + stage - Int32(1)) // stage
+        group = Int32(0)
+        while group < groups:
+            base = group * stage * threads + tidx
+            staged = []
+            for j in cutlass.range_constexpr(tiles_per_stage):
+                col = base + Int32(j) * threads
+                col_read = col
+                if col >= V:
+                    col_read = Int32(0)
+                staged.append(
+                    cute.math.exp(Float32(mZ[row, col_read]) - row_max, fastmath=True)
+                    * factor
+                )
+            cute.arch.barrier()
+            for j in cutlass.range_constexpr(tiles_per_stage):
+                col = base + Int32(j) * threads
+                if col < V:
+                    value = staged[j]
+                    if col == target:
+                        value = value - s
+                    mG[row, col] = out_dtype(value)
+            group = group + Int32(1)
+
+    @cute.jit
+    def _launch(
+        mZ: cute.Tensor,
+        mS: cute.Tensor,
+        mTarget: cute.Tensor,
+        mG: cute.Tensor,
+        mLse: cute.Tensor,
+        mTargetLogit: cute.Tensor,
+        stream: cuda.CUstream,
+        V: Int32,
+        num_rows: Int32,
+    ):
+        _kernel(mZ, mS, mTarget, mG, mLse, mTargetLogit, V).launch(
+            grid=[num_rows, 1, 1],
+            block=[threads_per_block, 1, 1],
+            stream=stream,
+        )
+
+    return _launch
+
+
+@instrumented_cutedsl_cache(
+    "torch_nn::_linear_cross_entropy_batch_chunked",
+    key_fn=lambda logits_torch_dtype, out_torch_dtype, threads, tiles: (
+        f"fused_grad_logits logits={logits_torch_dtype} out={out_torch_dtype}"
+        f" threads={threads} tiles={tiles}"
+    ),
+)
+def _compile_fused_grad_logits(
+    logits_torch_dtype: torch.dtype,
+    out_torch_dtype: torch.dtype,
+    threads: int,
+    tiles: int,
+):
+    # V and the row count stay runtime arguments: the kernel loops over the
+    # columns and takes the rows from the grid, so one compile per (dtype pair,
+    # block width, staging depth) serves every chunk shape.
+    launcher = _make_kernel(_TORCH_TO_CUTE[out_torch_dtype], threads, tiles)
+
+    def logits_2d():
+        return cute.runtime.make_fake_tensor(
+            _TORCH_TO_CUTE[logits_torch_dtype],
+            (cute.sym_int(), cute.sym_int()),
+            stride=(cute.sym_int64(), 1),
+        )
+
+    def f32_1d():
+        return cute.runtime.make_fake_tensor(Float32, (cute.sym_int(),), stride=(1,))
+
+    # A fresh fake tensor per parameter: reusing one object for two parameters
+    # makes the traced signature drop arguments, and the host call then shifts
+    # its positionals.
+    return cute.compile(
+        launcher,
+        logits_2d(),
+        f32_1d(),
+        cute.runtime.make_fake_tensor(Int64, (cute.sym_int(),), stride=(1,)),
+        cute.runtime.make_fake_tensor(
+            _TORCH_TO_CUTE[out_torch_dtype],
+            (cute.sym_int(), cute.sym_int()),
+            stride=(cute.sym_int64(), 1),
+        ),
+        f32_1d(),
+        f32_1d(),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),
+        Int32(0),
+        options="--enable-tvm-ffi",
+    )
+
+
+def fused_grad_logits_into(
+    g: torch.Tensor,
+    lse: torch.Tensor,
+    target_logit: torch.Tensor,
+    logits: torch.Tensor,
+    row_scale: torch.Tensor,
+    target: torch.Tensor,
+    **meta: int,
+) -> None:
+    """Writes ``g``, ``lse`` and ``target_logit`` from the raw ``logits``.
+
+    ``logits`` is (Bc, V) with unit inner stride, fp32 or a low-precision
+    buffer dtype. When ``g`` is a separate buffer the logits are left untouched;
+    ``g`` is a distinct (Bc, V) buffer at the input dtype.
+
+    When ``g`` is a view of that storage instead -- typically
+    ``logits.view(g.dtype).narrow(1, 0, V)``, so its rows carry the leading
+    dimension of the rows they overwrite -- the logits are CONSUMED: after the
+    call that memory holds ``g``. The kernel orders its writes against its reads
+    either way (see the module docstring), so the caller chooses the layout and
+    nothing else changes.
+
+    ``lse``, ``target_logit``, ``row_scale`` are fp32 (Bc,) and ``target`` is
+    int64 (Bc,), all contiguous.
+
+    ``meta`` carries the kernel's shape knobs, so a tuner -- or a caller who has
+    measured its own shapes -- can choose them without editing this file:
+
+    ``threads_per_block``
+        Block width, default 512. A multiple of 32, at most 1024.
+    ``tiles_per_stage``
+        Column tiles staged per barrier in pass 2, default 4. At least 1.
+
+    Each combination compiles its own kernel, so a caller sweeping them pays one
+    compile per point and hits the cache thereafter.
+    """
+    threads = meta.pop("threads_per_block", _DEFAULT_THREADS_PER_BLOCK)
+    tiles = meta.pop("tiles_per_stage", _DEFAULT_TILES_PER_STAGE)
+    if meta:
+        raise ValueError(
+            f"unknown meta parameters {sorted(meta)}; this kernel takes"
+            " threads_per_block and tiles_per_stage"
+        )
+    if threads % 32 or not 32 <= threads <= 1024:
+        raise ValueError(
+            f"threads_per_block must be a multiple of 32 in [32, 1024], got {threads}"
+        )
+    if tiles < 1:
+        raise ValueError(f"tiles_per_stage must be at least 1, got {tiles}")
+    num_rows, V = logits.shape
+    compiled = _compile_fused_grad_logits(logits.dtype, g.dtype, threads, tiles)
+    compiled(logits, row_scale, target, g, lse, target_logit, V, num_rows)

--- a/torch/nn/modules/linear_cross_entropy.py
+++ b/torch/nn/modules/linear_cross_entropy.py
@@ -94,9 +94,7 @@ def _neg_weight_target(
         # grad_output[n] for the VJP -- do NOT add a .neg_() here to mirror the
         # "sum" case.
         if loss_grad_output is not None:
-            neg_weight_target.neg_().mul_(
-                loss_grad_output.to(neg_weight_target.dtype)
-            )
+            neg_weight_target.neg_().mul_(loss_grad_output.to(neg_weight_target.dtype))
     return neg_weight_target
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #195830
* #197876
* #196134
* __->__ #195829

Per chunk the chunked path is three cuBLAS GEMM calls plus a set of pointwise
passes over the `(Bc, V)` logits buffer. This commit collects those passes into
one CuTeDSL kernel which also writes the dense gradient of logits into the
logits buffer itself, so the `index_add_` scatter and one buffer disappear.
Measured on an H100, the call takes 0.61-0.87 of eager's time at a lower peak
memory; on a B200, 0.30-0.78. The kernel is verified on sm_80, sm_90 and
sm_100, with its block knobs tuned on H100. Accuracy is level or better in
fp16; in bf16 the weight gradient's error runs 1.02x to 1.10x of eager's at the
same chunk size, from the same accumulation count.

> The `torch_nn::_linear_cross_entropy_batch_chunked` override stops delegating
> and computes the loss and gradients itself for the slice its `cond` claims.
> Per chunk: one cuBLAS matmul for the logits, one CuTeDSL kernel, and two more
> matmuls for the gradients.
>
> The kernel is what the change is about. Eager walks the `(Bc, V)` logits buffer
> five more times after the matmul -- row max, subtract, gather, `exp_`, row sum
> -- and then scatters the one-hot correction into `grad_linear_weight` with
> `index_add_`. Here one launch reads the raw logits twice (an online
> max-and-sumexp pass, then an apply pass) and writes the dense
> gradient-of-logits `g[n, v] = s_n * (softmax(z)[n, v] - [v == T_hat_n])`,
> emitting the two `(Bc,)` statistics the loss needs. Forming `g` densely is what
> makes both parameter gradients plain matmuls -- `grad_input = g @ W`,
> `grad_linear_weight = g^T @ X` -- so the scatter disappears: the backward is
> deterministic where eager's was not, and the separate `scatter_add` override
> stops being reachable from this path.
>
> `g` is written into the logits buffer's own storage rather than a second
> buffer, so a chunk costs one `(Bc, V)` buffer. That needs ordering, because
> `g[n, j]` occupies the bytes of `z[n, j / 2]`: pass 2 stages a group of column
> tiles in registers, synchronizes, and only then writes them, which is safe
> because a group's writes reach at most halfway into the columns it just read.
> The alternative that reaches the same footprint -- keeping the logits at low
> precision, as eager does for fp16 -- was measured and rejected for bf16: bf16
> stores `z` with absolute error ~|z| * 2^-9 while the softmax depends on
> DIFFERENCES of z, so gradients degrade once |z| reaches the tens, which is the
> regime a trained head operates in. At fp16 the buffer follows eager down to two
> bytes per element, since that is eager's own choice there and matching its
> footprint is the compatibility contract; the exponential and the scaled
> gradient still stay in fp32 registers, so this path is strictly more accurate
> than eager's at an identical footprint.
>
> Review `cutedsl_impl.py` first: it holds the eligibility predicate and the
> implementation, and it replaces the delegating implementation the routing commit
> installed. Eligibility is shapes, dtypes and device only, so it is safe under
> FakeTensor tracing; an input outside it never enters the override at all and the
> router falls back, which keeps "the kernel ran" observable rather than hidden
> behind an internal delegation. Its architecture condition is the DSL runtime's
> floor, which is also where this path's own arithmetic becomes available -- the
> logits matmul asks cuBLAS for an fp32 output from low-precision inputs, rejected
> below 8.0 -- and it lives in one predicate that `cond` and the tests both call.
> Holding out for a measurement on every capability would keep the kernel off
> hardware it runs on perfectly well; what is unmeasured below sm_90 is
> performance, not correctness.
>
> The implementation re-runs every check the op would have run -- an override
> installed at a backend key replaces the body that ran them, and the checks below
> it too -- by calling the op's own check functions, and it takes the per-row
> target correction and gradient weight the same way. Nothing about the op's
> contract is restated here; the previous commit moved each of those pieces out
> so this one could call them.
>
> Then `fused_grad_logits_kernel.py`: one block per row, because a row's own
> maximum and sum must be complete before any element of it can be written, and a
> block is the largest unit that can share them without a grid-wide barrier.
>
> Its two shape knobs -- the block width, and how many column tiles pass 2 stages
> per barrier -- are keyword arguments rather than constants, so a tuner or a
> caller with measured shapes can choose them without editing the file, and each
> combination compiles its own kernel. The defaults were measured on an H100 over
> a 3 x 5 grid at 20 chunk shapes, which the comment beside them summarizes: no
> setting wins everywhere, (512, 4) is never the worst and at most 1.39x behind
> the per-shape best, and since the chunked loop spends ~85% of its time in
> cuBLAS at the shapes where that share can be measured cleanly, the best setting
> at the loop's own chunk shapes is worth under 2% end to end. Their legal ranges
> are enforced, and one of them is a correctness limit rather than a preference
> -- above 32 warps per row the cross-warp combine would silently drop the
> surplus partials.
>
> Not covered here. The forward-only path (no gradient requested) has no `g` to
> write and keeps eager's statistics. `reduction='none'` keeps its own op and
> implementation. Probability targets, label smoothing, `acc_policy='accurate'`
> and fp32 input fall back through the router. One accuracy trade is worth
> naming: the dense `g` puts O(1) target-row contributions and O(1/V) off-target
> ones through a single matmul where eager keeps the scales apart, which costs
> ~14x on `grad_linear_weight` in isolation -- visible as ~15% at fp16 with
> `reduction='sum'`, invisible at bf16 where other error sources dominate. It
> buys the deleted scatter, the determinism and the speed.
>
> What the kernel buys, measured on an H100 through the op's own 12-shape sweep,
> in two comparisons.
>
> Against the op's own chunked path, at the same shapes and the same chunk size
> -- identical work, so this isolates the kernel: in bf16 the call takes
> 0.61-0.87 of eager's time (1.14-1.63x faster) at 0.77-0.97 of eager's peak
> memory; in fp16, 0.63-0.89 of the time at 0.86-1.00 of the peak.
>
> Accuracy splits by dtype. In fp16 the override is at least as accurate as
> eager everywhere: `grad_linear_weight` error is equal, 0.996-1.001 of
> eager's, and `grad_input` error is below it, 0.824-0.975. In bf16 the weight
> gradient is the one that gives ground -- 1.018-1.100 of eager's error,
> largest at `num_classes=16384` -- while `grad_input` stays level at
> 1.000-1.021. The dense `g^T @ X` accumulates in a different order than
> eager's `index_add_` scatter, which is where that comes from.
>
> The three matmuls are the same shapes at the same chunk size in both paths,
> so the whole win is in what surrounds them. Per chunk, eager makes five
> passes over the (Bc, V) logits buffer -- row max, subtract, exp, row sum, scale
> -- and then scatters the one-hot correction into grad_linear_weight with
> index_add_. Here one kernel reads the buffer twice and writes the dense
> gradient-of-logits once, and the dense form makes the scatter part of an
> ordinary matmul: less traffic and about a third of the launches (611 -> 195 per
> call at D=1024). The gain tracks how much of eager's time those passes were:
> 1.56x where the matmuls are cheap relative to the buffer (D=1024), 1.14x where
> they dominate (D=8192). Memory: one (Bc, V) fp32 buffer per chunk, with the
> gradient written into the same storage, replaces eager's logits buffer plus its
> downcast copy and its (Bc, D) scratch.
>
> Against liger-kernel 0.8.2, at constant memory: for each shape the override's
> chunk size is set so its peak matches liger's where that is reachable
> (0.997-1.025 of liger's peak at those points; elsewhere the whole batch fits
> one chunk and the peak stays at 0.48-0.87 of liger's). At that budget the
> override runs 1.25-6x faster than liger in bf16 (0.17-0.80 of its time) and
> 1.25-7x in fp16 (0.14-0.80), and 1.2-4x faster than eager at its default chunk
> size. The extra factor over the same-shape comparison is the memory itself: the
> override needs one (Bc, V) buffer per chunk where liger materializes more, so
> at equal peak it runs a chunk several times larger -- fewer chunks, fewer re-
> accumulations of grad_linear_weight, matmuls with a longer inner dimension. The
> chunk size stays under the caller's control; this comparison shows what the
> design returns when given liger's memory.
>
> This kernel's module imports the CuTeDSL runtime at import time, so the two
> tests that import every module under `torch/` --
> `test_public_bindings::test_modules_can_be_imported` and
> `test_testing::TestImports::test_circular_dependencies` -- need it in their
> optional-runtime ignore lists, where the other `_native` DSL kernels already
> sit. Both entries name the module rather than the package, so `cutedsl_impl`
> and the package `__init__` stay checked -- they import without the runtime
> and should keep having to.
>
> The new test files need the CuTeDSL runtime, so the B200 smoke job is the only
> place they can run at all -- nothing else collects them. That job already
> discovers every `test/python_native/test_*.py`, so they are picked up without
> being named. Added to it explicitly: `test_nn -k linear_cross_entropy`, the
> op's own accuracy harness. It compares fp16/bf16 against an fp64 reference
> with tolerances the op's author calibrated, and it runs in every CUDA job
> already -- but only where the DSL is installed does it measure this kernel
> instead of eager, so this job is where it earns its keep. The `-k` lines have
> to be named because `test_ops` and `test_nn` sit outside what that discovery
> reaches.
>
> Test Plan:
>
> The numbers above come from the out-of-tree benchmark harness, one process per
> configuration, over the same 12 shapes in both dtypes; the commands below are
> the in-tree correctness checks.
>
> ```
> python test/python_native/test_lce_fused_grad_logits_kernel.py
> python test/python_native/test_linear_cross_entropy_override.py
> python test/python_native/test_override_declarations.py
> python test/python_native/test_registry.py
> python test/test_nn.py -k linear_cross_entropy
> python test/test_ops.py -k linear_cross_entropy
> spin lint
> ```
>
> All of the above pass -- 54 kernel tests, 30 override tests -- including the
> two upstream batteries: `test_nn.py` runs 226 linear_cross_entropy tests and
> `test_ops.py` 191, both clean. Tests that
> need the kernel to be eligible skip where it is not, so a machine below its
> architecture floor reports skips rather than failures.
>
> The kernel's numerics are checked three ways. Against a torch expression of its
> contract, on its own, for three output dtypes across shapes that cross the block
> width and the staging group, including both aliasing ratios -- an fp32 buffer
> with narrower gradients, where a write lands halfway back, and the fp16 buffer
> where it lands on the column just read -- and including logits large enough
> that an unshifted exponential would overflow. End to end by the op's own
> fp64-referenced harness, which this change routes into the job that has the
> DSL. And two identical runs are required to produce bit-identical gradients,
> with `index_add_` asserted never to run, so the determinism the deleted scatter
> bought is pinned rather than asserted in prose.
>
> The op-level tests cover the paths a caller can reach rather than the kernel
> alone: the forward-only branch, which reimplements the loss with eager ops and
> which any `no_grad` call takes; `reduction='sum'`, a class weight and an
> `ignore_index` that fires, which are the four `_neg_weight_target` branches the
> row scale is built from; the empty batch, where the one allocation left
> unwritten has to be zeroed; and an out-of-range target, whose `nan` reaches
> both parameter gradients and the loss rather than staying in its row.

---
_🤖 Drafted by Claude Code (an AI agent) and reviewed & approved by pearu._