### PR TITLE
[Testcase Refactoring][DCP] Split accelerator staging coverage from #192957

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -1,6 +1,5 @@
 # Owner(s): ["oncall: distributed checkpointing"]
 
-from concurrent.futures import Future
 from unittest import skipIf
 
 import torch
@@ -8,14 +7,16 @@ from torch.distributed.checkpoint._experimental.staging import (
     CheckpointStagerConfig,
     DefaultStager,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TEST_ACCELERATOR, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
-class TestDefaultStager(TestCase):
+class _StagerTestMixin:
     def setUp(self) -> None:
         super().setUp()
-        # Create a test state dictionary with various data types
         self.state_dict = {
             "model": torch.nn.Linear(10, 5).state_dict(),
             "optimizer": {"param_groups": [{"lr": 0.01}]},
@@ -25,199 +26,85 @@ class TestDefaultStager(TestCase):
             "nested": {"inner_tensor": torch.ones(2, 2), "inner_value": 42},
         }
 
-    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
-    def test_sync_staging(self) -> None:
-        """Test synchronous staging."""
-        options = CheckpointStagerConfig(use_async_staging=False)
-        stager = DefaultStager(options)
 
-        # Stage the state dict
-        staged_dict = stager.stage(self.state_dict)
+class TestDefaultStagerGeneric(_StagerTestMixin, TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
-        # Verify that a state dict is returned (not a Future)
-        self.assertIsInstance(staged_dict, dict)
-
-        # Verify the staged state dictionary
-        self.assertIn("model", staged_dict)
-        self.assertIn("optimizer", staged_dict)
-        self.assertEqual(staged_dict["epoch"], 5)
-        self.assertEqual(staged_dict["step"], 1000)
-        self.assertIn("tensor", staged_dict)
-        self.assertIn("nested", staged_dict)
-
-        # Clean up
-        stager.close()
-
-    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
-    def test_async_staging(self) -> None:
-        """Test asynchronous staging."""
-        options = CheckpointStagerConfig(use_async_staging=True)
-        stager = DefaultStager(options)
-
-        # Stage the state dict
-        result = stager.stage(self.state_dict)
-
-        # Verify that a Future is returned
-        self.assertIsInstance(result, Future)
-
-        # Wait for the Future to complete
-        staged_dict = result.result()
-
-        # Verify the staged state dictionary
-        self.assertIn("model", staged_dict)
-        self.assertIn("optimizer", staged_dict)
-        self.assertEqual(staged_dict["epoch"], 5)
-        self.assertEqual(staged_dict["step"], 1000)
-
-        # Clean up
-        stager.close()
-
-    def test_cuda_non_blocking_without_cuda(self) -> None:
-        """Test that non-blocking copy fails when CUDA is not available."""
-        if torch.accelerator.is_available():
-            self.skipTest("CUDA is available, cannot test CUDA unavailable scenario")
-
-        options = CheckpointStagerConfig(use_non_blocking_copy=True)
-        with self.assertRaises(AssertionError):
+    @skipIf(
+        torch.accelerator.is_available(),
+        reason="requires no available accelerator",
+    )
+    def test_non_blocking_without_accelerator(self) -> None:
+        options = CheckpointStagerConfig(
+            use_pinned_memory=False,
+            use_shared_memory=False,
+            use_async_staging=False,
+            use_non_blocking_copy=True,
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Non-blocking copy requires that the current accelerator is available",
+        ):
             DefaultStager(options)
 
     def test_different_option_combinations(self) -> None:
-        """Test various combinations of staging options."""
-        test_cases = [
-            # All disabled
+        test_cases = (
             CheckpointStagerConfig(
                 use_pinned_memory=False,
                 use_shared_memory=False,
                 use_async_staging=False,
                 use_non_blocking_copy=False,
             ),
-            # Only pinned memory
-            CheckpointStagerConfig(
-                use_pinned_memory=True,
-                use_shared_memory=False,
-                use_async_staging=False,
-                use_non_blocking_copy=False,
-            ),
-            # Only shared memory
             CheckpointStagerConfig(
                 use_pinned_memory=False,
                 use_shared_memory=True,
                 use_async_staging=False,
                 use_non_blocking_copy=False,
             ),
-        ]
-
-        if torch.accelerator.is_available():
-            # Only async staging
-            test_cases.append(
-                CheckpointStagerConfig(
-                    use_pinned_memory=torch.accelerator.is_available(),
-                    use_shared_memory=False,
-                    use_async_staging=True,
-                    use_non_blocking_copy=False,
-                )
-            )
-            # Only CUDA non-blocking copy
-            test_cases.append(
-                CheckpointStagerConfig(
-                    use_pinned_memory=torch.accelerator.is_available(),
-                    use_shared_memory=False,
-                    use_async_staging=False,
-                    use_non_blocking_copy=torch.accelerator.is_available(),
-                )
-            )
+        )
 
         for options in test_cases:
             with self.subTest(options=options):
                 stager = DefaultStager(options)
-
-                # Test staging works with these options
-                if options.use_async_staging and torch.accelerator.is_available():
-                    result = stager.stage(self.state_dict)
-                    self.assertIsInstance(result, Future)
-                    staged_dict = result.result()
-                else:
-                    staged_dict = stager.stage(self.state_dict)
-
+                staged_dict = stager.stage(self.state_dict)
                 self.assertIsInstance(staged_dict, dict)
                 self.assertIn("model", staged_dict)
-
                 stager.close()
 
-    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
-    def test_cuda_tensors_staging(self) -> None:
-        """Test staging with CUDA tensors."""
-        # Create state dict with CUDA tensors
-        device = torch.accelerator.current_accelerator()
-        cuda_state_dict = {
-            "cuda_tensor": torch.randn(3, 4).to(device),
-            "cpu_tensor": torch.randn(2, 3),
-            "mixed_model": {
-                "weight": torch.randn(5, 5).to(device),
-                "bias": torch.randn(5).to(device),
-            },
-        }
-
-        options = CheckpointStagerConfig(use_async_staging=False)
-        stager = DefaultStager(options)
-
-        staged_dict = stager.stage(cuda_state_dict)
-        if not isinstance(staged_dict, dict):
-            raise AssertionError(f"Expected dict, got {type(staged_dict)}")
-
-        # Verify tensors are staged (should be moved to CPU)
-        self.assertIn("cuda_tensor", staged_dict)
-        self.assertIn("cpu_tensor", staged_dict)
-        self.assertIn("mixed_model", staged_dict)
-
-        stager.close()
-
-    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
     def test_resource_cleanup(self) -> None:
-        """Test that resources are properly cleaned up."""
-        options = CheckpointStagerConfig(use_async_staging=False)
+        options = CheckpointStagerConfig(
+            use_pinned_memory=False,
+            use_shared_memory=False,
+            use_async_staging=False,
+            use_non_blocking_copy=False,
+        )
         stager = DefaultStager(options)
-
-        # Verify initial state
         self.assertIsNotNone(stager._state_dict_stager)
-
-        # Close and verify cleanup
         stager.close()
 
     def test_multiple_staging_operations(self) -> None:
-        """Test multiple staging operations with the same stager."""
         options = CheckpointStagerConfig(
-            use_async_staging=False,
-            use_pinned_memory=torch.accelerator.is_available(),
+            use_pinned_memory=False,
             use_shared_memory=False,
-            use_non_blocking_copy=torch.accelerator.is_available(),
+            use_async_staging=False,
+            use_non_blocking_copy=False,
         )
         stager = DefaultStager(options)
-
-        # Stage multiple different state dicts
         state_dicts = [
             {"model1": torch.nn.Linear(5, 3).state_dict()},
             {"model2": torch.nn.Conv2d(3, 16, 3).state_dict()},
             {"optimizer": {"lr": 0.001, "momentum": 0.9}},
         ]
 
-        staged_results = []
-        for state_dict in state_dicts:
-            staged_dict = stager.stage(state_dict)
-            staged_results.append(staged_dict)
+        staged_results = [stager.stage(state_dict) for state_dict in state_dicts]
 
-        # Verify all staging operations succeeded
         self.assertEqual(len(staged_results), 3)
-        for i, result in enumerate(staged_results):
+        for result, state_dict in zip(staged_results, state_dicts):
             self.assertIsInstance(result, dict)
-            # Verify the result contains the expected keys
-            for key in state_dicts[i]:
+            for key in state_dict:
                 self.assertIn(key, result)
-
         stager.close()
 
-
-instantiate_device_type_tests(TestDefaultStager, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed checkpointing"]
 
+from concurrent.futures import Future
 from unittest import skipIf
 
 import torch
@@ -7,6 +8,7 @@ from torch.distributed.checkpoint._experimental.staging import (
     CheckpointStagerConfig,
     DefaultStager,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -105,6 +107,95 @@ class TestDefaultStagerGeneric(_StagerTestMixin, TestCase):
                 self.assertIn(key, result)
         stager.close()
 
+
+class TestDefaultStagerAccelerator(_StagerTestMixin, TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_accelerator_tensors_staging(self, device) -> None:
+        state_dict = {
+            "accelerator_tensor": torch.randn(3, 4, device=device),
+            "cpu_tensor": torch.randn(2, 3),
+            "mixed_model": {
+                "weight": torch.randn(5, 5, device=device),
+                "bias": torch.randn(5, device=device),
+            },
+        }
+        options = CheckpointStagerConfig(
+            use_pinned_memory=False,
+            use_shared_memory=False,
+            use_async_staging=False,
+            use_non_blocking_copy=False,
+        )
+        stager = DefaultStager(options)
+
+        staged_dict = stager.stage(state_dict)
+        self.assertIsInstance(staged_dict, dict)
+        self.assertIn("accelerator_tensor", staged_dict)
+        self.assertIn("cpu_tensor", staged_dict)
+        self.assertIn("mixed_model", staged_dict)
+        self.assertEqual(staged_dict["accelerator_tensor"].device.type, "cpu")
+        self.assertEqual(staged_dict["cpu_tensor"].device.type, "cpu")
+        self.assertEqual(staged_dict["mixed_model"]["weight"].device.type, "cpu")
+        self.assertEqual(staged_dict["mixed_model"]["bias"].device.type, "cpu")
+        stager.close()
+
+
+class TestDefaultStagerStreamAccelerator(_StagerTestMixin, TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_async_staging(self, device) -> None:
+        state_dict = {"tensor": torch.randn(3, 4, device=device)}
+        options = CheckpointStagerConfig(
+            use_pinned_memory=False,
+            use_shared_memory=False,
+            use_async_staging=True,
+            use_non_blocking_copy=False,
+        )
+        stager = DefaultStager(options)
+
+        result = stager.stage(state_dict)
+        self.assertIsInstance(result, Future)
+        staged_dict = result.result()
+        self.assertEqual(staged_dict["tensor"].device.type, "cpu")
+        stager.close()
+
+
+class TestDefaultStagerCUDA(_StagerTestMixin, TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_sync_staging(self, device) -> None:
+        """Test synchronous staging with the original optimized defaults."""
+        stager = DefaultStager(CheckpointStagerConfig(use_async_staging=False))
+
+        staged_dict = stager.stage(self.state_dict)
+
+        self.assertIsInstance(staged_dict, dict)
+        self.assertIn("model", staged_dict)
+        self.assertIn("optimizer", staged_dict)
+        self.assertEqual(staged_dict["epoch"], 5)
+        self.assertEqual(staged_dict["step"], 1000)
+        self.assertIn("tensor", staged_dict)
+        self.assertIn("nested", staged_dict)
+        stager.close()
+
+
+instantiate_device_type_tests(
+    TestDefaultStagerAccelerator,
+    globals(),
+    except_for=("cpu",),
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestDefaultStagerStreamAccelerator,
+    globals(),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestDefaultStagerCUDA,
+    globals(),
+    only_for=("cuda",),
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
I reviewed the code, the candidate commit, both reviewer findings, and all validation evidence, and take responsibility for this submission. The quoted body below was prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it.
>
> ## Summary
> Carry the accelerator-specific checkpoint staging coverage split from #192957 in a stacked child PR, and address review findings r3978653551 and r3978659317 by restoring the historical asynchronous staging test semantics and opening stream-suite admission to all available non-CPU accelerator test bases.
>
> ## Changes
> - Restore the pre-decoupling executable body of `TestDefaultStagerStreamAccelerator.test_async_staging`: `CheckpointStagerConfig(use_async_staging=True)` (default pinned/shared/non-blocking settings), the full `self.state_dict` payload, the `Future`/`result()` contract with `model`/`optimizer`/`epoch == 5`/`step == 1000` assertions, and `stager.close()`.
> - Open stream-suite admission: `instantiate_device_type_tests(TestDefaultStagerStreamAccelerator, globals(), only_for=("cuda", "xpu"), allow_xpu=True)` becomes `except_for=("cpu",), allow_xpu=True`, admitting every registered and available non-CPU accelerator test base (CUDA; XPU when `TEST_XPU`; HPU when `TEST_HPU`; registered PrivateUse1 backends; downstream `TORCH_TEST_DEVICES` bases such as XLA). MPS remains harness-disabled for generic device testing in this snapshot.
> - Keep the Option C split for the sibling suites; the intentional residual coverage differences are listed under Notes.
>
> ## Motivation
> Review feedback (r3978653551, r3978659317) correctly identified that the split had silently narrowed the async stream test: it replaced the default pinned/shared/non-blocking options with an all-disabled config, replaced the full CPU-carrier state dict with a single accelerator tensor, dropped the key-coverage assertions, and restricted collection to CUDA/XPU even though the async path (`torch.Stream()`, `torch.accelerator.synchronize()`, and the `torch.accelerator.is_available()` non-blocking gate) is accelerator-generic. The candidate restores the async executable body (verified by AST comparison against the pre-decoupling file) and uses open admission, the default the hardware-decoupling guide prescribes for accelerator-generic semantics.
>
> ## Test Plan
> Run from the repository root (`$PWD`) with the worktree-local environment:
>
> ```bash
> .venv/bin/python -m pytest test/distributed/checkpoint/_experimental/test_staging.py --collect-only -q
> .venv/bin/python test/distributed/checkpoint/_experimental/test_staging.py -v
> .venv/bin/python -m py_compile test/distributed/checkpoint/_experimental/test_staging.py
> .venv/bin/python -m spin quicklint -- test/distributed/checkpoint/_experimental/test_staging.py
> uvx --offline --python 3.10 lintrunner@0.12.7 -a
> git diff --check
> ```
>
> All commands returned 0. CUDA runtime (local editable CUDA 12.8 build): 7 tests collected and visited by the runner, 6 executed and passed, 1 expected skip (`TestDefaultStagerGeneric.test_non_blocking_without_accelerator`: `requires no available accelerator`), 0 failures, 0 errors, 0 timeouts. All three CUDA instances executed and passed, including the restored `TestDefaultStagerStreamAcceleratorCUDA.test_async_staging_cuda`, plus `TestDefaultStagerAcceleratorCUDA.test_accelerator_tensors_staging_cuda` and `TestDefaultStagerCUDACUDA.test_sync_staging_cuda`. Baseline (previous head) and candidate collected byte-identical test IDs. `py_compile`, candidate-local `spin quicklint` (no lint issues), repository-pinned `lintrunner -a` (no lint issues), and `git diff --check` all PASS. Source and native provenance PASS: `torch.__file__`, `torchgen`, the editable install mapping, and the loaded native extensions resolve under the candidate worktree; the only tracked change is this Python test file, the native compile-input diff is empty, and the existing native build was reused. Non-CUDA runtime is not claimed: HPU, XPU, PrivateUse1, downstream, and MPS execution remain unverified here and belong to target-hardware CI.
>
> ## Notes
> - Candidate head: `250252a9b5ae71a6dd623a28597e064312dec7db`, exactly one commit on top of the previous head `cad3cd5e66b38cd70b0bedc04972528ab3e81102`; remediation diff is +7/-10 in `test/distributed/checkpoint/_experimental/test_staging.py`.
> - Stack: parent #192957 head `af92a6af82515823247e2b5189ad4654d59a289f`; true topic merge-base `2988f7185c281580ae6e64e3fd73195fd9d17add`. GitHub records this PR's base as `main@543a80bde5962e7b4c0441806c79875a1f2e4bf8`; live `main` was `bea1fae02008a8483354d6fdccadd2067f1702c6` at review time. Both bases share merge-base `2988f718` with this topic, so the topic diff is identical against either; the recorded base SHA is not asserted to be current `main`.
> - Intentional residual coverage differences vs the pre-decoupling file (Option C scope decisions, not omissions; none is claimed to be equivalent isolated-tuple coverage):
>   1. `test_sync_staging` remains CUDA-only (`only_for=("cuda",)`) because its optimized default pin-memory path is CUDA-specific (`torch.cuda._pin_memory_utils`).
>   2. `test_accelerator_tensors_staging` retains its all-disabled `CheckpointStagerConfig` to isolate generic accelerator-to-CPU transfer behavior without the CUDA pin dependency.
>   3. The historical isolated `only-async` and `only-non-blocking` option tuples remain absent; async staging is covered under default (pinned/shared/non-blocking) options in the restored stream test, not as an isolated tuple.
>   4. The historical isolated `only-pinned` behavior is exercised within the CUDA sync test's default-pin coverage, which is not equivalent isolated-tuple coverage.
>
> ## Checklist
> - [x] Added/updated tests.
> - [x] Scoped lint (`spin quicklint` on the changed file; repository-pinned `lintrunner -a`).
> - [x] Documentation update not applicable; this is internal test classification.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No. Test-only change; no production API or behavior change.
