### PR TITLE
[Test] Unskip five parametrization tests that do not need LAPACK

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -6,7 +6,6 @@ from itertools import product
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.nn.init as init
 import torch.nn.utils.parametrize as parametrize
 from torch import Tensor
 from torch.__future__ import get_swap_module_params_on_conversion
@@ -33,10 +32,7 @@ class TestNNParametrization(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
-    # FIXME: Rewrite this test using functions not depending on LAPACK
-    #        and remove the `@skipIfNoLapack` (see #70995)
     # torch/nn/utils/parametrize
-    @skipIfNoLapack
     @swap([True, False])
     def test_register_and_remove_parametrization(self):
         r"""Test that it is possible to add a few parametrizations
@@ -52,14 +48,8 @@ class TestNNParametrization(NNTestCase):
 
         class Orthogonal(nn.Module):
             def forward(self, X):
-                # Cayley map
-                # If X is skew-symmetric it returns an orthogonal matrix
-                Id = torch.eye(X.size(0), device=X.device)
-                # We call contiguous because solve returns a tensor with strides that are Fortran-contiguous
-                # and autograd raises a performance warning.
-                # This happens when we remove the parametrization with leave_parametrized=True,
-                # which does a set_ with a non-contiguous tensor while the gradient is contiguous
-                return torch.linalg.solve(Id + X, Id - X).contiguous()
+                # The exponential of a skew-symmetric matrix is orthogonal
+                return torch.matrix_exp(X)
 
         class Resize(nn.Module):
             def forward(self, X):
@@ -379,9 +369,6 @@ class TestNNParametrization(NNTestCase):
         self.assertTrue((model.bias[1:-1] == torch.ones(6)).all())
         self.assertEqual(len(list(model.parameters())), 1)
 
-    # FIXME: Rewrite this test using functions not depending on LAPACK
-    #        and remove the `@skipIfNoLapack` (see #70995)
-    @skipIfNoLapack
     @skipIfTorchDynamo(
         "Not applicable; see https://github.com/pytorch/pytorch/issues/127738"
     )
@@ -393,14 +380,12 @@ class TestNNParametrization(NNTestCase):
         class Orthogonal(nn.Module):
             def __init__(self, n):
                 super().__init__()
-                self.id = Buffer(torch.eye(n))
-                self.B = Buffer(torch.empty(n, n))
-                init.orthogonal_(self.B)
+                B = torch.randn(n, n).triu(1)
+                self.B = Buffer(torch.matrix_exp(B - B.T))
 
             def forward(self, X):
                 A = X.triu(1)
-                A = A - A.T
-                return self.B @ torch.linalg.solve(self.id + A, self.id - A)
+                return self.B @ torch.matrix_exp(A - A.T)
 
         def get_model():
             model = torch.nn.Sequential(
@@ -432,9 +417,6 @@ class TestNNParametrization(NNTestCase):
             with TemporaryFileName() as fname:
                 torch.save(model, fname)
 
-    # FIXME: Rewrite this test using functions not depending on LAPACK
-    #        and remove the `@skipIfNoLapack` (see #70995)
-    @skipIfNoLapack
     @swap([True, False])
     def test_initialization_parametrization(self):
         r"""Test that it is possible to initialize a parametrization when it
@@ -454,15 +436,14 @@ class TestNNParametrization(NNTestCase):
                     raise ValueError("The matrix is not skew-symmetric.")
                 return X.triu(1)
 
-        # Implements a Cayley map where right_inverse is not quite the inverse of forward
+        # Implements a map where right_inverse is not quite the inverse of forward
         class Orthogonal(nn.Module):
             def __init__(self, n):
                 super().__init__()
                 self.B = Buffer(torch.eye(n))
 
             def forward(self, X):
-                Id = torch.eye(X.size(0))
-                return self.B @ torch.linalg.solve(Id + X, Id - X)
+                return self.B @ torch.matrix_exp(X)
 
             def is_orthogonal(self, X):
                 Id = torch.eye(X.size(0))
@@ -471,7 +452,7 @@ class TestNNParametrization(NNTestCase):
             def right_inverse(self, X):
                 if not self.is_orthogonal(X):
                     raise ValueError("The input is not orthogonal.")
-                # cayley(0) == Id, so B @ cayley(0) == B
+                # matrix_exp(0) == Id, so B @ matrix_exp(0) == B
                 self.B = X
                 return torch.zeros_like(X)
 
@@ -500,7 +481,8 @@ class TestNNParametrization(NNTestCase):
         # X is not orthogonal, so it throws an error
         with self.assertRaises(ValueError):
             model.weight = X
-        init.orthogonal_(X)
+        A = torch.rand(N, N).triu(1)
+        X = torch.matrix_exp(A - A.T)
         model.weight = X
         self.assertEqual(model.weight, X)
         self.assertEqual(model.parametrizations.weight.original, torch.zeros_like(X))
@@ -852,9 +834,6 @@ class TestNNParametrization(NNTestCase):
             loss.backward()
             sgd.step()
 
-    # FIXME: Rewrite this test using functions not depending on LAPACK
-    #        and remove the `@skipIfNoLapack` (see #70995)
-    @skipIfNoLapack
     @swap([True, False])
     def test_caching_parametrization(self):
         r"""Test the caching system of a parametrization"""
@@ -867,8 +846,8 @@ class TestNNParametrization(NNTestCase):
 
         class Orthogonal(nn.Module):
             def forward(self, X):
-                Id = torch.eye(X.size(0), device=X.device)
-                return torch.linalg.solve(Id + X, Id - X)
+                # The exponential of a skew-symmetric matrix is orthogonal
+                return torch.matrix_exp(X)
 
         model = nn.Linear(5, 5)
         parametrize.register_parametrization(model, "weight", Skew())
@@ -880,9 +859,6 @@ class TestNNParametrization(NNTestCase):
             Y = model.weight
             self.assertEqual(id(X), id(Y))
 
-    # FIXME: Rewrite this test using functions not depending on LAPACK
-    #        and remove the `@skipIfNoLapack` (see #70995)
-    @skipIfNoLapack
     @swap([True, False])
     def test_caching_parametrization_with_transfer_parametrizations_and_params(self):
         r"""Test that transferring parametrizations doesn't cause issues with caching"""
@@ -894,8 +870,8 @@ class TestNNParametrization(NNTestCase):
 
         class Orthogonal(nn.Module):
             def forward(self, X):
-                Id = torch.eye(X.size(0), device=X.device)
-                return torch.linalg.solve(Id + X, Id - X)
+                # The exponential of a skew-symmetric matrix is orthogonal
+                return torch.matrix_exp(X)
 
         model = nn.Linear(5, 5)
         parametrize.register_parametrization(model, "weight", Skew())


### PR DESCRIPTION
## Issue

Partially addresses #70995.

## Summary

These five tests were skipped only because their toy `Orthogonal` parametrization built an orthogonal matrix with the Cayley map (`torch.linalg.solve`) and `init.orthogonal_` — neither of which is what the tests actually exercise, since they cover registration and removal, caching, serialization and initialization of the parametrization machinery. Both are replaced with `torch.matrix_exp`, which sends a skew-symmetric matrix to an orthogonal one without touching LAPACK. This does **not** close #70995: of the 7 tests carrying the FIXME, 2 remain. Their `right_inverse` projects onto rank-1 matrices, which is defined by the SVD, so they need reworked assertions rather than a like-for-like substitution and are better handled in a follow-up.

## Test plan

Passing with LAPACK present would not show that the tests no longer need it, so the five were run against a build **without** LAPACK, at this commit and at its parent:

```
CMAKE_DISABLE_FIND_PACKAGE_LAPACK=ON pip install -e . -v --no-build-isolation
python -c "import torch; print(torch._C.has_lapack)"   # False

cd test && python nn/test_parametrization.py -v \
  -k test_register_and_remove_parametrization \
  -k test_serialization_parametrization \
  -k test_initialization_parametrization \
  -k test_caching_parametrization \
  -k test_caching_parametrization_with_transfer_parametrizations_and_params
```

Parent (6b2b0dd), before the change:

```
... skipped 'PyTorch compiled without Lapack'
Ran 10 tests in 0.009s
OK (skipped=10)
```

This commit, after the change:

```
Ran 10 tests in 0.071s
OK
```

Ten runs rather than five because `@swap([True, False])` doubles each test. The same five also pass against a normal LAPACK-enabled build (`Ran 10 tests, OK`).

## Checklist

- [x] Passes lint
- [x] Added/updated tests
- [ ] Updated documentation (not applicable — test-only change)
- [ ] Included benchmark results (not applicable — test-only change)

## BC-breaking?

No. Test-only change; no library code is touched.

---

Authored with AI assistance (Claude Code).
