### PR TITLE
fix: unpad_sequence mutates input tensor via in-place transpose_()

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -506,7 +506,7 @@ def unpad_sequence(
     unpadded_sequences = []
 
     if not batch_first:
-        padded_sequences.transpose_(0, 1)
+        padded_sequences = padded_sequences.transpose(0, 1)
 
     max_length = padded_sequences.shape[1]
     idx = torch.arange(max_length, device=lengths.device)


### PR DESCRIPTION
fix: unpad_sequence mutates caller's padded_sequences tensor in-place

`unpad_sequence` calls `padded_sequences.transpose_(0, 1)` (note trailing `_`),
which is an in-place operation that modifies the caller's tensor. This violates
the expected contract for a function that should only read its input.

**Impact:** Any code that reuses `padded_sequences` after calling `unpad_sequence`
sees a transposed tensor without warning. The mutation is silent and only
observable if the caller inspects the original tensor after the call.

**Fix:** Change `padded_sequences.transpose_(0, 1)` to
`padded_sequences = padded_sequences.transpose(0, 1)`, which rebinds the local
name without touching the caller's tensor.

One character removed (`_`), one assignment added.
