### PR TITLE
[compiled_autograd] Specialize the compiled-autograd backward on undefined tangent masks

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -11121,6 +11121,160 @@ def forward(self, primals_1, tangents_1):
         actual = self._run_with_compiled_autograd(run)
         self.assertEqual(actual, expected)
 
+    @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=True)
+    def test_backward_epilogue_compiled_autograd_unused_output(self):
+        @torch.compile(backend="aot_eager")
+        def f(x, y):
+            return x.sin(), y.sin()
+
+        x_base = torch.randn(4)
+        y_base = torch.randn(4)
+
+        def run(x_base, y_base):
+            x = x_base.detach().clone().requires_grad_()
+            y = y_base.detach().clone().requires_grad_()
+            out0, out1 = f(x, y)
+            out0.sum().backward()
+            self.assertIsNone(y.grad)
+            return x.grad, y.grad
+
+        expected = run(x_base, y_base)
+        torch._dynamo.reset()
+        actual = self._run_with_compiled_autograd(lambda: run(x_base, y_base))
+        self.assertEqual(actual, expected)
+
+    @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=True)
+    def test_compiled_autograd_custom_backward_observes_none_tangent(self):
+        class Fn(torch.autograd.Function):
+            @staticmethod
+            def forward(x, y):
+                return x * 2, y * 3
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                ctx.set_materialize_grads(False)
+                ctx.save_for_backward(*inputs)
+
+            @staticmethod
+            def backward(ctx, grad_x, grad_y):
+                x, y = ctx.saved_tensors
+                if grad_y is None:
+                    return grad_x * x, x * 7
+                return grad_x * x, grad_y * y
+
+        @torch._dynamo.allow_in_graph
+        def opaque(x, y):
+            return Fn.apply(x, y)
+
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def compiled(x, y):
+            return opaque(x, y)
+
+        x_base = torch.randn(4)
+        y_base = torch.randn(4)
+
+        def run():
+            x = x_base.detach().clone().requires_grad_()
+            y = y_base.detach().clone().requires_grad_()
+            compiled(x, y)[0].sum().backward()
+            return x.grad, y.grad
+
+        expected = (x_base, x_base * 7)
+        actual = self._run_with_compiled_autograd(run)
+        self.assertEqual(actual, expected)
+
+    @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=True)
+    def test_compiled_autograd_unused_mutated_input_output(self):
+        @torch.compile(backend="aot_eager")
+        def f(x, y):
+            x.mul_(2)
+            return y.sin(), x.cos()
+
+        def run():
+            x_leaf = torch.randn(4, requires_grad=True)
+            x = x_leaf + 0
+            y = torch.randn(4, requires_grad=True)
+            f(x, y)[0].sum().backward()
+            self.assertEqual(x_leaf.grad, torch.zeros_like(x_leaf))
+            self.assertIsNotNone(y.grad)
+
+        run()
+        torch._dynamo.reset()
+        self._run_with_compiled_autograd(run)
+
+    @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=True)
+    def test_compiled_autograd_runtime_grad_output_prototypes(self):
+        @torch.compile(backend="aot_eager", dynamic=True)
+        def f(x):
+            # repeat_backward contains an unsupported zero-propagation sum, so
+            # the missing second tangent must be materialized at runtime.
+            return x.sin(), x.repeat(2, 1)
+
+        def run(size):
+            x = torch.randn(size, requires_grad=True)
+            expected = x.cos().detach()
+            out, _ = f(x)
+            lazy_info = out.grad_fn._forward_cls._lazy_backward_info
+            lazy_info.autograd_trace_info = None
+            out.sum().backward()
+            self.assertEqual(x.grad, expected)
+
+        compiled_autograd_graphs = []
+
+        def compiler_fn(gm):
+            compiled_autograd_graphs.append(gm)
+            return torch.compile(gm, backend="aot_eager", fullgraph=True, dynamic=True)
+
+        self._run_with_compiled_autograd(
+            lambda: (run(4), run(7)), compiler_fn=compiler_fn
+        )
+        self.assertEqual(len(compiled_autograd_graphs), 1)
+        self.assertIn(
+            torch.ops.aten.sum.dim_IntList,
+            [node.target for node in compiled_autograd_graphs[0].graph.nodes],
+        )
+
+    @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=True)
+    def test_compiled_autograd_unresolved_none_tangent_diagnostic(self):
+        import torch._dynamo.compiled_autograd as compiled_autograd_impl
+        import torch._functorch._aot_autograd.graph_compile as graph_compile
+        import torch._functorch._aot_autograd.runtime_wrappers as runtime_wrappers
+        from torch._dynamo import compiled_autograd
+
+        def fn(x):
+            y = torch.sin(x)
+            return y[0:4], y[4:8], y.detach(), x * 3
+
+        torch._dynamo.reset()
+        x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        with (
+            patch.object(
+                runtime_wrappers, "_dealias_marked_returns", lambda raw, marked: None
+            ),
+            patch.object(
+                graph_compile,
+                "_retrace_backward_for_undefined_grad_outputs",
+                lambda *args, **kwargs: None,
+            ),
+            patch.object(
+                compiled_autograd_impl,
+                "_specialize_bw_module_for_undefined_grad_outputs",
+                lambda *args, **kwargs: None,
+            ),
+            patch.object(
+                runtime_wrappers, "_grad_output_prototype", lambda *args, **kwargs: None
+            ),
+        ):
+            outputs = torch.compile(fn, backend="aot_eager")(x)
+            with (
+                compiled_autograd._enable(lambda gm: gm),
+                torch.autograd.set_multithreading_enabled(False),
+                self.assertRaisesRegex(
+                    RuntimeError, "handed a non-Tensor for a tangent it requires"
+                ),
+            ):
+                outputs[3].sum().backward()
+
     def test_backward_epilogue_compiled_autograd_subclass(self):
         from torch.testing._internal.two_tensor import TwoTensor
 
