### PR TITLE
[RAWTHROW][11] torch/csrc/jit passes and runtime: 48 conversions

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -617,10 +617,6 @@ exclude_patterns = [
     # std::runtime_error is caught by name in distributed/rpc to drive an
     # overload-fallback retry - converting it disables the fallback silently.
     'torch/csrc/jit/python/**',
-    # 33 findings, mostly the interpreter and the static runtime.
-    'torch/csrc/jit/runtime/**',
-    # 19 findings across the optimisation passes.
-    'torch/csrc/jit/passes/**',
 ]
 command = [
     'python3',

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -3394,7 +3394,7 @@ TEST(StaticRuntime, TupleIndex) {
   torch::jit::Module mod("module");
   mod.define(src);
   StaticModule smod(mod);
-  EXPECT_THROW(smod({100, tuple}), std::out_of_range);
+  EXPECT_THROW(smod({100, tuple}), c10::IndexError);
 }
 
 TEST(StaticRuntime, RaiseException) {
@@ -3593,10 +3593,9 @@ TEST(StaticRuntime, IntImplicit_ThrowOnBadInputs) {
   auto graph = getGraphFromIR(src);
   torch::jit::StaticModule smod(graph);
   // Not 0D tensor
-  EXPECT_THROW(smod({at::tensor({1, 2}, at::kInt)}), std::runtime_error);
+  EXPECT_THROW(smod({at::tensor({1, 2}, at::kInt)}), c10::Error);
   // Wrong dtype
-  EXPECT_THROW(
-      smod({at::tensor({1}, at::kFloat).squeeze()}), std::runtime_error);
+  EXPECT_THROW(smod({at::tensor({1}, at::kFloat).squeeze()}), c10::Error);
 }
 
 TEST(StaticRuntime, Select) {

--- a/test/cpp/jit/test_interpreter.cpp
+++ b/test/cpp/jit/test_interpreter.cpp
@@ -250,7 +250,7 @@ graph(%0 : Tensor,
   try {
     FLAGS_torch_jit_enable_rethrow_caught_exception = false;
     interp.run(stack);
-  } catch (std::runtime_error& e) {
+  } catch (c10::Error& e) {
     exception_handled = true;
     std::string exception_msg = e.what();
     EXPECT_THAT(

--- a/tools/linter/adapters/raw_throw_linter.py
+++ b/tools/linter/adapters/raw_throw_linter.py
@@ -83,6 +83,10 @@ ALLOWED_EXCEPTION_TYPES = {
     # Carries the delegated backend's debug handle alongside the message, and
     # is caught by name in mobile/module.cpp and mobile/interpreter.cpp.
     "c10::BackendRuntimeException": "torch/csrc/jit/",
+    # Shape propagation's own bail-out signal, caught by name in
+    # shape_analysis.cpp to fall back to running the op. It carries no message
+    # at all, so it is a signal rather than an error report.
+    "propagation_error": "torch/csrc/jit/passes/",
 }
 
 

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -136,14 +136,20 @@ static void preprocessCaffe2Ops(Block* block) {
             }
             it->fs_(Symbol::attr(arg.name()), values);
           } else {
-            throw std::runtime_error(
-                "Unhandled scalar arg: " + arg.name() +
-                ", type: " + c10::typeKindToString(elem_type->kind()));
+            TORCH_CHECK(
+                false,
+                "Unhandled scalar arg: ",
+                arg.name(),
+                ", type: ",
+                c10::typeKindToString(elem_type->kind()));
           }
         } else {
-          throw std::runtime_error(
-              "Unsupported input type of arg " + arg.name() +
-              " in Caffe2 operator: " + c10::typeKindToString(type->kind()));
+          TORCH_CHECK(
+              false,
+              "Unsupported input type of arg ",
+              arg.name(),
+              " in Caffe2 operator: ",
+              c10::typeKindToString(type->kind()));
         }
       }
     }
@@ -173,7 +179,7 @@ std::shared_ptr<Graph> ToONNX(
         operator_export_type,
         env,
         values_in_env);
-  } catch (std::runtime_error&) {
+  } catch (const std::exception&) {
     ONNX_LOG(
         "ONNX graph being constructed during exception:\n",
         new_graph->toString());
@@ -290,7 +296,7 @@ void NodeToONNX(
       ss << "symbolic for " << op_name
          << " produced an incorrect number of outputs (expected ";
       ss << num_old_outputs << ", but got " << outputs.size() << ')';
-      throw std::runtime_error(std::move(ss).str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
     // For const node, it does not need params_dict info, so set it to {}.
     const ParamMap empty_params_dict = {};
@@ -390,7 +396,7 @@ void NodeToONNX(
           ss << " (indicating conversion for that particular output is not supported), ";
           ss << "but the network uses this output later";
           // TODO: Say what actually used it
-          throw std::runtime_error(std::move(ss).str());
+          TORCH_CHECK(false, std::move(ss).str());
         }
       }
     }
@@ -449,7 +455,7 @@ void NodeToONNX(
          << ": expected to return list of op nodes, instead received type ''"
          << py::str(py::type::handle_of(raw_output))
          << "': " << py::str(raw_output);
-      throw std::runtime_error(std::move(ss).str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
 
     setOutputs(op_name, n, outputs);
@@ -564,7 +570,7 @@ void NodeToONNX(
         TORCH_CHECK(node_it != inputs.end(), "expected too many inputs");
         obj = py::cast(envFn(*node_it++));
       } else {
-        throw std::runtime_error("unexpected calling convention");
+        TORCH_CHECK(false, "unexpected calling convention");
       }
       py_symbolic_args[input_nr++] = obj;
     }

--- a/torch/csrc/jit/passes/onnx/cast_all_constant_to_floating.cpp
+++ b/torch/csrc/jit/passes/onnx/cast_all_constant_to_floating.cpp
@@ -47,7 +47,7 @@ static void CastAllConstantToFloating(Block* block) {
             break;
 
           default:
-            throw std::runtime_error("Unsupported types: complex, string");
+            TORCH_CHECK(false, "Unsupported types: complex, string");
         }
         // create a cast node
         node->removeAttribute(attr::value);

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -423,10 +423,9 @@ std::optional<at::Tensor> runTorchBackendForOnnx(
       // at::reshape does not support shape dim value to be zero
       assert(shape_a[i] >= -1);
       if (shape_a[i] == 0 && !allowzero) {
-        if (i >= inputTensorValues[0].sizes().size()) {
-          throw std::runtime_error(
-              "Dimension with value 0 exceeds the input size dimensions.");
-        }
+        TORCH_CHECK(
+            i < inputTensorValues[0].sizes().size(),
+            "Dimension with value 0 exceeds the input size dimensions.");
         shape[i] = inputTensorValues[0].sizes()[i];
       } else {
         shape[i] = shape_a[i];
@@ -570,16 +569,14 @@ static std::vector<at::Tensor> getValues(
   for (auto val : node->inputs()) {
     if (val->node()->kind() == prim::Param) {
       auto itr = valsToParamsMap.find(val);
-      if (itr == valsToParamsMap.end()) {
-        throw std::runtime_error(
-            "getValues: Input value not found amongst constant parameters.");
-      }
+      TORCH_CHECK(
+          itr != valsToParamsMap.end(),
+          "getValues: Input value not found amongst constant parameters.");
       inputTensorValues.push_back(itr->second.second.toTensor());
     } else if (val->node()->kind() == onnx::Constant) {
       inputTensorValues.push_back(val->node()->t(attr::value));
     } else {
-      throw std::runtime_error(
-          "getValues: Unsupported kind of constant node found.");
+      TORCH_CHECK(false, "getValues: Unsupported kind of constant node found.");
     }
   }
   TORCH_INTERNAL_ASSERT(inputTensorValues.size() == numInputs);

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -707,9 +707,11 @@ static void eraseListUnpack(Node* n, int opset_version) {
   if (n->kind() == prim::ListUnpack) {
     if (opset_version < OPSET_VERSION_11) {
       // onnx::SequenceAt was introduced in onnx opset version 11
-      throw std::runtime_error(
-          "Unsupported: ONNX export of prim::ListUnpack in opset " +
-          std::to_string(opset_version) + ". Please try opset version 11.");
+      TORCH_CHECK(
+          false,
+          "Unsupported: ONNX export of prim::ListUnpack in opset ",
+          opset_version,
+          ". Please try opset version 11.");
     }
 
     auto g = n->owningGraph();

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -417,8 +417,9 @@ Value* findArgumentAsInputParam(
     if (input->debugName() == name)
       return input;
   }
-  throw std::runtime_error(
-      "Attribute is not part of model parameters. Cannot handle SetAttr and GetAttr nodes for : " +
+  TORCH_CHECK(
+      false,
+      "Attribute is not part of model parameters. Cannot handle SetAttr and GetAttr nodes for : ",
       name);
 }
 

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1202,8 +1202,9 @@ void ProcessTimeSeriesNode(Node* n) {
           hidden_size = c10::ShapeSymbol::fromStaticSize(input1_value / 3);
           break;
         default:
-          throw std::runtime_error(
-              std::string() + "This is not a valid TimeSeries Node with type " +
+          TORCH_CHECK(
+              false,
+              "This is not a valid TimeSeries Node with type ",
               n->kind().toDisplayString());
       }
     } else {
@@ -1893,7 +1894,8 @@ void ONNXShapeTypeInference(
       const_val_copy.copy_(const_val);
       ConstantValueMap::SetValue(value.first, const_val_copy);
     } else {
-      throw std::runtime_error(
+      TORCH_CHECK(
+          false,
           "ONNXShapeTypeInference - Unsupported kind of constant node found.");
     }
   }
@@ -2414,7 +2416,7 @@ static size_t ONNXAssignOutputShape(
         "Model output has unsupported type. See "
         "https://pytorch.org/docs/stable/onnx.html#types. Got type: ";
     msg += THPUtils_typename(output_obj);
-    throw std::runtime_error(msg);
+    TORCH_CHECK(false, msg);
   }
 
   index_check();

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -196,10 +196,9 @@ static void unpackQuantizedWeightsHelper(
         match_vmap.at(vmap.at("r"))->node()->inputs()[1]->debugName();
 
     auto itr = paramsDict.find(quantized_weight);
-    if (itr == paramsDict.end()) {
-      throw std::runtime_error(
-          "getValues: Quantized weight value not found amongst constant parameters.");
-    }
+    TORCH_CHECK(
+        itr != paramsDict.end(),
+        "getValues: Quantized weight value not found amongst constant parameters.");
     at::Tensor unpacked_weight;
     std::optional<at::Tensor> bias;
     constexpr int64_t stride_idx = 2;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -319,7 +319,7 @@ class ShapePropagator : public PropertyPropBase {
     std::stringstream ss;
     ss << "unable to create representative value for: " << type_->str()
        << ". File a bug report";
-    throw std::runtime_error(std::move(ss).str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
 
   void broadcastBinary(

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -174,11 +174,11 @@ class GradientHelper {
   GradientHelper(Node* n) : node(n) {}
 
   std::vector<Value*> gradient(ArrayRef<Value*> grad_values) {
-    if (!isDifferentiable(node)) {
-      throw std::runtime_error(
-          std::string("differentiation of ") + node->kind().toDisplayString() +
-          " is not supported, or it is missing necessary type information");
-    }
+    TORCH_CHECK(
+        isDifferentiable(node),
+        "differentiation of ",
+        node->kind().toDisplayString(),
+        " is not supported, or it is missing necessary type information");
     // If AD is defined using torchscript, use it instead of symbolic
     auto script_grads = build_script_grad(node, grad_values);
     if (script_grads)
@@ -283,9 +283,11 @@ class GradientHelper {
           nullptr};
     }
 
-    throw std::runtime_error(
-        std::string("failed to differentiate `") +
-        node->kind().toDisplayString() + "`");
+    TORCH_CHECK(
+        false,
+        "failed to differentiate `",
+        node->kind().toDisplayString(),
+        "`");
   }
 };
 } // namespace
@@ -514,7 +516,7 @@ static bool inBlock(Node* node, Block* container) {
 
 static void liftConstants(Node* node, Block* move_to_this_block) {
   static const auto err = [](Value*) -> Value* {
-    throw std::runtime_error("unexpected input");
+    TORCH_CHECK(false, "unexpected input");
   };
   auto& graph = *node->owningGraph();
   for (Value* input : node->inputs()) {

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -926,6 +926,10 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
       // save the original exception's message when creating a new JITException
       throw JITException(ss.str(), python_class_name, e.what());
     } else if (not_implemented_error) {
+      // Rethrows with the *original* exception's backtrace and caller, which
+      // is the whole point: TORCH_CHECK_NOT_IMPLEMENTED would stamp this
+      // interpreter frame over the location the user needs to see.
+      // @allow-raw-throw: carries the original backtrace and caller
       throw c10::NotImplementedError(
           ss.str(),
           not_implemented_error->backtrace(),
@@ -934,7 +938,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
       if (get_cpp_stacktraces_enabled()) {
         ss << e.what() << '\n';
       }
-      throw std::runtime_error(std::move(ss).str());
+      TORCH_CHECK(false, std::move(ss).str());
     }
   }
 

--- a/torch/csrc/jit/runtime/register_distributed_ops.cpp
+++ b/torch/csrc/jit/runtime/register_distributed_ops.cpp
@@ -86,12 +86,14 @@ void prepare_and_call_rpc_op(
     } else if (arg.default_value()) {
       push(userCallableStack, *arg.default_value());
     } else {
-      throw std::runtime_error(c10::str(
-          functionSchema.name(),
-          "() is missing value for argument '",
-          argName,
-          "'. Declaration: ",
-          functionSchema));
+      TORCH_CHECK(
+          false,
+          c10::str(
+              functionSchema.name(),
+              "() is missing value for argument '",
+              argName,
+              "'. Declaration: ",
+              functionSchema));
     }
   }
   // Raise exception showing the unexpected kwargs.
@@ -102,7 +104,7 @@ void prepare_and_call_rpc_op(
       const std::string& keyStr = keyIValue.toStringRef();
       names.emplace_back(keyStr);
     }
-    throw std::runtime_error(functionSchema.findErrorInKwargs(names));
+    TORCH_CHECK(false, functionSchema.findErrorInKwargs(names));
   }
 
   // Get destination WorkerName.
@@ -140,7 +142,7 @@ void prepare_and_call_rpc_op(
     futureIValuePtr->wait();
     if (futureIValuePtr->hasError()) {
       // throw error if future hasError
-      throw std::runtime_error(futureIValuePtr->tryRetrieveErrorMessage());
+      TORCH_CHECK(false, futureIValuePtr->tryRetrieveErrorMessage());
     } else {
       auto res = futureIValuePtr->value();
       // Push output to the stack.
@@ -159,8 +161,7 @@ void prepare_and_call_rpc_op(
     stack.emplace_back(
         c10::static_intrusive_pointer_cast<c10::RRefInterface>(rrefPtr));
   } else {
-    throw std::runtime_error(
-        c10::str(rpc_op, "() is not supported in TorchScript!'"));
+    TORCH_CHECK(false, rpc_op, "() is not supported in TorchScript!'");
   }
 }
 

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -130,8 +130,8 @@ void checkDoubleInRange(double a) {
   if (std::isnan(a) || std::isinf(a) ||
       a > double(std::numeric_limits<int64_t>::max()) ||
       a < double(std::numeric_limits<int64_t>::min())) {
-    throw c10::Error(
-        "Cannot convert float " + std::to_string(a) + " to integer");
+    TORCH_CHECK(
+        false, "Cannot convert float ", std::to_string(a), " to integer");
   }
 }
 
@@ -165,9 +165,7 @@ int nminussumofbits(int v) {
 }
 
 int64_t factorial(int n) {
-  if (n < 0) {
-    throw std::runtime_error("factorial() not defined for negative values");
-  }
+  TORCH_CHECK(n >= 0, "factorial() not defined for negative values");
   int64_t p = 1, r = 1;
   loop(n, p, r);
   return r << nminussumofbits(n);

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -72,9 +72,7 @@ inline double round_to_even(double a) {
 void checkImplicitTensorToNum(const at::Tensor& t, bool toInt);
 
 [[maybe_unused]] static int64_t floordiv(int64_t a, int64_t b) {
-  if (b == 0) {
-    throw std::runtime_error("division by 0");
-  }
+  TORCH_CHECK(b != 0, "division by 0");
   if ((a > 0) == (b > 0)) {
     // simple case, both have same sign
     return a / b;
@@ -124,9 +122,9 @@ template <typename T>
 auto getItem(const c10::List<T>& list, int64_t idx) {
   const int64_t list_size = list.size();
   const int64_t normalized_idx = normalizeIndex(idx, list_size);
-  if (normalized_idx < 0 || normalized_idx >= list_size) {
-    throw std::out_of_range("list index out of range");
-  }
+  TORCH_CHECK_INDEX(
+      normalized_idx >= 0 && normalized_idx < list_size,
+      "list index out of range");
   return list.get(normalized_idx);
 }
 
@@ -134,9 +132,9 @@ template <typename T>
 void setItem(const c10::List<T>& list, int64_t idx, T&& value) {
   const int64_t list_size = list.size();
   const int64_t normalized_idx = normalizeIndex(idx, list_size);
-  if (normalized_idx < 0 || normalized_idx >= list_size) {
-    throw std::out_of_range("list index out of range");
-  }
+  TORCH_CHECK_INDEX(
+      normalized_idx >= 0 && normalized_idx < list_size,
+      "list index out of range");
   list.set(normalized_idx, std::forward<T>(value));
 }
 
@@ -206,9 +204,7 @@ template <typename T>
 void listMin(Stack& stack) {
   c10::List<T> list = pop(stack).to<c10::List<T>>();
   size_t list_size = list.size();
-  if (list_size == 0) {
-    throw std::runtime_error("min() arg is an empty sequence");
-  }
+  TORCH_CHECK(list_size != 0, "min() arg is an empty sequence");
 
   T min_elem = list[0];
   for (const auto i : c10::irange(1, list_size)) {
@@ -223,9 +219,7 @@ template <typename T>
 void listMax(Stack& stack) {
   c10::List<T> list = pop(stack).to<c10::List<T>>();
   size_t list_size = list.size();
-  if (list_size == 0) {
-    throw std::runtime_error("max() arg is an empty sequence");
-  }
+  TORCH_CHECK(list_size != 0, "max() arg is an empty sequence");
 
   T max_elem = list[0];
   for (const auto i : c10::irange(1, list_size)) {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -423,11 +423,10 @@ at::Tensor interpolate(
     std::optional<bool> align_corners,
     std::optional<bool> recompute_scale_factor) {
   if ((mode == "nearest" || mode == "area")) {
-    if (align_corners != std::nullopt) {
-      throw std::runtime_error(
-          "align_corners option can only be set with the "
-          "interpolating modes: linear | bilinear | bicubic | trilinear");
-    }
+    TORCH_CHECK(
+        align_corners == std::nullopt,
+        "align_corners option can only be set with the "
+        "interpolating modes: linear | bilinear | bicubic | trilinear");
   } else {
     if (align_corners == std::nullopt) {
       TORCH_WARN(
@@ -533,13 +532,13 @@ at::Tensor interpolate(
         *align_corners,
         std::make_optional(scale_factors_1));
   if (input_dim == dim1d && mode == "bilinear")
-    throw std::runtime_error("Got 3D input, but bilinear mode needs 4D input");
+    TORCH_CHECK(false, "Got 3D input, but bilinear mode needs 4D input");
   if (input_dim == dim1d && mode == "bicubic")
-    throw std::runtime_error("Got 3D input, but bicubic mode needs 4D input");
+    TORCH_CHECK(false, "Got 3D input, but bicubic mode needs 4D input");
   if (input_dim == dim1d && mode == "trilinear")
-    throw std::runtime_error("Got 3D input, but trilinear mode needs 5D input");
+    TORCH_CHECK(false, "Got 3D input, but trilinear mode needs 5D input");
   if (input_dim == dim2d && mode == "linear")
-    throw std::runtime_error("Got 4D input, but linear mode needs 3D input");
+    TORCH_CHECK(false, "Got 4D input, but linear mode needs 3D input");
   if (input_dim == dim2d && mode == "bilinear")
     return at::upsample_bilinear2d(
         input,
@@ -555,13 +554,13 @@ at::Tensor interpolate(
         scale_factors_1,
         scale_factors_2);
   if (input_dim == dim2d && mode == "trilinear")
-    throw std::runtime_error("Got 4D input, but trilinear mode needs 5D input");
+    TORCH_CHECK(false, "Got 4D input, but trilinear mode needs 5D input");
   if (input_dim == dim3d && mode == "linear")
-    throw std::runtime_error("Got 5D input, but linear mode needs 3D input");
+    TORCH_CHECK(false, "Got 5D input, but linear mode needs 3D input");
   if (input_dim == dim3d && mode == "bilinear")
-    throw std::runtime_error("Got 5D input, but bilinear mode needs 4D input");
+    TORCH_CHECK(false, "Got 5D input, but bilinear mode needs 4D input");
   if (input_dim == dim3d && mode == "bicubic")
-    throw std::runtime_error("Got 5D input, but bicubic mode needs 4D input");
+    TORCH_CHECK(false, "Got 5D input, but bicubic mode needs 4D input");
   if (input_dim == dim3d && mode == "trilinear")
     return at::upsample_trilinear3d(
         input,
@@ -598,9 +597,7 @@ void interpolate_op(Stack& stack) {
       align_corners,
       recompute_scale_factor,
       antialias);
-  if (antialias) {
-    throw std::runtime_error("Antialias is not yet supported");
-  }
+  TORCH_CHECK(!antialias, "Antialias is not yet supported");
   at::Tensor res = interpolate(
       input,
       size,
@@ -628,7 +625,7 @@ IValue convert_scale_factor_to_double(const IValue& int_ivalue) {
     std::stringstream ss;
     ss << "Expecting optional int or int list arg for scale factor, got"
        << int_ivalue;
-    throw std::runtime_error(std::move(ss).str());
+    TORCH_CHECK(false, std::move(ss).str());
   }
   return scale_factor_double;
 }

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -42,7 +42,7 @@ void checkListInputType(const c10::TypePtr& elem_type, bool empty_list) {
                  "is the type of elements in the list for Python 2)";
       }
     }
-    throw std::runtime_error(std::move(error).str());
+    TORCH_CHECK(false, std::move(error).str());
   }
 }
 

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -295,9 +295,7 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         auto hi = p_node->Input(1).toInt();
         auto step = p_node->Input(2).toInt();
         // error handling when step_val == 0 during runtime
-        if (step == 0) {
-          throw std::runtime_error("range() arg 3 must not be zero");
-        }
+        TORCH_CHECK(step != 0, "range() arg 3 must not be zero");
         if (step > 0 && lo < hi) {
           p_node->Output(0) = 1 + (hi - 1 - lo) / step;
         } else if (step < 0 && lo > hi) {
@@ -1248,11 +1246,8 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         const auto num_elems = std::ssize(elems);
         const auto idx = pnode->Input(1).toInt();
         const auto norm_idx = normalizeIndex(idx, num_elems);
-        if (norm_idx < 0 || norm_idx >= num_elems) {
-          // Use std::runtime_error instead of c10::Error to be consistent with
-          // JIT
-          throw std::out_of_range("Tuple index out of range");
-        }
+        TORCH_CHECK_INDEX(
+            norm_idx >= 0 && norm_idx < num_elems, "Tuple index out of range");
         pnode->Output(0) = elems[norm_idx];
       };
     })
@@ -1266,6 +1261,12 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
       }
       return [](ProcessedNode* pnode) {
         const auto& message = pnode->Input(0).toStringRef();
+        // prim::RaiseException surfaces the message the scripted `raise` was
+        // given. test_static_runtime.cc catches this by name as
+        // std::runtime_error, which c10::Error does not derive from, and then
+        // asserts what() equals the message exactly - c10::Error::what()
+        // appends its backtrace.
+        // @allow-raw-throw: caught by name, and what() must equal the message
         throw std::runtime_error(message);
       };
     })
@@ -1481,15 +1482,14 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         const auto& tensor = pnode->Input(0).toTensor();
         // JIT does a check for requires_grad, but we skip it here since SR is
         // inference only
-        if (!tensor.sizes().empty()) {
-          throw std::runtime_error(
-              "Cannot convert a tensor of dimension > 0 to scalar");
-        }
+        TORCH_CHECK(
+            tensor.sizes().empty(),
+            "Cannot convert a tensor of dimension > 0 to scalar");
         if (!isIntegralType(tensor.scalar_type(), /*includeBool=*/false)) {
           std::stringstream ss;
           ss << "Cannot input a tensor of type " << tensor.scalar_type()
              << " as an integral argument";
-          throw std::runtime_error(std::move(ss).str());
+          TORCH_CHECK(false, std::move(ss).str());
         }
         pnode->Output(0) = at::native::item(tensor).toInt();
       };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #195859
* __->__ #195858
* #195764

## Author Notes

Standard update of TorchScript things.

## Agent Notes

Written by Claude Code:

> Deletes `torch/csrc/jit/passes/**` and `torch/csrc/jit/runtime/**`, leaving
> `tensorexpr` and `python` as the last two jit entries. 52 findings: 48
> conversions, one allow-list entry covering two sites, and two throws kept
> with a line-scoped reason.
>
> `passes` is 17 mechanical conversions, almost all in the ONNX exporter, plus
> `propagation_error` added to `ALLOWED_EXCEPTION_TYPES` scoped to
> `torch/csrc/jit/passes/`. That one is shape propagation's bail-out signal,
> caught by name in `shape_analysis.cpp` to fall back to running the op; it
> carries no message at all, so it is a signal rather than an error report and
> `TORCH_CHECK` cannot stand in for it.
>
> `runtime` is 31 conversions and two annotations:
>
> - `interpreter.cpp`'s `c10::NotImplementedError` rethrow passes the
>   *original* exception's backtrace and caller through the three-argument
>   constructor. `TORCH_CHECK_NOT_IMPLEMENTED` would stamp the interpreter
>   frame over the location the user actually needs.
> - `static/native_ops.cpp`'s `prim::RaiseException` must report the message
>   the scripted `raise` was given, verbatim. A check macro prepends its own
>   location to text the user wrote, and `test_static_runtime.cc` asserts the
>   message with `EXPECT_STREQ`.
>
> **On exception types, checked against current trunk rather than assumed.**
> #193451 routed `torch.ops.*` through torch's native translation instead of
> pybind's, and #195713 then restored `std::out_of_range` -> `IndexError` by
> adding an explicit arm to `CATCH_ALL_ERRORS`. Two consequences for this PR:
>
> 1. Every `std::out_of_range` becomes `TORCH_CHECK_INDEX`, never plain
>    `TORCH_CHECK`. Both raw `std::out_of_range` and `c10::IndexError` reach
>    Python as `IndexError` today, so the type is preserved; converting to
>    `TORCH_CHECK` would be the exact regression #195713 was written to undo.
> 2. The TorchScript interpreter flattens c10 subtypes anyway. Measured on
>    this build: `torch.select` with a bad index gives `IndexError` in eager
>    and `RuntimeError` under `torch.jit.script`. So the interpreter-side
>    sites in `register_ops_utils.h` were already `RuntimeError` at the Python
>    boundary and still are - `TORCH_CHECK_INDEX` there is for the reader, not
>    for Python.
>
> Three C++ assertions in `benchmarks/static_runtime/test_static_runtime.cc`
> had to be retyped, because `c10::Error` derives from `std::exception` but
> not from `std::runtime_error`: `aten::TupleIndex` now raises
> `c10::IndexError` and the two `aten::IntImplicit` cases raise `c10::Error`.
> The four `ModelCrashOn*` tests in the same file keep `std::runtime_error` -
> they go through the file's own `maybe_throw` helper, not through any site
> this PR touches. That distinction is the whole risk in this diff, so I
> traced each of the ten `EXPECT_THROW`s in that file to its throw rather than
> pattern-matching on the type.
>
> One stale comment goes with its throw: `native_ops.cpp` said "Use
> std::runtime_error instead of c10::Error to be consistent with JIT" above a
> `throw std::out_of_range`, so it was already describing something else. The
> JIT counterpart it names, `mobile/promoted_prim_ops.cpp`, already uses
> `TORCH_CHECK_INDEX`, so this restores the parity the comment claimed.
>
> Two C++ catch sites had to move with the conversions, both found by review
> rather than by the build, because `BUILD_TEST=0` here:
>
> - `test/cpp/jit/test_interpreter.cpp` catches the interpreter's error
>   wrapper as `std::runtime_error`; that is now `c10::Error`. Left alone it
>   would not just fail the assertion, it would skip the restore of
>   `FLAGS_torch_jit_enable_rethrow_caught_exception` and leak the flag into
>   the rest of the binary.
> - `passes/onnx.cpp` catches `std::runtime_error` around `BlockToONNX` purely
>   to log the partial graph before rethrowing. Four of this PR's conversions
>   are inside that try, so the dump would have silently stopped appearing. It
>   now catches `std::exception`.
>
> Two message-level notes. `register_ops_utils.cpp`'s float-to-int overflow
> message keeps `std::to_string(a)` rather than streaming the double, because
> `c10::str` would render `1e19` as `1e+19` where the old text said
> `10000000000000000000.000000`. And on Android the fbjni translator in
> `fbjni/detail/Exceptions.cpp` dispatches by C++ type: the list-index and
> `min`/`max`/`floordiv` helpers in `register_ops_utils.h` move from
> `ArrayIndexOutOfBoundsException` / `RuntimeException` to `CppException` for
> the lite interpreter. Nothing in-tree asserts on that, and neighbouring
> pre-existing `TORCH_CHECK`s already produce `CppException`, but it is a real
> type change outside the Python boundary and worth saying out loud.
>
> Test Plan:
>
> ```
> spin lint -- --take RAWTHROW --all-files
> spin lint -- --take CLANGFORMAT,RAWTHROW,NEWLINE,SPACES,TABS,TOML <changed>
> CMAKE_GENERATOR=Ninja USE_DISTRIBUTED=1 USE_CUDA=0 BUILD_TEST=0 \
>     pip install -e . -v --no-build-isolation
> ```
>
> All clean; `passes` and `runtime` go from 52 findings to 0.
>
> The Python-visible types were measured before and after on the same build,
> not reasoned about:
>
> ```
> scripted list[10]     -> RuntimeError   (unchanged)
> scripted tuple[100]   -> RuntimeError   (unchanged)
> scripted a // 0       -> RuntimeError
> scripted min([])      -> RuntimeError
> ```
>
> `BUILD_TEST=0` here, so `static_runtime_test` is not built locally and the
> three retyped assertions are checked by reading plus CI.
>
> This change was authored with the help of an AI assistant (Claude Code).