### PR TITLE
[profiler] Fix exit crashes when a profiler is left running

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1383,6 +1383,22 @@ class TestProfiler(TestCase):
                 )
                 self.assertTrue(ts_to_name[s_ts_2] == "aten::add")
 
+    def test_profiler_left_running_at_exit(self):
+        # A profiler that is never stopped (e.g. an exception between start() and
+        # stop()) used to segfault during static destruction: ~ProfilerStateBase
+        # soft-asserted through libkineto after libkineto's singleton was gone.
+        script = """
+import torch
+from torch.profiler import profile, ProfilerActivity
+p = profile(activities=[ProfilerActivity.CPU])
+p.start()
+torch.ones(10) * 2
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
     def test_profiler_disable_fwd_bwd_link(self):
         try:
             torch._C._profiler._set_fwd_bwd_enabled_val(False)

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -584,7 +584,14 @@ struct ProfilerStateInfo {
   std::shared_ptr<KinetoThreadLocalState> state_ptr;
   std::unordered_set<at::RecordScope> scopes;
 };
-std::shared_ptr<ProfilerStateInfo> profiler_state_info_ptr{nullptr};
+// Owns the main thread's profiler state. Intentionally leaked: if a profiler
+// is still running at exit, static destruction would run ~ProfilerStateBase
+// after the thread_local callback manager it registered with has already been
+// destroyed (TLS destructors run before static ones).
+std::shared_ptr<ProfilerStateInfo>& profilerStateInfo() {
+  static auto& ptr = *new std::shared_ptr<ProfilerStateInfo>();
+  return ptr;
+}
 
 } // namespace
 
@@ -682,7 +689,7 @@ static void toggleTorchOpCollectionDynamic(bool enable) {
       ProfilerStateBase::getGlobal();
   if (global_state) {
     if (enable) {
-      auto scopes = profiler_state_info_ptr->scopes;
+      auto scopes = profilerStateInfo()->scopes;
       // Mid-session re-arm on the same RecordQueue: do not bump the generation.
       pushGlobalProfilingCallbacks(scopes, /*new_session=*/false);
     } else {
@@ -692,7 +699,7 @@ static void toggleTorchOpCollectionDynamic(bool enable) {
     ProfilerStateBase* tls_state = ProfilerStateBase::getTLS();
     TORCH_CHECK(tls_state);
     if (enable) {
-      auto scopes = profiler_state_info_ptr->scopes;
+      auto scopes = profilerStateInfo()->scopes;
       pushTLSProfilingCallbacks(scopes);
     } else {
       tls_state->removeCallback();
@@ -846,16 +853,16 @@ void enableProfiler(
     auto state_info_ptr = std::make_shared<ProfilerStateInfo>();
     state_info_ptr->state_ptr = std::move(state_ptr);
     state_info_ptr->scopes = scopes;
-    profiler_state_info_ptr = std::move(state_info_ptr);
+    profilerStateInfo() = std::move(state_info_ptr);
   }
 }
 
 bool isProfilerEnabledInMainThread() {
-  return profiler_state_info_ptr != nullptr;
+  return profilerStateInfo() != nullptr;
 }
 
 void enableProfilerInChildThread() {
-  auto state_info_ptr = profiler_state_info_ptr;
+  auto state_info_ptr = profilerStateInfo();
   TORCH_CHECK(state_info_ptr, "Profiler is not enabled in main thread.");
   TORCH_CHECK(
       KinetoThreadLocalState::getTLS() == nullptr,
@@ -875,7 +882,7 @@ void disableProfilerInChildThread() {
 
 std::unique_ptr<ProfilerResult> disableProfiler() {
   // releasing to inform child threads to stop profiling
-  profiler_state_info_ptr = nullptr;
+  profilerStateInfo() = nullptr;
 
   // If global callbacks were installed (KINETO_ONDEMAND, or KINETO with
   // profile_all_threads), they may be running on other threads right now. Wait

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -117,7 +117,10 @@ ProfilerStateBase::~ProfilerStateBase() {
   if (handle_) {
     auto handle = handle_;
     removeCallback();
-    SOFT_ASSERT(false, "Leaked callback handle: ", handle);
+    // Not SOFT_ASSERT: this destructor runs during static destruction when a
+    // profiler is left running at exit, after libkineto's singleton is gone,
+    // and SOFT_ASSERT logs through libkineto::api().
+    TORCH_WARN("Leaked callback handle: ", handle);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195837

A profiler that is never stopped, most commonly because an exception was
raised between profile.start() and profile.stop(), made the process die
with SIGSEGV (and a core dump) at interpreter exit instead of exiting
with the Python error. It reproduces with CPU-only activities and needs
no CUDA. Two separate exit-time lifetime bugs are involved.

First: during __run_exit_handlers, libkineto's LibkinetoApi
function-local static is destroyed before the main thread's
ProfilerStateBase. ~ProfilerStateBase sees the still-registered callback
handle and runs SOFT_ASSERT, which calls logSoftAssert ->
kineto::logInvariantViolation -> libkineto::api(). That reads the
destroyed LibkinetoApi, whose stale activityProfiler_ pointer leads to a
virtual call through freed memory. Fix: report the leaked handle with
TORCH_WARN instead of SOFT_ASSERT. The non-raising branch of SOFT_ASSERT
already only warned; the only thing lost is the kineto
invariant-violation log, which is exactly the call that is unsafe from a
destructor at static-destruction time.

Second (found by ASAN once the new test ran): the namespace-scope static
profiler_state_info_ptr in profiler_kineto.cpp owns the main thread's
KinetoThreadLocalState so that child threads can pick it up. glibc runs
C++ thread_local destructors before static destructors, so by the time
that static is destroyed the main thread's thread_local
LocalCallbackManager in record_function.cpp is already gone and its
callback vector freed. ~ProfilerStateBase -> removeCallback then
searches the freed vector (heap-use-after-free). Fix: make the owner a
function-local leaky singleton (profilerStateInfo()) so it is never
destroyed from a static destructor. enableProfiler/disableProfiler still
assign through it and release prior states exactly as before; only a
state still running at exit is left undestroyed, which is the case where
destroying it is unsafe anyway.

Alternatives considered: a static-destruction canary guarding every
libkineto::api() access in kineto_shim (more invasive, still a
destruction-order hack); a Python atexit that stops a running profiler
(does not help C++ users and changes observable behavior); making
LocalCallbackManager::get() safe after TLS teardown (touches the
RecordFunction hot path and every call site, while the lifetime
inversion is really the profiler's).

Test Plan

New regression test runs a subprocess that starts a profiler and exits
without stopping it, asserting a zero exit code. Before this change it
exited with -11 on every run, and with only the SOFT_ASSERT change it
failed under ASAN with the use-after-free above.

```
python test/profiler/test_profiler.py -k test_profiler_left_running_at_exit
python test/profiler/test_profiler.py -k kineto
python test/profiler/test_profiler.py -k thread
valgrind --error-exitcode=99 python agent_space/leftrunning.py  # 0 errors
```

Also verified by hand on an aarch64 devgpu: 20/20 runs of a
profiler-left-running script (CPU-only and CPU+CUDA, with and without
background launch threads) exit cleanly, and a script raising between
start() and stop() now exits with code 1 instead of dumping core.

Authored with the help of an AI assistant (Claude).