@@ -11142,6 +11296,41 @@ def forward(self, primals_1, tangents_1):
         actual = self._run_with_compiled_autograd(run)
         self.assertEqual(actual[0], expected[0])
         self.assertEqual(actual[1], expected[1])
+
+    @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=True)
+    def test_backward_epilogue_compiled_autograd_subclass_fallback(self):
+        @torch.compile(backend="aot_eager", dynamic=True)
+        def f(x, y):
+            # Dynamic shapes add SymInt arguments between the subclass tensor
+            # leaves that the backward epilogue must group together.
+            return x.sin(), y.repeat(2, 1)
+
+        def run(size):
+            x = TwoTensor(torch.randn(size), torch.randn(size)).requires_grad_()
+            y = TwoTensor(torch.randn(size), torch.randn(size)).requires_grad_()
+            f(x, y)[0].sum().backward()
+            self.assertIsInstance(x.grad, TwoTensor)
+            self.assertEqual(x.grad.a, x.a.cos())
+            self.assertEqual(x.grad.b, x.b.cos())
+            # Masking to None requires the output to be PROVABLY zero; across
+            # the subclass boundary the walker cannot prove it, so the
+            # conservative fallback materializes a zero grad instead. Either
+            # outcome is numerically correct for the unused output.
+            if y.grad is not None:
+                self.assertIsInstance(y.grad, TwoTensor)
+                self.assertEqual(y.grad.a, torch.zeros(size))
+                self.assertEqual(y.grad.b, torch.zeros(size))
+
+        compiled_autograd_graphs = []
+
+        def compiler_fn(gm):
+            compiled_autograd_graphs.append(gm)
+            return torch.compile(gm, backend="aot_eager", fullgraph=True, dynamic=True)
+
+        self._run_with_compiled_autograd(
+            lambda: (run(4), run(7)), compiler_fn=compiler_fn
+        )
+        self.assertEqual(len(compiled_autograd_graphs), 1)
 
     # --- AOTSyntheticBaseWrapper codegen tests ---
 

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -4491,6 +4491,82 @@ class CompiledAutograd1(torch.nn.Module):
         finally:
             dist.destroy_process_group()
 
