### PR TITLE
[BE][MPS] Migrate conj_physical to Metal

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -3,6 +3,7 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/UnaryOps.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/Copy.h>
@@ -479,5 +480,11 @@ Tensor _copy_from_and_resize_mps(const at::Tensor& self, const at::Tensor& dst) 
 Tensor _copy_from_mps(const at::Tensor& self, const at::Tensor& dst, bool non_blocking) {
   return mps::mps_copy_(const_cast<Tensor&>(dst), self, non_blocking);
 }
+
+static void conj_physical_kernel_mps(TensorIteratorBase& iter) {
+  lib.exec_unary_kernel(iter, "copy_conj");
+}
+
+REGISTER_DISPATCH(conj_physical_stub, &conj_physical_kernel_mps)
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -15,7 +15,6 @@
 #include <ATen/ops/acos_native.h>
 #include <ATen/ops/asin_native.h>
 #include <ATen/ops/atan_native.h>
-#include <ATen/ops/conj_physical_native.h>
 #include <ATen/ops/cos_native.h>
 #include <ATen/ops/cosh_native.h>
 #include <ATen/ops/cumprod_native.h>
@@ -402,15 +401,6 @@ TORCH_IMPL_FUNC(sgn_out_mps)(const Tensor& self, const Tensor& output) {
   };
 
   mps::unary_op(realInput, realOutput, "sgn_out_mps", complex_sgn_op);
-}
-
-Tensor& conj_physical_out_mps(const Tensor& self, Tensor& result) {
-  TORCH_CHECK(self.is_complex());
-  TORCH_CHECK(self.dtype() != at::kComplexDouble);
-  mps::unary_op(self, result, "conj", ^MPSGraphTensor*(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
-    return [mpsGraph conjugateWithTensor:inputTensor name:nil];
-  });
-  return result;
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -475,8 +475,7 @@
 
 - func: conj_physical.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU, CUDA, XPU: conj_physical_out
-    MPS: conj_physical_out_mps
+    CPU, CUDA, XPU, MPS: conj_physical_out
     SparseCPU, SparseCUDA, SparseMPS, SparseXPU: conj_physical_out_sparse
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMPS, SparseCsrMeta, SparseCsrXPU: conj_physical_sparse_csr_out
   tags: pointwise

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13244,16 +13244,6 @@ op_db: list[OpInfo] = [
                        DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32, )),
                        DecorateInfo(unittest.skip("Skipped! conj_physical_ not implemented for sparse"),
                                     'TestSparseUnaryUfuncs', 'test_inplace'),
-                       # RuntimeError: false INTERNAL ASSERT FAILED at
-                       # "/Users/kurtamohler/develop/pytorch-1/aten/src/ATen/native/DispatchStub.cpp":276
-                       DecorateInfo(
-                           unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                           device_type='mps', dtypes=(torch.complex64,)
-                       ),
-                       # RuntimeError: Expected self.is_complex() to be true, but got false.
-                       DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                       DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-
                    )),
     OpInfo('resolve_conj',
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #195872

Kernel already exists in Copy.kernel, but UnaryOps had a redundant MPSGraph implementation of the same operation
Unify them thru single `REGISTER_DISPATCH`
Remove relevant xfails

Fixes https://github.com/pytorch/pytorch/issues/195822