### PR TITLE
[FSDP2] Raise a Python error instead of IMA when accessing freed unsharded storage

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -186,9 +186,16 @@ class TestFullyShardRegisteredParams(FSDPTestMultiThread):
             else:
                 self._assert_tensor_params(model.parameters())
             self._assert_same_params(model.parameters(), ref_model.parameters())
+            params_before_reshard = list(model.parameters())
             model.reshard()  # however, we can manually reshard
             self._assert_dtensor_params(model.parameters())
             self._assert_same_params(model.parameters(), ref_model.parameters())
+            if not reshard_after_forward:
+                # Stale references to the unsharded parameters have freed
+                # storage; accessing them should raise, not IMA
+                for param in params_before_reshard:
+                    with self.assertRaisesRegex(RuntimeError, "freed by FSDP"):
+                        param.data_ptr()
 
         # Multiple FSDP groups
         for reshard_after_forward in (True, False, 2, None):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -1347,15 +1347,27 @@ class FSDPParam:
         return f"FSDPParam(fqn={self._param_fqn}, orig_size={self._orig_size})"
 
 
+_FREED_MSG = (
+    "Cannot access data pointer of a tensor whose storage was freed by FSDP "
+    "(resharded). This is typically caused by holding a reference to an "
+    "unsharded parameter or all-gather output across a reshard. Access it "
+    "inside forward/backward or after calling unshard()."
+)
+
+
 def alloc_storage(tensor: torch.Tensor) -> None:
     size = tensor.numel() * tensor.itemsize
     if (storage := tensor.untyped_storage()).size() != size:
+        torch._C._clear_storage_data_ptr_access_error_msg(storage._cdata)
         storage.resize_(size)
 
 
 def free_storage(tensor: torch.Tensor) -> None:
     if (storage := tensor.untyped_storage()).size() != 0:
         storage.resize_(0)
+        # Turn accesses to the freed (null) data pointer into a Python error
+        # instead of a CUDA illegal memory access
+        torch._C._set_storage_data_ptr_access_error_msg(storage._cdata, _FREED_MSG)
 
 
 # NOTE: These bypass `nn.Module.__setattr__` checks, which incur non-trivial


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195862

FSDP2 frees unsharded parameters and all-gather outputs by resizing their
storage to zero bytes, which leaves any tensor still aliasing that storage
with a null data pointer. If a user holds a reference to an unsharded
parameter across a reshard (e.g. captured during forward, or between
`unshard()` and `reshard()`) and then runs a kernel on it, the kernel
dereferences the null pointer and the process dies with
`cudaErrorIllegalAddress`, which also takes down the NCCL watchdog and
gives no hint about the cause.

This change uses the storage data-pointer poison APIs so the access fails
eagerly in Python with an actionable message. `free_storage` sets the error
message after `resize_(0)`; `alloc_storage` clears it before `resize_(size)`.
The clear must come first because the CUDA resize path reads
`storage->data_ptr()` internally and would otherwise trip the poison itself.
The check lives on the StorageImpl, so every view of the freed storage is
covered, and it is an unlikely-branch flag check so there is no measurable
cost on the hot path.

Test Plan:

Extended `test_param_registration_after_forward`, which already runs forward
with `reshard_after_forward=False` and then manually reshards, to assert that
stale references to the unsharded parameters raise on `data_ptr()`. Without
the fix the new assertion fails with "RuntimeError not raised".

```
python test/distributed/_composable/fsdp/test_fully_shard_training.py -k test_param_registration_after_forward
```

Also ran the FSDP2 suites on 2 GPUs (training, comm, memory, state_dict,
extensions, autograd, frozen, mixed_precision, init); all 149 tests pass.

```
for t in test_fully_shard_training test_fully_shard_comm test_fully_shard_memory test_fully_shard_state_dict test_fully_shard_extensions test_fully_shard_autograd test_fully_shard_frozen test_fully_shard_mixed_precision test_fully_shard_init; do python test/distributed/_composable/fsdp/$t.py; done
```

Standalone repro (2-GPU torchrun): `unshard()`, keep `model.weight`,
`reshard()`, then `w.sum()`. Before: illegal memory access. After:
`RuntimeError: Cannot access data pointer of a tensor whose storage was freed by FSDP ...`.

Authored with Claude Code.