### PR TITLE
Use the Number union for isinstance instead of the _Number tuple

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -64,7 +64,7 @@ def type_casts(
     @functools.wraps(f)
     def inner(*args, **kwargs):
         allowed_types = (
-            (Tensor, torch.types._Number) if include_non_tensor_args else (Tensor,)
+            (Tensor, torch.types.Number) if include_non_tensor_args else (Tensor,)
         )  # type: ignore[arg-type]
         flat_args = [
             x

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -11,7 +11,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
-from torch.types import _Number, Number
+from torch.types import Number
 
 
 __all__ = ["Bernoulli"]
@@ -55,13 +55,13 @@ class Bernoulli(ExponentialFamily):
                 "Either `probs` or `logits` must be specified, but not both."
             )
         if probs is not None:
-            is_scalar = isinstance(probs, _Number)
+            is_scalar = isinstance(probs, Number)
             # pyrefly: ignore [read-only]
             (self.probs,) = broadcast_all(probs)
         else:
             if logits is None:
                 raise AssertionError("logits is unexpectedly None")
-            is_scalar = isinstance(logits, _Number)
+            is_scalar = isinstance(logits, Number)
             # pyrefly: ignore [read-only]
             (self.logits,) = broadcast_all(logits)
         self._param = self.probs if probs is not None else self.logits

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -6,7 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.dirichlet import Dirichlet
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["Beta"]
@@ -44,7 +44,7 @@ class Beta(ExponentialFamily):
         concentration0: Tensor | float,
         validate_args: bool | None = None,
     ) -> None:
-        if isinstance(concentration1, _Number) and isinstance(concentration0, _Number):
+        if isinstance(concentration1, Number) and isinstance(concentration0, Number):
             concentration1_concentration0 = torch.tensor(
                 [float(concentration1), float(concentration0)]
             )
@@ -96,7 +96,7 @@ class Beta(ExponentialFamily):
     @property
     def concentration1(self) -> Tensor:
         result = self._dirichlet.concentration[..., 0]
-        if isinstance(result, _Number):
+        if isinstance(result, Number):
             return torch.tensor([result])
         else:
             return result
@@ -104,7 +104,7 @@ class Beta(ExponentialFamily):
     @property
     def concentration0(self) -> Tensor:
         result = self._dirichlet.concentration[..., 1]
-        if isinstance(result, _Number):
+        if isinstance(result, Number):
             return torch.tensor([result])
         else:
             return result

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -6,7 +6,7 @@ from torch import inf, nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["Cauchy"]
@@ -42,7 +42,7 @@ class Cauchy(Distribution):
         validate_args: bool | None = None,
     ) -> None:
         self.loc, self.scale = broadcast_all(loc, scale)
