### PR TITLE
[CUDA] Enable C10_LAUNCH_BOUNDS_2 on ctc_loss_log_alpha_gpu_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -72,9 +72,7 @@ __device__ static inline int64_t get_target_prime(
 // computed when we start a new block_s. This is why we have our own for loop here.
 template<typename scalar_t, typename target_t>
 __global__ void
-#if defined (USE_ROCM)
 C10_LAUNCH_BOUNDS_2((std::is_same_v<scalar_t, float> ? 1024 : 896), 1)
-#endif
 ctc_loss_log_alpha_gpu_kernel(scalar_t* __restrict__ log_alpha_data,
                                     const scalar_t*log_probs_data, const int64_t* __restrict__ input_lengths, int64_t max_input_length,
                                     const target_t* __restrict__ targets_data, const int64_t* __restrict__ target_lengths, int64_t max_target_length,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15663,6 +15663,39 @@ if __name__ == '__main__':
 
     @skipMPS
     @onlyAccelerator
+    @dtypes(torch.float, torch.double)
+    def test_CTCLoss_max_threads_launch_bounds(self, device, dtype):
+        # Exercises maximum thread block sizes (768 for double, 1024 for float)
+        # in native CTC loss kernels when 2 * target_length + 1 > max_threads / 2.
+        target_length = 300
+        input_length = 600
+        vocab_size = 5
+        batch_size = 2
+
+        for target_dtype in [torch.int, torch.long]:
+            log_probs = (
+                torch.randn(input_length, batch_size, vocab_size, dtype=dtype, device=device)
+                .log_softmax(2)
+                .requires_grad_()
+            )
+            targets = torch.randint(
+                low=1, high=vocab_size, size=(batch_size, target_length), dtype=target_dtype, device=device
+            )
+            input_lengths = torch.full((batch_size,), input_length, dtype=target_dtype)
+            target_lengths = torch.full((batch_size,), target_length, dtype=target_dtype)
+
+            with torch.backends.cudnn.flags(enabled=False):
+                loss = torch.nn.functional.ctc_loss(
+                    log_probs, targets, input_lengths, target_lengths,
+                    reduction='sum', zero_infinity=True
+                )
+                grad, = torch.autograd.grad(loss, log_probs, torch.ones_like(loss))
+
+            self.assertFalse(torch.isnan(loss).any())
+            self.assertFalse(torch.isnan(grad).any())
+
+    @skipMPS
+    @onlyAccelerator
     def test_CTCLoss_critical_target_len(self, device):
         # cudnn has an unexpected problem with target length 256, see issue #53505
         N = 1

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15662,7 +15662,7 @@ if __name__ == '__main__':
         self.assertEqual(grad_cpu, grad_device, atol=1e-4, rtol=0)
 
     @skipMPS
-    @onlyAccelerator
+    @onlyCUDA
     @dtypes(torch.float, torch.double)
     def test_CTCLoss_max_threads_launch_bounds(self, device, dtype):
         # Exercises maximum thread block sizes (768 for double, 1024 for float)


### PR DESCRIPTION
## Summary
Fixes a `cudaErrorLaunchOutOfResources` (`CUDA error: too many resources requested for launch`) failure in `ctc_loss_log_alpha_gpu_kernel` when running CTC loss with `torch.double` and large target lengths (e.g., `test_CTCLoss_long_targets_cuda`).

## Root Cause
In `ctc_loss_gpu_template` (`aten/src/ATen/native/cuda/LossCTC.cu`), `ctc_loss_log_alpha_gpu_kernel` is launched with up to `max_threads = 768` threads per block for `double` inputs when `2 * max_target_length + 1 >= 384`.

On CUDA architectures with a 65,536 (64K) register-per-block limit, a 768-thread block allows at most 
65536/768 = 85 registers per thread (or 80 registers with 8-register allocation granularity).

Previously, `C10_LAUNCH_BOUNDS_2((std::is_same_v<scalar_t, float> ? 1024 : 896), 1)` was enabled unconditionally on `ctc_loss_backward_log_beta_gpu_kernel`, but was guarded by `#if defined(USE_ROCM)` on `ctc_loss_log_alpha_gpu_kernel`. Without `__launch_bounds__` on CUDA, `ptxas` under optimized builds can allocate >85
registers per thread for `ctc_loss_log_alpha_gpu_kernel<double, int64_t>`, causing the kernel launch to exceed 65,536 registers per block and fail with `cudaErrorLaunchOutOfResources`.

## Solution
Remove `#if defined(USE_ROCM)` around `C10_LAUNCH_BOUNDS_2` on `ctc_loss_log_alpha_gpu_kernel` (matching `ctc_loss_backward_log_beta_gpu_kernel`) so NVCC bounds per-thread register allocation on CUDA as well.

## Test Plan

Use `target_length = 300` so that `2 * max_target_length + 1 = 601 > max_threads / 2`, ensuring the kernel launches with the maximum block size (768 threads for double, 1024 threads for float) where the launch bounds are required
```
pytest test/test_nn.py -k test_CTCLoss_max_threads_launch_bounds
```

## Full error log

```
"torch/test/test_nn.py", line 15506, in test_CTCLoss_long_targets
    res_device = torch.nn.functional.ctc_loss(log_probs.to(device), targets.to(device), input_lengths, target_lengths,
                                              reduction='sum', zero_infinity=True)
  File "torch/nn/functional.py", line 3165, in ctc_loss
    return torch.ctc_loss(
           ~~~~~~~~~~~~~~^
        log_probs,
        ^^^^^^^^^^
    ...<5 lines>...
        zero_infinity,
        ^^^^^^^^^^^^^^
    )
    ^
torch.AcceleratorError: CUDA error: too many resources requested for launch
```