### PR TITLE
[Testcase Refactoring][FSDP] Split remaining state-dict coverage

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -1,15 +1,19 @@
 # Owner(s): ["module: PrivateUse1"]
 
-import inspect
 import unittest
 from collections import defaultdict
 from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_device_type import (
     Capability,
+    CPUTestBase,
+    CUDATestBase,
     dtypes,
+    HPUTestBase,
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
@@ -17,6 +21,7 @@ from torch.testing._internal.common_device_type import (
     precisionOverride,
     PrivateUse1TestBase,
     requires_capabilities,
+    XPUTestBase,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
@@ -308,22 +313,10 @@ class TestCapabilityGating(TestCase):
     """Verify that @requires_capabilities gates tests on PrivateUse1 backends."""
 
     executed_count = 0
-
-    @classmethod
-    def setUpClass(cls):
-        cls._saved_capabilities = inspect.getattr_static(
-            PrivateUse1TestBase, "_capabilities"
-        )
-        PrivateUse1TestBase._capabilities = classmethod(
-            lambda cls: {
-                Capability.dtype.fp8: lambda: True,
-                Capability.dtype.bf16: lambda: False,
-            }
-        )
+    setup_count = 0
 
     @classmethod
     def tearDownClass(cls):
-        PrivateUse1TestBase._capabilities = cls._saved_capabilities
         expected_runs = 3
         if cls.executed_count != expected_runs:
             raise AssertionError(
@@ -331,17 +324,23 @@ class TestCapabilityGating(TestCase):
                 f"Expected {expected_runs} tests to run, "
                 f"but {cls.executed_count} tests executed."
             )
+        if cls.setup_count != expected_runs:
+            raise AssertionError(
+                f"Capability preflight failed! "
+                f"Expected {expected_runs} test setups to run, "
+                f"but {cls.setup_count} setups executed."
+            )
         super().tearDownClass()
 
-    @requires_capabilities(Capability.dtype.fp8)
+    @requires_capabilities(Capability.lib.triton)
     def test_capability_supported(self, device):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
-    @requires_capabilities(Capability.dtype.bf16)
+    @requires_capabilities(Capability.dtype.fp64)
     def test_capability_unsupported(self, device):
         type(self).executed_count += 1
-        self.fail("Expected skip: dtype.bf16 is unsupported on this device")
+        self.fail("Expected skip: dtype.fp64 is unsupported on this device")
 
     def test_capability_missing(self, device):
         """@requires_capabilities raises AssertionError for undeclared capabilities."""
@@ -362,7 +361,7 @@ class TestCapabilityGating(TestCase):
         includes an undeclared capability."""
 
         @requires_capabilities(
-            Capability.dtype.fp8,
+            Capability.lib.triton,
             Capability.dtype.bf16,
             Capability.attention.flash_attention,
         )
@@ -377,7 +376,69 @@ class TestCapabilityGating(TestCase):
         type(self).executed_count += 1
 
 
+def _openreg_test_capabilities(_cls):
+    capabilities = PrivateUse1TestBase._capabilities()
+    capabilities[Capability.lib].update({Capability.lib.triton: lambda: True})
+    capabilities[Capability.dtype] = {
+        Capability.dtype.bf16: lambda: False,
+        Capability.dtype.fp64: lambda: False,
+    }
+    return capabilities
+
+
+def _openreg_capability_test_setup(self):
+    PrivateUse1TestBase.setUp(self)
+    type(self).setup_count += 1
+
+
 instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")
+_capability_test_cls = globals()["TestCapabilityGatingOPENREG"]
+_capability_test_cls._capabilities = classmethod(_openreg_test_capabilities)
+_capability_test_cls.setUp = _openreg_capability_test_setup
+del _capability_test_cls
+
+
+class TestFP64CapabilityDeclarations(TestCase):
+    def test_static_fp64_capabilities(self):
+        for test_base, expected in (
+            (CPUTestBase, True),
+            (CUDATestBase, True),
+            (HPUTestBase, False),
+        ):
+            predicate = test_base._capabilities()[Capability.dtype][
+                Capability.dtype.fp64
+            ]
+            self.assertEqual(predicate(), expected)
+
+    def test_hpu_distributed_capabilities_follow_backend_availability(self):
+        nested_capabilities = HPUTestBase._capabilities()
+        self.assertEqual(
+            set(nested_capabilities[Capability.distributed]),
+            {
+                Capability.distributed.backend,
+                Capability.distributed.fsdp,
+            },
+        )
+
+        for expected in (True, False):
+            with patch(
+                "torch.testing._internal.common_device_type._distributed_backend_available",
+                return_value=expected,
+            ) as backend_available:
+                capabilities = HPUTestBase.get_capabilities()
+                self.assertEqual(capabilities[Capability.distributed.backend], expected)
+                self.assertEqual(capabilities[Capability.distributed.fsdp], expected)
+                self.assertEqual(backend_available.call_count, 2)
+                backend_available.assert_called_with("hpu")
+
+    def test_xpu_fp64_capability_tracks_device_properties(self):
+        predicate = XPUTestBase._capabilities()[Capability.dtype][Capability.dtype.fp64]
+        for expected in (True, False):
+            properties = SimpleNamespace(has_fp64=expected)
+            with patch.object(
+                torch.xpu, "get_device_properties", return_value=properties
+            ):
+                self.assertEqual(predicate(), expected)
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -47,11 +47,14 @@ from torch.distributed.remote_device import _remote_device
 from torch.nn import Linear, Module, TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.parallel import DistributedDataParallel
 from torch.optim import SGD
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _assert_module_states,
-    _broadcast_state_dict,
-    _get_state_dict,
     _zero_model,
     DEVICEInitMode,
     FSDPInitMode,
@@ -61,7 +64,7 @@ from torch.testing._internal.common_fsdp import (
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
@@ -96,8 +99,6 @@ STATE_DICT_MAPPING = {
     "local_state_dict": StateDictType.LOCAL_STATE_DICT,
     "sharded_state_dict": StateDictType.SHARDED_STATE_DICT,
 }
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 class Model(Module):
@@ -156,17 +157,37 @@ class TestDummyModel(torch.nn.Module):
     def forward(self, x):
         return self.net3(self.net2(self.net1(x)))
 
-    def get_input(self):
+    def get_input(self, device):
+        device_type = torch.device(device).type
         return torch.rand(8, 8, device=device_type)
 
 
 class TestFSDPStateDict(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return min(torch.accelerator.device_count(), 2)
 
-    def _broadcast_state_dict(self, state_dict):
-        return _broadcast_state_dict(self.rank, state_dict)
+    def _broadcast_state_dict(self, state_dict, device_type):
+        for param_name, param in state_dict.items():
+            if param.device != torch.device("cpu"):
+                state_dict[param_name] = param.cpu()
+
+        object_list = [state_dict if self.rank == 0 else None]
+        dist.broadcast_object_list(object_list)
+        state_dict = object_list[0]
+        if state_dict is None:
+            raise AssertionError("Expected a broadcast state dict")
+        for param_name in state_dict:
+            state_dict[param_name] = state_dict[param_name].to(device_type)
+        return state_dict
+
+    @staticmethod
+    def _get_state_dict(model, half=False):
+        if half:
+            model.half()
+        return model.state_dict()
 
     def _state_compare(self, model, model_new, assert_fn, state_generator="parameters"):
         state_base = list(getattr(model, state_generator)())
@@ -198,7 +219,12 @@ class TestFSDPStateDict(FSDPTest):
                         self.assertEqual(tensor.dtype, torch.float16)
 
     def _get_simple_nested_model(
-        self, *fsdp_args, wrap=True, checkpoint_wrap=False, **fsdp_kwargs
+        self,
+        device_type,
+        *fsdp_args,
+        wrap=True,
+        checkpoint_wrap=False,
+        **fsdp_kwargs,
     ):
         if wrap:
             lin1 = nn.Linear(10, 10, bias=False).to(device_type)
@@ -217,7 +243,9 @@ class TestFSDPStateDict(FSDPTest):
             )
         return model
 
-    def _get_simple_model(self, *fsdp_args, checkpoint_wrap=False, **fsdp_kwargs):
+    def _get_simple_model(
+        self, device_type, *fsdp_args, checkpoint_wrap=False, **fsdp_kwargs
+    ):
         lin = nn.Linear(10, 10, bias=False).to(device_type)
         if checkpoint_wrap:
             lin = checkpoint_wrapper(lin)
@@ -225,7 +253,12 @@ class TestFSDPStateDict(FSDPTest):
         return model
 
     def _get_multibuffer_nested_model(
-        self, *fsdp_args, wrap=True, checkpoint_wrap=False, **fsdp_kwargs
+        self,
+        device_type,
+        *fsdp_args,
+        wrap=True,
+        checkpoint_wrap=False,
+        **fsdp_kwargs,
     ):
         full_p = torch.float32
         lin_mp = fsdp_kwargs.pop("mixed_precision", None)
@@ -258,7 +291,9 @@ class TestFSDPStateDict(FSDPTest):
             )
         return model
 
-    def _get_non_fsdp_root_module(self, *fsdp_args, wrap=True, **fsdp_kwargs):
+    def _get_non_fsdp_root_module(
+        self, device_type, *fsdp_args, wrap=True, **fsdp_kwargs
+    ):
         class FSDPContainer(nn.Module):
             def __init__(self, fsdp_1, fsdp_2):
                 super().__init__()
@@ -273,8 +308,12 @@ class TestFSDPStateDict(FSDPTest):
                 return x
 
         return FSDPContainer(
-            self._get_simple_nested_model(*fsdp_args, wrap=wrap, **fsdp_kwargs),
-            self._get_simple_nested_model(*fsdp_args, wrap=wrap, **fsdp_kwargs),
+            self._get_simple_nested_model(
+                device_type, *fsdp_args, wrap=wrap, **fsdp_kwargs
+            ),
+            self._get_simple_nested_model(
+                device_type, *fsdp_args, wrap=wrap, **fsdp_kwargs
+            ),
         )
 
     def _get_state_dict_mgr(
@@ -325,6 +364,7 @@ class TestFSDPStateDict(FSDPTest):
                         lambda msg: f"{msg}\nExpected empty state_dict but got {fsdp_state_dict} on rank {dist.get_rank()}",
                     )
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _UNFLATTENED_STATE_DICT_IMPLS)
     @parametrize(
@@ -333,7 +373,7 @@ class TestFSDPStateDict(FSDPTest):
     )
     @parametrize("rank0_only_and_offload", [False, True])
     def test_fsdp_state_dict_with_activation_checkpoint(
-        self, state_dict_type, checkpoint_wrap, rank0_only_and_offload
+        self, device, state_dict_type, checkpoint_wrap, rank0_only_and_offload
     ):
         """Tests saving the state dict, zeroing a target model's parameters, and
         loading the state dict, where the source and target models may have a
@@ -351,9 +391,10 @@ class TestFSDPStateDict(FSDPTest):
                 check_fn=lambda submodule: isinstance(submodule, nn.Linear),
             )
 
+        device_type = torch.device(device).type
         for model_call in [
-            partial(self._get_simple_model),
-            partial(self._get_simple_nested_model),
+            partial(self._get_simple_model, device_type),
+            partial(self._get_simple_nested_model, device_type),
         ]:
             model = model_call(checkpoint_wrap=(checkpoint_wrap in ("source", "both")))
             if checkpoint_wrap in ("source_after_wrap", "both_after_wrap"):
@@ -361,7 +402,7 @@ class TestFSDPStateDict(FSDPTest):
             with self._get_state_dict_mgr(
                 model, state_dict_type, rank0_only_and_offload
             ):
-                state_dict = _gather_state_dict(_get_state_dict(model, False, False))
+                state_dict = _gather_state_dict(self._get_state_dict(model))
                 # Possibly wrap new model in activation checkpoint wrapper to test save/
                 # load with this wrapper
                 model_new = model_call(
@@ -372,16 +413,18 @@ class TestFSDPStateDict(FSDPTest):
                 _zero_model(model_new)
                 self._compare_models(model, model_new, self.assertNotEqual)
                 if rank0_only_and_offload:
-                    state_dict = self._broadcast_state_dict(state_dict)
+                    state_dict = self._broadcast_state_dict(state_dict, device_type)
                 # Would fail if checkpoint_wrapper did not correctly implement state_dict pre/post hooks
                 model_new.load_state_dict(state_dict, strict=True)
                 self._compare_models(model, model_new, self.assertEqual)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _UNFLATTENED_STATE_DICT_IMPLS)
     @parametrize("rank0_only_and_offload", [False, True])
     def test_state_dict_with_manual_ac_wrapper(
         self,
+        device,
         state_dict_type: str,
         rank0_only_and_offload: bool,
     ):
@@ -395,11 +438,12 @@ class TestFSDPStateDict(FSDPTest):
         """
         if state_dict_type == "sharded_state_dict" and rank0_only_and_offload:
             return  # not supported
+        device_type = torch.device(device).type
         model_ac = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            DEVICEInitMode.DEVICE_BEFORE,
-        )
+            DEVICEInitMode.DEVICE_NEVER,
+        ).to(device_type)
         # Manually wrap FSDP without AC
         model_no_ac = deepcopy(model_ac)
         for i, layer in enumerate(model_no_ac.transformer.encoder.layers):
@@ -428,8 +472,8 @@ class TestFSDPStateDict(FSDPTest):
             state_dict_ac = model_ac.state_dict()
         self.assertEqual(state_dict_ac.keys(), state_dict_no_ac.keys())
         if rank0_only_and_offload:
-            state_dict_no_ac = self._broadcast_state_dict(state_dict_no_ac)
-            state_dict_ac = self._broadcast_state_dict(state_dict_ac)
+            state_dict_no_ac = self._broadcast_state_dict(state_dict_no_ac, device_type)
+            state_dict_ac = self._broadcast_state_dict(state_dict_ac, device_type)
         with self._get_state_dict_mgr(
             model_no_ac, state_dict_type, rank0_only_and_offload
         ):
@@ -440,9 +484,11 @@ class TestFSDPStateDict(FSDPTest):
             model_ac.load_state_dict(state_dict_ac)
         self._compare_models(model_ac, model_no_ac, self.assertEqual)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
-    def test_state_dict_with_shared_parameters(self, state_dict_type):
+    def test_state_dict_with_shared_parameters(self, device, state_dict_type):
+        device_type = torch.device(device).type
         auto_wrap_policy = ModuleWrapPolicy(
             {TransformerEncoderLayer, TransformerDecoderLayer}
         )
@@ -450,8 +496,8 @@ class TestFSDPStateDict(FSDPTest):
             TransformerWithSharedParams.init,
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            DEVICEInitMode.DEVICE_BEFORE,
-            {"auto_wrap_policy": auto_wrap_policy},
+            DEVICEInitMode.DEVICE_NEVER,
+            {"auto_wrap_policy": auto_wrap_policy, "device_id": device_type},
         )
 
         fsdp_model = model_creator()
@@ -463,23 +509,28 @@ class TestFSDPStateDict(FSDPTest):
         with self._get_state_dict_mgr(new_model, state_dict_type, False):
             new_model.load_state_dict(state_dict)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("use_orig_params", [False, True])
-    def test_state_dict_rank0_offload_save_load_flow(self, use_orig_params: bool):
+    def test_state_dict_rank0_offload_save_load_flow(
+        self, device, use_orig_params: bool
+    ):
         """Tests saving a model checkpoint only on rank 0 and loading it only
         on rank 0 with ``sync_module_states=True`` to emulate the workflow to
         avoid redundant CPU memory usage."""
+        device_type = torch.device(device).type
         auto_wrap_policy = ModuleWrapPolicy(
             {TransformerEncoderLayer, TransformerDecoderLayer}
         )
         fsdp_kwargs = {
             "auto_wrap_policy": auto_wrap_policy,
             "use_orig_params": use_orig_params,
+            "device_id": device_type,
         }
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            DEVICEInitMode.DEVICE_BEFORE,
+            DEVICEInitMode.DEVICE_NEVER,
             fsdp_kwargs,
         )
         # Force model parameters and buffers to be nonzero
@@ -491,13 +542,13 @@ class TestFSDPStateDict(FSDPTest):
                     with torch.no_grad():
                         tensor.add_(torch.ones_like(tensor))
         with self._get_state_dict_mgr(fsdp_model, "state_dict", True):
-            state_dict = deepcopy(_get_state_dict(fsdp_model))
+            state_dict = deepcopy(self._get_state_dict(fsdp_model))
         # Initialize a non-wrapped model on all ranks
         new_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            DEVICEInitMode.DEVICE_BEFORE,
-        )
+            DEVICEInitMode.DEVICE_NEVER,
+        ).to(device_type)
         _zero_model(new_model, zero_buffers=True)
         # Only load the checkpoint on rank 0
         if self.rank == 0:
@@ -510,7 +561,7 @@ class TestFSDPStateDict(FSDPTest):
         # Broadcast the module states from rank 0 with `sync_module_states=True`
         new_fsdp_model = FSDP(
             new_model,
-            device_id=torch.accelerator.current_device_index(),
+            device_id=device_type,
             auto_wrap_policy=auto_wrap_policy,
             sync_module_states=True,
         )
@@ -528,6 +579,7 @@ class TestFSDPStateDict(FSDPTest):
                 params_new = list(new_fsdp_model.parameters())
                 self.assertEqual(params, params_new)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
     @parametrize(
@@ -539,6 +591,7 @@ class TestFSDPStateDict(FSDPTest):
     @parametrize("use_orig_params", [True, False])
     def test_basic_save_and_load_state_dict(
         self,
+        device,
         state_dict_type: str,
         cpu_offload: bool,
         fp16: bool,
@@ -554,20 +607,24 @@ class TestFSDPStateDict(FSDPTest):
             use_orig_params and state_dict_type not in _UNFLATTENED_STATE_DICT_IMPLS
         ):
             return  # not supported
-        device = torch.device(self.rank)
+        device_type = torch.device(device).type
+        rank_device = torch.device(device_type, self.rank)
         for model_call in [
             partial(
                 self._get_non_fsdp_root_module,
+                device_type,
                 cpu_offload=cpu_offload,
                 use_orig_params=use_orig_params,
             ),
             partial(
                 self._get_simple_nested_model,
+                device_type,
                 cpu_offload=cpu_offload,
                 use_orig_params=use_orig_params,
             ),
             partial(
                 self._get_simple_model,
+                device_type,
                 cpu_offload=cpu_offload,
                 use_orig_params=use_orig_params,
             ),
@@ -577,7 +634,7 @@ class TestFSDPStateDict(FSDPTest):
                 model.half()
             # Run a forward/backward to compute gradients to test the case
             # where there are gradients populated
-            inp = torch.randn((3, 10), device=device)
+            inp = torch.randn((3, 10), device=rank_device)
             if fp16:
                 inp = inp.half()
             model(inp).sum().backward()
@@ -586,9 +643,7 @@ class TestFSDPStateDict(FSDPTest):
                 model, state_dict_type, state_dict_rank0_and_offload
             )
             with ctx:
-                fsdp_state_dict = _get_state_dict(
-                    model, cpu_offload.offload_params, fp16
-                )
+                fsdp_state_dict = self._get_state_dict(model, half=fp16)
 
             ignore_keys = [k for k in fsdp_state_dict if NON_ROOT_FSDP_PREFIX in k]
 
@@ -610,7 +665,7 @@ class TestFSDPStateDict(FSDPTest):
                 model_new.half()
             # Run a forward/backward to compute gradients to test the case
             # where there are gradients populated
-            inp = torch.randn((3, 10), device=device)
+            inp = torch.randn((3, 10), device=rank_device)
             if fp16:
                 inp = inp.half()
             model_new(inp).sum().backward()
@@ -621,12 +676,15 @@ class TestFSDPStateDict(FSDPTest):
 
             # Verify parameters are the same in the new model.
             if state_dict_rank0_and_offload:
-                fsdp_state_dict = self._broadcast_state_dict(fsdp_state_dict)
+                fsdp_state_dict = self._broadcast_state_dict(
+                    fsdp_state_dict, device_type
+                )
             with FSDP.state_dict_type(model_new, STATE_DICT_MAPPING[state_dict_type]):
                 model_new.load_state_dict(fsdp_state_dict, strict=True)
 
             self._compare_models(model, model_new, self.assertEqual, check_fp16=fp16)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
     @parametrize(
@@ -638,6 +696,7 @@ class TestFSDPStateDict(FSDPTest):
     @parametrize("use_orig_params", [True, False])
     def test_buffers_save_and_load_state_dict(
         self,
+        device,
         state_dict_type: str,
         cpu_offload: bool,
         mixed_precision: bool,
@@ -652,6 +711,7 @@ class TestFSDPStateDict(FSDPTest):
             use_orig_params and state_dict_type not in _UNFLATTENED_STATE_DICT_IMPLS
         ):
             return  # not supported
+        device_type = torch.device(device).type
         mixed_precision = (
             MixedPrecision(
                 param_dtype=torch.float16,
@@ -663,6 +723,7 @@ class TestFSDPStateDict(FSDPTest):
         )
         model_call = partial(
             self._get_multibuffer_nested_model,
+            device_type,
             cpu_offload=cpu_offload,
             use_orig_params=use_orig_params,
             mixed_precision=mixed_precision,
@@ -672,7 +733,7 @@ class TestFSDPStateDict(FSDPTest):
             model, state_dict_type, state_dict_rank0_and_offload
         )
         with ctx:
-            fsdp_state_dict = _get_state_dict(model, cpu_offload.offload_params, False)
+            fsdp_state_dict = self._get_state_dict(model)
 
         self._validate_state_dict_contents(
             model, fsdp_state_dict, state_dict_rank0_and_offload
@@ -688,18 +749,19 @@ class TestFSDPStateDict(FSDPTest):
 
         # Verify parameters are the same in the new model.
         if state_dict_rank0_and_offload:
-            fsdp_state_dict = self._broadcast_state_dict(fsdp_state_dict)
+            fsdp_state_dict = self._broadcast_state_dict(fsdp_state_dict, device_type)
         with FSDP.state_dict_type(model_new, STATE_DICT_MAPPING[state_dict_type]):
             model_new.load_state_dict(fsdp_state_dict, strict=True)
 
         self._compare_models(model, model_new, self.assertEqual)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
     @parametrize("mixed_precision", [True, False])
     @parametrize("state_dict_rank0_and_offload", [True, False])
     def test_save_and_load_after_forward_state_dict(
-        self, state_dict_type, mixed_precision, state_dict_rank0_and_offload
+        self, device, state_dict_type, mixed_precision, state_dict_rank0_and_offload
     ):
         """
         Test that saving after some training results in params being updated as
@@ -707,6 +769,7 @@ class TestFSDPStateDict(FSDPTest):
         """
         if state_dict_rank0_and_offload and state_dict_type != "state_dict":
             return
+        device_type = torch.device(device).type
         torch.accelerator.set_device_index(self.rank)
         mixed_precision = (
             MixedPrecision(
@@ -717,11 +780,13 @@ class TestFSDPStateDict(FSDPTest):
             if mixed_precision
             else None
         )
-        model = self._get_simple_nested_model(mixed_precision=mixed_precision)
+        model = self._get_simple_nested_model(
+            device_type, mixed_precision=mixed_precision
+        )
         optim = torch.optim.SGD(model.parameters(), lr=0.1)
         initial_params = get_full_params(model)
         for _ in range(6):
-            inp = torch.randn(1, 10, device=torch.accelerator.current_device_index())
+            inp = torch.randn(1, 10, device=torch.device(device_type))
             output = model(*inp)
             loss = output.sum()
             expected_dtype = torch.float32 if mixed_precision is None else torch.float16
@@ -755,7 +820,7 @@ class TestFSDPStateDict(FSDPTest):
 
         # Load state_dict into zeroed model
         if state_dict_rank0_and_offload:
-            state_dict = self._broadcast_state_dict(state_dict)
+            state_dict = self._broadcast_state_dict(state_dict, device_type)
 
         with FSDP.state_dict_type(model, STATE_DICT_MAPPING[state_dict_type]):
             model.load_state_dict(state_dict, strict=True)
@@ -764,6 +829,7 @@ class TestFSDPStateDict(FSDPTest):
 
     def _initialize_model(
         self,
+        device_type: str,
         wrap_fsdp: bool,
         wrap_ddp: bool = True,
         register_buffers: bool = False,
@@ -801,10 +867,14 @@ class TestFSDPStateDict(FSDPTest):
             return model.load_state_dict(state_dict, strict=True)
 
     def _dist_train(
-        self, wrap_fsdp: bool, state_dict_type: str = "", move_to_cpu: bool = False
+        self,
+        device_type: str,
+        wrap_fsdp: bool,
+        state_dict_type: str = "",
+        move_to_cpu: bool = False,
     ):
         # TODO: Move this test to common_fsdp.
-        model = self._initialize_model(wrap_fsdp)
+        model = self._initialize_model(device_type, wrap_fsdp)
         optim = SGD(model.parameters(), lr=0.1)
 
         in_data = torch.rand(

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -1466,13 +1466,13 @@ class TestFSDPStateDict4GPUs(FSDPTest):
 instantiate_device_type_tests(
     TestFSDPStateDict,
     globals(),
-    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestFSDPStateDict4GPUs,
     globals(),
-    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -905,44 +905,58 @@ class TestFSDPStateDict(FSDPTest):
         else:
             return list(model.parameters())
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
-    def test_state_dict_save_load_flow(self, state_dict_type):
+    def test_state_dict_save_load_flow(self, device, state_dict_type):
+        device_type = torch.device(device).type
         self.run_subtests(
             {"move_to_cpu": [True, False]},
             self._test_state_dict_save_load_flow,
             state_dict_type=state_dict_type,
+            device_type=device_type,
         )
 
-    def _test_state_dict_save_load_flow(self, state_dict_type, move_to_cpu):
+    def _test_state_dict_save_load_flow(
+        self, state_dict_type, move_to_cpu, device_type
+    ):
         fsdp_params = self._dist_train(
+            device_type,
             wrap_fsdp=True,
             state_dict_type=state_dict_type,
             move_to_cpu=move_to_cpu,
         )
-        ddp_params = self._dist_train(wrap_fsdp=False)
+        ddp_params = self._dist_train(device_type, wrap_fsdp=False)
         self.assertEqual(ddp_params, fsdp_params)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
-    def test_fsdp_state_dict_keys(self, state_dict_type):
-        state_dict = self._state_dict(self._initialize_model(True), state_dict_type)
+    def test_fsdp_state_dict_keys(self, device, state_dict_type):
+        device_type = torch.device(device).type
+        state_dict = self._state_dict(
+            self._initialize_model(device_type, True), state_dict_type
+        )
         if state_dict_type == "local_state_dict":
             self.assertEqual({FLAT_PARAM, f"inner.{FLAT_PARAM}"}, state_dict.keys())
         elif state_dict_type in ("state_dict", "sharded_state_dict"):
             # Keys should match local model.
-            local_model = self._initialize_model(wrap_fsdp=False, wrap_ddp=False)
+            local_model = self._initialize_model(
+                device_type, wrap_fsdp=False, wrap_ddp=False
+            )
             local_keys = local_model.state_dict().keys()
             self.assertEqual(state_dict.keys(), local_keys)
         else:
             raise NotImplementedError(f"No test for {state_dict_type}!")
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _UNFLATTENED_STATE_DICT_IMPLS)
     @parametrize("state_dict_rank0_and_offload", [True, False])
     @parametrize("fsdp_root", [True, False])
     def test_state_dict_load_into_local_module(
         self,
+        device,
         state_dict_type,
         state_dict_rank0_and_offload,
         fsdp_root,
@@ -952,10 +966,13 @@ class TestFSDPStateDict(FSDPTest):
         """
         if state_dict_rank0_and_offload and state_dict_type != "state_dict":
             return
+        device_type = torch.device(device).type
         if not fsdp_root:
-            model = self._get_non_fsdp_root_module()
+            model = self._get_non_fsdp_root_module(device_type)
         else:
-            model = self._initialize_model(wrap_fsdp=True, register_buffers=True)
+            model = self._initialize_model(
+                device_type, wrap_fsdp=True, register_buffers=True
+            )
         optim = SGD(model.parameters(), lr=0.1)
         if not fsdp_root:
             in_data = torch.randn(
@@ -990,10 +1007,13 @@ class TestFSDPStateDict(FSDPTest):
         )
         # Create zeroed local model
         if not fsdp_root:
-            blank_local_model = self._get_non_fsdp_root_module(wrap=False)
+            blank_local_model = self._get_non_fsdp_root_module(device_type, wrap=False)
         else:
             blank_local_model = self._initialize_model(
-                wrap_fsdp=False, wrap_ddp=False, register_buffers=True
+                device_type,
+                wrap_fsdp=False,
+                wrap_ddp=False,
+                register_buffers=True,
             )
 
         # Nothing should be FSDP
@@ -1009,24 +1029,26 @@ class TestFSDPStateDict(FSDPTest):
         # Load fsdp's full state dict into the local and verify params are as
         # expected.
         if state_dict_rank0_and_offload:
-            fsdp_state_dict = self._broadcast_state_dict(fsdp_state_dict)
+            fsdp_state_dict = self._broadcast_state_dict(fsdp_state_dict, device_type)
 
         blank_local_model.load_state_dict(fsdp_state_dict, strict=True)
         local_params = list(blank_local_model.parameters())
         for fsdp_param, local_param in zip(fsdp_params, local_params):
             self.assertEqual(fsdp_param, local_param)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
     @parametrize("double_nest", [True])
-    def test_state_dict_skip_module(self, state_dict_type, double_nest):
+    def test_state_dict_skip_module(self, device, state_dict_type, double_nest):
+        device_type = torch.device(device).type
         torch.accelerator.set_device_index(self.rank)
 
         def _create_module(wrap_fsdp=True):
             LINEAR_SKIP = "linear_skip"
             ctx = enable_wrap(wrapper_cls=FSDP) if wrap_fsdp else nullcontext()
             with ctx:
-                module = SkipModel(double_nest=double_nest)
+                module = SkipModel(double_nest=double_nest).to(device_type)
                 # Full name of linear_skip param tensors in SkipModel, as would be
                 # stored in checkpoint.
                 linear_skip_tensor_names = [
@@ -1043,7 +1065,7 @@ class TestFSDPStateDict(FSDPTest):
 
         fsdp, _ = _create_module()
         # Run a forward pass
-        inp = torch.randn((1, 10), device=torch.accelerator.current_device_index())
+        inp = torch.randn((1, 10), device=torch.device(device_type))
         loss = fsdp(inp)
         loss.sum().backward()
 
@@ -1089,8 +1111,10 @@ class TestFSDPStateDict(FSDPTest):
                 for p1, p2 in zip(fsdp.parameters(), local.parameters()):
                     self.assertEqual(p1, p2)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_wrong_state_dict_config(self):
+    def test_wrong_state_dict_config(self, device):
+        device_type = torch.device(device).type
         model = FSDP(Model(wrap_fsdp=True).to(device_type))
         with self.assertRaisesRegex(RuntimeError, "Expected state_dict_config of type"):
             with model.state_dict_type(
@@ -1098,14 +1122,16 @@ class TestFSDPStateDict(FSDPTest):
             ):
                 pass
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _UNFLATTENED_STATE_DICT_IMPLS)
     @parametrize("prefix", [True, False])
     @parametrize("ignore_inner", [True, False])
     @parametrize("mixed_precision", [True, False])
     def test_state_dict_with_ignored_modules(
-        self, state_dict_type, prefix, ignore_inner, mixed_precision
+        self, device, state_dict_type, prefix, ignore_inner, mixed_precision
     ):
+        device_type = torch.device(device).type
         # Initialize an FSDP-wrapped model with an ignored module that includes
         # both parameters and a buffer
         model = Model(
@@ -1198,9 +1224,11 @@ class TestFSDPStateDict(FSDPTest):
                 sd2[prefixed_tensor_name].data_ptr(),
             )
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_state_dict_type(self):
-        module = SkipModel(double_nest=True)
+    def test_state_dict_type(self, device):
+        device_type = torch.device(device).type
+        module = SkipModel(double_nest=True).to(device_type)
         with enable_wrap(wrapper_cls=FSDP):
             fsdp = wrap(module)
         with FSDP.state_dict_type(fsdp, StateDictType.LOCAL_STATE_DICT):
@@ -1208,8 +1236,11 @@ class TestFSDPStateDict(FSDPTest):
         for module in FSDP.fsdp_modules(fsdp):
             self.assertEqual(module._state_dict_type, StateDictType.FULL_STATE_DICT)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_local_state_dict_with_empty_ranks(self):
+    def test_local_state_dict_with_empty_ranks(self, device):
+        device_type = torch.device(device).type
+
         class Model(Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -1234,8 +1265,10 @@ class TestFSDPStateDict(FSDPTest):
             with FSDP.summon_full_params(model):
                 self.assertEqual(model.my_parameter.item(), 3.1415926)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_torch_save_load(self):
+    def test_torch_save_load(self, device):
+        device_type = torch.device(device).type
         model = Model(wrap_fsdp=True).to(device_type)
         with FSDP.state_dict_type(model, StateDictType.LOCAL_STATE_DICT):
             state_dict = model.state_dict()
@@ -1265,8 +1298,10 @@ class TestFSDPStateDict(FSDPTest):
                 else:
                     self.assertEqual(v, state_dict[k])
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_shared_module_and_shared_parameter(self):
+    def test_shared_module_and_shared_parameter(self, device):
+        device_type = torch.device(device).type
         model = FSDP(TestDummyModel().to(device_type))
         with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT):
             state_dict = model.state_dict()
@@ -1276,9 +1311,11 @@ class TestFSDPStateDict(FSDPTest):
             self.assertEqual(state_dict["net2.0.bias"], state_dict["net3.0.bias"])
             self.assertEqual(state_dict["net2.0.weight"], state_dict["net3.0.weight"])
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_full_state_dict_missing_unexpected_keys_cleaned(self):
-        model = self._get_simple_nested_model()
+    def test_full_state_dict_missing_unexpected_keys_cleaned(self, device):
+        device_type = torch.device(device).type
+        model = self._get_simple_nested_model(device_type)
         sd = model.state_dict()
         # Create a missing key
         sd.pop(next(iter(sd.keys())))
@@ -1294,14 +1331,17 @@ class TestFSDPStateDict(FSDPTest):
         self.assertTrue(FSDP_PREFIX not in missing[0])
         self.assertTrue(FSDP_PREFIX not in unexpected[0])
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_sharded_load_multi_backend_pg(self):
+    def test_sharded_load_multi_backend_pg(self, device):
+        device_type = torch.device(device).type
         auto_wrap_policy = ModuleWrapPolicy(
             {TransformerEncoderLayer, TransformerDecoderLayer}
         )
         fsdp_kwargs = {
             "auto_wrap_policy": auto_wrap_policy,
             "use_orig_params": True,
+            "device_id": device_type,
         }
         for load_cpu in [True, False]:
             with self.subTest(load_cpu=load_cpu):
@@ -1310,7 +1350,7 @@ class TestFSDPStateDict(FSDPTest):
                 fsdp_model = TransformerWithSharedParams.init(
                     pg,
                     FSDPInitMode.RECURSIVE,
-                    DEVICEInitMode.DEVICE_BEFORE,
+                    DEVICEInitMode.DEVICE_NEVER,
                     fsdp_kwargs,
                 )
                 FSDP.set_state_dict_type(fsdp_model, StateDictType.SHARDED_STATE_DICT)
@@ -1333,8 +1373,10 @@ class TestFSDPStateDict(FSDPTest):
                         lambda msg: f"{msg}\nnot equal: {p1.sum()} vs {p2.sum()}",
                     )
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_world_size_one(self):
+    def test_world_size_one(self, device):
+        device_type = torch.device(device).type
         my_pg = None
         for i in range(self.world_size):
             pg = dist.new_group(ranks=[i])
@@ -1344,7 +1386,8 @@ class TestFSDPStateDict(FSDPTest):
         model = TransformerWithSharedParams.init(
             my_pg,
             FSDPInitMode.RECURSIVE,
-            DEVICEInitMode.DEVICE_BEFORE,
+            DEVICEInitMode.DEVICE_NEVER,
+            {"device_id": device_type},
         )
         with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
             state_dict = model.state_dict()
@@ -1354,22 +1397,26 @@ class TestFSDPStateDict(FSDPTest):
 
 
 class TestFSDPStateDict4GPUs(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return torch.accelerator.device_count()
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(4)
-    def test_local_state_dict_reshard(self):
+    def test_local_state_dict_reshard(self, device):
         """
         This test demonstrates the ability to do resharding when using
         local_state_dict. Although we do not recommend users to use
         local_state_dict, there are still some corner cases that
         using local_state_dict is a better solution.
         """
+        device_type = torch.device(device).type
         model = FSDP(Model(wrap_fsdp=True)).to(device_type)
         optim = torch.optim.SGD(model.parameters(), lr=0.1)
 
-        batch = torch.randn(4, 4, device=torch.accelerator.current_device_index())
+        batch = torch.randn(4, 4, device=torch.device(device_type))
         output = model(batch)
         loss = output.sum()
         loss.backward()
@@ -1416,7 +1463,18 @@ class TestFSDPStateDict4GPUs(FSDPTest):
             self.assertEqual(full_state_dict1, full_state_dict2)
 
 
-instantiate_parametrized_tests(TestFSDPStateDict)
+instantiate_device_type_tests(
+    TestFSDPStateDict,
+    globals(),
+    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestFSDPStateDict4GPUs,
+    globals(),
+    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -37,6 +37,17 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+try:
+    from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+except ImportError:
+    # PyTorch can be built without distributed support (USE_DISTRIBUTED=0),
+    # e.g. standard macOS CI, where torch._C._distributed_c10d is absent and
+    # common_distributed cannot be imported. TestSkipIfLtXGpu is skipped below via
+    # _SKIP_IF_LT_X_GPU_DISTRIBUTED when USE_DISTRIBUTED=0.
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = False
+else:
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = True
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -2984,6 +2995,41 @@ class TestHardwareClassifications(TestCase):
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)
+
+
+@unittest.skipIf(
+    not _SKIP_IF_LT_X_GPU_DISTRIBUTED,
+    "requires a distributed build (USE_DISTRIBUTED=1)",
+)
+class TestSkipIfLtXGpu(TestCase):
+    @unittest.mock.patch("torch.get_device_module")
+    @unittest.mock.patch("torch._C._accelerator_getAccelerator")
+    def test_allow_cpu_with_compile_only_accelerator(
+        self, mock_get_accelerator, mock_get_device_module
+    ):
+        """Regression test: allow_cpu=True must fall back to CPU when PyTorch is
+        compiled with an accelerator but that accelerator is unavailable at runtime.
+
+        Without check_available=True, current_accelerator() returns the compile-time
+        accelerator even if no device is present. In that case acc is not None, but
+        device_module.is_available() is False, so the allow_cpu=True branch that
+        guards the CPU fallback (``acc is None``) is never taken and the test is
+        skipped instead of running on CPU.
+        """
+        mock_device = unittest.mock.MagicMock()
+        mock_device.type = "cuda"
+        mock_get_accelerator.return_value = mock_device
+
+        mock_module = unittest.mock.MagicMock()
+        mock_module.is_available.return_value = False
+        mock_module.device_count.return_value = 0
+        mock_get_device_module.return_value = mock_module
+
+        @skip_if_lt_x_gpu(2, allow_cpu=True)
+        def test_func():
+            return "cpu_fallback"
+
+        self.assertEqual(test_func(), "cpu_fallback")
 
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2,6 +2,7 @@
 
 import copy
 import gc
+import importlib.util
 import inspect
 import logging
 import os
@@ -328,9 +329,7 @@ class Capability:
 
     Tests declare requirements with :func:`requires_capabilities`::
 
-        @requires_capabilities(
-            Capability.dtype.fp8, Capability.attention.flash_attention
-        )
+        @requires_capabilities(Capability.lib.triton, Capability.dtype.fp8)
         def test_foo(self, device): ...
 
     Device test bases declare what they support by overriding
@@ -338,16 +337,81 @@ class Capability:
     """
 
     class dtype:
-        """Data type capabilities (fp8, bf16, etc.)."""
+        """Data type capabilities (fp8, bf16, fp64, etc.)."""
 
         fp8 = "dtype.fp8"
         bf16 = "dtype.bf16"
+        fp64 = "dtype.fp64"
+
+    class lib:
+        """Third-party library capabilities (triton, etc.)."""
+
+        safetensors = "lib.safetensors"
+        triton = "lib.triton"
 
     class attention:
         """Attention backend capabilities."""
 
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
+
+    class distributed:
+        """Distributed runtime capabilities."""
+
+        backend = "distributed.backend"
+        dtensor = "distributed.dtensor"
+        fsdp = "distributed.fsdp"
+
+    class memory:
+        """Device memory capabilities."""
+
+        non_blocking_copy = "memory.non_blocking_copy"
+
+    class stream:
+        """Device stream capabilities."""
+
+        generic = "stream.generic"
+
+
+def _check_capabilities(test_case, required_capabilities) -> None:
+    device_caps = type(test_case).get_capabilities()
+    missing = set(required_capabilities) - device_caps.keys()
+    unsupported = {
+        cap
+        for cap in required_capabilities
+        if cap in device_caps and not device_caps[cap]
+    }
+
+    if missing:
+        raise AssertionError(
+            f"Device '{type(test_case).device_type}' has not declared capabilities: "
+            f"{', '.join(sorted(missing))}. "
+            f"Add them to {type(test_case).__name__}._capabilities()."
+        )
+    if unsupported:
+        raise unittest.SkipTest(
+            f"Device '{type(test_case).device_type}' has unsupported capabilities: "
+            f"{', '.join(sorted(unsupported))}"
+        )
+
+
+def _distributed_backend_available(device_type: str) -> bool:
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        return False
+    try:
+        backend = dist.get_default_backend_for_device(device_type)
+    except (AttributeError, ValueError):
+        return False
+    return dist.is_backend_available(backend)
+
+
+def _device_module_available(device_type: str) -> bool:
+    try:
+        return torch.get_device_module(device_type).is_available()
+    except (AttributeError, RuntimeError):
+        return False
 
 
 class DeviceTypeTestBase(TestCase):
@@ -420,16 +484,38 @@ class DeviceTypeTestBase(TestCase):
 
     # Returns the capability map used by @requires_capabilities.
     # Subclasses (CPUTestBase, CUDATestBase, etc.) override _capabilities() to
-    # declare supported capabilities. This method evaluates the support checks.
+    # declare supported capabilities grouped by namespace. This method flattens
+    # the nested map and evaluates the support checks.
     @classmethod
     def get_capabilities(cls) -> dict[str, bool]:
-        return {k: bool(fn()) for k, fn in cls._capabilities().items()}
+        return {
+            k: bool(fn())
+            for sub in cls._capabilities().values()
+            for k, fn in sub.items()
+        }
 
-    # Returns a capability map from capability identifier to a callable that
-    # determines whether the current device supports it.
+    # Returns a nested capability map grouped by namespace.
+    # Each namespace (e.g. Capability.dtype) groups related capabilities
+    # (e.g. Capability.dtype.fp8) mapped to callables that determine whether
+    # the current device supports them.
     @classmethod
-    def _capabilities(cls) -> dict[str, Callable[[], bool]]:
-        return {}
+    def _capabilities(cls) -> dict[type, dict[str, Callable[[], bool]]]:
+        return {
+            Capability.lib: {
+                Capability.lib.safetensors: lambda: importlib.util.find_spec(
+                    "safetensors"
+                )
+                is not None,
+            }
+        }
+
+    def setUp(self) -> None:
+        test_method = getattr(self, self._testMethodName)
+        required_capabilities = getattr(test_method, "_required_capabilities", ())
+        if required_capabilities:
+            _check_capabilities(self, required_capabilities)
+
+        super().setUp()
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
@@ -788,12 +874,41 @@ class CPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
-        return {
-            Capability.dtype.fp8: lambda: True,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: True,
-            Capability.attention.mem_efficient_attention: lambda: False,
-        }
+        from torch.utils._triton import has_triton
+
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: False,
+                    Capability.dtype.fp64: lambda: True,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: False,
+                    Capability.attention.mem_efficient_attention: lambda: False,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: False,
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: False,
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: False,
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
 
 class CUDATestBase(DeviceTypeTestBase):
@@ -816,13 +931,47 @@ class CUDATestBase(DeviceTypeTestBase):
             PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
             SM80OrLater,
         )
+        from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
-            Capability.dtype.bf16: lambda: SM80OrLater,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-            Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                    Capability.dtype.bf16: lambda: SM80OrLater,
+                    Capability.dtype.fp64: lambda: True,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+                    Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -900,15 +1049,6 @@ class MPSTestBase(DeviceTypeTestBase):
     def _should_stop_test_suite(self):
         return False
 
-    @classmethod
-    def _capabilities(cls):
-        return {
-            Capability.dtype.fp8: lambda: False,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: False,
-            Capability.attention.mem_efficient_attention: lambda: False,
-        }
-
 
 class XPUTestBase(DeviceTypeTestBase):
     device_type = "xpu"
@@ -919,13 +1059,47 @@ class XPUTestBase(DeviceTypeTestBase):
         from torch.testing._internal.common_xpu import (
             PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
         )
+        from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype.fp8: lambda: True,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
-            Capability.attention.mem_efficient_attention: lambda: True,
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: True,
+                    Capability.dtype.fp64: lambda: torch.xpu.get_device_properties().has_fp64,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+                    Capability.attention.mem_efficient_attention: lambda: True,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -957,6 +1131,26 @@ class XPUTestBase(DeviceTypeTestBase):
 class HPUTestBase(DeviceTypeTestBase):
     device_type = "hpu"
     primary_device: ClassVar[str]
+
+    @classmethod
+    def _capabilities(cls):
+        capabilities = super()._capabilities()
+        capabilities.setdefault(Capability.dtype, {}).update(
+            {
+                Capability.dtype.fp64: lambda: False,
+            }
+        )
+        capabilities.setdefault(Capability.distributed, {}).update(
+            {
+                Capability.distributed.backend: lambda: _distributed_backend_available(
+                    cls.device_type
+                ),
+                Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                    cls.device_type
+                ),
+            }
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -1188,35 +1382,17 @@ def requires_capabilities(*caps: str):
     Raises AssertionError if a capability is not declared in the
     device's ``_capabilities()`` map.
     """
-    caps_set = set(caps)
+    caps_set = frozenset(caps)
 
     def decorator(fn):
         @wraps(fn)
         def wrapper(self, *args, **kwargs):
-            device_caps = type(self).get_capabilities()
-
-            unsupported = set()
-            missing = set()
-            for c in caps_set:
-                if c in device_caps:
-                    if not device_caps[c]:
-                        unsupported.add(c)
-                else:
-                    missing.add(c)
-
-            if missing:
-                raise AssertionError(
-                    f"Device '{type(self).device_type}' has not declared capabilities: "
-                    f"{', '.join(sorted(missing))}. "
-                    f"Add them to {type(self).__name__}._capabilities()."
-                )
-            if unsupported:
-                raise unittest.SkipTest(
-                    f"Device '{type(self).device_type}' has unsupported capabilities: "
-                    f"{', '.join(sorted(unsupported))}"
-                )
+            _check_capabilities(self, caps_set)
             return fn(self, *args, **kwargs)
 
+        wrapper._required_capabilities = (
+            frozenset(getattr(fn, "_required_capabilities", ())) | caps_set
+        )
         return wrapper
 
     return decorator

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -310,6 +310,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -318,15 +322,28 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if torch.cuda.is_available() and torch.cuda.device_count() >= x:
+            # Use check_available=True because current_accelerator() defaults to
+            # compile-time detection. On builds compiled with an accelerator but
+            # with no runtime device available, it would still return that
+            # accelerator, causing allow_cpu=True tests to be skipped instead of
+            # taking the CPU fallback.
+            acc = torch.accelerator.current_accelerator(check_available=True)
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if TEST_HPU and torch.hpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if TEST_XPU and torch.xpu.device_count() >= x:
-                return func(*args, **kwargs)
-            if allow_cpu and not (torch.cuda.is_available() or TEST_HPU or TEST_XPU):
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-gpu-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -73,17 +73,19 @@ if TEST_WITH_ROCM:
 else:
     DEVICE_COUNT = 4
 
-if TEST_CUDA:
-    DEVICE_TYPE = "cuda"
-    DISTRIBUTED_BACKEND = "nccl"
-    DEVICE_COUNT = torch.cuda.device_count()
-elif TEST_HPU:
+if TEST_HPU:
+    # HPU is registered as "fake" in Backend.default_device_backend_map by default.
+    # The real HCCL backend should be registered by torch_hpu; this branch handles
+    # environments where that registration has not occurred.
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
-elif TEST_XPU:
-    DEVICE_TYPE = "xpu"
-    DISTRIBUTED_BACKEND = "xccl"
-    DEVICE_COUNT = torch.xpu.device_count()
+elif torch.accelerator.is_available():
+    acc = torch.accelerator.current_accelerator()
+    DEVICE_TYPE = str(acc)
+    # Use the backend registered for this accelerator type. If no backend is
+    # registered, the accelerator's companion plugin is missing or broken.
+    DISTRIBUTED_BACKEND = dist.Backend.default_device_backend_map[acc.type]
+    DEVICE_COUNT = torch.get_device_module(acc.type).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1245,7 +1247,8 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1591,8 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1639,8 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
I reviewed the code and the quoted PR draft below, verified the reported results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590.
>
> ## Summary
> Complete the state-dict portion split from #193067 so the parent remains review-sized.
>
> ## Changes
> - Propagate the device-test harness device through the remaining FSDP state-dict paths.
> - Preserve existing capability gates, resource checks, assertions, and test coverage.
> - Keep framework and shared-helper ancestry out of the topic change; the consumer file is `test/distributed/fsdp/test_fsdp_state_dict.py`.
>
> ## Motivation
> The state-dict tests exercise accelerator-generic FSDP behavior and should use the harness-selected device without changing their semantics.
>
> ## Checklist
> - [x] Added/updated tests.
> - [x] Preserved existing state-dict coverage.
> - [ ] Passed lint: not run in the current WSL environment because `spin`/`uvx` is unavailable.
> - [x] Updated documentation: not applicable for this test-only split.
> - [x] Included benchmark results: not applicable; no performance behavior change.
>
> ## Test Plan
> - `/home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/fsdp/test_fsdp_state_dict.py`: PASS.
> - `git diff --check`: PASS.
> - Accelerator runtime and aligned CI: not run; no runtime pass is claimed.
>
> ## BC-breaking?
> No. This changes test plumbing only.
>
> ## Notes
> - Base: `main@fd23f0c97b4688e450d13a100a28bec5e3221528`.
> - Head: `f59bed3a742baeb99037656bb509a05db958178c`.
> - Current remote Files Changed: 6 files, 5 commits, because the branch includes stacked ancestry; the topic consumer is `test/distributed/fsdp/test_fsdp_state_dict.py`.
> - Stacked on #193067; review this child after its parent. The PR remains Draft.