-        if isinstance(loc, _Number) and isinstance(scale, _Number):
+        if isinstance(loc, Number) and isinstance(scale, Number):
             batch_shape = torch.Size()
         else:
             batch_shape = self.loc.size()

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -67,7 +67,7 @@ object.
 """
 
 from torch.distributions import constraints, transforms
-from torch.types import _Number
+from torch.types import Number
 
 
 __all__ = [
@@ -220,10 +220,10 @@ def _transform_to_less_than(constraint):
 def _transform_to_interval(constraint):
     # Handle the special case of the unit interval.
     lower_is_0 = (
-        isinstance(constraint.lower_bound, _Number) and constraint.lower_bound == 0
+        isinstance(constraint.lower_bound, Number) and constraint.lower_bound == 0
     )
     upper_is_1 = (
-        isinstance(constraint.upper_bound, _Number) and constraint.upper_bound == 1
+        isinstance(constraint.upper_bound, Number) and constraint.upper_bound == 1
     )
     if lower_is_0 and upper_is_1:
         return transforms.SigmoidTransform()

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -13,7 +13,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
-from torch.types import _Number, _size, Number
+from torch.types import _size, Number
 
 
 __all__ = ["ContinuousBernoulli"]
@@ -64,7 +64,7 @@ class ContinuousBernoulli(ExponentialFamily):
                 "Either `probs` or `logits` must be specified, but not both."
             )
         if probs is not None:
-            is_scalar = isinstance(probs, _Number)
+            is_scalar = isinstance(probs, Number)
             # pyrefly: ignore [read-only]
             (self.probs,) = broadcast_all(probs)
             # validate 'probs' here if necessary as it is later clamped for numerical stability
@@ -77,7 +77,7 @@ class ContinuousBernoulli(ExponentialFamily):
         else:
             if logits is None:
                 raise AssertionError("logits is unexpectedly None")
-            is_scalar = isinstance(logits, _Number)
+            is_scalar = isinstance(logits, Number)
             # pyrefly: ignore [read-only]
             (self.logits,) = broadcast_all(logits)
         self._param = self.probs if probs is not None else self.logits

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -5,7 +5,7 @@ from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["Exponential"]
@@ -54,7 +54,7 @@ class Exponential(ExponentialFamily):
         validate_args: bool | None = None,
     ) -> None:
         (self.rate,) = broadcast_all(rate)
-        batch_shape = torch.Size() if isinstance(rate, _Number) else self.rate.size()
+        batch_shape = torch.Size() if isinstance(rate, Number) else self.rate.size()
         super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -6,7 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.gamma import Gamma
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["FisherSnedecor"]
@@ -43,7 +43,7 @@ class FisherSnedecor(Distribution):
         self._gamma1 = Gamma(self.df1 * 0.5, self.df1)
         self._gamma2 = Gamma(self.df2 * 0.5, self.df2)
 
-        if isinstance(df1, _Number) and isinstance(df2, _Number):
+        if isinstance(df1, Number) and isinstance(df2, Number):
             batch_shape = torch.Size()
         else:
             batch_shape = self.df1.size()

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -5,7 +5,7 @@ from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["Gamma"]
@@ -61,7 +61,7 @@ class Gamma(ExponentialFamily):
         validate_args: bool | None = None,
     ) -> None:
         self.concentration, self.rate = broadcast_all(concentration, rate)
-        if isinstance(concentration, _Number) and isinstance(rate, _Number):
+        if isinstance(concentration, Number) and isinstance(rate, Number):
             batch_shape = torch.Size()
         else:
             batch_shape = self.concentration.size()

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -11,7 +11,7 @@ from torch.distributions.utils import (
     probs_to_logits,
 )
 from torch.nn.functional import binary_cross_entropy_with_logits
-from torch.types import _Number, Number
+from torch.types import Number
 
 
 __all__ = ["Geometric"]
@@ -66,7 +66,7 @@ class Geometric(Distribution):
             # pyrefly: ignore [read-only]
             (self.logits,) = broadcast_all(logits)
         probs_or_logits = probs if probs is not None else logits
-        if isinstance(probs_or_logits, _Number):
+        if isinstance(probs_or_logits, Number):
             batch_shape = torch.Size()
         else:
             if probs_or_logits is None:

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -8,7 +8,7 @@ from torch.distributions.transformed_distribution import TransformedDistribution
 from torch.distributions.transforms import AffineTransform, ExpTransform
 from torch.distributions.uniform import Uniform
 from torch.distributions.utils import broadcast_all, euler_constant
-from torch.types import _Number
+from torch.types import Number
 
 
 __all__ = ["Gumbel"]
@@ -42,7 +42,7 @@ class Gumbel(TransformedDistribution):
     ) -> None:
         self.loc, self.scale = broadcast_all(loc, scale)
         finfo = torch.finfo(self.loc.dtype)
-        if isinstance(loc, _Number) and isinstance(scale, _Number):
+        if isinstance(loc, Number) and isinstance(scale, Number):
             base_dist = Uniform(finfo.tiny, 1 - finfo.eps, validate_args=validate_args)
         else:
             base_dist = Uniform(

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -5,7 +5,7 @@ from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["Laplace"]
@@ -55,7 +55,7 @@ class Laplace(Distribution):
         validate_args: bool | None = None,
     ) -> None:
         self.loc, self.scale = broadcast_all(loc, scale)
-        if isinstance(loc, _Number) and isinstance(scale, _Number):
+        if isinstance(loc, Number) and isinstance(scale, Number):
             batch_shape = torch.Size()
         else:
             batch_shape = self.loc.size()

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -90,9 +90,7 @@ class Normal(ExponentialFamily):
         # compute the variance
         var = self.scale**2
         log_scale = (
-            math.log(self.scale)
-            if isinstance(self.scale, Number)
-            else self.scale.log()
+            math.log(self.scale) if isinstance(self.scale, Number) else self.scale.log()
         )
         return (
             -((value - self.loc) ** 2) / (2 * var)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import _standard_normal, broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["Normal"]
@@ -59,7 +59,7 @@ class Normal(ExponentialFamily):
         validate_args: bool | None = None,
     ) -> None:
         self.loc, self.scale = broadcast_all(loc, scale)
-        if isinstance(loc, _Number) and isinstance(scale, _Number):
+        if isinstance(loc, Number) and isinstance(scale, Number):
             batch_shape = torch.Size()
         else:
             batch_shape = self.loc.size()
@@ -91,7 +91,7 @@ class Normal(ExponentialFamily):
         var = self.scale**2
         log_scale = (
             math.log(self.scale)
-            if isinstance(self.scale, _Number)
+            if isinstance(self.scale, Number)
             else self.scale.log()
         )
         return (

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -5,7 +5,7 @@ from torch import Tensor
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, Number
+from torch.types import Number
 
 
 __all__ = ["Poisson"]
@@ -53,7 +53,7 @@ class Poisson(ExponentialFamily):
         validate_args: bool | None = None,
     ) -> None:
         (self.rate,) = broadcast_all(rate)
-        if isinstance(rate, _Number):
+        if isinstance(rate, Number):
             batch_shape = torch.Size()
         else:
             batch_shape = self.rate.size()

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -13,7 +13,7 @@ from torch.distributions.utils import (
     logits_to_probs,
     probs_to_logits,
 )
-from torch.types import _Number, _size, Number
+from torch.types import _size, Number
 
 
 __all__ = ["LogitRelaxedBernoulli", "RelaxedBernoulli"]
@@ -56,13 +56,13 @@ class LogitRelaxedBernoulli(Distribution):
                 "Either `probs` or `logits` must be specified, but not both."
             )
         if probs is not None:
-            is_scalar = isinstance(probs, _Number)
+            is_scalar = isinstance(probs, Number)
             # pyrefly: ignore [read-only]
             (self.probs,) = broadcast_all(probs)
         else:
             if logits is None:
                 raise AssertionError("logits is unexpectedly None")
-            is_scalar = isinstance(logits, _Number)
+            is_scalar = isinstance(logits, Number)
             # pyrefly: ignore [read-only]
             (self.logits,) = broadcast_all(logits)
         self._param = self.probs if probs is not None else self.logits

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -17,7 +17,7 @@ from torch.distributions.utils import (
     vec_to_tril_matrix,
 )
 from torch.nn.functional import pad, softplus
-from torch.types import _Number
+from torch.types import Number
 
 
 __all__ = [
@@ -804,14 +804,14 @@ class AffineTransform(Transform):
         if not isinstance(other, AffineTransform):
             return False
 
-        if isinstance(self.loc, _Number) and isinstance(other.loc, _Number):
+        if isinstance(self.loc, Number) and isinstance(other.loc, Number):
             if self.loc != other.loc:
                 return False
         else:
             if not (self.loc == other.loc).all().item():  # type: ignore[union-attr]
                 return False
 
-        if isinstance(self.scale, _Number) and isinstance(other.scale, _Number):
+        if isinstance(self.scale, Number) and isinstance(other.scale, Number):
             if self.scale != other.scale:
                 return False
         else:
@@ -822,7 +822,7 @@ class AffineTransform(Transform):
 
     @property
     def sign(self) -> Tensor | int:  # type: ignore[override]
-        if isinstance(self.scale, _Number):
+        if isinstance(self.scale, Number):
             return 1 if float(self.scale) > 0 else -1 if float(self.scale) < 0 else 0
         return self.scale.sign()
 
@@ -835,7 +835,7 @@ class AffineTransform(Transform):
     def log_abs_det_jacobian(self, x, y):
         shape = x.shape
         scale = self.scale
-        if isinstance(scale, _Number):
+        if isinstance(scale, Number):
             result = torch.full_like(x, math.log(abs(scale)))
         else:
             result = torch.abs(scale).log()

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -5,7 +5,7 @@ from torch import nan, Tensor
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
-from torch.types import _Number, _size
+from torch.types import _size, Number
 
 
 __all__ = ["Uniform"]
@@ -62,7 +62,7 @@ class Uniform(Distribution):
     ) -> None:
         self.low, self.high = broadcast_all(low, high)
 
-        if isinstance(low, _Number) and isinstance(high, _Number):
+        if isinstance(low, Number) and isinstance(high, Number):
             batch_shape = torch.Size()
         else:
             batch_shape = self.low.size()

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch import SymInt, Tensor
 from torch.overrides import is_tensor_like
-from torch.types import _dtype, _Number, Device, Number
+from torch.types import _dtype, Device, Number
 
 
 euler_constant: Final[float] = 0.57721566490153286060  # Euler Mascheroni Constant
@@ -41,7 +41,7 @@ def broadcast_all(*values: Tensor | Number) -> tuple[Tensor, ...]:
         ValueError: if any of the values is not a `Number` instance,
             a `torch.*Tensor` instance, or an instance implementing __torch_function__
     """
-    if not all(is_tensor_like(v) or isinstance(v, _Number) for v in values):
+    if not all(is_tensor_like(v) or isinstance(v, Number) for v in values):
         raise ValueError(
             "Input arguments must all be instances of Number, "
             "torch.Tensor or objects implementing __torch_function__."

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -8,7 +8,7 @@ from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.multivariate_normal import _precision_to_scale_tril
 from torch.distributions.utils import lazy_property
-from torch.types import _Number, _size, Number
+from torch.types import _size, Number
 
 
 __all__ = ["Wishart"]
@@ -105,7 +105,7 @@ class Wishart(ExponentialFamily):
                 "scale_tril must be at least two-dimensional, with optional leading batch dimensions"
             )
 
-        if isinstance(df, _Number):
+        if isinstance(df, Number):
             batch_shape = torch.Size(param.shape[:-2])
             self.df = torch.tensor(df, dtype=param.dtype, device=param.device)
         else:

--- a/torch/types.py
+++ b/torch/types.py
@@ -63,9 +63,6 @@ PySymType: TypeAlias = SymInt | SymFloat | SymBool
 
 # Meta-type for "numeric" things; matches our docs
 Number: TypeAlias = int | float | bool
-# tuple for isinstance(x, Number) checks.
-# FIXME: refactor once python 3.9 support is dropped.
-_Number = (int, float, bool)
 
 FileLike: TypeAlias = str | os.PathLike[str] | IO[bytes]
 


### PR DESCRIPTION
`torch.types` carries both `Number` (a PEP 604 union alias) and `_Number`, the same three types as a runtime tuple, because `isinstance` couldn't take a union before Python 3.10. `requires-python` has been `>=3.10` since 3.9 support was dropped, which is what the FIXME beside `_Number` was waiting on, so the tuple goes and call sites pass `Number` directly.

Test plan:

    python -m pytest test/distributions/test_distributions.py -q -k "Bernoulli or Normal or Uniform or Gamma"

64 passed, 166 deselected. Verified `isinstance(x, Number)` and `isinstance(x, (Tensor, Number))` both work under Python 3.10+ semantics.

This change was authored with the assistance of an AI coding agent and reviewed before submission.
