### PR TITLE
[Test][quantization] Classify test_quantized_op.py by hardware, enable pt2e max_pool2d on XPU

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -54,6 +54,7 @@ from torch.testing._internal.common_quantized import (
     supported_qengines,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_FBCODE,
     IS_MACOS,
@@ -471,6 +472,10 @@ class _QuantizedActivationTestMixin:
 
 
 class TestQuantizedOps(_QuantizedActivationTestMixin, TestCase):
+    # qint dtypes only dispatch to QuantizedCPU, so everything here is CPU-only.
+    # The handful of ops that also have a QuantizedCUDA kernel live in
+    # TestQuantizedOpsDevice.
+    hw_classification = HardwareClassification.CPU
 
     """Tests the correctness of the quantized::relu6 op."""
     def test_qrelu6(self):
@@ -3216,6 +3221,8 @@ class TestQuantizedOpsDevice(_QuantizedActivationTestMixin, TestCase):
     QuantizedXPU or QuantizedMPS kernel for any of these ops, hence the
     only_for below."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     """Tests the correctness of the quantized::relu op."""
     def test_qrelu(self, device):
         # override_qengines cannot be used here: it does not forward the
@@ -3359,6 +3366,12 @@ class TestQuantizedOpsDevice(_QuantizedActivationTestMixin, TestCase):
 
 
 class TestQuantizedOpsCUDNN(TestCase):
+    """These ops only have a QuantizedCUDA kernel in
+    aten/src/ATen/native/quantized/cudnn, so unlike TestQuantizedOpsDevice they
+    cannot be generalized over devices."""
+
+    hw_classification = HardwareClassification.CUDA
+
     """Tests the correctness of the cudnn add and add_relu op
     (Similar to test_qadd_relu_different_qparams, will probably merge in the future)"""
     @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
@@ -3482,6 +3495,8 @@ class TestQuantizedMaxPool2dPT2EDevice(TestCase):
     plain (non-quantized) key on CPU and XPU only -- CUDA has just the
     QuantizedCUDA/cudnn variant -- hence the only_for below."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     def test_max_pool2d_pt2e(self, device):
         kernel_list = [2, 3]
@@ -3519,6 +3534,8 @@ class TestQuantizedMaxPool2dPT2EDevice(TestCase):
 
 class TestDynamicQuantizedOps(TestCase):
     """Tests the correctness of the dynamic quantized linear and linear_relu op."""
+    hw_classification = HardwareClassification.CPU
+
     @override_qengines
     @given(
         batch_size=st.integers(1, 4),
@@ -4204,6 +4221,8 @@ class TestDynamicQuantizedOps(TestCase):
 
 
 class TestQuantizedLinear(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def _test_qlinear_impl(self, batch_size, input_channels, output_channels, use_bias,
                            post_op, use_multi_dim_input, use_channelwise, **post_op_kwargs):
         decimal_val = 4
@@ -5088,6 +5107,8 @@ class TestQuantizedLinear(TestCase):
 
 
 class TestQuantizedLinearCUDNN(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @given(batch_size=st.integers(1, 4),
            # in cudnn v. 8.4.0, there is a limitation that input channels
            # should be a multiple of 4 for int8 tensors. in cudnn v.8.3.3
@@ -5186,6 +5207,7 @@ class TestQuantizedLinearCUDNN(TestCase):
 
 @unittest.skipIf(IS_MACOS, "Known test failure on Mac.")
 class TestQuantizedEmbeddingOps(TestCase):
+    hw_classification = HardwareClassification.CPU
 
     def _test_embedding_bag_unpack_impl(self, pack_fn, unpack_fn, bit_rate, optimized_qparams, weights):
         data_type = weights.dtype
@@ -5545,6 +5567,8 @@ class TestQuantizedEmbeddingOps(TestCase):
 
 
 class TestQuantizedEmbeddingOpsCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """ Tests that the CUDA quantized embedding_bag operators agree with their
         CPU counterparts. This covers the bit-field extraction the dequantization
         path is built on, which is shared by both bit widths. """
@@ -5896,6 +5920,8 @@ class TestQuantizedEmbeddingOpsCUDA(TestCase):
 
 
 class TestQuantizedConv(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def _test_qconv_unpack_impl(self, qconv_prepack_fn, qconv_unpack_fn, inputs,
                                 strides, i_pads, o_pads, channelwise):
         (X_data, W_data, bias_data, groups, transposed) = inputs
@@ -8966,6 +8992,8 @@ class TestQuantizedConv(TestCase):
 
 
 class TestPadding(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     @given(batch_size=st.integers(1, 64),
            channels=st.integers(1, 64),
            width=st.integers(16, 128),
@@ -9053,6 +9081,8 @@ class TestPadding(TestCase):
                      "This Pytorch Build has not been built with or does not support QNNPACK")
 class TestQNNPackOps(TestCase):
     """Tests the correctness of the quantized::qnnpack_relu op."""
+    hw_classification = HardwareClassification.CPU
+
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
                        qparams=hu.qparams(dtypes=torch.quint8,
                                           zero_point_min=0,
@@ -9531,6 +9561,8 @@ class TestQNNPackOps(TestCase):
 """Tests the correctness of the tensor comparators."""
 class TestComparatorOps(TestCase):
     """Tests the element-wise equality ops."""
+    hw_classification = HardwareClassification.CPU
+
     @given(A=hu.tensor(shapes=((3, 4, 5),),
                        qparams=hu.qparams()),
            B=hu.tensor(shapes=((5,), (1, 5), (1, 1, 5), (4, 5), (3, 4, 5)),
@@ -9603,6 +9635,8 @@ class TestComparatorOps(TestCase):
 """Tests the correctness of the quantized::embedding_bag_(byte|4bit|2bit)_prepack_with_rowwise_min_max ops."""
 class TestQuantizedWithMinMax(TestCase):
     """Validates that the *rowwsie_min_max* quantization functions are equivalent to the ones without it."""
+    hw_classification = HardwareClassification.CPU
+
     def test_quantize_tensor_with_min_max(self):
         num_rows_list = [1, 2, 10, 100]
         num_cols_list = [4, 8, 16, 32, 64, 128]

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1134,77 +1134,6 @@ class TestQuantizedOps(TestCase):
             self.assertEqual(qCrelu_hat, qCrelu_out_hat,
                              msg="AddReLU.out failed")
 
-    """Tests the correctness of the cudnn add and add_relu op
-    (Similar to test_qadd_relu_different_qparams, will probably merge in the future)"""
-    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    @unittest.skipIf(not SM80OrLater, "requires sm80 or later.")
-    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
-    @unittest.skip("not currently working and feature isn't used")
-    def test_qadd_relu_cudnn(self):
-        dtype = torch.qint8
-        add_relu = torch.ops.quantized.add_relu
-        add = torch.ops.quantized.add
-
-        A = torch.arange(-128, 130, dtype=torch.float).to(torch.device("cuda"))
-        B = torch.arange(-128, 130, dtype=torch.float).to(torch.device("cuda"))
-        scale_A = 2.5
-        scale_B = 6.3
-        scale_C = 12.9
-        zero_point = 0
-        qA = torch.quantize_per_tensor(A, scale=scale_A, zero_point=zero_point,
-                                       dtype=dtype)
-        qB = torch.quantize_per_tensor(B, scale=scale_B, zero_point=zero_point,
-                                       dtype=dtype)
-        # Add ground truth
-        C = (qA.dequantize() + qB.dequantize()).to(device="cpu").numpy()
-        qC = _quantize(C, scale_C, zero_point, dtype=np_dtype[dtype])
-        qC_hat = add(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
-        np.testing.assert_equal(qC, qC_hat.int_repr(),
-                                "Quantized addition failed.")
-
-        # Add + ReLU ground truth
-        Crelu = C.copy()
-        Crelu[C < 0] = 0
-        qCrelu = _quantize(Crelu, scale_C, zero_point, dtype=np_dtype[dtype])
-        qCrelu_hat = add_relu(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
-        np.testing.assert_equal(qCrelu, qCrelu_hat.int_repr(),
-                                "Quantized addition with ReLU failed.")
-
-    """Tests the correctness of the cudnn add and add_relu op for nhwc format"""
-    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    @unittest.skipIf(not SM80OrLater, "requires sm80 or later.")
-    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
-    @unittest.skip("not currently working and feature isn't used")
-    def test_qadd_relu_cudnn_nhwc(self):
-        dtype = torch.qint8
-        add_relu = torch.ops.quantized.add_relu
-        add = torch.ops.quantized.add
-
-        A = torch.rand(16, 8, 4, 12).to(device="cuda")
-        B = torch.rand(16, 8, 4, 12).to(device="cuda")
-        scale_A = 2.5
-        scale_B = 6.3
-        scale_C = 12.9
-        zero_point = 0
-        qA = torch.quantize_per_tensor(A, scale=scale_A, zero_point=zero_point,
-                                       dtype=dtype)
-        qB = torch.quantize_per_tensor(B, scale=scale_B, zero_point=zero_point,
-                                       dtype=dtype)
-        # Add ground truth
-        C = (qA.dequantize() + qB.dequantize()).to(device="cpu").numpy()
-        qC = _quantize(C, scale_C, zero_point, dtype=np_dtype[dtype])
-        qC_hat = add(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
-        np.testing.assert_equal(qC, qC_hat.int_repr(),
-                                "Quantized addition failed.")
-
-        # Add + ReLU ground truth
-        Crelu = C.copy()
-        Crelu[C < 0] = 0
-        qCrelu = _quantize(Crelu, scale_C, zero_point, dtype=np_dtype[dtype])
-        qCrelu_hat = add_relu(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
-        np.testing.assert_equal(qCrelu, qCrelu_hat.int_repr(),
-                                "Quantized addition with ReLU failed.")
-
     """Tests the correctness of the add and add_relu op."""
     def test_qadd_relu_different_qparams(self):
         for dtype in [torch.quint8, torch.qint8, torch.qint32]:
@@ -1610,50 +1539,6 @@ class TestQuantizedOps(TestCase):
             ceil_mode=ceil_mode)
         self.assertEqual(a_ref, a_hat.dequantize(),
                          msg="ops.quantized.max_pool1d results are off")
-
-    # TODO: merge this test with test_max_pool2d
-    """Tests 2D cudnn max pool operation on quantized tensors."""
-    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
-                                              min_side=1, max_side=10),
-                       # cudnn's support for quantized pooling is limited to
-                       # int8 currently
-                       qparams=hu.qparams(dtypes=[torch.qint8])),
-           kernel=st.sampled_from((3, 5, 7)),
-           stride=st.sampled_from((None, 1, 2)),
-           # currently there is no support for dilation for cudnn
-           # pooling
-           dilation=st.integers(1, 1),
-           padding=st.integers(0, 2),
-           ceil_mode=st.booleans())
-    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
-    def test_max_pool2d_cudnn(self, X, kernel, stride, dilation, padding, ceil_mode):
-        X, (scale, zero_point, torch_type) = X
-        assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
-        iH, iW = X.shape[-2:]
-        oH = pool_output_shape(iH, kernel, padding, stride, dilation, ceil_mode)
-        assume(oH > 0)
-        oW = pool_output_shape(iW, kernel, padding, stride, dilation, ceil_mode)
-        assume(oW > 0)
-
-        a = torch.from_numpy(X).to(device="cuda")
-        a_pool = torch.nn.functional.max_pool2d(a, kernel_size=kernel,
-                                                stride=stride,
-                                                padding=padding, dilation=dilation,
-                                                ceil_mode=ceil_mode)
-        a_ref = torch.quantize_per_tensor(a_pool, scale=scale,
-                                          zero_point=zero_point, dtype=torch_type)
-        a_ref = a_ref.dequantize()
-        qa = torch.quantize_per_tensor(a, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type)
-
-        # Test the ops.quantized separately, because None is not treated.
-        a_hat = torch.ops.quantized.max_pool2d(
-            qa, kernel_size=_pair(kernel),
-            stride=_pair(kernel if stride is None else stride),
-            padding=_pair(padding), dilation=_pair(dilation), ceil_mode=ceil_mode)
-        self.assertEqual(a_ref, a_hat.dequantize(),
-                         msg="ops.quantized.max_pool2d results are off")
 
     """Tests 2D max pool operation on quantized tensors."""
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
@@ -3492,6 +3377,123 @@ class TestQuantizedOps(TestCase):
             self.assertEqual(y, y_ref, msg=lambda msg: f"{msg}\n{y} vs {y_ref}")
 
 
+class TestQuantizedOpsCUDNN(TestCase):
+    """Tests the correctness of the cudnn add and add_relu op
+    (Similar to test_qadd_relu_different_qparams, will probably merge in the future)"""
+    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
+    @unittest.skipIf(not SM80OrLater, "requires sm80 or later.")
+    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
+    @unittest.skip("not currently working and feature isn't used")
+    def test_qadd_relu_cudnn(self):
+        dtype = torch.qint8
+        add_relu = torch.ops.quantized.add_relu
+        add = torch.ops.quantized.add
+
+        A = torch.arange(-128, 130, dtype=torch.float).to(torch.device("cuda"))
+        B = torch.arange(-128, 130, dtype=torch.float).to(torch.device("cuda"))
+        scale_A = 2.5
+        scale_B = 6.3
+        scale_C = 12.9
+        zero_point = 0
+        qA = torch.quantize_per_tensor(A, scale=scale_A, zero_point=zero_point,
+                                       dtype=dtype)
+        qB = torch.quantize_per_tensor(B, scale=scale_B, zero_point=zero_point,
+                                       dtype=dtype)
+        # Add ground truth
+        C = (qA.dequantize() + qB.dequantize()).to(device="cpu").numpy()
+        qC = _quantize(C, scale_C, zero_point, dtype=np_dtype[dtype])
+        qC_hat = add(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
+        np.testing.assert_equal(qC, qC_hat.int_repr(),
+                                "Quantized addition failed.")
+
+        # Add + ReLU ground truth
+        Crelu = C.copy()
+        Crelu[C < 0] = 0
+        qCrelu = _quantize(Crelu, scale_C, zero_point, dtype=np_dtype[dtype])
+        qCrelu_hat = add_relu(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
+        np.testing.assert_equal(qCrelu, qCrelu_hat.int_repr(),
+                                "Quantized addition with ReLU failed.")
+
+    """Tests the correctness of the cudnn add and add_relu op for nhwc format"""
+    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
+    @unittest.skipIf(not SM80OrLater, "requires sm80 or later.")
+    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
+    @unittest.skip("not currently working and feature isn't used")
+    def test_qadd_relu_cudnn_nhwc(self):
+        dtype = torch.qint8
+        add_relu = torch.ops.quantized.add_relu
+        add = torch.ops.quantized.add
+
+        A = torch.rand(16, 8, 4, 12).to(device="cuda")
+        B = torch.rand(16, 8, 4, 12).to(device="cuda")
+        scale_A = 2.5
+        scale_B = 6.3
+        scale_C = 12.9
+        zero_point = 0
+        qA = torch.quantize_per_tensor(A, scale=scale_A, zero_point=zero_point,
+                                       dtype=dtype)
+        qB = torch.quantize_per_tensor(B, scale=scale_B, zero_point=zero_point,
+                                       dtype=dtype)
+        # Add ground truth
+        C = (qA.dequantize() + qB.dequantize()).to(device="cpu").numpy()
+        qC = _quantize(C, scale_C, zero_point, dtype=np_dtype[dtype])
+        qC_hat = add(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
+        np.testing.assert_equal(qC, qC_hat.int_repr(),
+                                "Quantized addition failed.")
+
+        # Add + ReLU ground truth
+        Crelu = C.copy()
+        Crelu[C < 0] = 0
+        qCrelu = _quantize(Crelu, scale_C, zero_point, dtype=np_dtype[dtype])
+        qCrelu_hat = add_relu(qA, qB, scale=scale_C, zero_point=zero_point).to(device="cpu")
+        np.testing.assert_equal(qCrelu, qCrelu_hat.int_repr(),
+                                "Quantized addition with ReLU failed.")
+
+    # TODO: merge this test with test_max_pool2d
+    """Tests 2D cudnn max pool operation on quantized tensors."""
+    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
+                                              min_side=1, max_side=10),
+                       # cudnn's support for quantized pooling is limited to
+                       # int8 currently
+                       qparams=hu.qparams(dtypes=[torch.qint8])),
+           kernel=st.sampled_from((3, 5, 7)),
+           stride=st.sampled_from((None, 1, 2)),
+           # currently there is no support for dilation for cudnn
+           # pooling
+           dilation=st.integers(1, 1),
+           padding=st.integers(0, 2),
+           ceil_mode=st.booleans())
+    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
+    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
+    def test_max_pool2d_cudnn(self, X, kernel, stride, dilation, padding, ceil_mode):
+        X, (scale, zero_point, torch_type) = X
+        assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!
+        iH, iW = X.shape[-2:]
+        oH = pool_output_shape(iH, kernel, padding, stride, dilation, ceil_mode)
+        assume(oH > 0)
+        oW = pool_output_shape(iW, kernel, padding, stride, dilation, ceil_mode)
+        assume(oW > 0)
+
+        a = torch.from_numpy(X).to(device="cuda")
+        a_pool = torch.nn.functional.max_pool2d(a, kernel_size=kernel,
+                                                stride=stride,
+                                                padding=padding, dilation=dilation,
+                                                ceil_mode=ceil_mode)
+        a_ref = torch.quantize_per_tensor(a_pool, scale=scale,
+                                          zero_point=zero_point, dtype=torch_type)
+        a_ref = a_ref.dequantize()
+        qa = torch.quantize_per_tensor(a, scale=scale, zero_point=zero_point,
+                                       dtype=torch_type)
+
+        # Test the ops.quantized separately, because None is not treated.
+        a_hat = torch.ops.quantized.max_pool2d(
+            qa, kernel_size=_pair(kernel),
+            stride=_pair(kernel if stride is None else stride),
+            padding=_pair(padding), dilation=_pair(dilation), ceil_mode=ceil_mode)
+        self.assertEqual(a_ref, a_hat.dequantize(),
+                         msg="ops.quantized.max_pool2d results are off")
+
+
 class TestDynamicQuantizedOps(TestCase):
     """Tests the correctness of the dynamic quantized linear and linear_relu op."""
     @override_qengines
@@ -4471,101 +4473,6 @@ class TestQuantizedLinear(TestCase):
             decimal_val = 1
             np.testing.assert_array_almost_equal(Y_fp32_ref.numpy(), Y_q_dq.numpy(), decimal=decimal_val)
 
-    @given(batch_size=st.integers(1, 4),
-           # in cudnn v. 8.4.0, there is a limitation that input channels
-           # should be a multiple of 4 for int8 tensors. in cudnn v.8.3.3
-           # this should be a multiple of 16
-           input_channels=st.sampled_from([4, 8, 12, 16, 32]),
-           # constraints on output channels appear to be relax, as it seems we can use any positive integer here
-           # except 1. It is not clear why 1 will not work. TODO: check with Yang
-           output_channels=st.integers(2, 36),
-           use_bias=st.booleans(),
-           use_relu=st.booleans(),
-           use_multi_dim_input=st.booleans(),
-           use_channelwise=st.sampled_from([False]))  # channelwise currently not supported for qlinear cudnn
-    @skipIfNoFBGEMM
-    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    @unittest.skipIf(TEST_CUDNN and torch.backends.cudnn.version() == 90100, "expected failure on cuDNN 9.1.0")
-    @unittest.skipIf(not SM80OrLater, "requires sm80 or later.")
-    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
-    # TODO: check with yang regarding CUDNN flags
-    @unittest.skip("not currently working and feature isn't used")
-    def test_qlinear_cudnn(self, batch_size, input_channels, output_channels, use_bias,
-                           use_relu, use_multi_dim_input, use_channelwise):
-        qlinear_prepack = torch.ops.quantized.linear_prepack
-        if use_relu:
-            qlinear_op = torch.ops.quantized.linear_relu
-        else:
-            qlinear_op = torch.ops.quantized.linear
-        X_scale = 1.5
-        X_zp = 0
-        X_value_min = -128
-        X_value_max = 127
-        X_q0 = np.round(
-            np.random.rand(batch_size, input_channels) *
-            (X_value_max - X_value_min)
-            + X_value_min).astype(np.int8)
-        W_scale = 2.5
-        W_zp = 0
-        W_value_min = -128
-        W_value_max = 127
-        W_q0 = np.round(
-            np.random.rand(output_channels, input_channels)
-            * (W_value_max - W_value_min)
-            + W_value_min
-        ).astype(np.int8)
-        b_value_min = -10
-        b_value_max = 10
-        b_q0 = np.round(
-            np.random.rand(output_channels) *
-            (b_value_max - b_value_min) + b_value_min
-        ).astype(np.int32) if use_bias else None
-        if use_bias:
-            b_value_min = -10
-            b_value_max = 10
-            b_q0 = np.round(
-                np.random.rand(output_channels) *
-                (b_value_max - b_value_min) + b_value_min
-            ).astype(np.int32)
-        else:
-            bias = None
-        avoid_vpmaddubsw_overflow_linear(
-            batch_size,
-            input_channels,
-            output_channels,
-            X_q0,
-            X_value_min,
-            X_value_max,
-            W_q0,
-            W_value_min,
-            W_value_max,
-        )
-        quant_dtype = torch.qint8
-        X = torch.from_numpy(_dequantize(
-            X_q0, X_scale, X_zp)).to(dtype=torch.float).to(device="cuda")
-        X_q = torch.quantize_per_tensor(
-            X, scale=X_scale, zero_point=X_zp, dtype=quant_dtype)
-        W = torch.from_numpy(_dequantize(
-            W_q0, W_scale, W_zp)).to(dtype=torch.float).to(device="cuda")
-        W_q = torch.quantize_per_tensor(W, scale=W_scale, zero_point=W_zp, dtype=quant_dtype)
-        b = torch.from_numpy(_dequantize(
-            b_q0, X_scale * (W_zp), 0)).to(dtype=torch.float).to(device="cuda") if use_bias else None
-        b_q = torch.quantize_per_tensor(
-            b, scale=X_scale * W_scale, zero_point=0, dtype=quant_dtype) if use_bias else None
-        Y_scale = 0.5
-        Y_zp = 0
-        # Weight prepacking operator for quantized Linear
-        float_bias = b if use_bias else None
-        W_prepack = qlinear_prepack(W_q, float_bias if use_bias else None)
-        # Quantized Linear operator with prepacked weight
-        Y_q = qlinear_op(X_q, W_prepack, Y_scale, Y_zp).to(device="cpu")
-        Y_q_ref = qlinear_ref(X_q0, X_scale, X_zp, W_q0,
-                              W_scale, W_zp, b_q0, Y_scale, Y_zp, dtype=np.int8)
-        if use_relu:
-            Y_q_ref[Y_q_ref < Y_zp] = Y_zp
-        decimal_val = 0
-        np.testing.assert_array_almost_equal(Y_q_ref, Y_q.int_repr().numpy(), decimal=decimal_val)
-
     """Tests the correctness of the quantized::linear_unpack op."""
     @given(W=hu.tensor(shapes=hu.array_shapes(2, 2,),
                        qparams=hu.qparams(dtypes=torch.qint8)),
@@ -5157,6 +5064,103 @@ class TestQuantizedLinear(TestCase):
         )
 
 
+class TestQuantizedLinearCUDNN(TestCase):
+    @given(batch_size=st.integers(1, 4),
+           # in cudnn v. 8.4.0, there is a limitation that input channels
+           # should be a multiple of 4 for int8 tensors. in cudnn v.8.3.3
+           # this should be a multiple of 16
+           input_channels=st.sampled_from([4, 8, 12, 16, 32]),
+           # constraints on output channels appear to be relax, as it seems we can use any positive integer here
+           # except 1. It is not clear why 1 will not work. TODO: check with Yang
+           output_channels=st.integers(2, 36),
+           use_bias=st.booleans(),
+           use_relu=st.booleans(),
+           use_multi_dim_input=st.booleans(),
+           use_channelwise=st.sampled_from([False]))  # channelwise currently not supported for qlinear cudnn
+    @skipIfNoFBGEMM
+    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
+    @unittest.skipIf(TEST_CUDNN and torch.backends.cudnn.version() == 90100, "expected failure on cuDNN 9.1.0")
+    @unittest.skipIf(not SM80OrLater, "requires sm80 or later.")
+    @unittest.skipIf(TEST_ROCM, "not supported on rocm.")
+    # TODO: check with yang regarding CUDNN flags
+    @unittest.skip("not currently working and feature isn't used")
+    def test_qlinear_cudnn(self, batch_size, input_channels, output_channels, use_bias,
+                           use_relu, use_multi_dim_input, use_channelwise):
+        qlinear_prepack = torch.ops.quantized.linear_prepack
+        if use_relu:
+            qlinear_op = torch.ops.quantized.linear_relu
+        else:
+            qlinear_op = torch.ops.quantized.linear
+        X_scale = 1.5
+        X_zp = 0
+        X_value_min = -128
+        X_value_max = 127
+        X_q0 = np.round(
+            np.random.rand(batch_size, input_channels) *
+            (X_value_max - X_value_min)
+            + X_value_min).astype(np.int8)
+        W_scale = 2.5
+        W_zp = 0
+        W_value_min = -128
+        W_value_max = 127
+        W_q0 = np.round(
+            np.random.rand(output_channels, input_channels)
+            * (W_value_max - W_value_min)
+            + W_value_min
+        ).astype(np.int8)
+        b_value_min = -10
+        b_value_max = 10
+        b_q0 = np.round(
+            np.random.rand(output_channels) *
+            (b_value_max - b_value_min) + b_value_min
+        ).astype(np.int32) if use_bias else None
+        if use_bias:
+            b_value_min = -10
+            b_value_max = 10
+            b_q0 = np.round(
+                np.random.rand(output_channels) *
+                (b_value_max - b_value_min) + b_value_min
+            ).astype(np.int32)
+        else:
+            bias = None
+        avoid_vpmaddubsw_overflow_linear(
+            batch_size,
+            input_channels,
+            output_channels,
+            X_q0,
+            X_value_min,
+            X_value_max,
+            W_q0,
+            W_value_min,
+            W_value_max,
+        )
+        quant_dtype = torch.qint8
+        X = torch.from_numpy(_dequantize(
+            X_q0, X_scale, X_zp)).to(dtype=torch.float).to(device="cuda")
+        X_q = torch.quantize_per_tensor(
+            X, scale=X_scale, zero_point=X_zp, dtype=quant_dtype)
+        W = torch.from_numpy(_dequantize(
+            W_q0, W_scale, W_zp)).to(dtype=torch.float).to(device="cuda")
+        W_q = torch.quantize_per_tensor(W, scale=W_scale, zero_point=W_zp, dtype=quant_dtype)
+        b = torch.from_numpy(_dequantize(
+            b_q0, X_scale * (W_zp), 0)).to(dtype=torch.float).to(device="cuda") if use_bias else None
+        b_q = torch.quantize_per_tensor(
+            b, scale=X_scale * W_scale, zero_point=0, dtype=quant_dtype) if use_bias else None
+        Y_scale = 0.5
+        Y_zp = 0
+        # Weight prepacking operator for quantized Linear
+        float_bias = b if use_bias else None
+        W_prepack = qlinear_prepack(W_q, float_bias if use_bias else None)
+        # Quantized Linear operator with prepacked weight
+        Y_q = qlinear_op(X_q, W_prepack, Y_scale, Y_zp).to(device="cpu")
+        Y_q_ref = qlinear_ref(X_q0, X_scale, X_zp, W_q0,
+                              W_scale, W_zp, b_q0, Y_scale, Y_zp, dtype=np.int8)
+        if use_relu:
+            Y_q_ref[Y_q_ref < Y_zp] = Y_zp
+        decimal_val = 0
+        np.testing.assert_array_almost_equal(Y_q_ref, Y_q.int_repr().numpy(), decimal=decimal_val)
+
+
 @unittest.skipIf(IS_MACOS, "Known test failure on Mac.")
 class TestQuantizedEmbeddingOps(TestCase):
 
@@ -5423,6 +5427,101 @@ class TestQuantizedEmbeddingOps(TestCase):
                                                sparsity=sparsity,
                                                atol=1.0, rtol=1e-1)
 
+    """ Tests the correctness of the quantized 8 bit embedding lookup operator """
+    @given(num_embeddings=st.integers(10, 100),
+           embedding_dim=st.integers(5, 50).filter(lambda x: x % 4 == 0))
+    def test_embedding(self, num_embeddings, embedding_dim):
+        dtypes = [torch.quint8, torch.quint4x2]
+        quant_ops = [torch.ops.quantized.embedding_byte, torch.ops.quantized.embedding_4bit]
+        atols = [0.005, 0.1]
+        rtols = [1e-3, 1e-2]
+        prepack_op = torch.ops.quantized.embedding_bag_prepack
+        for quant_op, dtype, atol, rtol in zip(quant_ops, dtypes, atols, rtols):
+            weights = torch.from_numpy((np.random.random_sample((
+                num_embeddings, embedding_dim)) + 1).astype(np.float32))
+
+            obs = PerChannelMinMaxObserver(dtype=dtype, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
+            obs(weights)
+            # Get the scale and zero point for the weight tensor
+            qparams = obs.calculate_qparams()
+
+            # Quantize the weights to 8bits
+            qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=dtype)
+            max_segments = 5
+            max_segment_length = 20
+            num_lengths = np.random.randint(1, max_segments + 1)
+            lengths = np.random.randint(1, max_segment_length + 1,
+                                        size=num_lengths).astype(np.int32)
+            num_indices = np.sum(lengths)
+            indices = torch.from_numpy(np.random.randint(
+                low=0, high=num_embeddings, size=num_indices, dtype=np.int64))
+
+            packed_weight = prepack_op(qweight)
+            qresult = quant_op(packed_weight, indices, pruned_weights=False)
+
+            ref = torch.embedding(weights, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False)
+            torch.testing.assert_close(ref, qresult, atol=atol, rtol=rtol)
+
+    def test_embedding_2d_indices(self):
+        """
+        Tests the case where 2D indices are passed into the operator
+        In this case the operator computes the correct offsets argument.
+        Output shape is dependent on the indices dimension.
+        """
+        quant_op = torch.ops.quantized.embedding_byte
+        prepack_op = torch.ops.quantized.embedding_bag_prepack
+
+        indices = torch.tensor([[9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8], [3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3]])
+        weights = torch.randn(10, 12, dtype=torch.float32)
+
+        ref = torch.embedding(weights, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False)
+        obs = PerChannelMinMaxObserver(dtype=torch.quint8, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
+        obs(weights)
+        qparams = obs.calculate_qparams()
+
+        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
+        packed_weight = prepack_op(qweight)
+        qresult = quant_op(packed_weight, indices, pruned_weights=False)
+        torch.testing.assert_close(ref, qresult, atol=0.05, rtol=1e-3)
+
+    def test_embedding_bag_2d_indices(self):
+        """
+        Tests the case where 2D indices are passed into the operator
+        In this case the operator computes the correct offsets argument.
+        """
+        indices = torch.tensor([[9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8], [3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3]])
+        weights = torch.randn(10, 12, dtype=torch.float32)
+
+        embedding_bag = torch.nn.EmbeddingBag(
+            num_embeddings=10,
+            embedding_dim=12,
+            include_last_offset=False, _weight=weights,
+            scale_grad_by_freq=False, mode='sum'
+        )
+        result = embedding_bag(indices)
+
+        pt_op = torch.ops.quantized.embedding_bag_byte_rowwise_offsets
+        pt_prepack_op = torch.ops.quantized.embedding_bag_byte_prepack
+        q_weights = pt_prepack_op(weights)
+        qresult = pt_op(q_weights, indices, mode=0, pruned_weights=False)
+        torch.testing.assert_close(result, qresult, atol=0.05, rtol=1e-3)
+
+        # Test TorchBind based embedding_bag operator
+        obs = PerChannelMinMaxObserver(dtype=torch.quint8, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
+        obs(weights)
+        # Get the scale and zero point for the weight tensor
+        qparams = obs.calculate_qparams()
+
+        # Quantize the weights to 8bits
+        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
+
+        packed_weight = torch.ops.quantized.embedding_bag_prepack(qweight)
+        qresult = torch.ops.quantized.embedding_bag_byte(packed_weight, indices, mode=0)
+
+        torch.testing.assert_close(result, qresult, atol=0.05, rtol=1e-3)
+
+
+class TestQuantizedEmbeddingOpsCUDA(TestCase):
     """ Tests that the CUDA quantized embedding_bag operators agree with their
         CPU counterparts. This covers the bit-field extraction the dequantization
         path is built on, which is shared by both bit widths. """
@@ -5771,99 +5870,6 @@ class TestQuantizedEmbeddingOps(TestCase):
                 pruned_weights=True, per_sample_weights=None,
                 compressed_indices_mapping=mapping.cuda(),
                 include_last_offset=False)
-
-    """ Tests the correctness of the quantized 8 bit embedding lookup operator """
-    @given(num_embeddings=st.integers(10, 100),
-           embedding_dim=st.integers(5, 50).filter(lambda x: x % 4 == 0))
-    def test_embedding(self, num_embeddings, embedding_dim):
-        dtypes = [torch.quint8, torch.quint4x2]
-        quant_ops = [torch.ops.quantized.embedding_byte, torch.ops.quantized.embedding_4bit]
-        atols = [0.005, 0.1]
-        rtols = [1e-3, 1e-2]
-        prepack_op = torch.ops.quantized.embedding_bag_prepack
-        for quant_op, dtype, atol, rtol in zip(quant_ops, dtypes, atols, rtols):
-            weights = torch.from_numpy((np.random.random_sample((
-                num_embeddings, embedding_dim)) + 1).astype(np.float32))
-
-            obs = PerChannelMinMaxObserver(dtype=dtype, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
-            obs(weights)
-            # Get the scale and zero point for the weight tensor
-            qparams = obs.calculate_qparams()
-
-            # Quantize the weights to 8bits
-            qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=dtype)
-            max_segments = 5
-            max_segment_length = 20
-            num_lengths = np.random.randint(1, max_segments + 1)
-            lengths = np.random.randint(1, max_segment_length + 1,
-                                        size=num_lengths).astype(np.int32)
-            num_indices = np.sum(lengths)
-            indices = torch.from_numpy(np.random.randint(
-                low=0, high=num_embeddings, size=num_indices, dtype=np.int64))
-
-            packed_weight = prepack_op(qweight)
-            qresult = quant_op(packed_weight, indices, pruned_weights=False)
-
-            ref = torch.embedding(weights, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False)
-            torch.testing.assert_close(ref, qresult, atol=atol, rtol=rtol)
-
-    def test_embedding_2d_indices(self):
-        """
-        Tests the case where 2D indices are passed into the operator
-        In this case the operator computes the correct offsets argument.
-        Output shape is dependent on the indices dimension.
-        """
-        quant_op = torch.ops.quantized.embedding_byte
-        prepack_op = torch.ops.quantized.embedding_bag_prepack
-
-        indices = torch.tensor([[9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8], [3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3]])
-        weights = torch.randn(10, 12, dtype=torch.float32)
-
-        ref = torch.embedding(weights, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False)
-        obs = PerChannelMinMaxObserver(dtype=torch.quint8, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
-        obs(weights)
-        qparams = obs.calculate_qparams()
-
-        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
-        packed_weight = prepack_op(qweight)
-        qresult = quant_op(packed_weight, indices, pruned_weights=False)
-        torch.testing.assert_close(ref, qresult, atol=0.05, rtol=1e-3)
-
-    def test_embedding_bag_2d_indices(self):
-        """
-        Tests the case where 2D indices are passed into the operator
-        In this case the operator computes the correct offsets argument.
-        """
-        indices = torch.tensor([[9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8], [3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3]])
-        weights = torch.randn(10, 12, dtype=torch.float32)
-
-        embedding_bag = torch.nn.EmbeddingBag(
-            num_embeddings=10,
-            embedding_dim=12,
-            include_last_offset=False, _weight=weights,
-            scale_grad_by_freq=False, mode='sum'
-        )
-        result = embedding_bag(indices)
-
-        pt_op = torch.ops.quantized.embedding_bag_byte_rowwise_offsets
-        pt_prepack_op = torch.ops.quantized.embedding_bag_byte_prepack
-        q_weights = pt_prepack_op(weights)
-        qresult = pt_op(q_weights, indices, mode=0, pruned_weights=False)
-        torch.testing.assert_close(result, qresult, atol=0.05, rtol=1e-3)
-
-        # Test TorchBind based embedding_bag operator
-        obs = PerChannelMinMaxObserver(dtype=torch.quint8, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
-        obs(weights)
-        # Get the scale and zero point for the weight tensor
-        qparams = obs.calculate_qparams()
-
-        # Quantize the weights to 8bits
-        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
-
-        packed_weight = torch.ops.quantized.embedding_bag_prepack(qweight)
-        qresult = torch.ops.quantized.embedding_bag_byte(packed_weight, indices, mode=0)
-
-        torch.testing.assert_close(result, qresult, atol=0.05, rtol=1e-3)
 
 
 class TestQuantizedConv(TestCase):

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1530,34 +1530,6 @@ class TestQuantizedOps(_QuantizedActivationTestMixin, TestCase):
                          msg="ops.quantized.max_pool2d results are off")
 
 
-    @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
-    def test_max_pool2d_pt2e(self):
-        kernel_list = [2, 3]
-        stride_list = [1, 2]
-        padding_list = [0, 2]
-        dilation_list = [1, 2]
-        ceil_mode_list = [False, True]
-        channels_last_input = [False, True]
-        options = itertools.product(kernel_list, stride_list, padding_list, dilation_list, ceil_mode_list, channels_last_input)
-        for kernel, stride, padding, dilation, ceil_mode, channels_last in options:
-            if padding >= (kernel // 2):
-                # Continue with invalid input
-                continue
-            input = torch.randint(0, 8, (1, 3, 8, 8), dtype=torch.uint8)
-            if channels_last:
-                input = input.contiguous(memory_format=torch.channels_last)
-            a_pool = torch.nn.functional.max_pool2d(input.to(torch.float32), kernel_size=kernel,
-                                                    stride=stride, padding=padding, dilation=dilation,
-                                                    ceil_mode=ceil_mode).to(torch.uint8)
-            a_hat = torch.ops.quantized.max_pool2d(input, kernel_size=_pair(kernel),
-                                                   stride=_pair(stride), padding=_pair(padding),
-                                                   dilation=_pair(dilation), ceil_mode=ceil_mode)
-            self.assertEqual(input.is_contiguous(), a_hat.is_contiguous(),
-                             msg="ops.quantized.max_pool2d input output diff memory format")
-            self.assertEqual(a_pool, a_hat,
-                             msg="ops.quantized.max_pool2d results are off")
-
-
     """Tests 3D max pool operation on quantized tensors."""
     def test_max_pool3d(self):
         torch_types = [torch.qint8, torch.quint8]
@@ -3501,6 +3473,48 @@ class TestQuantizedOpsCUDNN(TestCase):
             padding=_pair(padding), dilation=_pair(dilation), ceil_mode=ceil_mode)
         self.assertEqual(a_ref, a_hat.dequantize(),
                          msg="ops.quantized.max_pool2d results are off")
+
+
+class TestQuantizedMaxPool2dPT2EDevice(TestCase):
+    """The pt2e lowering of max_pool2d takes a plain uint8 tensor rather than a
+    quantized dtype, so unlike the rest of this file it is not tied to the
+    CPU-only QuantizedCPU backend. quantized::max_pool2d is registered for the
+    plain (non-quantized) key on CPU and XPU only -- CUDA has just the
+    QuantizedCUDA/cudnn variant -- hence the only_for below."""
+
+    @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
+    def test_max_pool2d_pt2e(self, device):
+        kernel_list = [2, 3]
+        stride_list = [1, 2]
+        padding_list = [0, 2]
+        dilation_list = [1, 2]
+        ceil_mode_list = [False, True]
+        channels_last_input = [False, True]
+        options = itertools.product(kernel_list, stride_list, padding_list, dilation_list, ceil_mode_list, channels_last_input)
+        for kernel, stride, padding, dilation, ceil_mode, channels_last in options:
+            if padding >= (kernel // 2):
+                # Continue with invalid input
+                continue
+            input = torch.randint(0, 8, (1, 3, 8, 8), dtype=torch.uint8, device=device)
+            if channels_last:
+                input = input.contiguous(memory_format=torch.channels_last)
+            a_pool = torch.nn.functional.max_pool2d(input.to(torch.float32), kernel_size=kernel,
+                                                    stride=stride, padding=padding, dilation=dilation,
+                                                    ceil_mode=ceil_mode).to(torch.uint8)
+            a_hat = torch.ops.quantized.max_pool2d(input, kernel_size=_pair(kernel),
+                                                   stride=_pair(stride), padding=_pair(padding),
+                                                   dilation=_pair(dilation), ceil_mode=ceil_mode)
+            self.assertEqual(input.is_contiguous(), a_hat.is_contiguous(),
+                             msg="ops.quantized.max_pool2d input output diff memory format")
+            self.assertEqual(a_pool, a_hat,
+                             msg="ops.quantized.max_pool2d results are off")
+
+    @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
+    def test_max_pool2d_invalid_padding(self, device):
+        input = torch.randint(0, 8, (1, 3, 8, 8), dtype=torch.uint8, device=device)
+        with self.assertRaisesRegex(RuntimeError, "padding should be smaller than half of kernel_size"):
+            torch.ops.quantized.max_pool2d(input, kernel_size=_pair(2), stride=_pair(1),
+                                           padding=_pair(2), dilation=_pair(1), ceil_mode=False)
 
 
 class TestDynamicQuantizedOps(TestCase):
@@ -9665,6 +9679,9 @@ class TestQuantizedWithMinMax(TestCase):
 
 
 instantiate_device_type_tests(TestQuantizedOpsDevice, globals(), only_for=("cpu", "cuda"))
+instantiate_device_type_tests(
+    TestQuantizedMaxPool2dPT2EDevice, globals(), only_for=("cpu", "xpu"), allow_xpu=True
+)
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_cuda import (
     TEST_CUDA,
     TEST_CUDNN,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_quantization import (
     skipIfNoFBGEMM,
     skipIfNoONEDNN,
@@ -371,9 +372,10 @@ def _test_qlinear_fp8_fast_path_helper(error_conn=None):
         if error_conn is not None:
             error_conn.close()
 
-class TestQuantizedOps(TestCase):
+class _QuantizedActivationTestMixin:
 
     """Helper function to test quantized activation functions."""
+
     def _test_activation_function(self, X, fn_name, test_configs):
         r"""
             When writing a unit test for the activation function,
@@ -467,41 +469,8 @@ class TestQuantizedOps(TestCase):
 
                     self.assertEqual(qY, qY_hat, msg=lambda msg: f'{msg}\n{fn_name} - {q_op} failed: ({qY} vs. {qY_hat})')
 
-    """Tests the correctness of the quantized::relu op."""
-    @override_qengines
-    def test_qrelu(self):
-        relu_test_configs = [
-            {
-                'quantized_fn': [
-                    torch.relu,
-                    torch.relu_,
-                    torch.nn.functional.relu,
-                    torch.nn.functional.relu,
-                ],
-                'reference_fn': torch.nn.functional.relu
-            },
-            {
-                'quantized_fn': [
-                    torch.nn.functional.relu,
-                    torch.nn.functional.relu,
-                ],
-                'reference_fn': torch.nn.functional.relu,
-                'extra_kwargs': {
-                    'inplace': True
-                }
-            }
-        ]
-        devices = ["cpu", "cuda"] if TEST_CUDA else ["cpu"]
-        for device in devices:
-            shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
-            dtypes = (torch.quint8, torch.qint8)
-            scales = (0.05, 0.1)
-            zero_points = (0, 5)
-            test_cases = itertools.product(shapes, dtypes, scales, zero_points)
-            for shape, dtype, scale, zero_point in test_cases:
-                X = torch.randn(*shape, device=device)
-                X = (X, (scale, zero_point, dtype))
-                self._test_activation_function(X, 'relu', relu_test_configs)
+
+class TestQuantizedOps(_QuantizedActivationTestMixin, TestCase):
 
     """Tests the correctness of the quantized::relu6 op."""
     def test_qrelu6(self):
@@ -704,35 +673,6 @@ class TestQuantizedOps(TestCase):
         qY = torch.ops.quantized.celu(qX, output_scale, output_zero_point, alpha=alpha)
         self.assertEqual(qY, qY_hat,
                          msg=lambda msg: f"{msg}\nF.celu failed ({qY} vs {qY_hat})")
-
-    """Tests the correctness of the quantized::gelu op."""
-    def test_qgelu(self):
-        shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
-        dtypes = (torch.quint8, torch.qint8)
-        memory_formats = (torch.channels_last, torch.contiguous_format)
-        approximation = ['none', 'tanh']
-        test_cases = itertools.product(shapes, dtypes, memory_formats, approximation)
-        devices = ["cpu", "cuda"] if TEST_CUDA else ["cpu"]
-        for shape, dtype, memory_format, approximate in test_cases:
-            if memory_format == torch.channels_last and len(shape) != 4:
-                continue
-
-            X, scale, zero_point, torch_type = \
-                torch.randn(*shape), 0.1, 0, dtype
-            X = X.to(memory_format=memory_format)
-            for device in devices:
-                X = X.to(device=device)
-                qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                               dtype=torch_type)
-                dqX = qX.dequantize()
-
-                op = torch.nn.functional.gelu
-                dqY = op(dqX, approximate=approximate)
-                qY = torch.quantize_per_tensor(dqY, scale=scale, zero_point=zero_point,
-                                               dtype=torch_type)
-                qY_hat = op(qX)
-                self.assertEqual(qY.dequantize(), qY_hat.dequantize(),
-                                 msg=lambda msg: f"{msg}\nF.gelu failed ({qY} vs {qY_hat})")
 
     """Tests the correctness of the quantized::prelu op."""
     def test_qprelu(self):
