### PR TITLE
[inductor] TORCHINDUCTOR_LITE_MODE: re-run the AOTInductor suites under all-fallback mode (#195880)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -198,7 +198,12 @@ try:
             SwitchModels,
             WhileLoopModels,
         )
-        from .test_torchinductor import copy_tests, requires_multigpu, TestFailure
+        from .test_torchinductor import (
+            copy_tests,
+            requires_multigpu,
+            skip_if_lite_mode,
+            TestFailure,
+        )
     except ImportError:
         from test_aot_inductor_utils import (  # @manual=fbcode//caffe2/test/inductor:aot_inductor_utils-library
             AOTIRunnerUtil,
@@ -216,6 +221,7 @@ try:
         from test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
             copy_tests,
             requires_multigpu,
+            skip_if_lite_mode,
             TestFailure,
         )
 except (unittest.SkipTest, ImportError):
@@ -390,6 +396,7 @@ class AOTInductorTestsTemplate:
             )
             FileCheck().check_count("// subgraph: ", 2).run(code)
 
+    @skip_if_lite_mode("the region patch would match the ambient config")
     def test_invoke_subgraph_nested_region_config(self):
         # Same, but the region carries a per-region Inductor config patch, so
         # the config.patch in CppWrapperCpu.codegen_subgraph is on the path too.

--- a/test/inductor/test_inductor_lite_mode.py
+++ b/test/inductor/test_inductor_lite_mode.py
@@ -1,0 +1,76 @@
+# Owner(s): ["module: inductor"]
+# Unit test for TORCHINDUCTOR_LITE_MODE, the env switch that re-runs an existing
+# test list under all-fallback mode without editing the tests. The variable is read
+# when torch._inductor.config is imported, so it cannot be toggled in-process: this
+# asserts both polarities instead, and is meaningful whether or not it is set.
+import os
+import sys
+import unittest
+
+import torch
+from torch._inductor import config, lite_mode_options
+from torch._inductor.test_case import TestCase
+from torch._inductor.utils import run_and_get_cpp_code
+from torch.testing import FileCheck
+from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS
+
+
+if IS_WINDOWS and IS_CI:
+    sys.stderr.write(
+        "Windows CI does not have necessary dependencies for test_torchinductor yet\n"
+    )
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise unittest.SkipTest("requires sympy/functorch/filelock")
+
+try:
+    try:
+        from .test_aot_inductor import AOTIRunnerUtil
+    except ImportError:
+        from test_aot_inductor import AOTIRunnerUtil  # @manual
+except (unittest.SkipTest, ImportError):
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise
+
+
+LITE_MODE = os.environ.get("TORCHINDUCTOR_LITE_MODE") == "1"
+
+
+class LiteModeEnvTest(TestCase):
+    def test_env_var_installs_the_whole_bundle(self):
+        # Every knob torch.compile(mode="lite") sets must already be in effect
+        # from the environment alone, before any test-side config.patch. The
+        # dict lookup also fails loudly if a lite_mode_options key is renamed.
+        current = {k: config.get_config_copy()[k] for k in lite_mode_options}
+        if LITE_MODE:
+            # Catches drift too: a knob added to lite_mode_options but not wired
+            # to lite_mode_default shows up here as a mismatch.
+            self.assertEqual(current, lite_mode_options)
+        else:
+            self.assertNotEqual(current, lite_mode_options)
+
+    def test_helper_is_not_a_config_entry(self):
+        # A module-level bool would become a settable config knob that does
+        # nothing once the defaults have been computed at import.
+        self.assertNotIn("_lite_mode", config.get_config_copy())
+
+    def test_ops_actually_fall_back(self):
+        # Ops Inductor would normally fuse into one generated kernel go to ATen
+        # instead, so no fused kernel is emitted at all.
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.cos(torch.sin(x) + 1)
+
+        example_inputs = (torch.randn(8, 8),)
+        _, code = run_and_get_cpp_code(AOTIRunnerUtil.compile, Model(), example_inputs)
+        if LITE_MODE:
+            self.assertNotIn("cpp_fused_", code)
+        else:
+            FileCheck().check("cpp_fused_").run(code)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests(needs="filelock")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1418,6 +1418,25 @@ class skip_if_cpp_wrapper:
         return wrapper
 
 
+class skip_if_lite_mode:
+    """For tests whose premise is that a region behaves differently from the
+    graph around it. Under TORCHINDUCTOR_LITE_MODE=1 the whole graph is already
+    all-fallback, so there is no contrast left to observe and the assertions are
+    either vacuous or unsatisfiable."""
+
+    def __init__(self, reason: str = "") -> None:
+        self.reason = reason
+
+    def __call__(self, fn, *args, **kwargs):
+        @functools.wraps(fn)
+        def wrapper(test_self):
+            if config.fallback_by_default:
+                raise unittest.SkipTest(f"no contrast under lite mode: {self.reason}")
+            return fn(test_self, *args, **kwargs)
+
+        return wrapper
+
+
 def is_dynamic_shape_enabled():
     # What's the best way to decide this?
     return not torch._dynamo.config.assume_static_by_default
@@ -18015,6 +18034,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertIn("aten::zeros_like", code[0])
         self.assertNotIn("from(nullptr, 0)", code[0])
 
+    @skip_if_lite_mode("the parent's cos falls back too, so assertNotIn fails")
     def test_regional_fallback_by_default_invoke_subgraph(self):
         # A nested region carrying inductor_config_patches={"fallback_by_default": True}
         # must fall back *only inside the region*: the region's ops become
@@ -18069,6 +18089,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         )
         self.assertNotIn("aten.cos", body)
 
+    @skip_if_lite_mode("neither half emits a Triton reduction to compare")
     def test_regional_codegen_only_config_cpp_wrapper(self):
         # A codegen-TIME knob on the region must reach the cpp wrapper.
         # `triton.persistent_reductions` is consulted while the region's kernels

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -53,6 +53,21 @@ def autotune_at_compile_time_default() -> bool | None:
     return get_tristate_env("TORCHINDUCTOR_AUTOTUNE_AT_COMPILE_TIME")
 
 
+def lite_mode_default(lite_value: bool, default: bool) -> bool:
+    """Default for a knob that lite_mode_options overrides.
+
+    TORCHINDUCTOR_LITE_MODE=1 installs the same bundle as
+    torch.compile(mode="lite"), so an existing test list can be re-run under
+    all-fallback mode without editing the tests, and so the setting reaches
+    model-generation subprocesses (e.g. test/cpp/aoti_inference). Keep this a
+    function rather than a module-level bool: a bool would be picked up as a
+    settable config entry that silently does nothing after import.
+    """
+    if os.environ.get("TORCHINDUCTOR_LITE_MODE") == "1":
+        return lite_value
+    return default
+
+
 def static_cuda_launcher_default() -> bool:
     STATIC_CUDA_LAUNCHER_VERSION = 2
 
@@ -257,7 +272,7 @@ pick_loop_orders = True
 inplace_buffers = True
 
 # reuse a buffer for an unrelated purpose
-allow_buffer_reuse = True
+allow_buffer_reuse = lite_mode_default(False, True)
 
 # Enable pooled allocations for non-output tensors
 memory_planning = os.environ.get("TORCHINDUCTOR_MEMORY_PLANNING", "0") == "1"
@@ -456,7 +471,7 @@ reorder_for_compute_comm_overlap_passes: list[
 reorder_prefetch_limit: int | None = None
 
 # enable operator reordering for peak memory optimization
-reorder_for_peak_memory = True
+reorder_for_peak_memory = lite_mode_default(False, True)
 reorder_for_peak_memory_debug = False
 
 # In some cases, when all the nodes that can be scheduled are quite large,
@@ -741,21 +756,21 @@ max_autotune_flex_search_space: Literal["DEFAULT", "EXHAUSTIVE"] = os.environ.ge
 # Different from default inductor mode that fuses all nodes, this config enables an
 # opt-in mode that only fuse for user-specified nodes. The motivation is to provide
 # guaranteed numeric correctness and give full control to users.
-fallback_by_default: bool = False
+fallback_by_default: bool = lite_mode_default(True, False)
 
 
 # This config allows selective decomposition of certain operators in the graph.
 # Currently the only use case is to patch the same-name config in functorch, for
 # inductor lite mode. See more details in [Note: Selective Decomposition]
-selective_decompose: bool = False
+selective_decompose: bool = lite_mode_default(True, False)
 
 
 # Use dead code elimination
-use_dce: bool = True
+use_dce: bool = lite_mode_default(False, True)
 
 
 # Use fx graph passes
-use_pre_grad_passes: bool = True
+use_pre_grad_passes: bool = lite_mode_default(False, True)
 
 # "early": pre-grad passes run before cache lookup (every compile).
 # "late": pre-grad passes run after cache lookup (only on cache miss);
@@ -765,8 +780,8 @@ use_pre_grad_passes: bool = True
 pre_grad_pass_timing: Literal["early", "late", "default"] = "default"
 
 
-use_joint_graph_passes: bool = True
-use_post_grad_passes: bool = True
+use_joint_graph_passes: bool = lite_mode_default(False, True)
+use_post_grad_passes: bool = lite_mode_default(False, True)
 
 
 cutedsl_enable_autotuning: bool = (
@@ -2031,7 +2046,7 @@ class triton:
 
     # reorder nodes to minimize the number of graph partitions while
     # not incurring large memory overhead
-    reorder_for_reducing_graph_partitions: bool = True
+    reorder_for_reducing_graph_partitions: bool = lite_mode_default(False, True)
 
     # Memory budget multiplier for cudagraph partition reordering.
     # When reordering nodes to minimize partitions, the reordering is only


### PR DESCRIPTION
Summary:

Adds an environment switch that installs the whole Inductor lite / all-fallback
config bundle, plus the `inductor_aoti_fallback` CI config that uses it to re-run
the existing AOTInductor suites -- including the C++ ones -- with every op falling
back to ATen.

## Why an environment variable

There are three established ways to re-run the AOTInductor template under a
different config, and only one of them can reach the C++ tests.

1. **In-file variant class** -- `AOTInductorTestDualWrapper` in
   `test_aot_inductor.py`: a `TestCase` whose `setUp` does a `config.patch`, then
   `copy_tests(AOTInductorTestsTemplate, ...)`. Needs no CI change at all, but it
   inflates the existing `test_aot_inductor` shard instead of getting its own
   runtime budget and its own signal.

2. **Separate file, class-attribute driven** -- `test_aot_inductor_arrayref.py`:
   `allow_stack_allocation` is a class attribute that `check_model` folds into a
   `config.patch`, and the `copy_tests` suffix doubles as an independent
   `TestFailure` namespace. Costs a duplicated suite and new BUCK targets.

3. **Env-var re-run of an existing include list** -- already used twice in
   `test.sh:765-802` (`export TORCHINDUCTOR_CPP_WRAPPER=1`, and
   `TORCHINDUCTOR_AUTOTUNE_AT_COMPILE_TIME=1 python test/run_test.py --include ...`).

This change uses (3), for a reason specific to `test_inductor_aoti_cpp`. That
function runs gtest binaries whose fixtures are AOTI artifacts produced by a
*separate Python process* -- `test/cpp/aoti_inference/test.py` calls
`torch._export.aot_compile`. Nothing in the test harness can reach into that
process to apply a `config.patch`, so an environment variable is the only thing
that crosses the boundary. Options (1) and (2) can only ever touch the Python
suites; with (3), `test_inductor_aoti_cpp` is reused verbatim.

## The config change

`torch.compile(mode="lite")` installs `lite_mode_options`
(`torch/_inductor/__init__.py:335`). Nine of its ten keys actually differ from the
defaults (`reorder_for_compute_comm_overlap` is already `False`), and each is now
wired through a new `lite_mode_default()` helper in `torch/_inductor/config.py`,
following the existing `autotune_at_compile_time_default()` idiom in that file.
`torch/utils/_config_module.py` has no generic JSON env-patch hook, so a per-knob
default is the available mechanism.

Binding the whole bundle rather than just `fallback_by_default` is deliberate --
see the comment already in `test_aot_inductor.py:476`: "use_post_grad_passes=False
is as load bearing as fallback_by_default: with post-grad passes on,
post_grad_passes decomposes the functional HOP itself and the graph takes the same
path with or without this change."

`lite_mode_default` is a function, not a module-level bool, on purpose. The config
walker (`_config_module.py:199-213`) skips `FunctionType` but *not*
single-underscore names, so a `_lite_mode: bool = ...` would have been registered
as a settable config entry that silently does nothing once the defaults are
computed at import. `test_helper_is_not_a_config_entry` pins that.

## The CI config

`test_inductor_aoti_fallback_shard()` exports the variable, runs the four AOTI
Python modules sharded, and the dispatch branch calls `test_inductor_aoti_cpp`
unchanged on shard 1 -- mirroring how the `inductor_cpp_wrapper` config already
invokes it. The branch is placed above the `*inductor*` catch-all, and the config
is spelled `aoti` rather than `aot_inductor` so it does not also match the
`DYNAMO_BENCHMARK_FLAGS+=(--export-aot-inductor)` branch at `test.sh:840`.

**No workflow matrix entry is included yet, deliberately.** A 51-test slice of the
CPU AOTI template run under the switch gave 18 ok / 5 error / 5 skipped and then a
hard process abort, from three real bugs:

- `torch.cond` (5 tests): `AssertionError: Can not find the original value for
  false_graph_0_constant0`, at `graph.py:1213` via `cpp_wrapper_cpu.py:1281
  codegen_model_constructor` -- subgraph constants are not in the parent's
  original-constant map, so the model constructor cannot classify them CPU vs CUDA.
- constant folding (2 tests): `aoti_torch_proxy_executor_call_function(...) API
  call failed` at runtime.
- `test_constant_folding_with_update`: `FbProxyExecutor.cpp:828 Check failed:
  tensor_id == num_tensors - num_output_tensors`, a glog CHECK that kills the
  interpreter and would take the rest of the shard with it.

Those are worth fixing and are the point of the shard, but wiring the config into
`inductor-unittest.yml` (reached from trunk via `inductor.yml`) before they are
triaged would just break CI. The follow-up adds the matrix line; until then the
config is reachable by hand, and the aborting case in particular will need a hard
skip rather than an xfail.

`test_inductor_lite_mode.py` needs no BUCK entry -- the `glob(["test_*.py"])` in
`test/inductor/BUCK:130` already generates `//caffe2/test/inductor:inductor_lite_mode`.
It asserts both polarities, so it is meaningful in the default shards (variable
unset) as well as in the new config (variable set), and the exact-match assertion
in the set case catches drift if a knob is added to `lite_mode_options` without
being wired to `lite_mode_default`.

Test Plan:
## fbcode (run locally on a gfx950 devserver, all green)

New unit test, both polarities -- same binary, only the environment differs:

```
buck2 run @//mode/opt fbcode//caffe2/test/inductor:inductor_lite_mode
  -> Ran 3 tests ... OK

TORCHINDUCTOR_LITE_MODE=1 \
buck2 run @//mode/opt fbcode//caffe2/test/inductor:inductor_lite_mode
  -> Ran 3 tests ... OK
```

With the variable set, all nine knobs match `lite_mode_options` exactly and a
`cos(sin(x)+1)` model emits no `cpp_fused_` kernel; with it unset, the bundle is
not installed and the fused kernel is present.

No regression on the default path. The change touches nine widely used knobs, so
the suites covering them:

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:inductor_utils
  -> Pass 7. Fail 0.          (covers should_fallback_by_default)

buck2 test @//mode/opt \
  fbcode//caffe2/test/inductor:memory \
  fbcode//caffe2/test/inductor:memory_planning \
  fbcode//caffe2/test/inductor:pattern_matcher
  -> Pass 142. Fail 0. Skip 15. Omit 2.
     (covers allow_buffer_reuse, reorder_for_peak_memory, and the
      pre/joint/post-grad pass and DCE knobs)
```

Shell and lint:

```
bash -n .ci/pytorch/test.sh                                        -> OK
arc lint .ci/pytorch/test.sh torch/_inductor/config.py \
         test/inductor/test_inductor_lite_mode.py                  -> No lint issues.
```

## OSS

Not executable from this devserver; these are the commands for the PR.

The new unit test, both polarities:

```
python test/run_test.py --include inductor/test_inductor_lite_mode --verbose
TORCHINDUCTOR_LITE_MODE=1 \
  python test/run_test.py --include inductor/test_inductor_lite_mode --verbose
```

No regression on the default path:

```
python test/run_test.py --verbose --include \
  inductor/test_inductor_utils inductor/test_memory \
  inductor/test_memory_planning inductor/test_pattern_matcher
```

Shell:

```
bash -n .ci/pytorch/test.sh
lintrunner --take SHELLCHECK .ci/pytorch/test.sh
```

The new config end to end, which is what the follow-up matrix line will run:

```
TEST_CONFIG=inductor_aoti_fallback NUM_TEST_SHARDS=2 SHARD_NUMBER=1 \
  .ci/pytorch/test.sh
```

CI signal: `ciflow/inductor` and `ciflow/trunk` exercise the no-regression claim
(`inductor-unittest.yml` and the `default` python shards both run inductor tests,
and `test_inductor_lite_mode.py` is auto-discovered into the latter with the
variable unset). The `inductor_aoti_fallback` config itself has no matrix entry in
this diff, so it will not run in CI yet.

## Not covered

- The `inductor_aoti_fallback` config has never executed in CI; the evidence for
  it is the local slice above, on CPU only, on one box.
- The GPU arm of the AOTI template was not sampled under the switch.
- `FbProxyExecutor.cpp` is fbcode-internal, so the exact fatal CHECK above may not
  reproduce in OSS -- but the same malformed proxy-executor call will reach the
  OSS executor.

Differential Revision: D118597109




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo