### PR TITLE
Add AOTI_TORCH_SAVE_DIR and fix the tensor-dump path join (#195869)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -90,6 +90,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     random_matrix_with_scaled_reduction_dim,
     runOnRocm,
+    set_cwd,
     skipIfRocmArch,
     skipIfWindows,
     skipIfWindowsXPU,
@@ -7266,6 +7267,54 @@ class AOTInductorTestsTemplate:
                     f"after_launch - {kernel_call}",
                     count,
                 ).run(code)
+
+    def test_aoti_debug_printer_save_dir(self):
+        # SAVE_ONLY dumps each intermediate tensor through the
+        # aoti_torch_save_tensor_handle C shim at runtime, so this has to run the
+        # compiled model rather than only inspect the generated code.
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                return x + torch.nn.functional.relu(y)
+
+        example_inputs = (
+            torch.randn(4, 4, device=self.device),
+            torch.randn(4, 4, device=self.device),
+        )
+        model = Model()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # A directory that does not exist yet, so the shim creates it. Anything
+            # written beside it rather than inside means the filename got
+            # concatenated onto the directory name instead of joined onto it.
+            save_dir = os.path.join(tmp_dir, "aoti_dump")
+            with (
+                config.patch({"aot_inductor.debug_intermediate_value_printer": "1"}),
+                patch.dict(os.environ, {"AOTI_TORCH_SAVE_DIR": save_dir}),
+            ):
+                AOTIRunnerUtil.run(model, example_inputs)
+
+            self.assertEqual(os.listdir(tmp_dir), ["aoti_dump"])
+            dumps = os.listdir(save_dir)
+            self.assertTrue(len(dumps) > 0)
+            self.assertTrue(all(name.endswith(".pt") for name in dumps))
+            self.assertTrue(
+                isinstance(torch.load(os.path.join(save_dir, dumps[0])), torch.Tensor)
+            )
+
+        # Unset, the dumps keep landing in <cwd>/tmp/aoti_torch, which schedulers
+        # collecting a job's working directory rely on. This process already ran
+        # with the variable set, so it also pins that the shim rereads the
+        # environment per call instead of caching the first value it saw.
+        with tempfile.TemporaryDirectory() as cwd, set_cwd(cwd):
+            with (
+                config.patch({"aot_inductor.debug_intermediate_value_printer": "1"}),
+                patch.dict(os.environ),
+            ):
+                os.environ.pop("AOTI_TORCH_SAVE_DIR", None)
+                AOTIRunnerUtil.run(model, example_inputs)
+
+            self.assertEqual(os.listdir(os.path.join(cwd, "tmp")), ["aoti_torch"])
+            self.assertTrue(len(os.listdir(os.path.join(cwd, "tmp", "aoti_torch"))) > 0)
 
     def test_aoti_debug_printing_model_inputs_codegen(self):
         if self.device not in ["cuda", "xpu"]:

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -6,6 +6,7 @@
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
+#include <c10/util/env.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
@@ -1244,9 +1245,16 @@ void aoti_torch_save_tensor_handle(
     const char* kernel_name) {
   at::Tensor* t = tensor_handle_to_tensor_pointer(self);
 #ifndef C10_MOBILE
-  // Save tensor to tmp .pt file for tensors and can be torch.load'ed later
-  auto cwd = c10::filesystem::current_path();
-  auto tmp_folder = cwd / "tmp" / "aoti_torch";
+  // Save tensor to tmp .pt file for tensors and can be torch.load'ed later.
+  // Defaults to <cwd>/tmp/aoti_torch so schedulers that collect a job's working
+  // directory pick the dumps up; AOTI_TORCH_SAVE_DIR writes them elsewhere.
+  // Read per call rather than cached, so a caller can redirect dumps per test
+  // or per session within one process.
+  const std::optional<std::string> save_dir_env =
+      c10::utils::get_env("AOTI_TORCH_SAVE_DIR");
+  auto tmp_folder = (save_dir_env.has_value() && !save_dir_env->empty())
+      ? c10::filesystem::path(*save_dir_env)
+      : c10::filesystem::current_path() / "tmp" / "aoti_torch";
   if (!c10::filesystem::exists(tmp_folder)) {
     std::cout
         << "aoti_torch_save_tensor_handle: Path does not exist, creating it..."
@@ -1259,8 +1267,13 @@ void aoti_torch_save_tensor_handle(
       return;
     }
   }
-  std::string tensor_filepath_to_save = tmp_folder.string() + launch_prefix +
-      "_" + kernel_name + "_" + tensor_name + "_" + t->device().str() + ".pt";
+  // Join as a path component: plain concatenation had no separator, so files
+  // landed beside the created directory rather than inside it.
+  std::string tensor_filepath_to_save =
+      (tmp_folder /
+       (std::string(launch_prefix) + "_" + kernel_name + "_" + tensor_name +
+        "_" + t->device().str() + ".pt"))
+          .string();
 
   auto bytes = torch::jit::pickle_save(c10::IValue(*t));
   std::ofstream fout(tensor_filepath_to_save, std::ios::out | std::ios::binary);


### PR DESCRIPTION
Summary:

`aoti_torch_save_tensor_handle` wrote to `<cwd>/tmp/aoti_torch` and built the
filename by string concatenation with no separator, so dumps landed *beside* the
directory it had just created (`tmp/aoti_torchbefore_launch_...`). Running
lowering from inside a source checkout therefore littered the repo, which then
trips the DISALLOWEDFILENAME linter.

Adds `AOTI_TORCH_SAVE_DIR` to redirect the dumps, and joins the filename as a
path component. The env var is read on each call rather than cached in a
function-static, so a caller can point dumps at a per-test or per-session
directory within one process. Default is unchanged, so schedulers that collect a
job's working directory still pick them up. Debug-only path, reached solely
under `AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER`.

Test Plan: `python test/inductor/test_aot_inductor.py -k test_aoti_debug_printer_save_dir`

Differential Revision: D118493165


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo