### PR TITLE
[inductor] Compile a Triton kernel in-process when a worker cannot import its constexpr module

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -2373,6 +2373,272 @@ def helper(x):
         self.assertIn("PlistFormat['FMT_XML']", code[0])
 
     @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_constexpr_module_missing_in_worker_falls_back_in_process(self):
+        # Compile workers snapshot PYTHONPATH when the pool spawns, so a module
+        # added to sys.path afterwards imports fine in the parent (where codegen
+        # validates it) but raises ModuleNotFoundError in the worker. The
+        # compile must fall back to in-process compilation instead of failing.
+        import importlib
+        import os
+        import sys
+        import tempfile
+
+        import triton
+        import triton.language as tl
+
+        from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
+        from torch._inductor.utils import fresh_cache
+
+        @triton.jit
+        def probe_kernel(
+            in_ptr, out_ptr, numel, MODE: tl.constexpr, BLOCK_SIZE: tl.constexpr
+        ):
+            offsets = tl.arange(0, BLOCK_SIZE)
+            mask = offsets < numel
+            x = tl.load(in_ptr + offsets, mask=mask)
+            if MODE.value == 1:
+                output = x + 1
+            else:
+                output = x * 2
+            tl.store(out_ptr + offsets, output, mask=mask)
+
+        module_name = f"inductor_constexpr_probe_{os.getpid()}"
+        module_src = "import enum\n\nclass Mode(enum.Enum):\n    ADD = 1\n    MUL = 2\n"
+        x = torch.randn(128, device=GPU_TYPE)
+        patched = {"compile_threads": 2, "worker_start_method": "subprocess"}
+        with tempfile.TemporaryDirectory() as tmpdir, inductor_config.patch(patched):
+            with open(os.path.join(tmpdir, f"{module_name}.py"), "w") as f:
+                f.write(module_src)
+            shutdown_compile_workers()
+            try:
+                # Spawn the worker pool before the module becomes importable so
+                # the workers' PYTHONPATH snapshot cannot contain tmpdir.
+                AsyncCompile.warm_pool()
+                AsyncCompile.wakeup()
+                AsyncCompile.wait_pool_ready()
+                self.assertTrue(AsyncCompile.use_process_pool())
+                sys.path.insert(0, tmpdir)
+                importlib.invalidate_caches()
+                mod = importlib.import_module(module_name)
+
+                def fn(x):
+                    y = torch.empty_like(x)
+                    probe_kernel[(1,)](x, y, x.numel(), mod.Mode.ADD, BLOCK_SIZE=256)
+                    return y
+
+                logger_name = "torch._inductor.async_compile"
+                with (
+                    fresh_cache(),
+                    self.assertLogs(logger_name, level="WARNING") as logs,
+                ):
+                    res, code = run_and_get_code(torch.compile(fn), x)
+                self.assertTrue(
+                    any("in-process compilation" in msg for msg in logs.output)
+                )
+                self.assertEqual(fn(x), res)
+                self.assertIn(module_name, code[0])
+            finally:
+                if tmpdir in sys.path:
+                    sys.path.remove(tmpdir)
+                sys.modules.pop(module_name, None)
+                shutdown_compile_workers()
+
+    def test_constexpr_fallback_result_is_memoized(self):
+        # LambdaFuture.result() re-runs its result_fn on every call and the
+        # worker task re-raises the same SubprocException, so without
+        # memoization every re-entry of the fallback path would warn again and
+        # recompile the kernel in-process again.
+        import os
+        from unittest.mock import Mock
+
+        from torch._inductor.async_compile import AsyncCompile
+        from torch._inductor.compile_worker.subproc_pool import SubprocException
+
+        module_name = f"inductor_fallback_probe_{os.getpid()}"
+        source_code = f"import {module_name} as __inductor_constexpr_module_0\n"
+        task = Mock()
+        task.result.side_effect = SubprocException(
+            f"ModuleNotFoundError: No module named '{module_name}'"
+        )
+        pool = Mock()
+        pool.submit.return_value = task
+        sentinel_kernel = object()
+        with (
+            patch.object(AsyncCompile, "use_process_pool", return_value=True),
+            patch.object(AsyncCompile, "process_pool", return_value=pool),
+            patch.object(
+                AsyncCompile, "_compile_triton_in_process", return_value=sentinel_kernel
+            ) as compile_in_process,
+        ):
+            future = AsyncCompile().triton("probe_kernel", source_code)
+            logger_name = "torch._inductor.async_compile"
+            with self.assertLogs(logger_name, level="WARNING") as logs:
+                self.assertIs(future.result(), sentinel_kernel)
+            fallback_warnings = [
+                msg for msg in logs.output if "in-process compilation" in msg
+            ]
+            self.assertEqual(len(fallback_warnings), 1)
+            with self.assertNoLogs(logger_name, level="WARNING"):
+                self.assertIs(future.result(), sentinel_kernel)
+            self.assertEqual(compile_in_process.call_count, 1)
+        self.assertEqual(task.result.call_count, 1)
+
+    def test_constexpr_fallback_survives_wait_timeout(self):
+        # With compile_worker_wait_timeout set, _wait_futures passes a timeout
+        # and LambdaFuture waits on the worker future first; that wait must not
+        # re-raise the worker failure ahead of the result_fn fallback.
+        import os
+        from unittest.mock import Mock
+
+        from torch._inductor.async_compile import AsyncCompile
+        from torch._inductor.compile_worker.subproc_pool import SubprocException
+
+        module_name = f"inductor_fallback_probe_{os.getpid()}"
+        source_code = f"import {module_name} as __inductor_constexpr_module_0\n"
+        failure = SubprocException(
+            f"ModuleNotFoundError: No module named '{module_name}'"
+        )
+        task = Mock()
+        task.result.side_effect = failure
+        task.exception.return_value = failure
+        pool = Mock()
+        pool.submit.return_value = task
+        sentinel_kernel = object()
+        with (
+            patch.object(AsyncCompile, "use_process_pool", return_value=True),
+            patch.object(AsyncCompile, "process_pool", return_value=pool),
+            patch.object(
+                AsyncCompile, "_compile_triton_in_process", return_value=sentinel_kernel
+            ),
+        ):
+            future = AsyncCompile().triton("probe_kernel", source_code)
+            with self.assertLogs("torch._inductor.async_compile", level="WARNING"):
+                self.assertIs(future.result(timeout=5), sentinel_kernel)
+        task.exception.assert_called_once_with(timeout=5)
+
+    def test_constexpr_module_missing_in_worker_accepts_exception(self):
+        # Spawn/fork worker pools re-raise the worker's ModuleNotFoundError
+        # directly instead of wrapping it in SubprocException; the helper must
+        # match on the exception's .name.
+        from torch._inductor.async_compile import _constexpr_module_missing_in_worker
+
+        src = "import foo.bar as __inductor_constexpr_module_0\n"
+        err = ModuleNotFoundError("No module named 'foo'", name="foo")
+        self.assertEqual(_constexpr_module_missing_in_worker(src, err), "foo.bar")
+        other = ModuleNotFoundError("No module named 'baz'", name="baz")
+        self.assertIsNone(_constexpr_module_missing_in_worker(src, other))
+        nameless = ModuleNotFoundError("No module named 'foo'")
+        self.assertIsNone(_constexpr_module_missing_in_worker(src, nameless))
+        # The root-name imports emitted for object-valued constexpr parameter
+        # defaults must also trigger the in-process fallback.
+        root_src = "from foo.bar import Cfg as Cfg\n"
+        self.assertEqual(_constexpr_module_missing_in_worker(root_src, err), "foo.bar")
+        self.assertIsNone(_constexpr_module_missing_in_worker(root_src, other))
+        aliased = "from foo.bar import Cfg as Renamed\n"
+        self.assertIsNone(_constexpr_module_missing_in_worker(aliased, err))
+        # `import foo` can fail because foo/__init__.py imports a submodule the
+        # worker lacks; the reported missing name is then a descendant of the
+        # constexpr module and must still be attributed to it.
+        parent_src = "import foo as __inductor_constexpr_module_0\n"
+        descendant = ModuleNotFoundError(
+            "No module named 'foo.helpers'", name="foo.helpers"
+        )
+        self.assertEqual(
+            _constexpr_module_missing_in_worker(parent_src, descendant), "foo"
+        )
+        lookalike = ModuleNotFoundError("No module named 'foobar'", name="foobar")
+        self.assertIsNone(_constexpr_module_missing_in_worker(parent_src, lookalike))
+        # torch.dtype / tl.dtype constexprs import the library roots themselves;
+        # a missing submodule under those is a real error in the worker, not a
+        # stale search path, so it must not trigger the in-process fallback.
+        for root in ("torch", "triton.language"):
+            root_src = f"import {root} as __inductor_constexpr_module_0\n"
+            missing_sub = ModuleNotFoundError(
+                f"No module named '{root}.zzz'", name=f"{root}.zzz"
+            )
+            self.assertIsNone(
+                _constexpr_module_missing_in_worker(root_src, missing_sub)
+            )
+        helper_src = "from triton.language import store as store\n"
+        self.assertIsNone(
+            _constexpr_module_missing_in_worker(
+                helper_src,
+                ModuleNotFoundError(
+                    "No module named 'triton.language.extra.x'",
+                    name="triton.language.extra.x",
+                ),
+            )
+        )
+        # A formatted worker traceback may chain the constexpr import failure
+        # before an unrelated secondary one; any reported missing module that
+        # matches a constexpr import is attributed regardless of chain order,
+        # so the in-process fallback still fires.
+        chained = (
+            "ModuleNotFoundError: No module named 'foo'\n\n"
+            "During handling of the above exception, another exception occurred:\n\n"
+            "ModuleNotFoundError: No module named 'baz'\n"
+        )
+        self.assertEqual(_constexpr_module_missing_in_worker(src, chained), "foo.bar")
+        reversed_chain = (
+            "ModuleNotFoundError: No module named 'baz'\n\n"
+            "During handling of the above exception, another exception occurred:\n\n"
+            "ModuleNotFoundError: No module named 'foo'\n"
+        )
+        self.assertEqual(
+            _constexpr_module_missing_in_worker(src, reversed_chain), "foo.bar"
+        )
+        # A traceback with only unrelated failures matches no constexpr import.
+        unrelated_chain = (
+            "ModuleNotFoundError: No module named 'baz'\n\n"
+            "During handling of the above exception, another exception occurred:\n\n"
+            "ModuleNotFoundError: No module named 'qux'\n"
+        )
+        self.assertIsNone(_constexpr_module_missing_in_worker(src, unrelated_chain))
+
+    @unittest.skipUnless(has_triton_package(), "requires Triton")
+    def test_constexpr_fallback_catches_raw_module_not_found(self):
+        # With TORCHINDUCTOR_WORKER_START=spawn/fork the worker's
+        # ModuleNotFoundError propagates raw from future.result(); the fallback
+        # must fire for constexpr imports and re-raise anything else unchanged.
+        import os
+        from unittest.mock import Mock
+
+        from torch._inductor.async_compile import AsyncCompile, CompiledTritonKernels
+
+        # The raw-raise path never calls remove_future, so without this a
+        # Mock-holding LambdaFuture would sit in the process-global kernel
+        # cache until the next compile_fx clears it.
+        self.addCleanup(CompiledTritonKernels.cache_clear)
+        module_name = f"inductor_spawn_probe_{os.getpid()}"
+        source_code = f"import {module_name} as __inductor_constexpr_module_0\n"
+        task = Mock()
+        task.result.side_effect = ModuleNotFoundError(
+            f"No module named '{module_name}'", name=module_name
+        )
+        pool = Mock()
+        pool.submit.return_value = task
+        sentinel_kernel = object()
+        with (
+            patch.object(AsyncCompile, "use_process_pool", return_value=True),
+            patch.object(AsyncCompile, "process_pool", return_value=pool),
+            patch.object(
+                AsyncCompile, "_compile_triton_in_process", return_value=sentinel_kernel
+            ),
+        ):
+            future = AsyncCompile().triton("probe_kernel", source_code)
+            logger_name = "torch._inductor.async_compile"
+            with self.assertLogs(logger_name, level="WARNING") as logs:
+                self.assertIs(future.result(), sentinel_kernel)
+            self.assertTrue(any("in-process compilation" in msg for msg in logs.output))
+            # An unrelated missing module must propagate unchanged.
+            unrelated = f"import {module_name}x as __inductor_constexpr_module_0\n"
+            future = AsyncCompile().triton("probe_kernel", unrelated)
+            with self.assertRaisesRegex(
+                ModuleNotFoundError, f"No module named '{module_name}'"
+            ):
+                future.result()
+
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
     def test_unspellable_enum_constexpr_errors_clearly(self):
         import triton
         import triton.language as tl

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -9,6 +9,7 @@ import multiprocessing
 import os
 import re
 import sys
+import threading
 from concurrent.futures import (
     Future,
     ThreadPoolExecutor,
@@ -84,6 +85,64 @@ _triton_kernel_metrics: dict[str, dict[str, Any]] | None = None
 size_hints_regex = re.compile(
     r"size_hints=(\{.*?\})",
 )
+
+# Matches the module imports that user-defined-Triton constexpr rendering
+# (torch/_inductor/codegen/wrapper.py, _constexpr_module_ref) emits into
+# generated kernel source.
+_constexpr_module_import_re = re.compile(
+    r"^import ([\w.]+) as __inductor_constexpr_module_\d+$", re.MULTILINE
+)
+# Matches the root-name imports emitted for object-valued constexpr parameter
+# defaults (define_user_defined_triton_kernel), e.g. `from m import Cfg as Cfg`.
+_constexpr_root_import_re = re.compile(
+    r"^from ([\w.]+) import (\w+) as \2$", re.MULTILINE
+)
+_worker_missing_module_re = re.compile(r"No module named '([^']+)'")
+_CONSTEXPR_LIBRARY_ROOTS = frozenset(OrderedSet(["torch", "triton"]))
+
+
+def _constexpr_module_missing_in_worker(
+    source_code: str, error: str | ModuleNotFoundError
+) -> str | None:
+    """Return the constexpr-referenced module a compile worker failed to import.
+
+    Codegen validates these imports in the parent process, but workers snapshot
+    sys.path/PYTHONPATH when the pool spawns, so a module made importable
+    afterwards (e.g. via sys.path.append) can raise ModuleNotFoundError only in
+    the worker. Takes either the subprocess pool's formatted traceback string or
+    the ModuleNotFoundError a spawn/fork pool re-raises directly. Returns None
+    if the failure is anything else.
+    """
+    if isinstance(error, ModuleNotFoundError):
+        candidates = [error.name] if error.name else []
+    else:
+        if "ModuleNotFoundError" not in error:
+            return None
+        candidates = _worker_missing_module_re.findall(error)
+    if not candidates:
+        return None
+    modules = _constexpr_module_import_re.findall(source_code)
+    modules += [module for module, _ in _constexpr_root_import_re.findall(source_code)]
+    # A formatted traceback can chain an unrelated secondary import failure
+    # after the constexpr one, so match any reported missing module against the
+    # constexpr imports rather than committing to whichever propagated last.
+    # The missing name may be an ancestor of the constexpr module (importing
+    # foo.bar fails at foo) or a descendant (foo/__init__.py imports
+    # foo.helpers, which is what the worker lacks). Descendant matching is
+    # skipped for the library roots constexprs themselves import (torch for
+    # dtypes, triton.language for tl dtypes and transitive-closure helpers):
+    # those are always importable in a worker, so a missing submodule under
+    # them is a genuine error, not a stale worker search path.
+    for name in candidates:
+        for module in modules:
+            library_root = module.split(".", 1)[0] in _CONSTEXPR_LIBRARY_ROOTS
+            if (
+                module == name
+                or module.startswith(name + ".")
+                or (not library_root and name.startswith(module + "."))
+            ):
+                return module
+    return None
 
 
 def _pycodecache_kernel_compile_env() -> dict[str, str | None]:
@@ -542,11 +601,52 @@ class AsyncCompile:
                 extra_config,
             )
 
