### PR TITLE
[native_aot][8/7] stage 2: refuse an import-time rebuild

### DIFF
--- a/tools/native_aot/build_stage2.py
+++ b/tools/native_aot/build_stage2.py
@@ -598,6 +598,42 @@ def _refuse_cache_drift(before: dict[str, tuple[str, str]]) -> None:
     )
 
 
+def _editable_rebuild_finder() -> object | None:
+    """The installed editable finder, if it rebuilds torch on import.
+
+    scikit-build-core's ``editable.rebuild`` (also SKBUILD_EDITABLE_REBUILD) installs a
+    meta-path finder that runs `cmake --build` and `cmake --install` on the first
+    `import torch`. Read from sys.meta_path rather than from pyproject.toml or the
+    environment: the finder is what the torch on this path actually does.
+    """
+    for finder in sys.meta_path:
+        if type(finder).__name__.startswith("ScikitBuild") and getattr(
+            finder, "rebuild_flag", False
+        ):
+            return finder
+    return None
+
+
+def _refuse_editable_rebuild() -> None:
+    """Refuse to run under an import-time rebuild.
+
+    Every probe here imports torch in a subprocess, so each one would trigger that
+    build and install -- overwriting the library this script relinked, and making the
+    final embedded-kernels check describe whatever the probe just built.
+    """
+    if _editable_rebuild_finder() is None:
+        return
+    raise RuntimeError(
+        "native-AOT stage 2: this torch was installed with scikit-build-core's "
+        "editable.rebuild enabled, so importing torch rebuilds and reinstalls it. "
+        "Stage 2 relinks torch_cuda and copies it over that install, and its probes "
+        "import torch, so the two would race and the result would not be the library "
+        "this script verified. Reinstall without editable.rebuild (unset "
+        "SKBUILD_EDITABLE_REBUILD and the pyproject setting), or set "
+        "TORCH_NATIVE_AOT=0 to skip stage 2."
+    )
+
+
 def _lib_snapshot() -> dict[str, tuple[int, int]]:
     """(mtime, size) for every file in the build tree's lib/ except torch_cuda's.
 
@@ -836,6 +872,8 @@ def main(argv: list[str] | None = None) -> int:
     # TORCH_NATIVE_AOT=0 is a kill switch even on the binary-build path.
     if _opted_out():
         return 0  # _opted_out() reports the value and where it came from
+    # After the opt-out, like every other refusal, and before the first probe.
+    _refuse_editable_rebuild()
     # --wheel means torch was installed on the line above, so "not importable" is a
     # broken build, not "not applicable"; hence ahead of the gates that need torch.
     if args.wheel and not _torch_probe("True"):

--- a/tools/test/test_native_aot_tools.py
+++ b/tools/test/test_native_aot_tools.py
@@ -4347,6 +4347,38 @@ class TestCiAndCMakeWiring(unittest.TestCase):
                 self.assertIn(in_contributing, contributing)
 
 
+class TestStageTwoRefusesAnImportTimeRebuild(unittest.TestCase):
+    """scikit-build-core's editable.rebuild rebuilds torch on import."""
+
+    class ScikitBuildRedirectingFinder:
+        rebuild_flag = True
+
+    def test_the_installed_finder_is_read_for_the_rebuild_flag(self):
+        with mock.patch.object(
+            build_stage2.sys, "meta_path", [self.ScikitBuildRedirectingFinder()]
+        ):
+            self.assertIsNotNone(build_stage2._editable_rebuild_finder())
+            with self.assertRaisesRegex(RuntimeError, "editable.rebuild"):
+                build_stage2.main([])
+
+    def test_a_finder_without_the_flag_is_left_alone(self):
+        finder = self.ScikitBuildRedirectingFinder()
+        finder.rebuild_flag = False
+        with mock.patch.object(build_stage2.sys, "meta_path", [finder]):
+            self.assertIsNone(build_stage2._editable_rebuild_finder())
+
+    def test_the_opt_out_still_wins(self):
+        # Ordered like every other refusal: TORCH_NATIVE_AOT=0 exempts it.
+        with (
+            mock.patch.object(
+                build_stage2.sys, "meta_path", [self.ScikitBuildRedirectingFinder()]
+            ),
+            mock.patch.dict(os.environ, {"TORCH_NATIVE_AOT": "0"}),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(build_stage2.main([]), 0)
+
+
 class TestStageTwoArgvContract(unittest.TestCase):
     """What main() passes to its two children, and the invariant that ties them:
     a tree export creates must be one generation was told about."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191669
* #190899
* #190898
* #190897
* __->__ #195877
* #194243
* #194242
* #194241
* #194240
* #194239
* #194238
* #190896

Human Note:

Not to say this **can't** be supported at some point, but for now it isn't,
so just fail nice and loudly.

Claude:

scikit-build-core's editable.rebuild (also SKBUILD_EDITABLE_REBUILD, or
-C editable.rebuild=true) installs a meta-path finder that runs `cmake --build`
and `cmake --install` on the first `import torch`. Stage 2 cannot work under it:
every probe it makes imports torch in a subprocess, so each one triggers that
build and install -- overwriting the library stage 2 relinked and copied, and
leaving the final embedded-kernels check describing whatever the probe just
built rather than what this script verified.

Detected from sys.meta_path rather than from pyproject.toml or the environment.
The finder is what the torch on this path actually does, and it carries the flag
(rebuild_flag) however the setting arrived. Refused after the opt-out, like every
other refusal here, so TORCH_NATIVE_AOT=0 still exempts it, and after
--print-verdict, so the word the CI shells compare stays RUN or SKIP.

Authored with an AI assistant (Claude Code).

Test Plan:

```
pytest tools/test/test_native_aot_tools.py -k ImportTimeRebuild
```

Covers the flag being read from the installed finder, a finder without it being
left alone, and the opt-out still winning.