+    @unittest.skipIf(
+        not HAS_DTENSOR,
+        "DTensor/FakePG requires distributed build",
+    )
+    @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=True)
+    def test_dtensor_unused_output_fallback(self):
+        # The sharding-prop cache is keyed by mesh equality, so an earlier test's
+        # hash-equal DeviceMesh (from a destroyed process group) would leak into
+        # this test's output specs and corrupt the traced joint graph.
+        from torch.distributed.tensor.debug import _clear_sharding_prop_cache
+
+        _clear_sharding_prop_cache()
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+        try:
+            mesh = DeviceMesh("cpu", torch.arange(2))
+
+            @torch.compile(backend="aot_eager", fullgraph=True)
+            def fn(x, y):
+                return x.sin(), y.std()
+
+            def run():
+                x = DTensor.from_local(
+                    torch.randn(4), mesh, [Shard(0)], run_check=False
+                ).requires_grad_()
+                y = DTensor.from_local(
+                    torch.randn(4), mesh, [Shard(0)], run_check=False
+                ).requires_grad_()
+                fn(x, y)[0].sum().backward()
+                self.assertIsInstance(x.grad, DTensor)
+                # Masking to None requires the output to be PROVABLY zero;
+                # across the subclass boundary the walker cannot prove it, so
+                # the conservative fallback always materializes a zero grad.
+                self.assertIsInstance(y.grad, DTensor)
+                self.assertEqual(y.grad.full_tensor(), torch.zeros(8))
+
+            run()
+            torch._dynamo.reset()
+            with compiled_autograd._enable(make_compiler_fn(backend="aot_eager")):
+                run()
+        finally:
+            dist.destroy_process_group()
+
+    def test_prune_unused_outputs_default_off(self):
+        # aot_autograd_prune_unused_outputs is opt-in: under the default
+        # config, a partial backward over a multi-output compiled function
+        # must not invoke the undefined-grad specialization machinery, and
+        # set_materialize_grads stays at its default, so the unused output's
+        # tangent is materialized as zeros and its input sees a zero grad.
+        from torch._functorch._aot_autograd import graph_compile
+
+        def fn(x, y):
+            return x.sin(), y.cos()
+
+        compiled = torch.compile(fn, backend="aot_eager", fullgraph=True)
+
+        def run():
+            x = torch.randn(4, requires_grad=True)
+            y = torch.randn(4, requires_grad=True)
+            compiled(x, y)[0].sum().backward()
+            ex = x.detach().clone().requires_grad_()
+            ey = y.detach().clone().requires_grad_()
+            fn(ex, ey)[0].sum().backward()
+            self.assertEqual(x.grad, ex.grad)
+            self.assertIsNone(ey.grad)
+            self.assertEqual(y.grad, torch.zeros_like(y))
+
+        with mock.patch.object(
+            graph_compile,
+            "_retrace_backward_for_undefined_grad_outputs",
+            side_effect=AssertionError("specialization machinery must stay opt-in"),
+        ):
+            run()
+            with compiled_autograd._enable(make_compiler_fn(backend="aot_eager")):
+                run()
+
     def test_anomaly_mode_already_nan(self):
         def fn():
             with torch.autograd.detect_anomaly():

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -41,10 +41,22 @@ from torch._dynamo.utils import (
     set_locals_to_steal,
 )
 from torch._functorch._aot_autograd.runtime_wrappers import (
+    _bitmask_to_indices,
+    _pruned_backward_output_indices_for_undefined_grad_outputs,
+    _specializable_user_grad_output_mask,
+    _specialize_bw_module_for_undefined_grad_outputs,
+    _tracing_context_compile_lock,
     AutogradLazyBackwardCompileInfo,
     CachedAutogradLazyBackwardCompileInfo,
 )
-from torch._guards import compile_context, CompileContext, CompileId, Source
+from torch._guards import (
+    compile_context,
+    CompileContext,
+    CompileId,
+    Source,
+    tracing,
+    TracingContext,
+)
 from torch._logging import getArtifactLogger, trace_structured
 from torch._prims_common import clone_preserve_strides
 from torch._subclasses import FakeTensorMode
@@ -68,7 +80,11 @@ from torch.utils._traceback import CapturedTraceback
 
 
 if TYPE_CHECKING:
-    from torch._functorch._aot_autograd.schemas import SubclassMeta, ViewAndMutationMeta
+    from torch._functorch._aot_autograd.schemas import (
+        AOTConfig,
+        SubclassMeta,
+        ViewAndMutationMeta,
+    )
     from torch.fx.proxy import Proxy
 
 
@@ -121,6 +137,7 @@ class _AOTCompiledFunction(Protocol):
     metadata: "ViewAndMutationMeta"
     maybe_subclass_metadata: "SubclassMeta | None"
     _aot_id: int
+    _aot_config: "AOTConfig"
     _bw_prologue_fn: Callable[..., Any]
     _bw_epilogue_fn: Callable[..., Any]
 
