### PR TITLE
[inductor] Stop decomposing _unsafe_index_put into checked index_put

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1577,6 +1577,25 @@ class TestInductorDynamic(DynamicShapesTestCase):
             actual = compiled_f(x)
             self.assertEqual(actual, expected)
 
+    @parametrize("dynamic", [False, True])
+    def test_unsafe_index_put_no_bounds_check(self, device, dynamic):
+        # _unsafe_index_put's contract is that its indices are already in
+        # bounds, so it must not emit one. Decomposing it to the checked
+        # index_put reintroduces a check whenever interval analysis cannot
+        # relate the index range to a padded destination size.
+        def f(dst, src):
+            idx = torch.arange(src.shape[0], device=src.device)
+            return torch.ops.aten._unsafe_index_put.default(dst, [idx], src, False)
+
+        n = 300
+        src = torch.randn(n, device=device)
+        dst = torch.zeros((n + 127) // 128 * 128, device=device)
+
+        fn_c = torch.compile(f, dynamic=dynamic, fullgraph=True)
+        actual, code = run_and_get_code(fn_c, dst, src)
+        self.assertEqual(actual, f(dst, src))
+        FileCheck().check_not("index out of bounds").run("\n".join(code))
+
 
 instantiate_device_type_tests(TestInductorDynamic, globals(), allow_xpu=True)
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -118,6 +118,7 @@ decompositions = {**core_aten_decompositions(), **inductor_decompositions}
 # the Inductor decomp table.
 decomps_to_exclude: list[torch._ops.OpOverload | torch._ops.OpOverloadPacket] = [
     aten._unsafe_index,
+    aten._unsafe_index_put,
     aten._unsafe_masked_index,
     aten._unsafe_masked_index_put_accumulate,
     aten._scaled_dot_product_flash_attention_for_cpu.default,  # See comments in torch/_decomp/decompositions.py


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195873

_unsafe_index_put's contract is that its indices are already in bounds, and
Inductor's lowering honors that by passing check=False to index_put_impl_
(lowering.py). That lowering is unreachable, because
torch/_decomp/decompositions.py rewrites the op to plain aten.index_put first,
which lowers with check=True. The unchecked contract is silently lost and a
bounds check is emitted.

The check is not always visible. Inductor still elides it whenever interval
analysis can bound the index, which covers most static-shape cases. It survives
when the destination is padded, because proving the index fits requires
relating the index range to a ceil-rounded size -- e.g. scattering N rows into
a ceil(N/128)*128 destination needs n - 1 < ((n + 127)//128)*128, which
ValueRanges cannot derive. That shape shows up in blocked-scale swizzle layouts
for FP4/FP8 quantization.

Excluding the decomposition is the same treatment aten._unsafe_index already
gets in the list directly above, and it only affects Inductor: decomps_to_exclude
is Inductor's table, so eager and other backends keep the decomposition.

Test Plan:

New device-generic regression test, parametrized over static and dynamic
shapes. It asserts no "index out of bounds" appears in the generated code --
that string is emitted by CSEProxy.indirect_assert for every backend, so the
test covers CPU and Triton alike.

```
python test/inductor/test_torchinductor_dynamic_shapes.py -k test_unsafe_index_put_no_bounds_check
```

```
Ran 4 tests in 13.853s

OK
```

Reverting the decomposition.py change fails the two dynamic-shape variants
(CPU and CUDA) and leaves the static ones passing, which matches the analysis
above.

Performance, B200, scattering 16000x512 FP8 scales into a padded swizzled
destination, one variant per process with a cooldown between samples:

```
dynamic=True, index_put         (assert emitted)  59.66 us
dynamic=True, _unsafe_index_put (no assert)       55.26 us
```

Static shapes are unchanged at 22.6 us either way, since the bound is already
proven there.

This change was prepared with AI assistance and reviewed by the author.