### PR TITLE
fix: ConstantLR ZeroDivisionError when factor=0

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -810,9 +810,9 @@ class ConstantLR(LRScheduler):
         total_iters: int = 5,
         last_epoch: int = -1,
     ) -> None:
-        if factor > 1.0 or factor < 0:
+        if factor > 1.0 or factor <= 0:
             raise ValueError(
-                "Constant multiplicative factor expected to be between 0 and 1."
+                "Constant multiplicative factor expected to be between 0 and 1 (exclusive)."
             )
 
         self.factor = factor


### PR DESCRIPTION
fix: ConstantLR raises ZeroDivisionError when factor=0

`ConstantLR.__init__` validates `factor < 0` but allows `factor=0`. The
scheduler then computes `group["lr"] * (1.0 / self.factor)` during warmup,
which raises `ZeroDivisionError` at runtime rather than at construction.

**Impact:** A zero factor is semantically unrecoverable -- there is no learning
rate that, when multiplied by 0, yields the base lr. The error should be caught
at construction, not silently deferred to the first `step()` call.

**Fix:** Change the validator from `factor < 0` to `factor <= 0` and update
the error message to reflect that zero is also invalid. Fail-early in `__init__`
is the correct place; `_get_closed_form_lr` is fine for any nonzero factor.