@@ -2065,86 +2005,6 @@ class TestQuantizedOps(TestCase):
                                  msg=lambda msg: f"{msg}\n" + (error_message.format(name + '.zero_point', scale,
                                  X_hat.q_zero_point())))
 
-    @unittest.skip("not currently working and feature isn't used")
-    def test_adaptive_avg_pool(self):
-
-        side_lens = (range(1, 10))
-        dim_lens = (range(3, 5))
-        torch_type = torch.qint8
-        zero_points = (0, 1)
-        combined = [side_lens, dim_lens, zero_points]
-        test_cases = itertools.product(*combined)
-        for test_case in test_cases:
-            output_size_d = random.randint(1, 10)
-            output_size_h = random.randint(1, 10)
-            output_size_w = random.randint(1, 10)
-            side_len, dim_len, zero_point = test_case
-            shapes = [side_len] * dim_len
-            X, X_scale, X_zero_point = \
-                _get_random_tensor_and_q_params(shapes, 1.0, zero_point)
-            X = np.array(X)
-            scale = 1
-            ndim = X.ndim
-            dim_to_check = []
-            if ndim <= 4:
-                dim_to_check.append(2)
-            if ndim >= 4:
-                dim_to_check.append(3)
-
-            D, H, W = X.shape[-3:]
-            output_size_d = min(output_size_d, D)
-            output_size_h = min(output_size_h, H)
-            output_size_w = min(output_size_w, W)
-
-            X = torch.from_numpy(X)
-            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                           dtype=torch_type)
-
-            for dim in dim_to_check:
-                if dim == 2:
-                    if output_size_h == output_size_w:
-                        output_size = output_size_h
-                    else:
-                        output_size = (output_size_h, output_size_w)
-                elif dim == 3:
-                    if output_size_d == output_size_h == output_size_w:
-                        output_size = output_size_h
-                    else:
-                        output_size = (output_size_d, output_size_h, output_size_w)
-
-                # Run reference on int_repr + round to avoid double rounding error.
-                ref_op = getattr(torch.nn.functional, f'adaptive_avg_pool{dim}d')
-                X_ref = ref_op(qX.int_repr().to(torch.float), output_size).round()
-
-                ops_under_test = {
-                    "nn.functional":
-                        getattr(torch.nn.functional, f'adaptive_avg_pool{dim}d'),
-                    "nn.quantized.functional":
-                        getattr(torch.ao.nn.quantized.functional, f'adaptive_avg_pool{dim}d'),
-                    "ao.nn.quantized.functional":
-                        getattr(torch.ao.nn.quantized.functional, f'adaptive_avg_pool{dim}d')
-                }
-
-                error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
-
-                for name, op in ops_under_test.items():
-                    # TODO: torch.cuda.is_available() should be swapped for a flag that checks if cudnn
-                    # is enabled in the build when cudnn supports adaptive average pooling
-                    devices = ["cpu", "cuda"] if (dim == 2 and torch.cuda.is_available()) else ["cpu"]
-                    for device in devices:
-                        qX_hat = op(qX.to(device=device), output_size=output_size)
-                        self.assertEqual(
-                            X_ref, qX_hat.int_repr(), atol=1.0,
-                            rtol=0, msg=lambda msg: f"{msg}\n" + (error_message.format(name, X_ref, qX_hat)), exact_dtype=False)
-                        self.assertEqual(
-                            scale, qX_hat.q_scale(),
-                            msg=lambda msg: f"{msg}\n" + (error_message.format(name + '.scale', scale,
-                                                     qX_hat.q_scale())))
-                        self.assertEqual(
-                            zero_point, qX_hat.q_zero_point(),
-                            msg=lambda msg: f"{msg}\n" + (error_message.format(name + '.zero_point', scale,
-                                                     qX_hat.q_zero_point())))
-
     """Tests adaptive average pool operation on NHWC quantized tensors."""
     def test_adaptive_avg_pool3d_ndhwc(self):
         side_lens = (range(1, 10))
@@ -3375,6 +3235,155 @@ class TestQuantizedOps(TestCase):
                 )
             y_ref = y_ref.to(out_dtype)
             self.assertEqual(y, y_ref, msg=lambda msg: f"{msg}\n{y} vs {y_ref}")
+
+
+class TestQuantizedOpsDevice(_QuantizedActivationTestMixin, TestCase):
+    """Quantized ops that have a kernel for more than one device.
+
+    qint dtypes dispatch to QuantizedCPU and QuantizedCUDA only; there is no
+    QuantizedXPU or QuantizedMPS kernel for any of these ops, hence the
+    only_for below."""
+
+    """Tests the correctness of the quantized::relu op."""
+    def test_qrelu(self, device):
+        # override_qengines cannot be used here: it does not forward the
+        # signature, so instantiate_device_type_tests would not inject `device`.
+        relu_test_configs = [
+            {
+                'quantized_fn': [
+                    torch.relu,
+                    torch.relu_,
+                    torch.nn.functional.relu,
+                    torch.nn.functional.relu,
+                ],
+                'reference_fn': torch.nn.functional.relu
+            },
+            {
+                'quantized_fn': [
+                    torch.nn.functional.relu,
+                    torch.nn.functional.relu,
+                ],
+                'reference_fn': torch.nn.functional.relu,
+                'extra_kwargs': {
+                    'inplace': True
+                }
+            }
+        ]
+        shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
+        dtypes = (torch.quint8, torch.qint8)
+        scales = (0.05, 0.1)
+        zero_points = (0, 5)
+        for qengine in supported_qengines:
+            with override_quantized_engine(qengine):
+                for shape, dtype, scale, zero_point in itertools.product(shapes, dtypes, scales, zero_points):
+                    X = torch.randn(*shape, device=device)
+                    X = (X, (scale, zero_point, dtype))
+                    self._test_activation_function(X, 'relu', relu_test_configs)
+
+    """Tests the correctness of the quantized::gelu op."""
+    def test_qgelu(self, device):
+        shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
+        dtypes = (torch.quint8, torch.qint8)
+        memory_formats = (torch.channels_last, torch.contiguous_format)
+        approximation = ['none', 'tanh']
+        test_cases = itertools.product(shapes, dtypes, memory_formats, approximation)
+        for shape, dtype, memory_format, approximate in test_cases:
+            if memory_format == torch.channels_last and len(shape) != 4:
+                continue
+
+            X, scale, zero_point, torch_type = \
+                torch.randn(*shape), 0.1, 0, dtype
+            X = X.to(memory_format=memory_format).to(device=device)
+            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
+            dqX = qX.dequantize()
+
+            op = torch.nn.functional.gelu
+            dqY = op(dqX, approximate=approximate)
+            qY = torch.quantize_per_tensor(dqY, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
+            qY_hat = op(qX)
+            self.assertEqual(qY.dequantize(), qY_hat.dequantize(),
+                             msg=lambda msg: f"{msg}\nF.gelu failed ({qY} vs {qY_hat})")
+
+    @unittest.skip("not currently working and feature isn't used")
+    def test_adaptive_avg_pool(self, device):
+
+        side_lens = (range(1, 10))
+        dim_lens = (range(3, 5))
+        torch_type = torch.qint8
+        zero_points = (0, 1)
+        combined = [side_lens, dim_lens, zero_points]
+        test_cases = itertools.product(*combined)
+        for test_case in test_cases:
+            output_size_d = random.randint(1, 10)
+            output_size_h = random.randint(1, 10)
+            output_size_w = random.randint(1, 10)
+            side_len, dim_len, zero_point = test_case
+            shapes = [side_len] * dim_len
+            X, X_scale, X_zero_point = \
+                _get_random_tensor_and_q_params(shapes, 1.0, zero_point)
+            X = np.array(X)
+            scale = 1
+            ndim = X.ndim
+            dim_to_check = []
+            if ndim <= 4:
+                dim_to_check.append(2)
+            if ndim >= 4:
+                dim_to_check.append(3)
+
+            D, H, W = X.shape[-3:]
+            output_size_d = min(output_size_d, D)
+            output_size_h = min(output_size_h, H)
+            output_size_w = min(output_size_w, W)
+
+            X = torch.from_numpy(X)
+            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
+
+            for dim in dim_to_check:
+                # cudnn only supports the 2d case; the 3d kernel is CPU-only.
+                if device != 'cpu' and dim != 2:
+                    continue
+                if dim == 2:
+                    if output_size_h == output_size_w:
+                        output_size = output_size_h
+                    else:
+                        output_size = (output_size_h, output_size_w)
+                elif dim == 3:
+                    if output_size_d == output_size_h == output_size_w:
+                        output_size = output_size_h
+                    else:
+                        output_size = (output_size_d, output_size_h, output_size_w)
+
+                # Run reference on int_repr + round to avoid double rounding error.
+                ref_op = getattr(torch.nn.functional, f'adaptive_avg_pool{dim}d')
+                X_ref = ref_op(qX.int_repr().to(torch.float), output_size).round()
+
+                ops_under_test = {
+                    "nn.functional":
+                        getattr(torch.nn.functional, f'adaptive_avg_pool{dim}d'),
+                    "nn.quantized.functional":
+                        getattr(torch.ao.nn.quantized.functional, f'adaptive_avg_pool{dim}d'),
+                    "ao.nn.quantized.functional":
+                        getattr(torch.ao.nn.quantized.functional, f'adaptive_avg_pool{dim}d')
+                }
+
+                error_message = r"Results are off for {}:\n\tExpected:\n{}\n\tGot:\n{}"
+
+                for name, op in ops_under_test.items():
+                    qX_hat = op(qX.to(device=device), output_size=output_size)
+                    self.assertEqual(
+                        X_ref, qX_hat.int_repr(), atol=1.0,
+                        rtol=0, msg=lambda msg: f"{msg}\n" + (error_message.format(name, X_ref, qX_hat)), exact_dtype=False)
+                    self.assertEqual(
+                        scale, qX_hat.q_scale(),
+                        msg=lambda msg: f"{msg}\n" + (error_message.format(name + '.scale', scale,
+                                                 qX_hat.q_scale())))
+                    self.assertEqual(
+                        zero_point, qX_hat.q_zero_point(),
+                        msg=lambda msg: f"{msg}\n" + (error_message.format(name + '.zero_point', scale,
+                                                 qX_hat.q_zero_point())))
 
 
 class TestQuantizedOpsCUDNN(TestCase):
@@ -9653,6 +9662,9 @@ class TestQuantizedWithMinMax(TestCase):
                             "weight_incorrectly_quantized should not equal "
                             "weight_quantized_no_rowwise_min_max"
                         )
+
+
+instantiate_device_type_tests(TestQuantizedOpsDevice, globals(), only_for=("cpu", "cuda"))
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -152,5 +152,15 @@ try:
 except ImportError as e:
     log.warning(e)
 
+# Device-instantiated; the CUDA/XPU variants only exist on a box that has that device.
+try:
+    from quantization.core.test_quantized_op import TestQuantizedOpsDeviceCPU  # noqa: F401
+except ImportError as e:
+    log.warning(e)
+try:
+    from quantization.core.test_quantized_op import TestQuantizedOpsDeviceCUDA  # noqa: F401
+except ImportError as e:
+    log.warning(e)
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -20,6 +20,7 @@ from quantization.core.test_quantized_op import TestDynamicQuantizedOps  # noqa:
 from quantization.core.test_quantized_op import TestComparatorOps  # noqa: F401
 from quantization.core.test_quantized_op import TestPadding  # noqa: F401
 from quantization.core.test_quantized_op import TestQuantizedEmbeddingOps  # noqa: F401
+from quantization.core.test_quantized_op import TestQuantizedWithMinMax  # noqa: F401
 # 2. Quantized Functional/Workflow Ops
 from quantization.core.test_quantized_functional import TestQuantizedFunctionalOps  # noqa: F401
 from quantization.core.test_workflow_ops import TestFakeQuantizeOps  # noqa: F401

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -161,6 +161,14 @@ try:
     from quantization.core.test_quantized_op import TestQuantizedOpsDeviceCUDA  # noqa: F401
 except ImportError as e:
     log.warning(e)
+try:
+    from quantization.core.test_quantized_op import TestQuantizedMaxPool2dPT2EDeviceCPU  # noqa: F401
+except ImportError as e:
+    log.warning(e)
+try:
+    from quantization.core.test_quantized_op import TestQuantizedMaxPool2dPT2EDeviceXPU  # noqa: F401
+except ImportError as e:
+    log.warning(e)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -20,6 +20,9 @@ from quantization.core.test_quantized_op import TestDynamicQuantizedOps  # noqa:
 from quantization.core.test_quantized_op import TestComparatorOps  # noqa: F401
 from quantization.core.test_quantized_op import TestPadding  # noqa: F401
 from quantization.core.test_quantized_op import TestQuantizedEmbeddingOps  # noqa: F401
+from quantization.core.test_quantized_op import TestQuantizedEmbeddingOpsCUDA  # noqa: F401
+from quantization.core.test_quantized_op import TestQuantizedOpsCUDNN  # noqa: F401
+from quantization.core.test_quantized_op import TestQuantizedLinearCUDNN  # noqa: F401
 from quantization.core.test_quantized_op import TestQuantizedWithMinMax  # noqa: F401
 # 2. Quantized Functional/Workflow Ops
 from quantization.core.test_quantized_functional import TestQuantizedFunctionalOps  # noqa: F401


### PR DESCRIPTION
`test/quantization/core/test_quantized_op.py` had no hardware classification at all, so `--hw-classification` treated the whole file as unclassified.

Key changes:

- Every test class is now classified. Most stay `CPU` - the qint dtypes they exercise only dispatch to `QuantizedCPU`.
- CUDA-only tests no longer sit in CPU classes: 13 of them move into dedicated CUDA-tagged classes (`TestQuantizedOpsCUDNN`, `TestQuantizedLinearCUDNN`, `TestQuantizedEmbeddingOpsCUDA`).
- The three activation tests that do have a `QuantizedCUDA` kernel (`test_qrelu`, `test_qgelu`, `test_adaptive_avg_pool`) move to `TestQuantizedOpsDevice` (`ACCELERATOR`), driven by `instantiate_device_type_tests` instead of an in-test `for device in ["cpu", "cuda"]` loop.
- The pt2e `max_pool2d` tests are now device-generic (`ACCELERATOR`) and **run on Intel GPU**, which previously required a monkey-patch from torch-xpu-ops.
- `TestQuantizedWithMinMax` is now collected - it was imported nowhere and had never run.

This is not a pure refactor: it adds coverage. The commits are ordered to be reviewed front to back; the last one only adds `hw_classification` lines.

The same treatment for the four `*_cudnn` tests still sitting in `TestQuantizedConv` is a follow-up PR - together the two changes are over the 2000 LOC cap in `.github/scripts/pr-sanity-check.sh`, which counts moved code twice.

### Test coverage delta

Collected test IDs via `test_quantization.py`, 192 before the change; nothing lost.

| Runner | After | Delta |
|---|---|---|
| CPU only | 194 | `test_quantize_tensor_with_min_max` (previously collected nowhere), `test_max_pool2d_invalid_padding` |
| Intel GPU | 196 | the above, plus both pt2e `max_pool2d` tests **on XPU** |
| CUDA | 197 | the CPU-only rows, plus `test_qrelu`/`test_qgelu`/`test_adaptive_avg_pool` as separate CUDA IDs (same coverage as the old in-test device loop, now visible per device) |

The 13 relocated CUDA tests keep exactly the coverage they had.

A follow-up in torch-xpu-ops will delete the now-redundant downstream wrapper and the 7 skip entries for it; three of those skips (`test_qgelu_xpu`, `test_qrelu_xpu`, `test_max_pool2d_cudnn_xpu`) name tests that no longer live in `TestQuantizedOps` after this change.

Fixes part of #142029.

---

*Authored with the assistance of an AI coding agent (Claude Code) and reviewed by a human before submission.*
