### PR TITLE
Use __VA_OPT__ instead of the GNU ,##__VA_ARGS__ extension

### DIFF
--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -66,7 +66,7 @@
  *
  *   #define TORCH_ILISTREF_FORALL_TAGS(_, ...) \
  *     ...
- *     _(Chest, ##__VA_ARGS__)
+ *     _(Chest __VA_OPT__(,) __VA_ARGS__)
  *
  * 2. Add type aliases, union members, and constructors.
  *
@@ -161,9 +161,9 @@ class IListRef;
  * Applies arbitrary macros to each `IListRefTag`.
  */
 #define TORCH_ILISTREF_FORALL_TAGS(_, ...) \
-  _(Unboxed, ##__VA_ARGS__)                \
-  _(Boxed, ##__VA_ARGS__)                  \
-  _(Materialized, ##__VA_ARGS__)
+  _(Unboxed __VA_OPT__(,) __VA_ARGS__)                \
+  _(Boxed __VA_OPT__(,) __VA_ARGS__)                  \
+  _(Materialized __VA_OPT__(,) __VA_ARGS__)
 
 /*
  * Defines a "switch-case" for `TAG`. Inside, it executes `BODY`,

--- a/aten/src/ATen/cuda/Exceptions.h
+++ b/aten/src/ATen/cuda/Exceptions.h
@@ -36,7 +36,7 @@ class CuDNNError : public c10::Error {
     }                                                                                           \
   } while (0)                                                                                   \
 
-#define AT_CUDNN_CHECK_WITH_SHAPES(EXPR, ...) AT_CUDNN_CHECK(EXPR, "\n", ##__VA_ARGS__)
+#define AT_CUDNN_CHECK_WITH_SHAPES(EXPR, ...) AT_CUDNN_CHECK(EXPR, "\n" __VA_OPT__(,) __VA_ARGS__)
 
 // See Note [CHECK macro]
 #define AT_CUDNN_CHECK(EXPR, ...)                                                               \
@@ -47,10 +47,10 @@ class CuDNNError : public c10::Error {
         TORCH_CHECK_WITH(CuDNNError, false,                                                     \
             "cuDNN error: ",                                                                    \
             cudnnGetErrorString(status),                                                        \
-            ". This error may appear if you passed in a non-contiguous input.", ##__VA_ARGS__); \
+            ". This error may appear if you passed in a non-contiguous input." __VA_OPT__(,) __VA_ARGS__); \
       } else {                                                                                  \
         TORCH_CHECK_WITH(CuDNNError, false,                                                     \
-            "cuDNN error: ", cudnnGetErrorString(status), ##__VA_ARGS__);                       \
+            "cuDNN error: ", cudnnGetErrorString(status) __VA_OPT__(,) __VA_ARGS__);                       \
       }                                                                                         \
     }                                                                                           \
   } while (0)

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/debug_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/debug_utils.h
@@ -30,12 +30,12 @@
   if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 &&        \
       threadIdx.x == PRINT_LANE_ID && threadIdx.y == PRINT_WARP_ID && \
       threadIdx.z == 0) {                                             \
-    printf(msg "\n", ##__VA_ARGS__);                                  \
+    printf(msg "\n" __VA_OPT__(,) __VA_ARGS__);                                  \
   }
 #define PRINT_T0(msg, ...)                                            \
   if (threadIdx.x == PRINT_LANE_ID && threadIdx.y == PRINT_WARP_ID && \
       threadIdx.z == 0) {                                             \
-    printf(msg "\n", ##__VA_ARGS__);                                  \
+    printf(msg "\n" __VA_OPT__(,) __VA_ARGS__);                                  \
   }
 #define PRINT_TX_LX(msg, ...)                                                 \
   for (int bx = 0; bx < gridDim.x; ++bx) {                                    \
@@ -55,8 +55,8 @@
                     bz,                                                       \
                     tx,                                                       \
                     ty,                                                       \
-                    tz,                                                       \
-                    ##__VA_ARGS__);                                           \
+                    tz                                                       \
+                    __VA_OPT__(,) __VA_ARGS__);                                           \
               }                                                               \
             }                                                                 \
           }                                                                   \

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -612,33 +612,36 @@ void record_function_with_scope_and_debug_handle(
   at::RecordFunction guard(scope);                         \
   if (guard.isActive()) {                                  \
     ::at::detail::record_function_with_scope(              \
-        guard, fn, inputs, ##__VA_ARGS__);                 \
+        guard, fn, inputs __VA_OPT__(, ) __VA_ARGS__);     \
   }
 
-#define RECORD_FUNCTION_WITH_SCOPE_INPUTS_OUTPUTS( \
-    scope, fn, inputs, outputs, ...)               \
-  at::RecordFunction guard(scope);                 \
-  if (guard.isActive()) {                          \
-    if (guard.needsInputs()) {                     \
-      guard.before(fn, inputs, ##__VA_ARGS__);     \
-    } else {                                       \
-      guard.before(fn, ##__VA_ARGS__);             \
-    }                                              \
-    if (guard.needsOutputs()) {                    \
-      guard.setOutputs(outputs);                   \
-    }                                              \
+#define RECORD_FUNCTION_WITH_SCOPE_INPUTS_OUTPUTS(         \
+    scope, fn, inputs, outputs, ...)                       \
+  at::RecordFunction guard(scope);                         \
+  if (guard.isActive()) {                                  \
+    if (guard.needsInputs()) {                             \
+      guard.before(fn, inputs __VA_OPT__(, ) __VA_ARGS__); \
+    } else {                                               \
+      guard.before(fn __VA_OPT__(, ) __VA_ARGS__);         \
+    }                                                      \
+    if (guard.needsOutputs()) {                            \
+      guard.setOutputs(outputs);                           \
+    }                                                      \
   }
 
 #define RECORD_FUNCTION(fn, inputs, ...) \
   RECORD_FUNCTION_WITH_SCOPE(            \
-      at::RecordScope::FUNCTION, fn, inputs, ##__VA_ARGS__)
+      at::RecordScope::FUNCTION, fn, inputs __VA_OPT__(, ) __VA_ARGS__)
 
 #define RECORD_TORCHSCRIPT_FUNCTION(mn, inputs) \
   RECORD_FUNCTION_WITH_SCOPE(at::RecordScope::TORCHSCRIPT_FUNCTION, mn, inputs)
 
 #define RECORD_FUNCTION_WITH_INPUTS_OUTPUTS(fn, inputs, outputs, ...) \
   RECORD_FUNCTION_WITH_SCOPE_INPUTS_OUTPUTS(                          \
-      at::RecordScope::FUNCTION, fn, inputs, outputs, ##__VA_ARGS__)
+      at::RecordScope::FUNCTION,                                      \
+      fn,                                                             \
+      inputs,                                                         \
+      outputs __VA_OPT__(, ) __VA_ARGS__)
 
 // Custom user scopes in C++; similar to Python's 'with record_function("..."):'
 #define RECORD_USER_SCOPE(fn) \
@@ -658,12 +661,12 @@ void record_function_with_scope_and_debug_handle(
 
 // Helper macro to pass in debug handle that is used to
 // post process events
-#define RECORD_WITH_SCOPE_DEBUG_HANDLE_AND_INPUTS(             \
-    scope, fn, debug_handle, inputs, ...)                      \
-  at::RecordFunction guard(scope);                             \
-  if (guard.isActive()) {                                      \
-    ::at::detail::record_function_with_scope_and_debug_handle( \
-        guard, fn, debug_handle, inputs, ##__VA_ARGS__);       \
+#define RECORD_WITH_SCOPE_DEBUG_HANDLE_AND_INPUTS(                   \
+    scope, fn, debug_handle, inputs, ...)                            \
+  at::RecordFunction guard(scope);                                   \
+  if (guard.isActive()) {                                            \
+    ::at::detail::record_function_with_scope_and_debug_handle(       \
+        guard, fn, debug_handle, inputs __VA_OPT__(, ) __VA_ARGS__); \
   }
 
 // Helper macros to record LITE INTERPRETER scope events with debug handles

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -521,13 +521,13 @@ inline C10_API const char* torchCheckMsgImpl(
 }
 } // namespace c10::detail
 
-#define TORCH_CHECK_MSG(cond, type, ...)                   \
-  (::c10::detail::torchCheckMsgImpl(                       \
-      "Expected " #cond                                    \
-      " to be true, but got false.  "                      \
-      "(Could this error message be improved?  If so, "    \
-      "please report an enhancement request to PyTorch.)", \
-      ##__VA_ARGS__))
+#define TORCH_CHECK_MSG(cond, type, ...)                                 \
+  (::c10::detail::torchCheckMsgImpl(                                     \
+      "Expected " #cond                                                  \
+      " to be true, but got false.  "                                    \
+      "(Could this error message be improved?  If so, "                  \
+      "please report an enhancement request to PyTorch.)" __VA_OPT__(, ) \
+          __VA_ARGS__))
 #define TORCH_CHECK_WITH_MSG(error_t, cond, type, ...)                  \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                                 \
     C10_THROW_ERROR(error_t, TORCH_CHECK_MSG(cond, type, __VA_ARGS__)); \
@@ -607,8 +607,7 @@ namespace c10::detail {
         __FILE__,                                          \
         ":",                                               \
         __LINE__,                                          \
-        ", ",                                              \
-        ##__VA_ARGS__));                                   \
+        ", " __VA_OPT__(, ) __VA_ARGS__));                 \
   }
 #endif
 
@@ -624,13 +623,13 @@ namespace c10::detail {
         TORCH_CHECK_MSG(cond, "", __VA_ARGS__)); \
   }
 #else
-#define TORCH_CHECK(cond, ...)                     \
-  if (C10_UNLIKELY_OR_CONST(!(cond))) {            \
-    ::c10::detail::torchCheckFail(                 \
-        __func__,                                  \
-        __FILE__,                                  \
-        static_cast<uint32_t>(__LINE__),           \
-        TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
+#define TORCH_CHECK(cond, ...)                                 \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                        \
+    ::c10::detail::torchCheckFail(                             \
+        __func__,                                              \
+        __FILE__,                                              \
+        static_cast<uint32_t>(__LINE__),                       \
+        TORCH_CHECK_MSG(cond, "" __VA_OPT__(, ) __VA_ARGS__)); \
   }
 #endif
 
@@ -642,7 +641,8 @@ namespace c10::detail {
 #if defined(__CUDACC__) || defined(__HIPCC__)
 #define TORCH_CHECK_IF_NOT_ON_CUDA(cond, ...)
 #else
-#define TORCH_CHECK_IF_NOT_ON_CUDA(cond, ...) TORCH_CHECK(cond, ##__VA_ARGS__)
+#define TORCH_CHECK_IF_NOT_ON_CUDA(cond, ...) \
+  TORCH_CHECK(cond __VA_OPT__(, ) __VA_ARGS__)
 #endif
 
 // Debug only version of TORCH_INTERNAL_ASSERT. This macro only checks in debug
@@ -698,7 +698,7 @@ namespace c10::detail {
 
 #define TORCH_CHECK_ALWAYS_SHOW_CPP_STACKTRACE(cond, ...) \
   TORCH_CHECK_WITH_MSG(                                   \
-      ErrorAlwaysShowCppStacktrace, cond, "TYPE", ##__VA_ARGS__)
+      ErrorAlwaysShowCppStacktrace, cond, "TYPE" __VA_OPT__(, ) __VA_ARGS__)
 
 #ifdef STRIP_ERROR_MESSAGES
 #define WARNING_MESSAGE_STRING(...) \

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -231,7 +231,7 @@ void enforceThatImpl(
       nullptr,                                            \
       [&](const auto& arg1, const auto& arg2) {           \
         return ::c10::enforce_detail::enforceFailMsgImpl( \
-            arg1, arg2, ##__VA_ARGS__);                   \
+            arg1, arg2 __VA_OPT__(, ) __VA_ARGS__);       \
       })
 
 #define CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER(op, lhs, rhs, expr, ...) \
@@ -245,49 +245,57 @@ void enforceThatImpl(
       this,                                                          \
       [&](const auto& arg1, const auto& arg2) {                      \
         return ::c10::enforce_detail::enforceFailMsgImpl(            \
-            arg1, arg2, ##__VA_ARGS__);                              \
+            arg1, arg2 __VA_OPT__(, ) __VA_ARGS__);                  \
       })
 
 } // namespace enforce_detail
 
 #define CAFFE_ENFORCE_THAT(cmp, op, lhs, rhs, ...) \
-  CAFFE_ENFORCE_THAT_IMPL(cmp, lhs, rhs, #lhs " " #op " " #rhs, ##__VA_ARGS__)
+  CAFFE_ENFORCE_THAT_IMPL(                         \
+      cmp, lhs, rhs, #lhs " " #op " " #rhs __VA_OPT__(, ) __VA_ARGS__)
 
 #define CAFFE_ENFORCE_BINARY_OP(cmp, op, x, y, ...) \
-  CAFFE_ENFORCE_THAT_IMPL(cmp, x, y, #x " " #op " " #y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_THAT_IMPL(                          \
+      cmp, x, y, #x " " #op " " #y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_EQ(x, y, ...) \
-  CAFFE_ENFORCE_BINARY_OP(std::equal_to<void>(), ==, x, y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_BINARY_OP(          \
+      std::equal_to<void>(), ==, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_NE(x, y, ...) \
-  CAFFE_ENFORCE_BINARY_OP(std::not_equal_to<void>(), !=, x, y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_BINARY_OP(          \
+      std::not_equal_to<void>(), !=, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_LE(x, y, ...) \
-  CAFFE_ENFORCE_BINARY_OP(std::less_equal<void>(), <=, x, y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_BINARY_OP(          \
+      std::less_equal<void>(), <=, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_LT(x, y, ...) \
-  CAFFE_ENFORCE_BINARY_OP(std::less<void>(), <, x, y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_BINARY_OP(std::less<void>(), <, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_GE(x, y, ...) \
-  CAFFE_ENFORCE_BINARY_OP(std::greater_equal<void>(), >=, x, y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_BINARY_OP(          \
+      std::greater_equal<void>(), >=, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_GT(x, y, ...) \
-  CAFFE_ENFORCE_BINARY_OP(std::greater<void>(), >, x, y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_BINARY_OP(          \
+      std::greater<void>(), >, x, y __VA_OPT__(, ) __VA_ARGS__)
 
 #define CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(cmp, op, x, y, ...) \
   CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER(                          \
-      cmp, x, y, #x " " #op " " #y, ##__VA_ARGS__)
+      cmp, x, y, #x " " #op " " #y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_EQ_WITH_CALLER(x, y, ...) \
   CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(          \
-      std::equal_to<void>(), ==, x, y, ##__VA_ARGS__)
+      std::equal_to<void>(), ==, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_NE_WITH_CALLER(x, y, ...) \
   CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(          \
-      std::not_equal_to<void>(), !=, x, y, ##__VA_ARGS__)
+      std::not_equal_to<void>(), !=, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_LE_WITH_CALLER(x, y, ...) \
   CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(          \
-      std::less_equal<void>(), <=, x, y, ##__VA_ARGS__)
+      std::less_equal<void>(), <=, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_LT_WITH_CALLER(x, y, ...) \
-  CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(std::less<void>(), <, x, y, ##__VA_ARGS__)
+  CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(          \
+      std::less<void>(), <, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_GE_WITH_CALLER(x, y, ...) \
   CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(          \
-      std::greater_equal<void>(), >=, x, y, ##__VA_ARGS__)
+      std::greater_equal<void>(), >=, x, y __VA_OPT__(, ) __VA_ARGS__)
 #define CAFFE_ENFORCE_GT_WITH_CALLER(x, y, ...) \
   CAFFE_ENFORCE_BINARY_OP_WITH_CALLER(          \
-      std::greater<void>(), >, x, y, ##__VA_ARGS__)
+      std::greater<void>(), >, x, y __VA_OPT__(, ) __VA_ARGS__)
 
 struct IValue;
 class C10_API EventSampledHandler {

--- a/c10/util/Registry.h
+++ b/c10/util/Registry.h
@@ -212,51 +212,62 @@ class Registerer {
 // dllexport are mixed, but the warning is fine and linker will be properly
 // exporting the symbol. Same thing happens in the gflags flag declaration and
 // definition caes.
-#define C10_DECLARE_TYPED_REGISTRY(                                      \
-    RegistryName, SrcType, ObjectType, PtrType, ...)                     \
-  C10_API ::c10::Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*  \
-  RegistryName();                                                        \
-  typedef ::c10::Registerer<SrcType, PtrType<ObjectType>, ##__VA_ARGS__> \
-      Registerer##RegistryName
+#define C10_DECLARE_TYPED_REGISTRY(                                       \
+    RegistryName, SrcType, ObjectType, PtrType, ...)                      \
+  C10_API ::c10::                                                         \
+      Registry<SrcType, PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>*  \
+      RegistryName();                                                     \
+  typedef ::c10::                                                         \
+      Registerer<SrcType, PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__> \
+          Registerer##RegistryName
 
 #define TORCH_DECLARE_TYPED_REGISTRY(                                     \
     RegistryName, SrcType, ObjectType, PtrType, ...)                      \
-  TORCH_API ::c10::Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>* \
-  RegistryName();                                                         \
-  typedef ::c10::Registerer<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>  \
-      Registerer##RegistryName
+  TORCH_API ::c10::                                                       \
+      Registry<SrcType, PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>*  \
+      RegistryName();                                                     \
+  typedef ::c10::                                                         \
+      Registerer<SrcType, PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__> \
+          Registerer##RegistryName
 
-#define C10_DEFINE_TYPED_REGISTRY(                                         \
-    RegistryName, SrcType, ObjectType, PtrType, ...)                       \
-  C10_EXPORT ::c10::Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>* \
-  RegistryName() {                                                         \
-    static ::c10::Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*   \
-        registry = new ::c10::                                             \
-            Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>();       \
-    return registry;                                                       \
+#define C10_DEFINE_TYPED_REGISTRY(                                       \
+    RegistryName, SrcType, ObjectType, PtrType, ...)                     \
+  C10_EXPORT ::c10::                                                     \
+      Registry<SrcType, PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>* \
+      RegistryName() {                                                   \
+    static ::c10::Registry<                                              \
+        SrcType,                                                         \
+        PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>* registry =      \
+        new ::c10::Registry<                                             \
+            SrcType,                                                     \
+            PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>();           \
+    return registry;                                                     \
   }
 
-#define C10_DEFINE_TYPED_REGISTRY_WITHOUT_WARNING(                            \
-    RegistryName, SrcType, ObjectType, PtrType, ...)                          \
-  C10_EXPORT ::c10::Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*    \
-  RegistryName() {                                                            \
-    static ::c10::Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>*      \
-        registry =                                                            \
-            new ::c10::Registry<SrcType, PtrType<ObjectType>, ##__VA_ARGS__>( \
-                false);                                                       \
-    return registry;                                                          \
+#define C10_DEFINE_TYPED_REGISTRY_WITHOUT_WARNING(                             \
+    RegistryName, SrcType, ObjectType, PtrType, ...)                           \
+  C10_EXPORT ::c10::                                                           \
+      Registry<SrcType, PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>*       \
+      RegistryName() {                                                         \
+    static ::c10::Registry<                                                    \
+        SrcType,                                                               \
+        PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>* registry =            \
+        new ::c10::                                                            \
+            Registry<SrcType, PtrType<ObjectType> __VA_OPT__(, ) __VA_ARGS__>( \
+                false);                                                        \
+    return registry;                                                           \
   }
 
 // Note(Yangqing): The __VA_ARGS__ below allows one to specify a templated
 // creator with comma in its templated arguments.
 #define C10_REGISTER_TYPED_CREATOR(RegistryName, key, ...)                  \
   static Registerer##RegistryName C10_ANONYMOUS_VARIABLE(g_##RegistryName)( \
-      key, RegistryName(), ##__VA_ARGS__);
+      key, RegistryName() __VA_OPT__(, ) __VA_ARGS__);
 
 #define C10_REGISTER_TYPED_CREATOR_WITH_PRIORITY(                           \
     RegistryName, key, priority, ...)                                       \
   static Registerer##RegistryName C10_ANONYMOUS_VARIABLE(g_##RegistryName)( \
-      key, priority, RegistryName(), ##__VA_ARGS__);
+      key, priority, RegistryName() __VA_OPT__(, ) __VA_ARGS__);
 
 #define C10_REGISTER_TYPED_CLASS(RegistryName, key, ...)                    \
   static Registerer##RegistryName C10_ANONYMOUS_VARIABLE(g_##RegistryName)( \
@@ -278,36 +289,60 @@ class Registerer {
 // std::string as the key type, because that is the most commonly used cases.
 #define C10_DECLARE_REGISTRY(RegistryName, ObjectType, ...) \
   C10_DECLARE_TYPED_REGISTRY(                               \
-      RegistryName, std::string, ObjectType, std::unique_ptr, ##__VA_ARGS__)
+      RegistryName,                                         \
+      std::string,                                          \
+      ObjectType,                                           \
+      std::unique_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 #define TORCH_DECLARE_REGISTRY(RegistryName, ObjectType, ...) \
   TORCH_DECLARE_TYPED_REGISTRY(                               \
-      RegistryName, std::string, ObjectType, std::unique_ptr, ##__VA_ARGS__)
+      RegistryName,                                           \
+      std::string,                                            \
+      ObjectType,                                             \
+      std::unique_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 #define C10_DEFINE_REGISTRY(RegistryName, ObjectType, ...) \
   C10_DEFINE_TYPED_REGISTRY(                               \
-      RegistryName, std::string, ObjectType, std::unique_ptr, ##__VA_ARGS__)
+      RegistryName,                                        \
+      std::string,                                         \
+      ObjectType,                                          \
+      std::unique_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 #define C10_DEFINE_REGISTRY_WITHOUT_WARNING(RegistryName, ObjectType, ...) \
   C10_DEFINE_TYPED_REGISTRY_WITHOUT_WARNING(                               \
-      RegistryName, std::string, ObjectType, std::unique_ptr, ##__VA_ARGS__)
+      RegistryName,                                                        \
+      std::string,                                                         \
+      ObjectType,                                                          \
+      std::unique_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 #define C10_DECLARE_SHARED_REGISTRY(RegistryName, ObjectType, ...) \
   C10_DECLARE_TYPED_REGISTRY(                                      \
-      RegistryName, std::string, ObjectType, std::shared_ptr, ##__VA_ARGS__)
+      RegistryName,                                                \
+      std::string,                                                 \
+      ObjectType,                                                  \
+      std::shared_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 #define TORCH_DECLARE_SHARED_REGISTRY(RegistryName, ObjectType, ...) \
   TORCH_DECLARE_TYPED_REGISTRY(                                      \
-      RegistryName, std::string, ObjectType, std::shared_ptr, ##__VA_ARGS__)
+      RegistryName,                                                  \
+      std::string,                                                   \
+      ObjectType,                                                    \
+      std::shared_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 #define C10_DEFINE_SHARED_REGISTRY(RegistryName, ObjectType, ...) \
   C10_DEFINE_TYPED_REGISTRY(                                      \
-      RegistryName, std::string, ObjectType, std::shared_ptr, ##__VA_ARGS__)
+      RegistryName,                                               \
+      std::string,                                                \
+      ObjectType,                                                 \
+      std::shared_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 #define C10_DEFINE_SHARED_REGISTRY_WITHOUT_WARNING( \
     RegistryName, ObjectType, ...)                  \
   C10_DEFINE_TYPED_REGISTRY_WITHOUT_WARNING(        \
-      RegistryName, std::string, ObjectType, std::shared_ptr, ##__VA_ARGS__)
+      RegistryName,                                 \
+      std::string,                                  \
+      ObjectType,                                   \
+      std::shared_ptr __VA_OPT__(, ) __VA_ARGS__)
 
 // C10_REGISTER_CREATOR and C10_REGISTER_CLASS are hard-wired to use std::string
 // as the key

--- a/c10/util/static_tracepoint.h
+++ b/c10/util/static_tracepoint.h
@@ -9,12 +9,18 @@
 
 #define TORCH_SDT(name, ...) \
   TORCH_SDT_PROBE_N(         \
-      pytorch, name, 0, TORCH_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+      pytorch,               \
+      name,                  \
+      0,                     \
+      TORCH_SDT_NARG(0 __VA_OPT__(, ) __VA_ARGS__) __VA_OPT__(, ) __VA_ARGS__)
 // Use TORCH_SDT_DEFINE_SEMAPHORE(name) to define the semaphore
 // as global variable before using the TORCH_SDT_WITH_SEMAPHORE macro
 #define TORCH_SDT_WITH_SEMAPHORE(name, ...) \
   TORCH_SDT_PROBE_N(                        \
-      pytorch, name, 1, TORCH_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+      pytorch,                              \
+      name,                                 \
+      1,                                    \
+      TORCH_SDT_NARG(0 __VA_OPT__(, ) __VA_ARGS__) __VA_OPT__(, ) __VA_ARGS__)
 #define TORCH_SDT_IS_ENABLED(name) (TORCH_SDT_SEMAPHORE(pytorch, name) > 0)
 
 #else

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegException.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegException.h
@@ -10,6 +10,6 @@ void orCheckFail(const char* func, const char* file, uint32_t line, const char* 
   do {                                                                                 \
     const orError_t __err = EXPR;                                                      \
     if (C10_UNLIKELY(__err != orSuccess)) {                                            \
-      orCheckFail(__func__, __FILE__, static_cast<uint32_t>(__LINE__), ##__VA_ARGS__); \
+      orCheckFail(__func__, __FILE__, static_cast<uint32_t>(__LINE__) __VA_OPT__(,) __VA_ARGS__); \
     }                                                                                  \
   } while (0)

--- a/torch/csrc/distributed/c10d/nccl2/Logging.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/Logging.hpp
@@ -47,8 +47,8 @@ inline std::string getRankPrefix(Comm* comm) {
 #define TC_LOG_PICKER(x, level, comm, FUNC, ...) FUNC
 #define TC_LOG(...)                            \
   TC_LOG_PICKER(                               \
-      ,                                        \
-      ##__VA_ARGS__,                           \
+                                               \
+      __VA_OPT__(, ) __VA_ARGS__,              \
       TC_LOG_WITH_PREFIX_BUILDER(__VA_ARGS__), \
       TC_LOG_PLAIN(__VA_ARGS__))
 

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -30,7 +30,7 @@ constexpr int kUnsetDivFactor = -1;
     if (!logger_.expired()) {                         \
       logger_.lock()->set_error_and_log(__VA_ARGS__); \
     }                                                 \
-    TORCH_CHECK(false, ##__VA_ARGS__);                \
+    TORCH_CHECK(false __VA_OPT__(, ) __VA_ARGS__);    \
   }
 
 } // namespace

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -649,14 +649,14 @@ AOTI_TORCH_EXPORT void aoti_torch_check(
         STD_TORCH_CHECK_MSG(cond, "", __VA_ARGS__)); \
   }
 #else
-#define AOTI_TORCH_CHECK(cond, ...)                    \
-  if (!(cond)) {                                       \
-    aoti_torch_check(                                  \
-        false,                                         \
-        __func__,                                      \
-        __FILE__,                                      \
-        static_cast<uint32_t>(__LINE__),               \
-        STD_TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
+#define AOTI_TORCH_CHECK(cond, ...)                                \
+  if (!(cond)) {                                                   \
+    aoti_torch_check(                                              \
+        false,                                                     \
+        __func__,                                                  \
+        __FILE__,                                                  \
+        static_cast<uint32_t>(__LINE__),                           \
+        STD_TORCH_CHECK_MSG(cond, "" __VA_OPT__(, ) __VA_ARGS__)); \
   }
 #endif
 

--- a/torch/csrc/multiprocessing/init.cpp
+++ b/torch/csrc/multiprocessing/init.cpp
@@ -13,8 +13,11 @@
 #include <sys/prctl.h>
 #endif
 
-#define SYSASSERT(rv, ...) \
-  TORCH_CHECK((rv) >= 0, ##__VA_ARGS__, ": ", c10::utils::str_error(errno))
+#define SYSASSERT(rv, ...)                  \
+  TORCH_CHECK(                              \
+      (rv) >= 0 __VA_OPT__(, ) __VA_ARGS__, \
+      ": ",                                 \
+      c10::utils::str_error(errno))
 
 namespace torch::multiprocessing {
 

--- a/torch/csrc/profiler/unwind/unwind_error.h
+++ b/torch/csrc/profiler/unwind/unwind_error.h
@@ -9,12 +9,14 @@ struct UnwindError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-#define UNWIND_CHECK(cond, fmtstring, ...)                          \
-  do {                                                              \
-    if (!(cond)) {                                                  \
-      throw unwind::UnwindError(fmt::format(                        \
-          "{}:{}: " fmtstring, __FILE__, __LINE__, ##__VA_ARGS__)); \
-    }                                                               \
+#define UNWIND_CHECK(cond, fmtstring, ...)       \
+  do {                                           \
+    if (!(cond)) {                               \
+      throw unwind::UnwindError(fmt::format(     \
+          "{}:{}: " fmtstring,                   \
+          __FILE__,                              \
+          __LINE__ __VA_OPT__(, ) __VA_ARGS__)); \
+    }                                            \
   } while (0)
 
 // #define LOG_INFO(...) fmt::print(__VA_ARGS__)

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -478,8 +478,7 @@ __host__ __device__
         blockIdx.z,                                                   \
         threadIdx.x,                                                  \
         threadIdx.y,                                                  \
-        threadIdx.z,                                                  \
-        ##__VA_ARGS__));                                              \
+        threadIdx.z __VA_OPT__(, ) __VA_ARGS__));                     \
     (void)(_wassert(                                                  \
                _CRT_WIDE(#cond),                                      \
                _CRT_WIDE(__FILE__),                                   \
@@ -576,8 +575,8 @@ __host__ __device__
         blockIdx.z,                                                    \
         threadIdx.x,                                                   \
         threadIdx.y,                                                   \
-        threadIdx.z,                                                   \
-        ##__VA_ARGS__); \
+        threadIdx.z                                                   \
+        __VA_OPT__(,) __VA_ARGS__); \
     __assert_fail(                                                       \
         #cond, __FILE__, static_cast<unsigned int>(__LINE__), __func__); \
   }

--- a/torch/headeronly/util/Exception.h
+++ b/torch/headeronly/util/Exception.h
@@ -61,13 +61,13 @@ inline const char* stdTorchCheckMsgImpl(const char* /*msg*/, const char* args) {
 }
 HIDDEN_NAMESPACE_END(torch, headeronly, detail)
 
-#define STD_TORCH_CHECK_MSG(cond, type, ...)               \
-  (torch::headeronly::detail::stdTorchCheckMsgImpl(        \
-      "Expected " #cond                                    \
-      " to be true, but got false.  "                      \
-      "(Could this error message be improved?  If so, "    \
-      "please report an enhancement request to PyTorch.)", \
-      ##__VA_ARGS__))
+#define STD_TORCH_CHECK_MSG(cond, type, ...)                             \
+  (torch::headeronly::detail::stdTorchCheckMsgImpl(                      \
+      "Expected " #cond                                                  \
+      " to be true, but got false.  "                                    \
+      "(Could this error message be improved?  If so, "                  \
+      "please report an enhancement request to PyTorch.)" __VA_OPT__(, ) \
+          __VA_ARGS__))
 #endif // STRIP_ERROR_MESSAGES
 
 #define STD_TORCH_CHECK(cond, ...)                                    \
@@ -81,6 +81,5 @@ HIDDEN_NAMESPACE_END(torch, headeronly, detail)
         __FILE__,                                                     \
         ":",                                                          \
         __LINE__,                                                     \
-        ", ",                                                         \
-        ##__VA_ARGS__));                                              \
+        ", " __VA_OPT__(, ) __VA_ARGS__));                            \
   }


### PR DESCRIPTION
`, ## __VA_ARGS__` swallowing the comma on an empty variadic pack is a GNU extension; clang flags every use under `-Wpedantic`, which makes `-Werror=pedantic` (already in `torch_compile_options`) unusable. C++20's `__VA_OPT__(,)` is the standard spelling, and the tree has compiled as C++20 for a while. 72 occurrences across 16 files, all the same shape.

Test plan:

    clang++ -std=c++20 -E <TU exercising the macros> | <normalize whitespace> > new.i
    git stash && clang++ ... > old.i && git stash pop
    cmp old.i new.i

Preprocessed output is identical before and after (verified across `TORCH_CHECK`, `TORCH_INTERNAL_ASSERT`, `TORCH_WARN`, and the registry macros, with zero, one, and several variadic arguments); the only raw diff is a space where the comma used to sit. Also confirmed clang and g++-15 accept the result under `-std=c++20 -Wpedantic -Werror`.

This change was authored with the assistance of an AI coding agent and reviewed before submission.