+            # LambdaFuture.result() does not memoize, and task.result()
+            # re-raises the same worker exception on every call; cache the
+            # fallback kernel so re-entry neither recompiles nor re-warns. The
+            # future is shared process-wide through CompiledTritonKernels, so
+            # the memo is guarded against concurrent resolvers.
+            fallback_kernel: CachingAutotuner | None = None
+            fallback_lock = threading.Lock()
+
             def get_result() -> CachingAutotuner:
+                with fallback_lock:
+                    return _get_result()
+
+            def _get_result() -> CachingAutotuner:
+                nonlocal fallback_kernel
+                if fallback_kernel is not None:
+                    return fallback_kernel
                 try:
                     kernel, elapsed_us = task.result()
-                except SubprocException as e:
-                    raise e.with_name(kernel_name) from e
+                except (SubprocException, ModuleNotFoundError) as e:
+                    # The subprocess pool wraps worker failures in
+                    # SubprocException; spawn/fork pools re-raise the worker's
+                    # ModuleNotFoundError directly.
+                    error = e.details if isinstance(e, SubprocException) else e
+                    module = _constexpr_module_missing_in_worker(source_code, error)
+                    if module is None:
+                        if isinstance(e, SubprocException):
+                            raise e.with_name(kernel_name) from e
+                        raise
+                    # The parent validated this import at codegen time, so only
+                    # the worker's stale module search path is at fault; compile
+                    # in-process instead of failing the whole compile.
+                    log.warning(
+                        "Compile worker could not import module %r referenced by "
+                        "a constexpr of Triton kernel %s; workers snapshot "
+                        "PYTHONPATH when the pool spawns. Falling back to "
+                        "in-process compilation. Make the module importable at "
+                        "worker startup (installed or on PYTHONPATH before "
+                        "compile) to keep parallel compile.",
+                        module,
+                        kernel_name,
+                    )
+                    CompiledTritonKernels.remove_future(source_code)
+                    fallback_kernel = self._compile_triton_in_process(
+                        kernel_name, source_code, load_kernel, compile_id, is_backward
+                    )
+                    return fallback_kernel
 
                 # Now that we've compiled, we should clear the future
                 # so it can't be used again
@@ -567,32 +667,44 @@ class AsyncCompile:
             CompiledTritonKernels.save(source_code, future)
             return future
         else:
-            with dynamo_timed(
-                "async_compile.precompile",
-                log_pt2_compile_event=True,
-                dynamo_compile_column_us="triton_compile_time_us",
-                log_waitcounter=True,
-                waitcounter_name_override="compile_triton",
-            ):
-                fail = None
-                try:
-                    start_ns = time_ns()
-                    _set_triton_ptxas_path()
-                    _set_triton_libdevice_path()
-                    kernel = load_kernel()
-                    kernel.set_compile_info(compile_id, is_backward)
-                    kernel.precompile(
-                        warm_cache_only=False,
-                        static_triton_bundle_key=CompiledTritonKernels.key(source_code),
-                    )
-                    elapsed_us = (time_ns() - start_ns) // 1000
-                    _emit_triton_kernel_compile_metric(kernel, kernel_name, elapsed_us)
-                    return kernel
-                except Exception as e:
-                    fail = str(e)
-                    raise
-                finally:
-                    log_triton_builds(fail=fail)
+            return self._compile_triton_in_process(
+                kernel_name, source_code, load_kernel, compile_id, is_backward
+            )
+
+    @staticmethod
+    def _compile_triton_in_process(
+        kernel_name: str,
+        source_code: str,
+        load_kernel: Callable[[], CachingAutotuner],
+        compile_id,
+        is_backward: bool,
+    ) -> CachingAutotuner:
+        with dynamo_timed(
+            "async_compile.precompile",
+            log_pt2_compile_event=True,
+            dynamo_compile_column_us="triton_compile_time_us",
+            log_waitcounter=True,
+            waitcounter_name_override="compile_triton",
+        ):
+            fail = None
+            try:
+                start_ns = time_ns()
+                _set_triton_ptxas_path()
+                _set_triton_libdevice_path()
+                kernel = load_kernel()
+                kernel.set_compile_info(compile_id, is_backward)
+                kernel.precompile(
+                    warm_cache_only=False,
+                    static_triton_bundle_key=CompiledTritonKernels.key(source_code),
+                )
+                elapsed_us = (time_ns() - start_ns) // 1000
+                _emit_triton_kernel_compile_metric(kernel, kernel_name, elapsed_us)
+                return kernel
+            except Exception as e:
+                fail = str(e)
+                raise
+            finally:
+                log_triton_builds(fail=fail)
 
     def multi_kernel(self, *args, **kwargs) -> Any:
         from torch._inductor.codegen.multi_kernel import MultiKernelCall

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -5638,9 +5638,10 @@ class LambdaFuture(CodeCacheFuture):
         if timeout is not None and self.future is not None:
             # Wait on the underlying cross-process future with the caller's
             # timeout; raises concurrent.futures.TimeoutError if it does not
