### PR TITLE
[Docs] Update build and CI persons of interest

### DIFF
--- a/docs/source/community/persons_of_interest.md
+++ b/docs/source/community/persons_of_interest.md
@@ -246,11 +246,11 @@ orphan: true
 
 ### Build + CI
 
-- Nikita Shulga ([malfet](https://github.com/malfet))
-- Eli Uriegas ([seemethere](https://github.com/seemethere))
 - Alban Desmaison ([alband](https://github.com/alband))
 - Andrey Talman ([atalman](https://github.com/atalman))
-- Zain Rizvi ([ZainRizvi](https://github.com/ZainRizvi))
+- Nikita Shulga ([malfet](https://github.com/malfet))
+- (emeritus) Eli Uriegas ([seemethere](https://github.com/seemethere))
+- (emeritus) Zain Rizvi ([ZainRizvi](https://github.com/ZainRizvi))
 - (emeritus) Mikey Dagitses ([dagitses](https://github.com/dagitses))
 - (emeritus) Omkar Salpekar ([osalpekar](https://github.com/osalpekar))
 - (emeritus) Nirav Mehta ([mehtanirav](https://github.com/mehtanirav))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #195860

Move Eli and Zain to emeritus