### PR TITLE
[Test][XPU] Make test/export/{test_export,test_draft_export}.py device-agnostic and enable on XPU

### DIFF
--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -12,7 +12,12 @@ from torch.export import Dim, draft_export, export
 from torch.export._draft_export import DraftExportReport, FailureReport, FailureType
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,
     init_torchbind_implementations,
@@ -21,6 +26,8 @@ from torch.utils._pytree import tree_leaves
 
 
 class TestDraftExport(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         init_torchbind_implementations()

--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -12,6 +12,11 @@ from torch.export import Dim, draft_export, export
 from torch.export._draft_export import DraftExportReport, FailureReport, FailureType
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing import FileCheck
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    largeTensorTest,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_WINDOWS,
@@ -291,50 +296,6 @@ class TestDraftExport(TestCase):
                     RuntimeError, "no profiles match the given inputs"
                 ):
                     torch.ops.mylib.foo8(*inp)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "Requires cuda")
-    def test_missing_meta_kernel_guard(self):
-        with torch.library._scoped_library("mylib", "FRAGMENT"):
-
-            @torch.library.custom_op("mylib::foo4", mutates_args={})
-            def foo4_impl(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-                return a + b
-
-            class M(torch.nn.Module):
-                def forward(self, a, b):
-                    res1 = torch.ops.mylib.foo4(a, b)
-                    return res1
-
-            inp = (
-                torch.ones(3, 4),
-                torch.ones(3, 4),
-            )
-
-            ep = draft_export(
-                M(),
-                inp,
-                dynamic_shapes={
-                    "a": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
-                    "b": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
-                },
-            )
-
-            inp = (torch.randn(2, 3), torch.randn(2, 3))
-            self.assertEqual(ep.module()(*inp), M()(*inp))
-            m = ep.module()
-            with self.assertRaisesRegex(RuntimeError, "Tensor device mismatch!"):
-                bad_device_inps = (
-                    torch.randn(2, 3, device=torch.device("cuda")),
-                    torch.randn(2, 3, device=torch.device("cuda")),
-                )
-                m(*bad_device_inps)
-
-            with self.assertRaisesRegex(RuntimeError, "Tensor dtype mismatch!"):
-                bad_dtype_inps = (
-                    torch.randn(2, 3, dtype=torch.float16),
-                    torch.randn(2, 3, dtype=torch.float16),
-                )
-                m(*bad_dtype_inps)
 
     def test_fake_infer_dense_in_memory_check(self):
         with torch.library._scoped_library("mylib", "FRAGMENT"):
@@ -774,12 +735,59 @@ class TestDraftExport(TestCase):
                 package_path=f.name,
             )
 
-    @unittest.skipIf(
-        not torch.cuda.is_available()
-        or torch.cuda.get_device_properties(0).total_memory < 2**28,
-        "Requires 16 MB GPU memory to pass the test; setting it higher to catch violations",
-    )
-    def test_cuda_memory_usage(self):
+
+class TestDraftExportDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    def test_missing_meta_kernel_guard(self, device):
+        with torch.library._scoped_library("mylib", "FRAGMENT"):
+
+            @torch.library.custom_op("mylib::foo4", mutates_args={})
+            def foo4_impl(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                return a + b
+
+            class M(torch.nn.Module):
+                def forward(self, a, b):
+                    res1 = torch.ops.mylib.foo4(a, b)
+                    return res1
+
+            inp = (
+                torch.ones(3, 4),
+                torch.ones(3, 4),
+            )
+
+            ep = draft_export(
+                M(),
+                inp,
+                dynamic_shapes={
+                    "a": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+                    "b": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+                },
+            )
+
+            inp = (torch.randn(2, 3), torch.randn(2, 3))
+            self.assertEqual(ep.module()(*inp), M()(*inp))
+            m = ep.module()
+            with self.assertRaisesRegex(RuntimeError, "Tensor device mismatch!"):
+                bad_device_inps = (
+                    torch.randn(2, 3, device=device),
+                    torch.randn(2, 3, device=device),
+                )
+                m(*bad_device_inps)
+
+            with self.assertRaisesRegex(RuntimeError, "Tensor dtype mismatch!"):
+                bad_dtype_inps = (
+                    torch.randn(2, 3, dtype=torch.float16),
+                    torch.randn(2, 3, dtype=torch.float16),
+                )
+                m(*bad_dtype_inps)
+
+    # 16 MB is enough to run the test; ask for more so a regression OOMs
+    # instead of silently passing.
+    @onlyAccelerator
+    @largeTensorTest(2**28)
+    def test_accelerator_memory_usage(self, device):
         # This used to OOM
         class Foo(torch.nn.Module):
             def forward(self, x):
@@ -788,21 +796,23 @@ class TestDraftExport(TestCase):
                 return x
 
         # measure base usage
-        device = torch.device("cuda:0")
-        torch.cuda.reset_peak_memory_stats()
-        base_usage = torch.cuda.memory_allocated(device)
+        torch.accelerator.reset_peak_memory_stats(device)
+        base_usage = torch.accelerator.memory_allocated(device)
 
         # usage with input tensor allocated
         x = torch.randn(2**10, 2**10).to(device)
-        x_usage = torch.cuda.memory_allocated(device)
+        x_usage = torch.accelerator.memory_allocated(device)
 
         # draft export peak memory usage
         draft_export(Foo(), (x,), strict=False)
-        peak_mem_usage = torch.cuda.memory_stats(device)["allocated_bytes.all.peak"]
+        peak_mem_usage = torch.accelerator.max_memory_allocated(device)
 
         # right now it's actually exactly 4x;
         # I guess original tensor, 2 tensors per add op, 1 for clone stored in node.meta["val"]
         self.assertTrue((peak_mem_usage - base_usage) <= (x_usage - base_usage) * 4.0)
+
+
+instantiate_device_type_tests(TestDraftExportDevice, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -78,6 +78,7 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_utils import (
     find_library_location,
+    HardwareClassification,
     IS_FBCODE,
     IS_MACOS,
     IS_SANDCASTLE,
@@ -318,6 +319,8 @@ def cleanup_dispatch_trace_metadata(mod: torch.export.ExportedProgram) -> None:
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestDynamismExpression(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_export_inline_constraints(self):
         class Module(torch.nn.Module):
             def forward(self, x):
@@ -580,6 +583,8 @@ class InputModuleWithNestedSubclass(torch.nn.Module):
 @unittest.skipIf(IS_WINDOWS, "Windows isn't supported for this case")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestExport(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _test_export_same_as_eager(self, f, args, kwargs=None):
         kwargs = kwargs or {}
         exported_program = export(f, args, kwargs)
@@ -18632,6 +18637,8 @@ def forward(self, q, k, v):
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestOneOffModelExportResult(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_scaled_dot_product_attention_cpu(self):
         """
         This test makes sure we are always getting the same decomposition result for SDPA.
@@ -19321,6 +19328,8 @@ def forward(self, x):
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestExportCustomClass(TorchTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         load_torchbind_test_lib()

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -87,7 +87,6 @@ from torch.testing._internal.common_utils import (
     skipIfCrossRef,
     skipIfRocm,
     skipIfTorchDynamo,
-    skipIfXpu,
     TEST_WITH_CROSSREF,
     TestCase as TorchTestCase,
 )
@@ -18674,19 +18673,18 @@ class TestOneOffModelExportResult(TestCase):
             ep = torch.export.export(ScaledDotProductAttention(), (q, k, v))
             ep.run_decompositions()
 
-    @skipIfXpu(msg="scaled_dot_product_attention issue on xpu")
     @skipIfCrossRef
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION,
         "Can't run fused SDPA on this platform",
     )
-    def test_scaled_dot_product_attention_cuda(self):
+    def test_scaled_dot_product_attention_gpu(self):
         """
         This test makes sure we are always getting the same decomposition result for SDPA.
-        As of now _scaled_dot_product_flash_attention is expected to show up in
-        export() result (GPU tensors are given). Currently there's no downstream
-        backend relies on this export result so if this test fails, feel free to
-        change it to the latest export() result.
+        As of now a fused SDPA op is expected to show up in export() result (GPU
+        tensors are given); which one depends on the backend. Currently there's no
+        downstream backend relies on this export result so if this test fails, feel
+        free to change it to the latest export() result.
         """
 
         class ScaledDotProductAttention(torch.nn.Module):
@@ -18706,26 +18704,32 @@ class TestOneOffModelExportResult(TestCase):
         ep = torch.export.export(
             ScaledDotProductAttention(), (q, k, v)
         ).run_decompositions()
-        code_str = """\
+        # Which fused SDPA op survives decomposition is a property of the backend
+        # (flash or cuDNN on CUDA, the overrideable fused op on XPU), so compare
+        # against the golden graph for whichever op actually shows up.
+        expected_graphs = {
+            "_scaled_dot_product_flash_attention": """\
 def forward(self, q, k, v):
     _scaled_dot_product_flash_attention_default = torch.ops.aten._scaled_dot_product_flash_attention.default(q, k, v, 0.0, True, scale = 0.125);  q = k = v = None
     getitem = _scaled_dot_product_flash_attention_default[0];  _scaled_dot_product_flash_attention_default = None
-    return (getitem,)"""
-        try:
-            self.assertExpectedInline(
-                ep.graph_module.code.strip(),
-                code_str,
-            )
-        except AssertionError:
-            code_str = """\
+    return (getitem,)""",  # noqa: B950
+            "_scaled_dot_product_cudnn_attention": """\
 def forward(self, q, k, v):
     _scaled_dot_product_cudnn_attention_default = torch.ops.aten._scaled_dot_product_cudnn_attention.default(q, k, v, None, False, 0.0, True);  q = k = v = None
     getitem = _scaled_dot_product_cudnn_attention_default[0];  _scaled_dot_product_cudnn_attention_default = None
-    return (getitem,)"""
-            self.assertExpectedInline(
-                ep.graph_module.code.strip(),
-                code_str,
-            )
+    return (getitem,)""",  # noqa: B950
+            "_scaled_dot_product_fused_attention_overrideable": """\
+def forward(self, q, k, v):
+    _scaled_dot_product_fused_attention_overrideable_default = torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default(q, k, v, None, 0.0, True);  q = k = v = None
+    getitem = _scaled_dot_product_fused_attention_overrideable_default[0];  _scaled_dot_product_fused_attention_overrideable_default = None
+    return (getitem,)""",  # noqa: B950
+        }
+        code = ep.graph_module.code.strip()
+        matched = next((op for op in expected_graphs if op in code), None)
+        self.assertIsNotNone(
+            matched, f"no fused SDPA op in the decomposed graph:\n{code}"
+        )
+        self.assertExpectedInline(code, expected_graphs[matched])
 
     def test_int_list_output(self):
         class M(torch.nn.Module):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -76,6 +76,10 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     xfailIfDistributedNotSupported,
 )
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     find_library_location,
     HardwareClassification,
@@ -17874,79 +17878,6 @@ class GraphModule(torch.nn.Module):
             ignore_empty_lines=True,
         )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
-    def test_module_to_with_shared_weights(self):
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.embedding = torch.nn.Embedding(num_embeddings=10, embedding_dim=8)
-
-            def forward(self, x):
-                token_ids = torch.ones((4,), device=x.device, dtype=torch.int64)
-                embedded = self.embedding(token_ids).sum()
-                return x.sum() + embedded.sum()
-
-        class Container(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.mod = Model()
-
-            def forward(self, x):
-                if "cuda" in str(x.device):
-                    mod = self.mod.to(x.device)
-                    return mod(x)
-                else:
-                    return x.sum()
-
-        with (
-            torch._dynamo.config.patch(graph_break_on_nn_param_ctor=False),
-            torch._export.config.patch(use_legacy_dynamo_graph_capture=False),
-        ):
-            torch.manual_seed(0)
-            container = Container()
-            container_eager = copy.deepcopy(container)
-            gm = torch.export.export(
-                container,
-                (torch.randn(4, 4, 4, device="cuda"),),
-                strict=True,
-            ).module()
-
-            self.assertExpectedInline(
-                str(gm.code).strip(),
-                """\
-def forward(self, x):
-    args_0, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
-    mod_embedding_weight = self.mod.embedding.weight
-    _guards_fn = self._guards_fn(args_0);  _guards_fn = None
-    empty_memory_format = torch.ops.aten.empty.memory_format([10, 8], dtype = torch.float32, device = device(type='cuda', index=0), pin_memory = False)
-    detach_default = torch.ops.aten.detach.default(empty_memory_format);  empty_memory_format = None
-    submod_1 = self.submod_1
-    wrap_with_set_grad_enabled = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_1, mod_embedding_weight);  submod_1 = mod_embedding_weight = None
-    getitem = wrap_with_set_grad_enabled[0];  wrap_with_set_grad_enabled = None
-    set__source_tensor = torch.ops.aten.set_.source_Tensor(detach_default, getitem);  detach_default = getitem = None
-    view_as_default = torch.ops.aten.view_as.default(set__source_tensor, set__source_tensor);  set__source_tensor = None
-    ones_default = torch.ops.aten.ones.default([4], dtype = torch.int64, device = device(type='cuda', index=0), pin_memory = False)
-    embedding_default = torch.ops.aten.embedding.default(view_as_default, ones_default);  view_as_default = ones_default = None
-    sum_default = torch.ops.aten.sum.default(embedding_default);  embedding_default = None
-    sum_default_1 = torch.ops.aten.sum.default(args_0);  args_0 = None
-    sum_default_2 = torch.ops.aten.sum.default(sum_default);  sum_default = None
-    add_tensor = torch.ops.aten.add.Tensor(sum_default_1, sum_default_2);  sum_default_1 = sum_default_2 = None
-    return pytree.tree_unflatten((add_tensor,), self._out_spec)""",
-            )
-
-            inp = torch.randn(4, 4, 4, device="cuda")
-
-            # Call container first to move shared weights to CUDA
-            export_out = gm(inp)
-            eager_out = container_eager(inp)
-            self.assertEqual(export_out, eager_out)
-
-            # This should not fail even though weights are now on CUDA
-            # and .to(cuda) returns the same parameter with requires_grad=True
-            export_out_v2 = gm(inp)
-            eager_out_v2 = container_eager(inp)
-            self.assertEqual(export_out_v2, eager_out_v2)
-
     @testing.expectedFailureStrict  # test_hop doesn't have a dynamo implementation
     @testing.expectedFailureStrictV2  # test_hop doesn't have a dynamo implementation
     @testing.expectedFailureRetraceability  # test_hop doesn't have a dynamo implementation
@@ -19165,22 +19096,6 @@ def forward(self, x):
             len(list(new_ep.graph.nodes)[-1].args[0]), len(signature.output_specs)
         )
 
-    @requires_cuda_and_triton
-    def test_assert_tensor_metadata_device_index(self):
-        class N(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, x, y):
-                x = x.float()
-                y = y.float()
-                return x + y
-
-        inp = (torch.randn(3, device="cuda"), torch.randn(3, device="cuda"))
-        ep = export(N(), inp)
-        ep = move_to_device_pass(ep, {"cuda:0": "cuda"})
-        ep.module()(torch.randn(3, device="cuda:0"), torch.randn(3, device="cuda:0"))
-
     @unittest.skipIf(not HAS_TORCHREC, "only run when there is torchrec imported")
     def test_torchrec_jagged_tensor(self):
         class Foo(torch.nn.Module):
@@ -19328,6 +19243,115 @@ def forward(self, x):
             for e, d_ in zip(eager_out[0], decomp_out[0]):
                 self.assertEqual(e, d_)
             self.assertEqual(eager_out[1], decomp_out[1])
+
+
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+class TestExportDevice(TorchTestCase):
+    # Not the Dynamo TestCase: instantiate_device_type_tests calls setUpClass at
+    # import time, and the Dynamo TestCase enters a config.patch there that is
+    # never exited, which would leak into every other test in this file.
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    def test_assert_tensor_metadata_device_index(self, device):
+        class N(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                x = x.float()
+                y = y.float()
+                return x + y
+
+        # The pass drops the device index, so the metadata asserts baked into the
+        # graph must still accept an indexed device at runtime.
+        inp = (torch.randn(3, device=device), torch.randn(3, device=device))
+        ep = export(N(), inp)
+        ep = move_to_device_pass(ep, {device: torch.device(device).type})
+        ep.module()(torch.randn(3, device=device), torch.randn(3, device=device))
+
+    @onlyAccelerator
+    def test_module_to_with_shared_weights(self, device):
+        device_type = self.device_type
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = torch.nn.Embedding(num_embeddings=10, embedding_dim=8)
+
+            def forward(self, x):
+                token_ids = torch.ones((4,), device=x.device, dtype=torch.int64)
+                embedded = self.embedding(token_ids).sum()
+                return x.sum() + embedded.sum()
+
+        class Container(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mod = Model()
+
+            def forward(self, x):
+                if device_type in str(x.device):
+                    mod = self.mod.to(x.device)
+                    return mod(x)
+                else:
+                    return x.sum()
+
+        with (
+            # The golden below is in canonical node naming, which the Dynamo
+            # TestCase turns on class-wide but this class does not inherit.
+            torch._dynamo.config.patch(
+                graph_break_on_nn_param_ctor=False,
+                canonicalize_output_graph_node_order=True,
+            ),
+            torch._export.config.patch(use_legacy_dynamo_graph_capture=False),
+        ):
+            torch.manual_seed(0)
+            container = Container()
+            container_eager = copy.deepcopy(container)
+            gm = torch.export.export(
+                container,
+                (torch.randn(4, 4, 4, device=device),),
+                strict=True,
+            ).module()
+
+            self.assertExpectedInline(
+                str(gm.code).strip(),
+                f"""\
+def forward(self, x):
+    args_0, = fx_pytree.tree_flatten_spec(([x], {{}}), self._in_spec)
+    mod_embedding_weight = self.mod.embedding.weight
+    _guards_fn = self._guards_fn(args_0);  _guards_fn = None
+    empty_memory_format = torch.ops.aten.empty.memory_format([10, 8], dtype = torch.float32, device = device(type='{device_type}', index=0), pin_memory = False)
+    detach_default = torch.ops.aten.detach.default(empty_memory_format);  empty_memory_format = None
+    submod_1 = self.submod_1
+    wrap_with_set_grad_enabled = torch.ops.higher_order.wrap_with_set_grad_enabled(False, submod_1, mod_embedding_weight);  submod_1 = mod_embedding_weight = None
+    getitem = wrap_with_set_grad_enabled[0];  wrap_with_set_grad_enabled = None
+    set__source_tensor = torch.ops.aten.set_.source_Tensor(detach_default, getitem);  detach_default = getitem = None
+    view_as_default = torch.ops.aten.view_as.default(set__source_tensor, set__source_tensor);  set__source_tensor = None
+    ones_default = torch.ops.aten.ones.default([4], dtype = torch.int64, device = device(type='{device_type}', index=0), pin_memory = False)
+    embedding_default = torch.ops.aten.embedding.default(view_as_default, ones_default);  view_as_default = ones_default = None
+    sum_default = torch.ops.aten.sum.default(embedding_default);  embedding_default = None
+    sum_default_1 = torch.ops.aten.sum.default(args_0);  args_0 = None
+    sum_default_2 = torch.ops.aten.sum.default(sum_default);  sum_default = None
+    add_tensor = torch.ops.aten.add.Tensor(sum_default_1, sum_default_2);  sum_default_1 = sum_default_2 = None
+    return pytree.tree_unflatten((add_tensor,), self._out_spec)""",  # noqa: B950
+            )
+
+            inp = torch.randn(4, 4, 4, device=device)
+
+            # Call container first to move shared weights to the accelerator
+            export_out = gm(inp)
+            eager_out = container_eager(inp)
+            self.assertEqual(export_out, eager_out)
+
+            # This should not fail even though the weights have already moved
+            # and .to() returns the same parameter with requires_grad=True
+            export_out_v2 = gm(inp)
+            eager_out_v2 = container_eager(inp)
+            self.assertEqual(export_out_v2, eager_out_v2)
+
+
+instantiate_device_type_tests(TestExportDevice, globals(), allow_xpu=True)
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -17973,51 +17973,6 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(x.sin(), ep.module()(x))
         pytree._deregister_pytree_node(torch.FunctionSchema)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
-    def test_exception(self):
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.embedding = torch.nn.Embedding(num_embeddings=10, embedding_dim=8)
-                self.register_buffer("buffer", torch.ones(4, 4))
-                self.register_buffer("param", torch.ones(4, 4))
-
-            def forward(self, x):
-                token_ids = torch.randint(0, 10, (4,), device=x.device)
-                embedded = self.embedding(token_ids).sum()
-                return self.buffer.sum() + self.param.sum() + x.sum() + embedded
-
-        class BarModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.mod = Model()
-
-            def forward(self, x):
-                if "cuda" in str(x.device):
-                    mod = self.mod.to(x.device)
-                    return mod(x)
-                else:
-                    return x.sum()
-
-        class BarBar(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.mod = BarModel()
-
-            def forward(self, x):
-                with torch.amp.autocast(device_type="cuda"):
-                    y = self.mod(x)
-                return y
-
-        with torch.no_grad():
-            with self.assertRaisesRegex(RuntimeError, "Couldn't swap Embedding.weight"):
-                _ = torch.export.export(
-                    BarBar(),
-                    (),
-                    {"x": torch.randn(4, 4, 4, device="cuda")},
-                    strict=False,
-                ).module()
-
     def test_export_for_training_with_state_dict_hooks(self):
         def _state_dict_pre_hook(mod, prefix, keep_vars):
             mod._buffers["test"] = torch.Tensor([1])
@@ -19349,6 +19304,53 @@ def forward(self, x):
             export_out_v2 = gm(inp)
             eager_out_v2 = container_eager(inp)
             self.assertEqual(export_out_v2, eager_out_v2)
+
+    @onlyAccelerator
+    def test_exception(self, device):
+        device_type = self.device_type
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = torch.nn.Embedding(num_embeddings=10, embedding_dim=8)
+                self.register_buffer("buffer", torch.ones(4, 4))
+                self.register_buffer("param", torch.ones(4, 4))
+
+            def forward(self, x):
+                token_ids = torch.randint(0, 10, (4,), device=x.device)
+                embedded = self.embedding(token_ids).sum()
+                return self.buffer.sum() + self.param.sum() + x.sum() + embedded
+
+        class BarModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mod = Model()
+
+            def forward(self, x):
+                if device_type in str(x.device):
+                    mod = self.mod.to(x.device)
+                    return mod(x)
+                else:
+                    return x.sum()
+
+        class BarBar(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mod = BarModel()
+
+            def forward(self, x):
+                with torch.amp.autocast(device_type=device_type):
+                    y = self.mod(x)
+                return y
+
+        with torch.no_grad():
+            with self.assertRaisesRegex(RuntimeError, "Couldn't swap Embedding.weight"):
+                _ = torch.export.export(
+                    BarBar(),
+                    (),
+                    {"x": torch.randn(4, 4, 4, device=device_type)},
+                    strict=False,
+                ).module()
 
 
 instantiate_device_type_tests(TestExportDevice, globals(), allow_xpu=True)

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -98,9 +98,9 @@ from torch.testing._internal.custom_tensor import (
     ConstantExtraMetadataTensor,
     CustomTensorPlainOut,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, requires_triton
 from torch.testing._internal.torchbind_impls import load_torchbind_test_lib
-from torch.testing._internal.triton_utils import requires_cuda_and_triton, requires_gpu
+from torch.testing._internal.triton_utils import requires_gpu
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._pytree import (
     register_constant,
@@ -2635,26 +2635,6 @@ graph():
         self.assertEqual(exp_out, ep_decomposed.module()(x, y, out_copy2))
         # For non-functional graph module, out_copy is not mutated
         self.assertEqual(out_copy2, out_copy3)
-
-    @requires_cuda_and_triton
-    def test_export_raw_triton_kernel_non_strict_error(self):
-        from torch.testing._internal.triton_utils import add_kernel
-
-        class M(torch.nn.Module):
-            def forward(self, x, y):
-                out = torch.empty_like(x)
-                add_kernel[(1,)](x, y, out, x.numel(), BLOCK_SIZE=16)
-                return out
-
-        args = (
-            torch.randn(3, device="cuda"),
-            torch.randn(3, device="cuda"),
-        )
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Raw Triton kernel calls are not supported by non-strict torch.export",
-        ):
-            export(M(), args, strict=False)
 
     def test_masked_select_dynamic(self):
         class M(torch.nn.Module):
@@ -10928,99 +10908,6 @@ def forward(self, b_a_buffer, x):
                 continue
             self.assertEqual(
                 len([node for node in gm.graph.nodes if node.op == "placeholder"]), 1
-            )
-
-    @requires_cuda_and_triton
-    @testing.expectedFailureCppRuntime
-    def test_export_associative_scan_symbol_dim(self):
-        device = torch.device("cuda")
-        combine_mode = "pointwise"
-
-        dim1 = torch.export.Dim("dim0", min=5, max=15)
-        xs = torch.ones(3, 10, 2, device=device)
-
-        class Foo(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-
-            def combine_fn(self, x, y):
-                return x + y
-
-            def forward(self, x):
-                return associative_scan(
-                    self.combine_fn, x, 2, combine_mode=combine_mode
-                )
-
-        ep = export(Foo(), (xs,), dynamic_shapes={"x": {1: dim1}})
-        module_out = Foo()(xs)
-        self.assertTrue(torch.allclose(ep.module()(xs), module_out))
-
-    @requires_cuda_and_triton
-    @testing.expectedFailureCppRuntime
-    def test_export_associative_scan_symbol_scandim(self):
-        device = torch.device("cuda")
-        combine_mode = "pointwise"
-
-        dim1 = torch.export.Dim("dim0", min=5, max=15)
-        xs = torch.ones(3, 10, 2, device=device)
-
-        class Foo(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-
-            def combine_fn(self, x, y):
-                return x + y
-
-            def forward(self, x):
-                return associative_scan(
-                    self.combine_fn, x, 1, combine_mode=combine_mode
-                )
-
-        ep = export(Foo(), (xs,), dynamic_shapes={"x": {1: dim1}})
-        module_out = Foo()(xs)
-        self.assertTrue(torch.allclose(ep.module()(xs), module_out))
-
-    @requires_cuda_and_triton
-    def test_export_associative_scan_lifted_buffers(self):
-        if "cpp_runtime_nonstrict" in self.id():
-            self.skipTest("TODO Unexpected success in OSS but not in fbcode.")
-
-        device = torch.device("cuda")
-        combine_mode = "pointwise"
-
-        class A(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.buffer = torch.nn.Buffer(torch.ones(3, 2, device=device))
-
-            def forward(self):
-                return self.buffer.cos()
-
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.a = A()
-
-            def combine_fn(self, x, y):
-                return (x + y) * self.a()
-
-            def forward(self, x):
-                return associative_scan(
-                    self.combine_fn, x, 1, combine_mode=combine_mode
-                )
-
-        inp = torch.ones(3, 10, 2, device=device)
-        ep = export(M(), (inp,))
-        epm = ep.module()
-
-        self.assertTrue(torch.allclose(epm(inp), M()(inp)))
-
-        for gm in epm.named_modules():
-            if not isinstance(gm, torch.fx.GraphModule):
-                continue
-            self.assertEqual(
-                len([node for node in gm.graph.nodes if node.op == "placeholder"]),
-                1,
             )
 
     # associative_scan is not supported by the cpp (NativeRT) runtime yet
@@ -19351,6 +19238,112 @@ def forward(self, x):
                     {"x": torch.randn(4, 4, 4, device=device_type)},
                     strict=False,
                 ).module()
+
+    @onlyAccelerator
+    @requires_triton()
+    def test_export_raw_triton_kernel_non_strict_error(self, device):
+        from torch.testing._internal.triton_utils import add_kernel
+
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                out = torch.empty_like(x)
+                add_kernel[(1,)](x, y, out, x.numel(), BLOCK_SIZE=16)
+                return out
+
+        args = (
+            torch.randn(3, device=device),
+            torch.randn(3, device=device),
+        )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Raw Triton kernel calls are not supported by non-strict torch.export",
+        ):
+            export(M(), args, strict=False)
+
+    @onlyAccelerator
+    @requires_triton()
+    @testing.expectedFailureCppRuntime
+    def test_export_associative_scan_symbol_dim(self, device):
+        combine_mode = "pointwise"
+        dim1 = torch.export.Dim("dim0", min=5, max=15)
+        xs = torch.ones(3, 10, 2, device=device)
+
+        class Foo(torch.nn.Module):
+            def combine_fn(self, x, y):
+                return x + y
+
+            def forward(self, x):
+                return associative_scan(
+                    self.combine_fn, x, 2, combine_mode=combine_mode
+                )
+
+        ep = export(Foo(), (xs,), dynamic_shapes={"x": {1: dim1}})
+        module_out = Foo()(xs)
+        self.assertTrue(torch.allclose(ep.module()(xs), module_out))
+
+    @onlyAccelerator
+    @requires_triton()
+    @testing.expectedFailureCppRuntime
+    def test_export_associative_scan_symbol_scandim(self, device):
+        combine_mode = "pointwise"
+        dim1 = torch.export.Dim("dim0", min=5, max=15)
+        xs = torch.ones(3, 10, 2, device=device)
+
+        class Foo(torch.nn.Module):
+            def combine_fn(self, x, y):
+                return x + y
+
+            def forward(self, x):
+                return associative_scan(
+                    self.combine_fn, x, 1, combine_mode=combine_mode
+                )
+
+        ep = export(Foo(), (xs,), dynamic_shapes={"x": {1: dim1}})
+        module_out = Foo()(xs)
+        self.assertTrue(torch.allclose(ep.module()(xs), module_out))
+
+    @onlyAccelerator
+    @requires_triton()
+    def test_export_associative_scan_lifted_buffers(self, device):
+        if "cpp_runtime_nonstrict" in self.id():
+            self.skipTest("TODO Unexpected success in OSS but not in fbcode.")
+
+        combine_mode = "pointwise"
+
+        class A(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.buffer = torch.nn.Buffer(torch.ones(3, 2, device=device))
+
+            def forward(self):
+                return self.buffer.cos()
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.a = A()
+
+            def combine_fn(self, x, y):
+                return (x + y) * self.a()
+
+            def forward(self, x):
+                return associative_scan(
+                    self.combine_fn, x, 1, combine_mode=combine_mode
+                )
+
+        inp = torch.ones(3, 10, 2, device=device)
+        ep = export(M(), (inp,))
+        epm = ep.module()
+
+        self.assertTrue(torch.allclose(epm(inp), M()(inp)))
+
+        for gm in epm.named_modules():
+            if not isinstance(gm, torch.fx.GraphModule):
+                continue
+            self.assertEqual(
+                len([node for node in gm.graph.nodes if node.op == "placeholder"]),
+                1,
+            )
 
 
 instantiate_device_type_tests(TestExportDevice, globals(), allow_xpu=True)


### PR DESCRIPTION
## Summary

This PR makes selected export tests device-agnostic and enables their accelerator coverage on XPU.

## What changed

- Added device-templated accelerator test classes for `test_export.py` and `test_draft_export.py`.
- Moved 9 CUDA-gated tests to accelerator-generic coverage so they run on CUDA and XPU.
- Removed an unnecessary Triton requirement from tensor metadata validation.
- Generalized the scaled dot product attention and accelerator memory usage tests.
- Added hardware classification metadata to the test classes.
- Test-only change; no CPU coverage was added or removed.

## Test coverage delta

| Test suite | Before | After |
|---|---:|---:|
| `test_export.py`, XPU | 509 passed / 12 skipped / 2 xfailed | 517 passed / 11 skipped / 2 xfailed |
| `test_draft_export.py`, XPU | 23 passed / 2 skipped | 25 passed / 2 skipped |
| Derived export suites, XPU | — | 4,239 passed / 31 skipped / 71 xfailed |

No unexpected failures occurred. The derived suites collect 54 fewer test instances because tests moved into device-templated classes are no longer redundantly re-instantiated by those suites.