-            # resolve in time. result_fn will then consume the completed
-            # future without blocking further.
-            self.future.result(timeout=timeout)
+            # resolve in time. Only wait: a worker failure is left for
+            # result_fn, which consumes the completed future and owns the
+            # error handling (it may fall back to an in-process compile).
+            self.future.exception(timeout=timeout)
         return self.result_fn()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195288
* #195885
* #195884
* #195689
* #195688
* #195883
* __->__ #195882
* #195687
* #195686
* #195287
* #195286

The previous commit renders a user-defined Triton kernel's constexpr values as
importable source, so the generated kernel module imports the constexpr's
defining module. Compile workers snapshot sys.path when the pool spawns, so a
module the parent imports fine (codegen validated it) can raise
ModuleNotFoundError in the worker, which failed the whole compile.

The worker's failure is attributed to a constexpr import when the missing
module is that import, an ancestor of it, or (for user modules only) a
descendant of it; torch and triton roots are excluded from descendant matching
since a missing submodule under them is a real error. On such a failure the
kernel is compiled in-process instead, with a warning naming the module and how
to keep parallel compile (make it importable at worker startup). The fallback
result is memoized: LambdaFuture.result() re-runs its result_fn on every call
and the worker future re-raises the same exception, so each re-entry would
otherwise warn and recompile again. LambdaFuture.result(timeout) waits on the
worker future with Future.exception(timeout) rather than result(), so a worker
failure is left to result_fn and the fallback also runs when
compile_worker_wait_timeout is set. The subprocess pool wraps worker failures
in SubprocException while spawn/fork pools re-raise ModuleNotFoundError
directly; both forms are recognized.

Test Plan:

```
python test/inductor/test_codegen_triton.py -k constexpr_module_missing -k constexpr_fallback
```

The end-to-end worker test needs a GPU and Triton; the attribution, memoization
and timeout tests run with a mocked worker future.

Authored with an AI assistant.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo