### PR TITLE
Fix ref leaks in CUDA array interface conversion

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: cuda"]
 
+import sys
 import unittest
 
 import torch
@@ -20,6 +21,46 @@ if TEST_NUMBA_CUDA:
 
 
 class TestNumbaIntegration(common.TestCase):
+    @unittest.skipIf(not TEST_NUMPY, "No numpy")
+    @unittest.skipIf(not TEST_CUDA, "No cuda")
+    def test_from_cuda_array_interface_does_not_leak_references(self):
+        class TrackedString(str):
+            pass
+
+        class Wrapper:
+            def __init__(self, tensor):
+                self.shape = list(tensor.shape)
+                element_size = tensor.element_size()
+                self.strides = [stride * element_size for stride in tensor.stride()]
+                self.typestr = TrackedString("<f4")
+                self.data = (tensor.data_ptr(), False)
+                self.interface = {
+                    "shape": self.shape,
+                    "strides": self.strides,
+                    "typestr": self.typestr,
+                    "data": self.data,
+                    "version": 3,
+                }
+
+            @property
+            def __cuda_array_interface__(self):
+                return self.interface
+
+        source = torch.ones(1, device="cuda")
+        wrapper = Wrapper(source)
+        tracked = (
+            wrapper.shape,
+            wrapper.strides,
+            wrapper.typestr,
+            wrapper.data,
+        )
+        refcounts = tuple(sys.getrefcount(item) for item in tracked)
+        for _ in range(10):
+            converted = torch.as_tensor(wrapper)
+            del converted
+
+        self.assertEqual(tuple(sys.getrefcount(item) for item in tracked), refcounts)
+
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     def test_cuda_array_interface(self):

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -25,7 +25,7 @@ class TestNumbaIntegration(common.TestCase):
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     def test_from_cuda_array_interface_does_not_leak_references(self):
         class TrackedString(str):
-            pass
+            __slots__ = ()
 
         class Wrapper:
             def __init__(self, tensor):
@@ -57,6 +57,7 @@ class TestNumbaIntegration(common.TestCase):
         refcounts = tuple(sys.getrefcount(item) for item in tracked)
         for _ in range(10):
             converted = torch.as_tensor(wrapper)
+            self.assertEqual(converted, source)
             del converted
 
         self.assertEqual(tuple(sys.getrefcount(item) for item in tracked), refcounts)

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -396,10 +396,10 @@ at::Tensor tensor_from_cuda_array_interface(
   // Extract the `obj.__cuda_array_interface__['shape']` attribute
   std::vector<int64_t> sizes;
   {
-    PyObject* py_shape = nullptr;
+    PyObject* py_shape_raw = nullptr;
     TORCH_CHECK_PYTHON(
-        PyDict_GetItemStringRef(cuda_dict, "shape", &py_shape) >= 0);
-    THPObjectPtr py_shape_guard(py_shape);
+        PyDict_GetItemStringRef(cuda_dict, "shape", &py_shape_raw) >= 0);
+    THPObjectPtr py_shape(py_shape_raw);
     if (py_shape == nullptr) {
       TORCH_CHECK_TYPE(false, "attribute `shape` must exist");
     }
@@ -410,17 +410,17 @@ at::Tensor tensor_from_cuda_array_interface(
   ScalarType dtype{};
   int64_t dtype_size_in_bytes = 0;
   {
-    PyObject* py_typestr = nullptr;
+    PyObject* py_typestr_raw = nullptr;
     TORCH_CHECK_PYTHON(
-        PyDict_GetItemStringRef(cuda_dict, "typestr", &py_typestr) >= 0);
-    THPObjectPtr py_typestr_guard(py_typestr);
+        PyDict_GetItemStringRef(cuda_dict, "typestr", &py_typestr_raw) >= 0);
+    THPObjectPtr py_typestr(py_typestr_raw);
     if (py_typestr == nullptr) {
       TORCH_CHECK_TYPE(false, "attribute `typestr` must exist");
     }
     PyArray_Descr* descr = nullptr;
-    const auto converted = PyArray_DescrConverter(py_typestr, &descr);
+    TORCH_CHECK_VALUE(
+        PyArray_DescrConverter(py_typestr, &descr), "cannot parse `typestr`");
     THPObjectPtr descr_guard(reinterpret_cast<PyObject*>(descr));
-    TORCH_CHECK_VALUE(converted, "cannot parse `typestr`");
     dtype = numpy_dtype_to_aten(descr->type_num);
 #if NPY_ABI_VERSION >= 0x02000000
     dtype_size_in_bytes = PyDataType_ELSIZE(descr);
@@ -433,10 +433,10 @@ at::Tensor tensor_from_cuda_array_interface(
   // Extract the `obj.__cuda_array_interface__['data']` attribute
   void* data_ptr = nullptr;
   {
-    PyObject* py_data = nullptr;
+    PyObject* py_data_raw = nullptr;
     TORCH_CHECK_PYTHON(
-        PyDict_GetItemStringRef(cuda_dict, "data", &py_data) >= 0);
-    THPObjectPtr py_data_guard(py_data);
+        PyDict_GetItemStringRef(cuda_dict, "data", &py_data_raw) >= 0);
+    THPObjectPtr py_data(py_data_raw);
     if (py_data == nullptr) {
       TORCH_CHECK_TYPE(false, "attribute `shape` data exist");
     }
@@ -456,10 +456,10 @@ at::Tensor tensor_from_cuda_array_interface(
   // Extract the `obj.__cuda_array_interface__['strides']` attribute
   std::vector<int64_t> strides;
   {
-    PyObject* py_strides = nullptr;
+    PyObject* py_strides_raw = nullptr;
     TORCH_CHECK_PYTHON(
-        PyDict_GetItemStringRef(cuda_dict, "strides", &py_strides) >= 0);
-    THPObjectPtr py_strides_guard(py_strides);
+        PyDict_GetItemStringRef(cuda_dict, "strides", &py_strides_raw) >= 0);
+    THPObjectPtr py_strides(py_strides_raw);
     if (py_strides != nullptr && !Py_IsNone(py_strides)) {
       if (PySequence_Length(py_strides) == -1 ||
           static_cast<size_t>(PySequence_Length(py_strides)) != sizes.size()) {

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -399,6 +399,7 @@ at::Tensor tensor_from_cuda_array_interface(
     PyObject* py_shape = nullptr;
     TORCH_CHECK_PYTHON(
         PyDict_GetItemStringRef(cuda_dict, "shape", &py_shape) >= 0);
+    THPObjectPtr py_shape_guard(py_shape);
     if (py_shape == nullptr) {
       TORCH_CHECK_TYPE(false, "attribute `shape` must exist");
     }
@@ -412,12 +413,14 @@ at::Tensor tensor_from_cuda_array_interface(
     PyObject* py_typestr = nullptr;
     TORCH_CHECK_PYTHON(
         PyDict_GetItemStringRef(cuda_dict, "typestr", &py_typestr) >= 0);
+    THPObjectPtr py_typestr_guard(py_typestr);
     if (py_typestr == nullptr) {
       TORCH_CHECK_TYPE(false, "attribute `typestr` must exist");
     }
     PyArray_Descr* descr = nullptr;
-    TORCH_CHECK_VALUE(
-        PyArray_DescrConverter(py_typestr, &descr), "cannot parse `typestr`");
+    const auto converted = PyArray_DescrConverter(py_typestr, &descr);
+    THPObjectPtr descr_guard(reinterpret_cast<PyObject*>(descr));
+    TORCH_CHECK_VALUE(converted, "cannot parse `typestr`");
     dtype = numpy_dtype_to_aten(descr->type_num);
 #if NPY_ABI_VERSION >= 0x02000000
     dtype_size_in_bytes = PyDataType_ELSIZE(descr);
@@ -433,6 +436,7 @@ at::Tensor tensor_from_cuda_array_interface(
     PyObject* py_data = nullptr;
     TORCH_CHECK_PYTHON(
         PyDict_GetItemStringRef(cuda_dict, "data", &py_data) >= 0);
+    THPObjectPtr py_data_guard(py_data);
     if (py_data == nullptr) {
       TORCH_CHECK_TYPE(false, "attribute `shape` data exist");
     }
@@ -455,6 +459,7 @@ at::Tensor tensor_from_cuda_array_interface(
     PyObject* py_strides = nullptr;
     TORCH_CHECK_PYTHON(
         PyDict_GetItemStringRef(cuda_dict, "strides", &py_strides) >= 0);
+    THPObjectPtr py_strides_guard(py_strides);
     if (py_strides != nullptr && !Py_IsNone(py_strides)) {
       if (PySequence_Length(py_strides) == -1 ||
           static_cast<size_t>(PySequence_Length(py_strides)) != sizes.size()) {

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -440,12 +440,12 @@ at::Tensor tensor_from_cuda_array_interface(
     if (py_data == nullptr) {
       TORCH_CHECK_TYPE(false, "attribute `shape` data exist");
     }
-    if (!PyTuple_Check(py_data) || PyTuple_GET_SIZE(py_data) != 2) {
+    if (!PyTuple_Check(py_data) || PyTuple_GET_SIZE(py_data.get()) != 2) {
       TORCH_CHECK_TYPE(false, "`data` must be a 2-tuple of (int, bool)");
     }
-    data_ptr = PyLong_AsVoidPtr(PyTuple_GET_ITEM(py_data, 0));
+    data_ptr = PyLong_AsVoidPtr(PyTuple_GET_ITEM(py_data.get(), 0));
     TORCH_CHECK_PYTHON(data_ptr != nullptr || !PyErr_Occurred());
-    int read_only = PyObject_IsTrue(PyTuple_GET_ITEM(py_data, 1));
+    int read_only = PyObject_IsTrue(PyTuple_GET_ITEM(py_data.get(), 1));
     TORCH_CHECK_PYTHON(read_only != -1);
     if (read_only) {
       TORCH_CHECK_TYPE(


### PR DESCRIPTION
## Issue

Fixes #194877

## Summary

`tensor_from_cuda_array_interface` uses `PyDict_GetItemStringRef` and `PyArray_DescrConverter`, both of which return owned references. Wrap those results in `THPObjectPtr` so conversion through `torch.as_tensor(obj_with_cuda_array_interface)` releases the temporary Python references.

Adds a CUDA array interface regression test that repeatedly converts a wrapper object and checks that the interface dictionary values keep stable reference counts.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.

## Test plan

- `git diff --check`
- `python test/test_numba_integration.py -k test_from_cuda_array_interface_does_not_leak_references` (blocked locally: this checkout has not loaded built PyTorch C extensions and raises the standard in-tree import error before running tests)