@@ -495,6 +512,7 @@ class AutogradCompilerInstance:
 
     def proxy_call_aot_backward(
         self,
+        inputs: Sequence[Any],
         pinputs: Sequence[Any],
         psaved_tensors: Sequence[torch.Tensor],
         saved_tensors: Sequence[torch.Tensor],
@@ -526,13 +544,104 @@ class AutogradCompilerInstance:
 
         # NOTE: we should only close over constants
         CompiledFunction: _AOTCompiledFunction = ctx._forward_cls  # type: ignore[attr-defined]
+        lazy_backward_info = CompiledFunction._lazy_backward_info
         bw_module = extract_bw_module(CompiledFunction)
         metadata = CompiledFunction.metadata
         maybe_subclass_metadata = CompiledFunction.maybe_subclass_metadata
         aot_id = CompiledFunction._aot_id
+        aot_config = CompiledFunction._aot_config
         bw_prologue_fn = CompiledFunction._bw_prologue_fn
         bw_epilogue_fn = CompiledFunction._bw_epilogue_fn
         del CompiledFunction
+        # Undefined-tangent backward specialization is opt-in: the specialization
+        # key is derived from which grads arrive undefined at runtime and the
+        # backward topology, neither of which depends on the flag, so gate the
+        # whole path here to keep the default compiled-autograd graph unchanged.
+        specialization_key = 0
+        specialization_indices: tuple[int, ...] = ()
+        pruned_output_indices: tuple[int, ...] = ()
+        ca_specialized_bw_module = None
+        ca_kept_arg_indices = None
+        skip_materialize_grad_output_indices: tuple[int, ...] = ()
+        exact_specialization = False
+        if aot_config.prune_unused_outputs:
+            undefined_grad_out_indices = tuple(
+                i for i, grad in enumerate(inputs) if grad is None
+            )
+            specialization_key = _specializable_user_grad_output_mask(
+                metadata, undefined_grad_out_indices
+            )
+            specialization_indices = _bitmask_to_indices(specialization_key)
+            pruned_output_indices = (
+                _pruned_backward_output_indices_for_undefined_grad_outputs(
+                    cast(GraphModule, bw_module),
+                    metadata,
+                    specialization_indices,
+                )
+            )
+        if specialization_key:
+            bw_placeholders = bw_module.graph.find_nodes(op="placeholder")  # type: ignore[attr-defined]
+            ca_specialized = None
+            if (
+                isinstance(lazy_backward_info, AutogradLazyBackwardCompileInfo)
+                and lazy_backward_info.autograd_trace_info is not None
+            ):
+                from torch._functorch._aot_autograd.graph_compile import (
+                    _retrace_backward_for_undefined_grad_outputs,
+                    retrace_backward_handling_errors,
+                )
+
+                retrace_decline_reasons: list[str] = []
+
+                def _retrace() -> Any:
+                    # Same per-context lock as the runtime path: the retrace
+                    # re-runs the joint trace under the shared TracingContext's
+                    # fake mode, which is not safe to use from two threads.
+                    saved_context = lazy_backward_info.saved_context
+                    retrace_lock = (
+                        _tracing_context_compile_lock(saved_context)
+                        if isinstance(saved_context, TracingContext)
+                        else contextlib.nullcontext()
+                    )
+                    with (
+                        retrace_lock,
+                        _disable(),
+                        tracing(lazy_backward_info.saved_context),
+                        compile_context(lazy_backward_info.saved_compile_context),
+                    ):
+                        return _retrace_backward_for_undefined_grad_outputs(
+                            lazy_backward_info.autograd_trace_info,
+                            aot_config,
+                            specialization_indices,
+                            cast(GraphModule, bw_module),
+                            list(range(len(bw_placeholders))),
+                            decline_reason=retrace_decline_reasons,
+                        )
+
+                ca_specialized = retrace_backward_handling_errors(
+                    _retrace, retrace_decline_reasons, specialization_indices
+                )
+                exact_specialization = ca_specialized is not None
+                if ca_specialized is None and retrace_decline_reasons:
+                    verbose_log.debug(
+                        "compiled autograd backward retrace for undefined grad "
+                        "outputs %s declined (%s); using structural specialization",
+                        tuple(specialization_indices),
+                        "; ".join(retrace_decline_reasons),
+                    )
+            if ca_specialized is None:
+                ca_specialized = _specialize_bw_module_for_undefined_grad_outputs(
+                    cast(GraphModule, bw_module),
+                    list(range(len(bw_placeholders))),
+                    metadata,
+                    specialization_indices,
+                    list(range(len(bw_placeholders))),
+                )
+            if ca_specialized is not None:
+                ca_specialized_bw_module, _, ca_kept_arg_indices = ca_specialized
+                skip_materialize_grad_output_indices = specialization_indices
+                if exact_specialization:
+                    pruned_output_indices = ()
 
         if torch.is_grad_enabled():
             for output_alias_info in metadata.output_info:
@@ -541,18 +650,41 @@ class AutogradCompilerInstance:
                         "torch.compile does not currently support higher order gradients."
                     )
 
+        # The prototype schema contains only static topology and tensor
+        # properties.  All per-invocation tensors and sizes live in the runtime
+        # objects tuple, which must be read through an explicit FX getattr node.
+        # Passing the context itself to an allow_in_graph target would require
+        # Dynamo to proxy AutogradFunctionContextVariable.
+        grad_output_prototypes = ctx._aot_grad_output_prototypes  # type: ignore[attr-defined]
+        # With the feature off nothing consumes the prototypes, and the default
+        # compiled-autograd graph must stay byte-for-byte unchanged, so the
+        # getattr node is only emitted when pruning is on.
+        pgrad_output_prototype_objects = None
+        if aot_config.prune_unused_outputs:
+            pgrad_output_prototype_objects = self.fx_tracer.create_proxy(
+                kind="call_function",
+                target=getattr,
+                args=(pctx, "_aot_grad_output_prototype_objects"),
+                kwargs={},
+            )
+
         @torch._dynamo.allow_in_graph  # type: ignore[misc]
         def call_aot_bwd_prologue(
             ctx_saved_tensors: Sequence[torch.Tensor],
             ctx_symints: Sequence[IntLikeType],
             ctx_opaque_objs: Sequence[Any],
             flat_args: Sequence[Any],
+            grad_output_prototype_objects: Sequence[Any] = (),
         ) -> Any:
+            flat_args_list = list(flat_args)
             return bw_prologue_fn(
                 ctx_saved_tensors,
                 ctx_symints,
                 ctx_opaque_objs,
-                flat_args,
+                flat_args_list,
+                grad_output_prototypes,
+                grad_output_prototype_objects,
+                skip_materialize_grad_output_indices,
             )
 
         pgrads = self.fx_tracer.create_proxy(
@@ -564,6 +696,11 @@ class AutogradCompilerInstance:
                 psymints,
                 popaque_objects,
                 pinputs,
+                *(
+                    [pgrad_output_prototype_objects]
+                    if pgrad_output_prototype_objects is not None
+                    else []
+                ),
             ),
             kwargs={},
         )
@@ -573,7 +710,7 @@ class AutogradCompilerInstance:
             pbackward_state = self.hooks_proxy[maybe_backward_state_idx]  # type: ignore[index]
 
         # Copy-paste the AOT backward graph into the compiled autograd graph
-        def copy_paste_aot_backward_graph() -> list[torch.Tensor]:
+        def copy_paste_aot_backward_graph() -> list[torch.Tensor | None]:
             def num_inputs(graph: torch.fx.Graph) -> int:
                 num_args = 0
                 for node in graph.nodes:
@@ -586,9 +723,21 @@ class AutogradCompilerInstance:
 
             # set up the proxy inputs to bw_module
             # the calling convention is: [*symints, *args (primals and tangents), backward_state]
-            num_args = num_inputs(bw_module.graph)
-            pall_args = [
-                pgrads[i] for i in range(num_args - int(pbackward_state is not None))
+            # When undefined-tangent specialization applied, we copy the pruned
+            # backward module (fewer placeholders, kept args selected via
+            # ca_kept_arg_indices below) instead of the base one, so the CA graph
+            # inlines only the surviving backward computation. With the feature off,
+            # ca_specialized_bw_module is None and this is exactly the base module,
+            # leaving the default compiled-autograd graph unchanged.
+            bw_module_to_copy = (
+                ca_specialized_bw_module
+                if ca_specialized_bw_module is not None
+                else bw_module
+            )
+            original_num_args = num_inputs(bw_module.graph)  # type: ignore[attr-defined]
+            original_pall_args = [
+                pgrads[i]
+                for i in range(original_num_args - int(pbackward_state is not None))
             ]
             # replace the symints with our symints
             symints = ctx._get_compiled_autograd_symints()  # type: ignore[attr-defined]
@@ -597,17 +746,21 @@ class AutogradCompilerInstance:
                     f"symints length mismatch: {len(symints)} vs {len(ctx.symints)}"  # type: ignore[attr-defined]
                 )
             psymints = [self.to_proxy(e) for e in symints]
-            pall_args[: len(symints)] = psymints
+            original_pall_args[: len(symints)] = psymints
             # Add backward_state
             if pbackward_state is not None:
-                pall_args.append(pbackward_state)
+                original_pall_args.append(pbackward_state)
+            if ca_kept_arg_indices is not None:
+                pall_args = [original_pall_args[i] for i in ca_kept_arg_indices]
+            else:
+                pall_args = original_pall_args
 
             # run over all nodes of the aot_backward graph.
             # copy and paste them all into the compiled autograd graph.
             args_idx = 0
             # pyrefly: ignore [implicit-any]
             value_remap = {}
-            poutputs: list[torch.fx.Proxy] | None = None
+            poutputs: list[torch.fx.Proxy | None] | None = None
 
             # names of nodes must appear only once in the fx.Graph
             # dedup AOT backwards that appear multiple times
@@ -620,7 +773,7 @@ class AutogradCompilerInstance:
                 # make it both informative and unique
                 return f"aot{deduped_aot_id}_{node_name}"
 
-            for node in bw_module.graph.nodes:
+            for node in bw_module_to_copy.graph.nodes:  # type: ignore[attr-defined]
                 if node.op == "placeholder":
                     ph = pall_args[args_idx].node
                     ph.name = make_unique(node.name)
@@ -640,7 +793,9 @@ class AutogradCompilerInstance:
                 elif node.op == "get_attr":
                     name = node.target
                     qualname = self.fx_tracer.get_fresh_qualname(name)
-                    setattr(self.fx_tracer.root, qualname, getattr(bw_module, name))
+                    setattr(
+                        self.fx_tracer.root, qualname, getattr(bw_module_to_copy, name)
+                    )
                     result = self.fx_tracer.create_node("get_attr", qualname, (), {})
                     result.name = make_unique(node.name)
                     value_remap[node] = result
@@ -658,7 +813,9 @@ class AutogradCompilerInstance:
                 elif node.op == "call_module":
                     name = node.target
                     qualname = self.fx_tracer.get_fresh_qualname(name)
-                    setattr(self.fx_tracer.root, qualname, getattr(bw_module, name))
+                    setattr(
+                        self.fx_tracer.root, qualname, getattr(bw_module_to_copy, name)
+                    )
                     result = self.fx_tracer.graph.node_copy(
                         node, lambda n: value_remap[n]
                     )
@@ -669,6 +826,13 @@ class AutogradCompilerInstance:
 
             if poutputs is None:
                 raise AssertionError("No output node found in backward graph")
+
+            # Grad outputs the specialization proved statically zero are replaced
+            # by None in the CA graph so downstream accumulation skips them; empty
+            # when the feature is off, so the output list is untouched by default.
+            for idx in pruned_output_indices:
+                if idx < len(poutputs):
+                    poutputs[idx] = None
 
             # In general we don't know what the shapes of the outputs are, so allocate
             # some dummy sizes for them.
@@ -738,6 +902,7 @@ class AutogradCompilerInstance:
         if hasattr(ctx._forward_cls, "_aot_id"):  # type: ignore[attr-defined]
             # AOT backward
             proxies = self.proxy_call_aot_backward(
+                inputs,
                 pinputs,
                 psaved_tensors,
                 saved_tensors,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195288
* #195885
* __->__ #195884
* #195689
* #195688
* #195883
* #195882
* #195687
* #195686
* #195287
* #195286

Compiled autograd traces the AOTAutograd backward through its own graph, so the
undefined-tangent specialization the previous commit adds to the live runtime
has to be mirrored there: the compiled-autograd backward observes the mask of
defined tangents at runtime, retraces the AOTAutograd backward for that mask
through graph_compile.retrace_backward_handling_errors under the same
per-TracingContext lock the runtime path uses (it re-runs the joint trace under
the shared fake mode), and falls back to structural pruning or the zero-tangent
base backward under the same policy. The grad-output prototype getattr node is
emitted only when pruning is on, so the flag-off compiled-autograd graph is
byte-for-byte unchanged (the goldens assert this).

Test Plan:

```
python test/inductor/test_compiled_autograd.py -k TestCompiledAutograd
python test/functorch/test_aotdispatch.py -k compiled_autograd
python test/dynamo/test_backward_higher_order_ops.py
```

Authored with an AI assistant.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk