### PR TITLE
[aot_autograd] compile_to_python training support

### DIFF
--- a/test/functorch/test_compile_to_python.py
+++ b/test/functorch/test_compile_to_python.py
@@ -1,6 +1,8 @@
 # Owner(s): ["oncall: pt2"]
 import ast
+import os
 import unittest
+from unittest import mock
 
 import torch
 import torch._functorch.config as functorch_config
@@ -8,20 +10,25 @@ import torch.fx as fx
 import torch.utils._pytree as pytree
 from torch._functorch._aot_autograd.codegen import GeneratedSource
 from torch._functorch._aot_autograd.to_standalone_python import (
+    _compile_to_python_with_state,
     _compose_standalone_module,
+    _compose_training_module,
     _find_effectful_op,
     _known_helper_table,
     _module_level_names,
+    AOT_OBSERVED_UNDEFINED_TANGENT_MASKS,
 )
 from torch._functorch.aot_autograd import compile_to_python, load_from_python
 from torch._higher_order_ops.effects import _get_effect, hop_print
 from torch._inductor.utils import fresh_cache
+from torch.compiler._cache import CacheArtifactManager
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.utils import stateless
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    skipIfTorchDynamo,
     subtest,
     TestCase,
 )
@@ -202,6 +209,524 @@ class TestAOTCompileToPython(TestCase):
                 self.assertEqual(
                     load_from_python(src, cache)(_flat_inputs(m, x))[0], m(x)
                 )
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_graph_composes_forward_and_backward(self):
+        # grad_enabled with inputs that require grad makes AOTAutograd emit a
+        # JOINT forward+backward: two dense graphs, bridged by an autograd
+        # Function the composer emits (its forward/backward bodies are
+        # AOTAutograd's own codegen'd source). The served output must therefore
+        # carry grad_fn and its .backward() must run the compiled backward.
+        m = torch.nn.Linear(4, 3)
+        x = torch.randn(5, 4)
+        for p in m.parameters():
+            p.grad = None
+        m(x).sum().backward()
+        expected = {n: p.grad.detach().clone() for n, p in m.named_parameters()}
+
+        gm = _capture(m, x)
+        with torch.enable_grad():
+            src, cache = compile_to_python(gm, _flat_inputs(m, x), grad_enabled=True)
+        if cache is None:
+            raise AssertionError("expected forward and backward cache artifacts")
+        artifacts = CacheArtifactManager.deserialize(cache)
+        if artifacts is None:
+            raise AssertionError("expected a readable cache bundle")
+        self.assertGreaterEqual(len(artifacts.get("inductor", [])), 2)
+        # Both inductor modules and the backward wrappers are inlined as source.
+        self.assertIn("_inner_call_fw", src)
+        self.assertIn("_inner_call_bw", src)
+        self.assertIn("def _backward_prologue(", src)
+        self.assertIn("class _CompiledFunction(torch.autograd.Function):", src)
+        self.assertNotIn("pickle.loads", src)
+
+        out = _exec(src)(_flat_inputs(m, x))
+        out = out[0] if isinstance(out, (list, tuple)) else out
+        self.assertIsNotNone(out.grad_fn)
+        for p in m.parameters():
+            p.grad = None
+        out.sum().backward()
+        for name, param in m.named_parameters():
+            self.assertEqual(param.grad, expected[name])
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_preserves_undefined_output_tangents(self):
+        def flat_fn(flat):
+            return [flat[0].sin(), flat[1].sin()]
+
+        x = torch.randn(4, requires_grad=True)
+        y = torch.randn(4, requires_grad=True)
+        with torch.enable_grad():
+            gm = make_fx(flat_fn)([x, y])
+            src, _cache = compile_to_python(gm, [x, y], grad_enabled=True)
+
+        run_x = x.detach().clone().requires_grad_()
+        run_y = y.detach().clone().requires_grad_()
+        out = _exec(src)([run_x, run_y])
+        out[0].sum().backward()
+
+        self.assertEqual(run_x.grad, x.cos())
+        self.assertIsNone(run_y.grad)
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_passthrough_backward_runs_like_eager(self):
+        def flat_fn(flat):
+            return [flat[0] + 1]
+
+        x = torch.randn(4, requires_grad=True)
+        gm = make_fx(flat_fn)([x])
+        source, cache = compile_to_python(gm, [x], grad_enabled=True)
+        actual_x = x.detach().clone().requires_grad_()
+        actual = load_from_python(source, cache)([actual_x])[0]
+        actual.sum().backward()
+        self.assertEqual(actual_x.grad, torch.ones_like(actual_x))
+
+    def test_passthrough_source_renders_nonfinite_floats(self):
+        # repr(float("inf")) is "inf", which is not valid Python source; the
+        # passthrough renderer must spell nonfinite floats as float(...) calls.
+        import math
+
+        from torch._inductor.standalone_compile import _passthrough_source
+
+        gm = torch.fx.symbolic_trace(lambda x: (x, float("inf"), float("nan")))
+        source = _passthrough_source(gm)
+        namespace = {}
+        exec(source, namespace)
+        x = torch.randn(2)
+        out = namespace["call"]([x])
+        self.assertIs(out[0], x)
+        self.assertEqual(out[1], float("inf"))
+        self.assertTrue(math.isnan(out[2]))
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_serializes_observed_tangent_mask(self):
+        def flat_fn(flat):
+            return [flat[0].sin(), flat[1].sin()]
+
+        x = torch.randn(4, requires_grad=True)
+        y = torch.randn(4, requires_grad=True)
+        with mock.patch.object(
+            torch._inductor,
+            "compile_to_python",
+            wraps=torch._inductor.compile_to_python,
+        ) as inner_compile:
+            with torch.enable_grad():
+                gm = make_fx(flat_fn)([x, y])
+                capture_source, cache, state = _compile_to_python_with_state(
+                    gm, [x, y], grad_enabled=True
+                )
+            if state is None:
+                raise AssertionError("expected a training compile state")
+
+            capture_call = load_from_python(capture_source, cache)
+            state.install_capture(capture_call.__globals__)
+            capture_x = x.detach().clone().requires_grad_()
+            capture_y = y.detach().clone().requires_grad_()
+            capture_call([capture_x, capture_y])[0].sum().backward()
+        backward_flags = [
+            call.kwargs.get("is_backward", False)
+            for call in inner_compile.call_args_list
+        ]
+        self.assertGreaterEqual(len(backward_flags), 3)
+        self.assertFalse(backward_flags[0])
+        self.assertTrue(all(backward_flags[1:]))
+        masks = capture_call.__globals__[AOT_OBSERVED_UNDEFINED_TANGENT_MASKS]
+        self.assertEqual(masks, {0b10})
+        self.assertIn(0b10, state._observed_variants)
+
+        source, final_cache = state.finalize(tuple(masks))
+        # Mask 0 (a full backward) is always served alongside the observed
+        # mask; the capture-time default variant is gone after finalize.
+        self.assertIn("0: (_inner_call_bw_0", source)
+        self.assertIn("2: (_inner_call_bw_1", source)
+        self.assertIn("_AOT_DEFAULT_BACKWARD_VARIANT = None", source)
+        self.assertIn("KeptTangentInfo", source)
+        loaded = load_from_python(source, final_cache)
+        run_x = x.detach().clone().requires_grad_()
+        run_y = y.detach().clone().requires_grad_()
+        loaded([run_x, run_y])[0].sum().backward()
+        self.assertEqual(run_x.grad, x.cos())
+        self.assertIsNone(run_y.grad)
+
+        unseen_x = x.detach().clone().requires_grad_()
+        unseen_y = y.detach().clone().requires_grad_()
+        with self.assertRaisesRegex(
+            torch.compiler.PrecompileError, "not covered by example_inputs"
+        ):
+            loaded([unseen_x, unseen_y])[1].sum().backward()
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_nondifferentiable_output_uses_canonical_mask(self):
+        # A non-differentiable output's tangent is ALWAYS undefined, so the
+        # emitted backward must canonicalize its scanned mask over the
+        # specializable (surviving user-output) indices before the variant
+        # lookup AND before recording it -- like the live runtime path
+        # (_specializable_user_grad_output_mask). Keying on the raw mask makes
+        # the auto-covered mask 0 unreachable: every backward of a forward-only
+        # capture then raises PrecompileError.
+        def f(x):
+            return x.sin(), x.detach() + 1
+
+        holder = {}
+
+        def backend(gm, example_inputs):
+            holder["gm"] = gm
+            return gm.forward
+
+        # A Dynamo graph keeps the detach (a genuinely non-differentiable
+        # output); make_fx would trace it as aten.alias, which stays
+        # differentiable under AOTAutograd and never hits this case.
+        x = torch.randn(4, requires_grad=True)
+        torch.compile(f, backend=backend, fullgraph=True)(x)
+        gm = holder["gm"]
+        graph_inputs = [
+            node.meta["example_value"]
+            for node in gm.graph.nodes
+            if node.op == "placeholder"
+        ]
+        capture_source, cache, state = _compile_to_python_with_state(
+            gm, graph_inputs, grad_enabled=True
+        )
+        if state is None:
+            raise AssertionError("expected a training compile state")
+
+        # A backward run through the live capture call records the CANONICAL
+        # mask (0, not 0b10 for the always-undefined non-diff slot).
+        capture_call = load_from_python(capture_source, cache)
+        state.install_capture(capture_call.__globals__)
+        capture_x = x.detach().clone().requires_grad_()
+        capture_call([capture_x])[0].sum().backward()
+        masks = capture_call.__globals__[AOT_OBSERVED_UNDEFINED_TANGENT_MASKS]
+        self.assertEqual(masks, {0})
+
+        # A forward-only finalize (mask 0 only) must serve that same backward.
+        source, final_cache = state.finalize((0,))
+        loaded = load_from_python(source, final_cache)
+        run_x = x.detach().clone().requires_grad_()
+        out = loaded([run_x])
+        self.assertIsNone(out[1].grad_fn)
+        out[0].sum().backward()
+        self.assertEqual(run_x.grad, x.detach().cos())
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_default_variant_keeps_affine_custom_backward_grad(self):
+        # The default variant's fallback masks backward outputs to None when
+        # their tangent dependencies are all undefined -- but ONLY if the
+        # output is also provably zero. A custom Function backward that is not
+        # linear in its tangents (g1 + 1) produces a nonzero grad from an
+        # undefined tangent, which eager materializes zeros for; masking it by
+        # dependency alone silently drops the gradient.
+        class AddOne(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.sin(), x.cos()
+
+            @staticmethod
+            def backward(ctx, g0, g1):
+                return g1 + 1
+
+        def f(x):
+            return AddOne.apply(x)
+
+        holder = {}
+
+        def backend(gm, example_inputs):
+            holder["gm"] = gm
+            return gm.forward
+
+        # Dynamo preserves the custom backward as an autograd_function_apply
+        # HOP; make_fx would trace only the forward ops and lose it.
+        x = torch.randn(4, requires_grad=True)
+        torch.compile(f, backend=backend, fullgraph=True)(x)
+        gm = holder["gm"]
+        graph_inputs = [
+            node.meta["example_value"]
+            for node in gm.graph.nodes
+            if node.op == "placeholder"
+        ]
+        source, cache = compile_to_python(gm, graph_inputs, grad_enabled=True)
+        loaded = load_from_python(source, cache)
+        run_x = x.detach().clone().requires_grad_()
+        out = loaded([run_x])
+        out[0].sum().backward()
+        self.assertEqual(run_x.grad, torch.ones_like(run_x))
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_synthetic_base_and_undefined_tangent(self):
+        def flat_fn(flat):
+            first, alias, unused = flat
+            first.mul_(2)
+            return [first + alias, unused.sin()]
+
+        def make_inputs():
+            leaf = torch.arange(1.0, 5.0, requires_grad=True)
+            base = leaf + 0
+            unused = torch.randn(4, requires_grad=True)
+            return leaf, [base[:], base, unused]
+
+        _, example = make_inputs()
+        gm = make_fx(flat_fn)(example)
+        _, compile_inputs = make_inputs()
+        capture_source, cache, state = _compile_to_python_with_state(
+            gm, compile_inputs, grad_enabled=True
+        )
+        if state is None:
+            raise AssertionError("expected a training compile state")
+
+        capture_call = load_from_python(capture_source, cache)
+        state.install_capture(capture_call.__globals__)
+        _, capture_inputs = make_inputs()
+        capture_call(capture_inputs)[0].sum().backward()
+        masks = capture_call.__globals__[AOT_OBSERVED_UNDEFINED_TANGENT_MASKS]
+        # The recorded mask is CANONICAL (specializable user outputs only,
+        # matching the live runtime's _specializable_user_grad_output_mask):
+        # the undefined mutated-input tangent at bit 0 is not specializable
+        # (it is zero-materialized instead), so only output 1's bit remains.
+        self.assertEqual(masks, {0b100})
+
+        source, final_cache = state.finalize(tuple(masks))
+        self.assertIn("_synthetic_base_wrapper", source)
+        actual_leaf, actual_inputs = make_inputs()
+        expected_leaf, expected_inputs = make_inputs()
+        actual = load_from_python(source, final_cache)(actual_inputs)
+        expected = flat_fn(expected_inputs)
+        actual[0].sum().backward()
+        expected[0].sum().backward()
+
+        self.assertEqual(actual[0], expected[0])
+        self.assertEqual(actual_inputs[1], expected_inputs[1])
+        self.assertEqual(actual_leaf.grad, expected_leaf.grad)
+        self.assertIsNone(actual_inputs[2].grad)
+        self.assertIsNone(expected_inputs[2].grad)
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_dedup_mutated_duplicate_input(self):
+        def flat_fn(a, b, c, d):
+            d.mul_(2)
+            return [a.sin() + d.cos()]
+
+        def make_inputs(x, y):
+            x_leaf = x.detach().clone().requires_grad_()
+            y_leaf = y.detach().clone().requires_grad_()
+            x_input = x_leaf + 0
+            y_input = y_leaf + 0
+            return x_leaf, y_leaf, [x_input, x_input, y_input, y_input]
+
+        x = torch.randn(4)
+        y = torch.randn(4)
+        _, _, example = make_inputs(x, y)
+        gm = make_fx(flat_fn)(*example)
+        _, _, compile_inputs = make_inputs(x, y)
+        source, cache = compile_to_python(gm, compile_inputs, grad_enabled=True)
+        self.assertIn("deduped_args", source)
+        self.assertIn("_autograd_orchestration_entry", source)
+
+        actual_x, actual_y, actual_inputs = make_inputs(x, y)
+        actual = load_from_python(source, cache)(actual_inputs)[0]
+        actual.sum().backward()
+        expected_x, expected_y, expected_inputs = make_inputs(x, y)
+        expected = flat_fn(*expected_inputs)[0]
+        expected.sum().backward()
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_inputs[3], expected_inputs[3])
+        self.assertEqual(actual_x.grad, expected_x.grad)
+        self.assertEqual(actual_y.grad, expected_y.grad)
+
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_output_alias_regen(self):
+        def flat_fn(flat):
+            return [flat[0].view(-1)]
+
+        x = torch.randn(2, 3, requires_grad=True)
+        gm = make_fx(flat_fn)([x])
+        source, cache = compile_to_python(gm, [x], grad_enabled=True)
+        self.assertIn("gen_alias_from_base", source)
+
+        actual_x = x.detach().clone().requires_grad_()
+        actual = load_from_python(source, cache)([actual_x])[0]
+        self.assertEqual(
+            actual.untyped_storage().data_ptr(),
+            actual_x.untyped_storage().data_ptr(),
+        )
+        actual.sum().backward()
+        self.assertEqual(actual_x.grad, torch.ones_like(actual_x))
+
+    def _training_artifact(self):
+        def flat_fn(flat):
+            return [torch.nn.functional.linear(flat[0], flat[1], flat[2]).relu()]
+
+        lin = torch.nn.Linear(4, 3)
+        x = torch.randn(2, 4, requires_grad=True)
+        args = [x, lin.weight, lin.bias]
+        gm = make_fx(flat_fn)(args)
+        return compile_to_python(gm, args, grad_enabled=True)
+
+    def test_training_artifact_imports_only_stable_surface(self):
+        # The training composer and the metadata it bakes must reference
+        # AOTAutograd only through standalone_runtime, like the inference path.
+        import re
+
+        from torch.testing._internal.two_tensor import TwoTensor
+
+        surface = {"torch._functorch._aot_autograd.standalone_runtime"}
+        # Every private path an artifact could otherwise reach AOTAutograd
+        # internals through: the package itself, the FunctionalTensor raw_type
+        # and SymIntEqByExpr metadata baked into output metadata, and the
+        # BackwardState helper.
+        pattern = (
+            r"(?:from|import) (torch\.(?:_functorch|_subclasses|fx\.experimental)\S*)"
+        )
+        source, _cache = self._training_artifact()
+        self.assertEqual(set(re.findall(pattern, source)), surface)
+        # Subclass tangents route through the subclass prologue/epilogue
+        # helpers, which must come from the surface too.
+        tt = TwoTensor(torch.randn(4), torch.randn(4)).requires_grad_()
+        gm = make_fx(lambda flat: [flat[0].sin()])([tt])
+        subclass_source, _ = compile_to_python(gm, [tt], grad_enabled=True)
+        self.assertEqual(set(re.findall(pattern, subclass_source)), surface)
+        self.assertIn("_CompiledFunction", subclass_source)
+
+        # Input mutation and intermediate-base outputs bake their own descriptor
+        # classes into the training metadata (an alias-only function is demoted
+        # to the inference path and would not exercise the training composer).
+        def mutation_fn(flat):
+            x = flat[0]
+            x.mul_(2)
+            return [x.sin()]
+
+        def intermediate_base_fn(flat):
+            y = flat[0].sin()
+            return [y.view(-1), y[0]]
+
+        for fn in (mutation_fn, intermediate_base_fn):
+            x = torch.randn(2, 3, requires_grad=True).clone()
+            gm = make_fx(fn)([x])
+            source, _ = compile_to_python(gm, [x], grad_enabled=True)
+            self.assertIn("_CompiledFunction", source)
+            self.assertEqual(set(re.findall(pattern, source)), surface)
+
+    def test_training_artifact_loads_in_fresh_process(self):
+        # Self-containment is only real if the artifact runs where nothing but
+        # torch has been imported: load it, run forward and backward, in a
+        # subprocess.
+        import subprocess
+        import sys
+        import tempfile
+
+        source, cache = self._training_artifact()
+        self.assertIsNotNone(cache)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "artifact.py")
+            cache_path = os.path.join(tmp, "artifact.cache")
+            with open(path, "w") as f:
+                f.write(source)
+            with open(cache_path, "wb") as f:
+                f.write(cache)
+            # Load WITH the cache bundle so the fresh process also exercises
+            # cache deserialization, and check every gradient, not just x's.
+            script = (
+                "import sys, torch\n"
+                "from torch._functorch.aot_autograd import load_from_python\n"
+                f"call = load_from_python(open({path!r}).read(), open({cache_path!r}, 'rb').read())\n"
+                "torch.manual_seed(0)\n"
+                "x = torch.randn(2, 4, requires_grad=True)\n"
+                "w = torch.randn(3, 4, requires_grad=True)\n"
+                "b = torch.randn(3, requires_grad=True)\n"
+                "out = call([x, w, b])[0]\n"
+                "out.sum().backward()\n"
+                "refs = [t.detach().clone().requires_grad_() for t in (x, w, b)]\n"
+                "ref_out = torch.nn.functional.linear(*refs).relu()\n"
+                "ref_out.sum().backward()\n"
+                "torch.testing.assert_close(out, ref_out)\n"
+                "for t, ref in zip((x, w, b), refs):\n"
+                "    torch.testing.assert_close(t.grad, ref.grad)\n"
+                "print('OK')\n"
+            )
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("OK", result.stdout)
+
+    def test_namespace_module_names_non_ascii(self):
+        # ast column offsets are UTF-8 byte offsets; a non-ASCII character
+        # earlier on the line must not shift the rename.
+        from torch._functorch._aot_autograd.to_standalone_python import (
+            namespace_module_names,
+        )
+
+        source = 'def call(args):\n    return args\ns = "\u00e9" + str(call)\n'
+        (renamed,) = namespace_module_names([source])
+        compile(renamed, "<renamed>", "exec")
+        self.assertIn("str(call_s0)", renamed)
+
+    def test_cache_merge_skips_unreadable_bundle(self):
+        from torch.compiler._cache import CacheArtifactManager
+
+        _source, cache = self._training_artifact()
+        self.assertIsNotNone(cache)
+        with self.assertLogs("torch.compiler._cache", level="WARNING"):
+            self.assertIsNone(CacheArtifactManager.merge((b"not a bundle", None)))
+        with self.assertLogs("torch.compiler._cache", level="WARNING"):
+            merged = CacheArtifactManager.merge((cache, b"not a bundle"))
+        self.assertEqual(merged, CacheArtifactManager.merge((cache,)))
+
+    def test_training_forward_and_backward_do_not_share_names(self):
+        # The two inductor modules are spliced into ONE namespace and both define
+        # call / Runner / their kernels. A module resolves those as late-bound
+        # globals when INVOKED, so without per-module renaming the forward runs
+        # the backward's kernels -- which surfaces as an arity error, or worse.
+        m = torch.nn.Linear(4, 3)
+        x = torch.randn(5, 4)
+        gm = _capture(m, x)
+        with torch.enable_grad():
+            src, _cache = compile_to_python(gm, _flat_inputs(m, x), grad_enabled=True)
+        tree = ast.parse(src)
+        names = [
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.ClassDef))
+        ]
+        self.assertEqual(len(names), len(set(names)), f"duplicate top-level: {names}")
 
     def test_linear_addmm_runs_like_eager(self):
         m = torch.nn.Linear(4, 3).eval()
@@ -549,6 +1074,35 @@ class TestAOTCompileToPython(TestCase):
             eager = m(x)
         self.assertEqual(out, eager)
 
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "functionalize_rng_ops requires CUDA RNG state",
+    )
+    @skipIfTorchDynamo(
+        "under dynamo-wrapped testing the test body itself is compiled, so the"
+        " artifact's backward runs under compiled autograd, which deliberately"
+        " rejects _CompiledFunction's boxed_grads_call"
+    )
+    def test_training_functionalized_rng_runs_like_eager(self):
+        def flat_fn(flat):
+            return [torch.nn.functional.dropout(flat[0], p=0.5, training=True)]
+
+        x = torch.randn(64, requires_grad=True)
+        with functorch_config.patch(functionalize_rng_ops=True):
+            gm = make_fx(flat_fn, tracing_mode="real")([x])
+            src, cache = compile_to_python(gm, [x], grad_enabled=True)
+
+        actual_x = x.detach().clone().requires_grad_()
+        expected_x = x.detach().clone().requires_grad_()
+        torch.manual_seed(123)
+        actual = load_from_python(src, cache)([actual_x])[0]
+        actual.sum().backward()
+        torch.manual_seed(123)
+        expected = flat_fn([expected_x])[0]
+        expected.sum().backward()
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_x.grad, expected_x.grad)
+
     def test_helpers_imported_from_standalone_runtime_surface(self):
         # End-to-end lock for the stability contract: a graph closing over a runtime helper
         # (here gen_alias_from_base, via output-alias regen) must import it from the
@@ -602,6 +1156,73 @@ class TestAOTCompileToPython(TestCase):
         _assert_composed(self, src)
         with torch.no_grad():
             self.assertEqual(_exec(src)(_flat_inputs(m, x))[0], m(x))
+
+    def test_compile_to_python_ignores_warm_aot_autograd_cache(self):
+        import copy
+
+        from torch._dynamo.utils import counters
+        from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
+        from torch._inductor.codecache import FxGraphCache
+        from torch._inductor.compile_fx import compile_fx
+        from torch._inductor.standalone_compile import _standalone_context
+
+        x = torch.randn(8)
+        gm = make_fx(lambda flat: [flat[0].sin()])([x])
+        with (
+            fresh_cache(),
+            functorch_config.patch(
+                enable_autograd_cache=True,
+                enable_remote_autograd_cache=True,
+                bundled_autograd_cache=False,
+                bypass_autograd_cache_key=False,
+            ),
+            torch._inductor.config.patch(
+                fx_graph_cache=True, fx_graph_remote_cache=False
+            ),
+        ):
+            try:
+                AOTAutogradCache.clear()
+                FxGraphCache.clear()
+                counters.clear()
+                with (
+                    mock.patch.object(
+                        AOTAutogradCache, "get_remote_cache", return_value=None
+                    ),
+                    torch.no_grad(),
+                    _standalone_context(gm, "from_example_inputs", aot=False),
+                ):
+                    compile_fx(copy.deepcopy(gm), [x], ignore_shape_env=True)
+
+                self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+                with mock.patch.object(
+                    AOTAutogradCache,
+                    "try_load",
+                    wraps=AOTAutogradCache.try_load,
+                ) as try_load:
+                    src, cache = compile_to_python(gm, [x])
+                try_load.assert_not_called()
+                self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+                self.assertTrue(functorch_config.enable_autograd_cache)
+                self.assertTrue(functorch_config.enable_remote_autograd_cache)
+                self.assertEqual(load_from_python(src, cache)([x])[0], x.sin())
+            finally:
+                AOTAutogradCache.clear()
+                FxGraphCache.clear()
+
+    def test_inline_backward_graph_is_not_lowered_as_inference(self):
+        def loss(x, weight):
+            return torch.nn.functional.conv2d(x, weight).sum()
+
+        x = torch.randn(1, 2, 5, 5)
+        weight = torch.randn(3, 2, 3, 3)
+        gm = make_fx(torch.func.grad(loss, argnums=(0, 1)))(x, weight)
+        with mock.patch.object(
+            torch._inductor,
+            "compile_to_python",
+            wraps=torch._inductor.compile_to_python,
+        ) as lower:
+            compile_to_python(gm, [x, weight])
+        self.assertFalse(lower.call_args_list[0].kwargs["is_inference"])
 
     def test_concurrent_compile_to_python_smoke(self):
         # End-to-end concurrency smoke test: _COMPILE_LOCK serializes the entry point (the
@@ -697,18 +1318,28 @@ class TestComposerHelpers(TestCase):
     # _find_effectful_op scan. (Source-emission helper tests live in test_source_emit.py.)
 
     def test_known_helper_table_imports_are_stable_surface(self):
-        # Stability contract: every runtime helper the composer recognizes must emit an
-        # import via the stable standalone_runtime surface (or `import torch` for public
-        # torch paths), never a deep AOTAutograd-internal module. Lock the table so a new
-        # entry pointing at an unstable location is caught.
+        # Stability contract, both halves: the remaining helper-table rows use
+        # public torch paths, and every object standalone_runtime re-exports is
+        # emitted from that surface by identity (a wrapped or aliased re-export
+        # would silently route to the internal module instead).
+        import inspect
+
+        from torch._functorch._aot_autograd import standalone_runtime as rt
+        from torch._functorch._aot_autograd.source_emit import emit_value
+
         for import_stmt, _expr in _known_helper_table().values():
-            self.assertTrue(
-                import_stmt == "import torch"
-                or import_stmt.startswith(
-                    "from torch._functorch._aot_autograd.standalone_runtime import "
-                ),
-                f"helper import {import_stmt!r} bypasses the standalone_runtime surface",
-            )
+            self.assertEqual(import_stmt, "import torch")
+        surface_import = (
+            "from torch._functorch._aot_autograd.standalone_runtime import "
+        )
+        for name in rt.__all__:
+            obj = getattr(rt, name)
+            if not (isinstance(obj, type) or inspect.isfunction(obj)):
+                continue
+            imports = set()
+            expr = emit_value(obj, imports)
+            self.assertEqual(expr, name)
+            self.assertEqual(imports, {surface_import + name}, name)
 
     def test_module_level_names_excludes_deleted(self):
         # Inductor's inner module binds then dels a name (async_compile = AsyncCompile();
@@ -1029,6 +1660,16 @@ class TestAOTComposeGuards(TestCase):
             lambda: None,
             origin_id,
         )
+
+    def test_backward_state_training_graph_rejected(self):
+        # A BackwardState-carrying training graph must be rejected up front:
+        # composed into standalone source, its backward hooks would silently
+        # never fire and served gradients would be wrong.
+        import types as _types
+
+        spec = _types.SimpleNamespace(backward_state_indices=[0])
+        with self.assertRaisesRegex(NotImplementedError, "BackwardState"):
+            _compose_training_module("", [], [], spec, None, lambda: None)
 
     def test_backward_wrapper_rejected(self):
         # A backward wrapper is out of scope for forward lowering, so it is rejected up

--- a/test/inductor/test_compile_to_python.py
+++ b/test/inductor/test_compile_to_python.py
@@ -196,6 +196,23 @@ def call(args):
         with self.assertRaises(NoRunnableInductorModuleError):
             compile_to_python(gm, _flat_inputs(m, x))
 
+    def test_backward_flag_forwarded_to_compile_fx_inner(self):
+        from torch._inductor import compile_fx
+
+        m = _Pointwise().eval()
+        x = torch.randn(5, 4)
+        gm = _capture(m, x)
+        with mock.patch.object(
+            compile_fx, "compile_fx_inner", wraps=compile_fx.compile_fx_inner
+        ) as inner_compile:
+            compile_to_python(
+                gm,
+                _flat_inputs(m, x),
+                is_inference=False,
+                is_backward=True,
+            )
+        self.assertTrue(inner_compile.call_args.kwargs["is_backward"])
+
 
 @requires_cuda_and_triton
 class TestInductorCompileToPythonCudaCodegen(TestCase):
@@ -537,6 +554,22 @@ class TestInductorCompileToPythonContract(TestCase):
         self.assertIn("def call(", src2)
         with torch.no_grad():
             self.assertEqual(_exec(src2)(_flat_inputs(m, x))[0], m(x))
+
+
+class TestInductorCompileToPythonPassthrough(TestCase):
+    def test_passthrough_source_releases_args(self):
+        # The passthrough used for a trivial backward must honor inductor's
+        # boxed-call contract of consuming its argument list so saved tensors
+        # are released as early as a real kernel would release them.
+        from torch._inductor.standalone_compile import _passthrough_source
+
+        gm = torch.fx.symbolic_trace(lambda x: (x,))
+        namespace = {}
+        exec(_passthrough_source(gm), namespace)
+        args = [torch.randn(2)]
+        out = namespace["call"](args)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(args, [])
 
 
 if __name__ == "__main__":

--- a/torch/_functorch/_aot_autograd/source_emit.py
+++ b/torch/_functorch/_aot_autograd/source_emit.py
@@ -80,8 +80,31 @@ def _emit_importable(obj: Any, imports: set[str]) -> str:
             f"compile_to_python cannot reference {qualname} from {module}: it does "
             "not round-trip to the same object."
         )
+    # Anything AOTAutograd re-exports on its stable surface is referenced from
+    # there (by identity of the root object, so ``Cls.staticmethod`` routes
+    # through the re-exported ``Cls``), never by its internal module path.
+    root_name, _, attr_path = qualname.partition(".")
+    root = getattr(importlib.import_module(module), root_name, None)
+    exported = _standalone_runtime_exports().get(id(root))
+    if exported is not None:
+        imports.add(f"{_STANDALONE_RUNTIME_IMPORT} {exported}")
+        return f"{exported}.{attr_path}" if attr_path else exported
     imports.add(f"import {module}")
     return f"{module}.{qualname}"
+
+
+_STANDALONE_RUNTIME_IMPORT = (
+    "from torch._functorch._aot_autograd.standalone_runtime import"
+)
+
+
+def _standalone_runtime_exports() -> dict[int, str]:
+    # Lazy so that importing source_emit on its own does not pull in
+    # standalone_runtime's torch._dynamo import chain; nothing needs the table
+    # before an object is actually emitted.
+    from . import standalone_runtime as rt
+
+    return {id(getattr(rt, name)): name for name in rt.__all__}
 
 
 def _reject_shared_mutable(obj: Any, _seen: set[_ObjId]) -> None:

--- a/torch/_functorch/_aot_autograd/standalone_runtime.py
+++ b/torch/_functorch/_aot_autograd/standalone_runtime.py
@@ -15,29 +15,160 @@ stable, and update generated-artifact compatibility deliberately if it changes.
 # dynamo/aot chain to fully initialize before the ``from .runtime_wrappers``
 # import below so a bare ``import torch`` artifact stays self-contained.
 import torch._dynamo  # noqa: F401
-from torch._prims_common import CUDARngStateHelper
 
 # IDENTITY CONTRACT: these names MUST be plain re-exports that preserve the original
 # object identity -- never wrap, decorate, or alias them (e.g. functools.wraps, a thin
-# forwarding lambda, a partial). to_standalone_python._known_helper_table keys on
-# id() of these exact objects to recognize a global the codegen'd wrappers close over.
-# A wrapper would change id(), so the table lookup would silently miss and that global
-# would route to its internal AOTAutograd location instead of this stable surface.
-# The same contract covers ``CUDARngStateHelper`` (imported above for circular-import
-# ordering): the table keys on id() of its ``get_torch_state_as_tuple`` /
-# ``set_new_offset`` staticmethods, so it too must not be wrapped or aliased.
-from .functional_utils import gen_alias_from_base
+# forwarding lambda, a partial). source_emit._standalone_runtime_exports keys on id()
+# of these exact objects to recognize a global the codegen'd wrappers close over or a
+# type their baked metadata is rebuilt from (``CUDARngStateHelper`` included: its
+# staticmethods are routed through the class's identity). A wrapper would change
+# id(), so the lookup would silently miss and that object would be referenced by
+# its internal AOTAutograd location instead of this stable surface.
+from torch._prims_common import CUDARngStateHelper
+
+# Baked OutputAliasInfo.raw_type for every non-subclass output, and the
+# size/stride entries of every baked MetadataKey.
+from torch._subclasses.functional_tensor import FunctionalTensor
+from torch.fx.experimental.symbolic_shapes import SymIntEqByExpr
+
+# The whole closed set of descriptor classes: baked ViewAndMutationMeta carries
+# whichever ones the traced function produced (tangent descs wrap input-mutation
+# and intermediate-base outputs as readily as plain ones).
+from .descriptors import (
+    BackwardTokenAOTInput,
+    BackwardTokenAOTOutput,
+    BufferAOTInput,
+    DummyAOTInput,
+    DummyAOTOutput,
+    ForwardTokenAOTInput,
+    ForwardTokenAOTOutput,
+    GradAOTOutput,
+    InputMutationAOTOutput,
+    IntermediateBaseAOTOutput,
+    MetadataMutationAOTOutput,
+    ParamAOTInput,
+    PhiloxBackwardBaseOffsetAOTInput,
+    PhiloxBackwardSeedAOTInput,
+    PhiloxForwardBaseOffsetAOTInput,
+    PhiloxForwardSeedAOTInput,
+    PhiloxUpdatedBackwardOffsetAOTOutput,
+    PhiloxUpdatedForwardOffsetAOTOutput,
+    PlainAOTInput,
+    PlainAOTOutput,
+    SavedForBackwardsAOTOutput,
+    SavedForBackwardsNoVcCheckAOTOutput,
+    SubclassGetAttrAOTInput,
+    SubclassGetAttrAOTOutput,
+    SubclassSizeAOTInput,
+    SubclassSizeAOTOutput,
+    SubclassStrideAOTInput,
+    SubclassStrideAOTOutput,
+    SyntheticBaseAOTInput,
+    TangentAOTInput,
+    ViewBaseAOTInput,
+)
+from .functional_utils import gen_alias_from_base, MetadataKey, ViewMetaSequence
 from .runtime_wrappers import (
+    _AutogradRngStateTracker,
+    _AutogradSavedState,
+    _dealias_marked_returns,
+    _grad_output_prototypes,
+    _mask_pruned_backward_outputs,
+    _materialize_missing_grad_outputs,
+    _process_runtime_or_materialized_tangent,
+    _pruned_backward_output_indices_from_dependencies,
+    _snapshot_external_objects,
     _unwrap_tensoralias,
+    _wrap_backward_outputs_with_subclasses,
+    AOTDispatchAutograd,
+    index_to_external_object_weakref,
+    KeptTangentInfo,
     mark_dynamo_propagated_dynamic_indices,
 )
+from .schemas import (
+    InputAliasInfo,
+    MemoryFormatMeta,
+    OutputAliasInfo,
+    OutputType,
+    PlainTensorMeta,
+    SubclassCreationMeta,
+    TensorAlias,
+    ViewAndMutationMeta,
+)
+from .subclass_utils import wrap_tensor_subclasses
 from .utils import normalize_as_list
 
 
+# Inference artifacts use the first group; training artifacts (compile_to_python
+# with grad_enabled=True) additionally use the autograd-function epilogue and
+# prologue helpers and the metadata types their baked ViewAndMutationMeta is
+# reconstructed from. source_emit redirects any reference to one of these
+# objects to this module, so a generated artifact never imports an AOTAutograd
+# module by its internal path. (The wrappers' torch._C calls are attribute
+# chains off the ``torch`` global and are emitted as such; they are not routed
+# here.)
 __all__ = [
     "gen_alias_from_base",
     "_unwrap_tensoralias",
     "mark_dynamo_propagated_dynamic_indices",
     "normalize_as_list",
     "CUDARngStateHelper",
+    "FunctionalTensor",
+    "SymIntEqByExpr",
+    "_AutogradRngStateTracker",
+    "_AutogradSavedState",
+    "_dealias_marked_returns",
+    "_grad_output_prototypes",
+    "_mask_pruned_backward_outputs",
+    "_materialize_missing_grad_outputs",
+    "_pruned_backward_output_indices_from_dependencies",
+    "_snapshot_external_objects",
+    "AOTDispatchAutograd",
+    "index_to_external_object_weakref",
+    "KeptTangentInfo",
+    "InputAliasInfo",
+    "MemoryFormatMeta",
+    "OutputAliasInfo",
+    "OutputType",
+    "PlainTensorMeta",
+    "SubclassCreationMeta",
+    "TensorAlias",
+    "ViewAndMutationMeta",
+    "BackwardTokenAOTInput",
+    "BackwardTokenAOTOutput",
+    "BufferAOTInput",
+    "DummyAOTInput",
+    "DummyAOTOutput",
+    "ForwardTokenAOTInput",
+    "ForwardTokenAOTOutput",
+    "GradAOTOutput",
+    "InputMutationAOTOutput",
+    "IntermediateBaseAOTOutput",
+    "MetadataMutationAOTOutput",
+    "ParamAOTInput",
+    "PhiloxBackwardBaseOffsetAOTInput",
+    "PhiloxBackwardSeedAOTInput",
+    "PhiloxForwardBaseOffsetAOTInput",
+    "PhiloxForwardSeedAOTInput",
+    "PhiloxUpdatedBackwardOffsetAOTOutput",
+    "PhiloxUpdatedForwardOffsetAOTOutput",
+    "PlainAOTInput",
+    "PlainAOTOutput",
+    "SavedForBackwardsAOTOutput",
+    "SavedForBackwardsNoVcCheckAOTOutput",
+    "SubclassGetAttrAOTInput",
+    "SubclassGetAttrAOTOutput",
+    "SubclassSizeAOTInput",
+    "SubclassSizeAOTOutput",
+    "SubclassStrideAOTInput",
+    "SubclassStrideAOTOutput",
+    "SyntheticBaseAOTInput",
+    "TangentAOTInput",
+    "ViewBaseAOTInput",
+    # Subclass-tangent training and output-alias regeneration.
+    "_process_runtime_or_materialized_tangent",
+    "_wrap_backward_outputs_with_subclasses",
+    "wrap_tensor_subclasses",
+    "MetadataKey",
+    "ViewMetaSequence",
 ]

--- a/torch/_functorch/_aot_autograd/to_standalone_python.py
+++ b/torch/_functorch/_aot_autograd/to_standalone_python.py
@@ -40,12 +40,18 @@ eager / compiled path would error -- an intentional trade-off, not a numerics bu
 from __future__ import annotations
 
 import ast
+import itertools
+import logging
 import re
 import threading
-from typing import Any, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import Any, cast, TYPE_CHECKING
 
 from .codegen import capture_generated_sources, GeneratedSource
 from .source_emit import _REBUILD_HELPER, emit_value
+
+
+log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -116,7 +122,8 @@ _COMPILE_LOCK = threading.RLock()
 # We do NOT reimplement any of this. We CAPTURE AOTAutograd's exact codegen'd wrapper
 # source together with the (pre-exec) globals dict each wrapper closed over: a
 # thread-local sink in codegen.py records one GeneratedSource per wrapper.
-# To trigger the capture we run AOTAutograd ourselves (under no_grad, the inference path)
+# To trigger the capture we run AOTAutograd ourselves, using grad mode to select the
+# inference path or a joint forward/backward; see ``compile_to_python.grad_enabled``.
 # with a capture-only inner compiler: it grabs the dense inner graph and returns a
 # placeholder callable, so AOTAutograd still codegen's the runtime-wrapper chain AROUND
 # that placeholder -- which is what the sink records. Inductor does not run in that pass;
@@ -135,8 +142,11 @@ _COMPILE_LOCK = threading.RLock()
 # structures it consults, in order:
 #   - inner_call_id         -> the inner ``call`` becomes ``_inner_call``
 #   - fn_id_to_name         -> a sibling wrapper's fn becomes that wrapper's own name
-#   - _known_helper_table() -> an importable helper becomes (import, expr)
-#   - anything else: reconstruct field-by-field as source (_emit_value), or raise.
+#   - _known_helper_table() -> ``torch`` itself and public torch paths become (import, expr)
+#   - anything else: reconstruct as source via emit_value, which references any
+#     object re-exported by standalone_runtime from that surface (by identity,
+#     see source_emit._standalone_runtime_exports) and rebuilds the rest
+#     field-by-field, or raises.
 # Recognition is by id() (object identity), not value-equality: for "is this the EXACT
 # object the wrapper closed over," == is the wrong tool (functions don't compare by
 # value, and an equal-but-different object would mis-resolve). Value-equality IS used,
@@ -166,9 +176,10 @@ _COMPILE_LOCK = threading.RLock()
 # torch.autograd.graph.increment_version) or an import from the single small surface
 # standalone_runtime.py (for the AOTAutograd-area internals -- plus CUDARngStateHelper,
 # re-exported there for import-ordering -- whose locations are not themselves a stable
-# contract). That file's IDENTITY CONTRACT -- re-exports must preserve object id --
-# exists purely so the COMPOSER's id-lookup keeps matching; it is a compile-time
-# requirement, and the runtime artifact has no id dependency of its own.
+# contract), the latter routed by source_emit._emit_importable off the identities in
+# standalone_runtime.__all__. That file's IDENTITY CONTRACT -- re-exports must
+# preserve object id -- exists purely so that compile-time lookup keeps matching; the
+# runtime artifact has no id dependency of its own.
 # ======================================================================
 
 
@@ -176,39 +187,19 @@ _COMPILE_LOCK = threading.RLock()
 # import in the standalone module (rather than reconstructed field-by-field). Maps
 # object id -> (import_statement, expression). Built lazily to avoid import cycles.
 def _known_helper_table() -> dict[int, tuple[str, str]]:
-    # Generated artifacts import runtime helpers from the single stable surface
-    # ``standalone_runtime`` (not scattered AOTAutograd internals).
+    # Only objects that emit_value cannot route to standalone_runtime by
+    # identity live here; see source_emit._emit_importable for the rest.
     import torch
 
-    from . import standalone_runtime as rt
-
-    _RT = "from torch._functorch._aot_autograd.standalone_runtime import"
     table: dict[int, tuple[str, str]] = {
+        # Modules have no __qualname__ and increment_version's import path is
+        # not the stable ``import torch``; everything re-exported by
+        # standalone_runtime is routed there by source_emit._emit_importable
+        # (keyed on the same object identities), so it needs no row here.
         id(torch): ("import torch", "torch"),
-        id(rt.normalize_as_list): (f"{_RT} normalize_as_list", "normalize_as_list"),
-        id(rt.mark_dynamo_propagated_dynamic_indices): (
-            f"{_RT} mark_dynamo_propagated_dynamic_indices",
-            "mark_dynamo_propagated_dynamic_indices",
-        ),
         id(torch.autograd.graph.increment_version): (
             "import torch",
             "torch.autograd.graph.increment_version",
-        ),
-        id(rt.gen_alias_from_base): (
-            f"{_RT} gen_alias_from_base",
-            "gen_alias_from_base",
-        ),
-        id(rt._unwrap_tensoralias): (
-            f"{_RT} _unwrap_tensoralias",
-            "_unwrap_tensoralias",
-        ),
-        id(rt.CUDARngStateHelper.get_torch_state_as_tuple): (
-            f"{_RT} CUDARngStateHelper",
-            "CUDARngStateHelper.get_torch_state_as_tuple",
-        ),
-        id(rt.CUDARngStateHelper.set_new_offset): (
-            f"{_RT} CUDARngStateHelper",
-            "CUDARngStateHelper.set_new_offset",
         ),
     }
     return table
@@ -236,13 +227,14 @@ def _resolve_global(
     imports: set[str],
     orch_closure_id: int | None = None,
     orch_entry_name: str | None = None,
+    inner_call_name: str = "_inner_call",
 ) -> str:
     """Return a Python expression (valid in the generated module) that reproduces
     ``obj``, recording any needed import. Raises NotImplementedError if ``obj`` is
     neither the inner call, a sibling wrapper, a known helper, nor source-
     reconstructible (see ``_emit_value``)."""
     if inner_call_id is not None and id(obj) == inner_call_id:
-        return "_inner_call"
+        return inner_call_name
     # An OUTER wrapper (dedup / synthetic base) closes over the orchestration's outer
     # closure as its inner. That closure is not a captured wrapper and has no import
     # path, so wire it to the single-arg orchestration entry adapter the composer emits.
@@ -252,6 +244,12 @@ def _resolve_global(
         return orch_entry_name
     if id(obj) in fn_id_to_name:
         return fn_id_to_name[id(obj)]
+    if (
+        getattr(obj, "__self__", None) is itertools.chain
+        and getattr(obj, "__name__", None) == "from_iterable"
+    ):
+        imports.add("import itertools")
+        return "itertools.chain.from_iterable"
     if id(obj) in helper_table:
         import_stmt, expr = helper_table[id(obj)]
         if import_stmt:
@@ -828,7 +826,12 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     strides has static sizes, and treating it as static would silently specialize the
     artifact to the example strides. (Unbacked symints appearing only in intermediates,
     not on any placeholder, are still missed here, but such a graph fails loudly
-    downstream when emit_value rejects the still-symbolic metadata.)"""
+    downstream when emit_value rejects the still-symbolic metadata.)
+
+    Both metadata keys are checked, like ``_resolve_fake_mode``: make_fx stashes the fake
+    under "val", while a Dynamo graph (which torch.compiler.precompile's dynamo tracer
+    feeds here) stashes it under "example_value" -- reading only "val" would call a
+    dynamic Dynamo graph static and silently specialize it to the example sizes."""
     import torch
 
     def _is_symbolic(v: Any) -> bool:
@@ -837,25 +840,968 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     for node in gm.graph.nodes:
         if node.op != "placeholder":
             continue
+        for key in ("val", "example_value"):
+            val = node.meta.get(key)
+            if _is_symbolic(val):
+                return True
+            if isinstance(val, torch.Tensor) and (
+                any(_is_symbolic(s) for s in val.shape)
+                or any(_is_symbolic(s) for s in val.stride())
+                or _is_symbolic(val.storage_offset())
+            ):
+                return True
+    return False
+
+
+def namespace_module_names(sources: Sequence[str]) -> list[str]:
+    """Suffix every top-level name each module DEFINES, per module.
+
+    Splicing several Inductor modules into ONE namespace is only safe if their
+    top-level names are disjoint, because the code inside a module resolves its
+    siblings as late-bound globals: a module's ``call`` looks up its kernels and
+    its ``_runtime_wrapper`` when INVOKED, not when defined. Two modules of the
+    same computation -- a forward and its backward, or two shape variants of one
+    frame -- otherwise define the same names, and the first silently runs the
+    second's code. Snapshotting each module's entry is not enough for the same
+    reason.
+
+    Rewriting is driven by AST positions rather than a text match, which is what
+    keeps three lookalikes out of it: an attribute (``runner.call`` is an
+    ``Attribute``, not a ``Name``), a nested binding (``def call`` inside
+    ``class Runner`` is not module-level), and an import (``async_compile`` is
+    both a local binding and part of ``torch._inductor.async_compile``).
+    """
+    out: list[str] = []
+    for slot, source in enumerate(sources):
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        defined: set[str] = set()
+        headers: list[tuple[int, str]] = []
+        for node in tree.body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    imported.add((alias.asname or alias.name).split(".")[0])
+            elif isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                defined.add(node.name)
+                headers.append((node.lineno, node.name))
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        defined.add(target.id)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                defined.add(node.target.id)
+        targets = defined - imported
+        if not targets:
+            out.append(source)
+            continue
+        suffix = f"_s{slot}"
+        lines = source.split("\n")
+
+        def char_offset(lineno: int, byte_offset: int) -> int:
+            # ast col offsets are UTF-8 byte offsets; the lines are str.
+            line = lines[lineno - 1]
+            if line.isascii():
+                return byte_offset
+            return len(line.encode("utf-8")[:byte_offset].decode("utf-8"))
+
+        edits: dict[int, list[tuple[int, int, str]]] = {}
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Name)
+                and node.id in targets
+                and node.end_col_offset is not None
+            ):
+                edits.setdefault(node.lineno, []).append(
+                    (
+                        char_offset(node.lineno, node.col_offset),
+                        char_offset(node.lineno, node.end_col_offset),
+                        node.id + suffix,
+                    )
+                )
+        for lineno, name in headers:
+            if name not in targets:
+                continue
+            found = re.search(rf"\b{re.escape(name)}\b", lines[lineno - 1])
+            if found is not None:
+                edits.setdefault(lineno, []).append(
+                    (found.start(), found.end(), name + suffix)
+                )
+        for lineno, spans in edits.items():
+            line = lines[lineno - 1]
+            for begin, finish, text in sorted(spans, reverse=True):
+                line = line[:begin] + text + line[finish:]
+            lines[lineno - 1] = line
+        out.append("\n".join(lines))
+    return out
+
+
+# Names the emitted training module binds at module scope and that the capture
+# driver (torch._precompile) reads and writes through call.__globals__. Both
+# sides go through these constants.
+AOT_OBSERVED_UNDEFINED_TANGENT_MASKS = "_AOT_OBSERVED_UNDEFINED_TANGENT_MASKS"
+AOT_BACKWARD_VARIANT_COMPILER = "_AOT_BACKWARD_VARIANT_COMPILER"
+AOT_BACKWARD_VARIANTS = "_AOT_BACKWARD_VARIANTS"
+
+
+def _inner_call_bw_name(index: int) -> str:
+    # Emitted binding of the index-th backward variant's inner inductor call.
+    return f"_inner_call_bw_{index}"
+
+
+@dataclass(frozen=True)
+class _StandaloneBackwardVariant:
+    undefined_grad_out_mask: int | None
+    python_code: str
+    kept_arg_indices: tuple[int, ...] | None = None
+    pruned_output_indices: tuple[int, ...] | None = ()
+    skip_materialize_grad_output_indices: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class _CompiledBackwardSpecialization:
+    python_code: str
+    call: Callable[[list[Any]], Any]
+    cache: bytes | None
+    kept_arg_indices: tuple[int, ...] | None = None
+    pruned_output_indices: tuple[int, ...] | None = ()
+    skip_materialize_grad_output_indices: tuple[int, ...] = ()
+
+
+@dataclass
+class _CompileToPythonState:
+    """Capture-only state for specializing standalone backwards.
+
+    ``install_capture`` connects the generated module's private compiler hook to
+    ``compile_mask``. Bit ``i`` is set when grad output ``i`` is undefined. Masks are
+    kept CANONICAL throughout -- restricted to the specializable user-output indices
+    (``_specializable_user_grad_output_mask``), exactly like the live runtime path --
+    so a non-differentiable output's always-undefined tangent cannot fork spurious
+    variants or make the auto-covered mask 0 unreachable; every entry point
+    re-canonicalizes defensively. The first
+    real backward with a new mask compiles and runs that specialization immediately,
+    then records its source and cache. After running its examples, the CALLER reads
+    the observed masks out of ``call.__globals__[AOT_OBSERVED_UNDEFINED_TANGENT_MASKS]``
+    and passes them to ``finalize``, which emits only those recorded variants.
+    ``finalize`` does not touch the module globals: the caller is responsible for
+    setting ``AOT_BACKWARD_VARIANT_COMPILER`` back to ``None`` and clearing
+    ``AOT_BACKWARD_VARIANTS`` in that globals dict (see
+    ``torch._precompile._DynamoPythonBackend.finalize_training``). The names are
+    the module-level constants of the same name in this module; consumers must
+    use those rather than the literal strings.
+    """
+
+    forward_python: str
+    backward_python: str
+    captured: list[GeneratedSource]
+    spec: Any
+    backward_graph: GraphModule
+    backward_inputs: list[Any]
+    options: dict[str, Any] | None
+    forward_cache: bytes | None
+    backward_cache: bytes | None
+    forward_inner_call: Callable[..., Any]
+    _capture_backward_call: Callable[[list[Any]], Any] | None = field(
+        default=None, init=False
+    )
+    _specializations: dict[int, _CompiledBackwardSpecialization] = field(
+        default_factory=dict, init=False
+    )
+    _observed_variants: dict[int, _StandaloneBackwardVariant] = field(
+        default_factory=dict, init=False
+    )
+
+    def install_capture(self, globals_dict: dict[str, Any]) -> None:
+        self._capture_backward_call = globals_dict[_inner_call_bw_name(0)]
+        globals_dict[AOT_BACKWARD_VARIANT_COMPILER] = self.compile_mask
+
+    def canonical_mask(self, mask: int) -> int:
+        from . import runtime_wrappers as _rw
+
+        return _rw._specializable_user_grad_output_mask(
+            self.spec.fw_metadata, _rw._bitmask_to_indices(mask)
+        )
+
+    def compile_mask(
+        self, mask: int
+    ) -> tuple[
+        Callable[[list[Any]], Any],
+        tuple[int, ...] | None,
+        tuple[int, ...] | None,
+        tuple[int, ...],
+    ]:
+        with _COMPILE_LOCK:
+            return self._compile_mask(mask)
+
+    def _compile_mask(
+        self, mask: int
+    ) -> tuple[
+        Callable[[list[Any]], Any],
+        tuple[int, ...] | None,
+        tuple[int, ...] | None,
+        tuple[int, ...],
+    ]:
+        # Re-canonicalize defensively: the emitted backward records canonical
+        # masks, but finalize can be handed masks observed on a superseded
+        # sibling backend (a stateful automatic-dynamic recompile) whose
+        # canonical form is computed against ITS metadata.
+        mask = self.canonical_mask(mask)
+        if mask in self._observed_variants:
+            compiled = self._specializations[mask]
+            return (
+                compiled.call,
+                compiled.kept_arg_indices,
+                compiled.pruned_output_indices,
+                compiled.skip_materialize_grad_output_indices,
+            )
+
+        from torch._guards import compile_context, tracing
+        from torch._inductor import (
+            compile_to_python as _inductor_compile_to_python,
+            load_from_python as _inductor_load_from_python,
+        )
+
+        from . import runtime_wrappers as _rw
+        from .graph_compile import _retrace_backward_for_undefined_grad_outputs
+
+        compiled = self._specializations.get(mask)
+        if compiled is None:
+            if not mask:
+                call = self._capture_backward_call
+                if call is None:
+                    call = _inductor_load_from_python(
+                        self.backward_python, self.backward_cache
+                    )
+                compiled = _CompiledBackwardSpecialization(
+                    python_code=self.backward_python,
+                    call=call,
+                    cache=self.backward_cache,
+                )
+            else:
+                specialization_indices = _rw._bitmask_to_indices(mask)
+                result = None
+                attempted_exact_retrace = False
+                retrace_decline_reasons: list[str] = []
+                lazy_info = self.spec.lazy_backward_info
+                if (
+                    isinstance(lazy_info, _rw.AutogradLazyBackwardCompileInfo)
+                    and lazy_info.autograd_trace_info is not None
+                ):
+                    attempted_exact_retrace = True
+                    from .graph_compile import retrace_backward_handling_errors
+
+                    def _retrace() -> Any:
+                        with (
+                            tracing(lazy_info.saved_context),
+                            compile_context(lazy_info.saved_compile_context),
+                        ):
+                            return _retrace_backward_for_undefined_grad_outputs(
+                                lazy_info.autograd_trace_info,
+                                self.spec.aot_config,
+                                specialization_indices,
+                                self.backward_graph,
+                                self.backward_inputs,
+                                decline_reason=retrace_decline_reasons,
+                            )
+
+                    result = retrace_backward_handling_errors(
+                        _retrace, retrace_decline_reasons, specialization_indices
+                    )
+                if result is None:
+                    # The retrace can decline for reasons unrelated to the ABI
+                    # (e.g. the ambient autocast state differs between forward
+                    # and backward, the standard AMP pattern); structural
+                    # specialization preserves the saved-activation ABI and
+                    # stays available, exactly as on the live runtime path.
+                    result = _rw._specialize_bw_module_for_undefined_grad_outputs(
+                        self.backward_graph,
+                        self.backward_inputs,
+                        self.spec.fw_metadata,
+                        specialization_indices,
+                        list(self.backward_inputs),
+                    )
+                if result is None and attempted_exact_retrace:
+                    # Same policy as the live runtime's get_or_compile: a
+                    # declined retrace falls back to the base backward with
+                    # materialized zero tangents (the emitted glue always builds
+                    # grad-output prototypes), never a hard error.
+                    log.warning(
+                        "standalone backward for undefined-output mask %s uses the "
+                        "base backward with materialized zero tangents: %s; "
+                        "structural specialization did not apply",
+                        f"{mask:#b}",
+                        "; ".join(retrace_decline_reasons) or "the retrace declined",
+                    )
+                if result is None:
+                    pruned = (
+                        _rw._pruned_backward_output_indices_for_undefined_grad_outputs(
+                            self.backward_graph,
+                            self.spec.fw_metadata,
+                            specialization_indices,
+                        )
+                    )
+                    call = self._capture_backward_call
+                    if call is None:
+                        call = _inductor_load_from_python(
+                            self.backward_python, self.backward_cache
+                        )
+                    compiled = _CompiledBackwardSpecialization(
+                        python_code=self.backward_python,
+                        call=call,
+                        cache=self.backward_cache,
+                        pruned_output_indices=pruned,
+                    )
+                else:
+                    graph, inputs, kept_arg_indices = result
+                    python_code, cache = _inductor_compile_to_python(
+                        graph,
+                        inputs,
+                        options=self.options,
+                        is_inference=False,
+                        is_backward=True,
+                    )
+                    compiled = _CompiledBackwardSpecialization(
+                        python_code=python_code,
+                        call=_inductor_load_from_python(python_code, cache),
+                        cache=cache,
+                        kept_arg_indices=kept_arg_indices,
+                        skip_materialize_grad_output_indices=specialization_indices,
+                    )
+            self._specializations[mask] = compiled
+
+        self._observed_variants[mask] = _StandaloneBackwardVariant(
+            undefined_grad_out_mask=mask,
+            python_code=compiled.python_code,
+            kept_arg_indices=compiled.kept_arg_indices,
+            pruned_output_indices=compiled.pruned_output_indices,
+            skip_materialize_grad_output_indices=(
+                compiled.skip_materialize_grad_output_indices
+            ),
+        )
+        return (
+            compiled.call,
+            compiled.kept_arg_indices,
+            compiled.pruned_output_indices,
+            compiled.skip_materialize_grad_output_indices,
+        )
+
+    def finalize(self, tangent_masks: Sequence[int]) -> tuple[str, bytes | None]:
+        with _COMPILE_LOCK:
+            return self._finalize(tangent_masks)
+
+    def _finalize(self, tangent_masks: Sequence[int]) -> tuple[str, bytes | None]:
+        from torch.compiler._cache import CacheArtifactManager
+
+        # Mask 0 (a full backward) is always served, whatever the captures ran.
+        canonical = {0, *(self.canonical_mask(mask) for mask in tangent_masks)}
+        masks = sorted(canonical)
+        for mask in masks:
+            if mask not in self._observed_variants:
+                self._compile_mask(mask)
+
+        variants = [self._observed_variants[mask] for mask in masks]
+        caches = [self._specializations[mask].cache for mask in masks]
+
+        return (
+            _compose_training_module(
+                self.forward_python,
+                variants,
+                self.captured,
+                self.spec,
+                self.backward_graph,
+                self.forward_inner_call,
+            ),
+            CacheArtifactManager.merge((self.forward_cache, *caches)),
+        )
+
+
+def _compose_training_module(
+    fw_python: str,
+    backward_variants: Sequence[_StandaloneBackwardVariant],
+    captured: list[GeneratedSource],
+    spec: Any,
+    bw_gm: GraphModule,
+    forward_inner_call: Callable[..., Any],
+) -> str:
+    """Compose a FORWARD and BACKWARD lowering into one standalone module.
+
+    The inference composer nests wrappers around a single ``call``. Training is a
+    different shape: AOTAutograd's own bridge is a ``torch.autograd.Function``
+    whose ``forward``/``backward`` bodies ARE codegen'd source
+    (``compiled_function_forward`` / ``compiled_function_backward``, with
+    ``backward_prologue`` / ``backward_epilogue`` beside them), but the class
+    holding them is ordinary Python, so the composer emits it.
+
+    Both inductor modules are spliced at module level and each one's entry is
+    snapshotted immediately, because the second block rebinds ``call`` /
+    ``Runner`` / the kernels that the first block's code resolves as late-bound
+    globals.
+    """
+
+    from . import runtime_wrappers as _rw
+
+    if spec.backward_state_indices:
+        raise NotImplementedError(
+            "aot_autograd.compile_to_python cannot compose a training graph that "
+            "carries a BackwardState into standalone source yet."
+        )
+
+    orchestrations = [
+        gen for gen in captured if gen.artifact_name == "runtime_wrapper_orchestration"
+    ]
+    if orchestrations:
+        target_origin = orchestrations[-1].origin_id
+        captured = [gen for gen in captured if gen.origin_id == target_origin]
+
+    by_name: dict[str, list[GeneratedSource]] = {}
+    for gen in captured:
+        by_name.setdefault(gen.artifact_name, []).append(gen)
+    missing = [
+        name
+        for name in (
+            "backward_prologue",
+            "backward_epilogue",
+            "compiled_function_forward",
+            "compiled_function_backward",
+            "runtime_wrapper_orchestration",
+        )
+        if name not in by_name
+    ]
+    if missing:
+        raise NotImplementedError(
+            f"aot_autograd.compile_to_python: the training compose expects "
+            f"AOTAutograd to codegen {missing}, which this graph did not produce."
+        )
+
+    imports: set[str] = set()
+    helper_table = _known_helper_table()
+    core_artifacts = {
+        "backward_prologue",
+        "backward_epilogue",
+        "compiled_fn_wrapper",
+        "compiled_function_forward",
+        "compiled_function_backward",
+        "runtime_wrapper_orchestration",
+    }
+    auxiliary = [gen for gen in captured if gen.artifact_name not in core_artifacts]
+    fn_id_to_name = {id(gen.fn): gen.fn_name for gen in auxiliary}
+    orchestration = by_name["runtime_wrapper_orchestration"]
+    if len(orchestration) != 1:
+        raise NotImplementedError(
+            "aot_autograd.compile_to_python expected exactly one training "
+            f"orchestration wrapper, captured {len(orchestration)}."
+        )
+    orch = orchestration[0]
+
+    # Dedupe and synthetic-base wrappers sit outside AOTAutograd's orchestration.
+    # Their innermost closure is not itself a captured function, so identify it and
+    # rebuild the chain around a generated adapter for the autograd Function.
+    inner_names = ("compiled_fn", "_compiled_fn_")
+
+    def inner_ref(gen: GeneratedSource) -> Any:
+        for name in inner_names:
+            if name in gen.globals_dict:
+                return gen.globals_dict[name]
+        return None
+
+    known_inner_ids = {id(forward_inner_call), *fn_id_to_name}
+    orch_closure_ids = {
+        id(ref)
+        for gen in auxiliary
+        if (ref := inner_ref(gen)) is not None and id(ref) not in known_inner_ids
+    }
+    if len(orch_closure_ids) > 1:
+        raise NotImplementedError(
+            "aot_autograd.compile_to_python captured multiple training wrappers "
+            "whose inner callable could not be identified."
+        )
+    orch_closure_id = next(iter(orch_closure_ids), None)
+    outer_wrappers: list[GeneratedSource] = []
+    if orch_closure_id is not None:
+        target_id: int | None = orch_closure_id
+        while target_id is not None:
+            wrapper = next(
+                (
+                    gen
+                    for gen in auxiliary
+                    if gen not in outer_wrappers
+                    and inner_ref(gen) is not None
+                    and id(inner_ref(gen)) == target_id
+                ),
+                None,
+            )
+            if wrapper is None:
+                break
+            outer_wrappers.append(wrapper)
+            target_id = id(wrapper.fn)
+    outer_ids = {id(gen) for gen in outer_wrappers}
+    inner_auxiliary = [gen for gen in auxiliary if id(gen) not in outer_ids]
+
+    forward_call_name = "_inner_call_fw"
+    if id(spec.compiled_fw_func) != id(forward_inner_call):
+        forward_wrapper = fn_id_to_name.get(id(spec.compiled_fw_func))
+        if forward_wrapper is None or id(spec.compiled_fw_func) in {
+            id(gen.fn) for gen in outer_wrappers
+        }:
+            raise NotImplementedError(
+                "aot_autograd.compile_to_python could not identify the captured "
+                "training forward wrapper chain."
+            )
+        forward_call_name = forward_wrapper
+
+    entry_name = "_autograd_orchestration_entry"
+    global_bindings: dict[str, str] = {}
+
+    def splice(gen: GeneratedSource) -> str:
+        hoists = []
+        for name, obj in gen.globals_dict.items():
+            if name == "__builtins__":
+                continue
+            expr = _resolve_global(
+                obj,
+                helper_table,
+                id(forward_inner_call),
+                fn_id_to_name,
+                imports,
+                orch_closure_id,
+                entry_name,
+                inner_call_name="_inner_call_fw",
+            )
+            if name == expr:
+                continue
+            previous = global_bindings.get(name)
+            if previous is not None and previous != expr:
+                raise NotImplementedError(
+                    "aot_autograd.compile_to_python cannot inline training wrappers "
+                    f"that bind {name!r} to different values."
+                )
+            if previous is None:
+                global_bindings[name] = expr
+                hoists.append(f"{name} = {expr}")
+        return "\n".join(hoists + [gen.source, ""])
+
+    blocks = [splice(gen) for gen in inner_auxiliary]
+    blocks += [
+        splice(gen)
+        for name in (
+            "backward_prologue",
+            "backward_epilogue",
+            "compiled_fn_wrapper",
+            "compiled_function_forward",
+            "compiled_function_backward",
+        )
+        for gen in by_name.get(name, [])
+    ]
+    orchestration_block = splice(orch)
+    outer_blocks = [splice(gen) for gen in outer_wrappers]
+
+    fw_metadata_src = emit_value(spec.fw_metadata, imports)
+    # Emit a constructor call, not the pickled object: the tracker's runtime
+    # state belongs fresh in the artifact anyway, and its curr_fwd_iter
+    # (itertools.count) default is unpicklable on Python >= 3.14.
+    rng_src = (
+        "_AutogradRngStateTracker("
+        f"num_rng={emit_value(spec.fw_metadata.num_graphsafe_rng_states, imports)}, "
+        f"graphsafe_idx={emit_value(spec.fw_metadata.graphsafe_rng_state_index, imports)}, "
+        f"device={emit_value(spec.fw_metadata.graphsafe_rng_device, imports)})"
+    )
+    backward_output_dependencies = _rw._backward_output_tangent_dependencies(
+        bw_gm, spec.fw_metadata
+    )
+    backward_output_dependencies_src = emit_value(backward_output_dependencies, imports)
+    # The grad-output indices a backward variant may specialize on (surviving
+    # user outputs). The emitted backward canonicalizes its scanned
+    # undefined-tangent mask over these, exactly like the live runtime path
+    # (_specializable_user_grad_output_mask): a non-differentiable output's
+    # tangent is ALWAYS undefined, so keying the variant table on the raw mask
+    # would make the auto-covered mask 0 unreachable and fail every backward.
+    specializable_indices = _rw._specializable_user_grad_output_indices(
+        spec.fw_metadata, range(spec.fw_metadata.num_forward_returns)
+    )
+    specializable_src = f"frozenset({tuple(sorted(specializable_indices))!r})"
+    # Provably-zero bit per backward output, computed once with EVERY
+    # specializable tangent pruned: a dependency-eligible output's cone
+    # contains exactly the visible tangents its dependency entry lists, so one
+    # pass answers "is output i zero once the tangents it depends on are
+    # undefined" for all of them. The default-variant fallback in
+    # _backward_impl masks only outputs that are BOTH dependency-implied AND in
+    # this set -- dependency alone is wrong for a backward that is not linear
+    # in its tangents (a custom Function returning g + 1 yields a nonzero grad
+    # from an undefined tangent, which eager materializes zeros for). Mirrors
+    # the runtime _pruned_backward_output_indices_for_undefined_grad_outputs.
+    tangent_placeholders = [
+        node
+        for node in bw_gm.graph.find_nodes(op="placeholder")
+        if _rw._is_grad_tangent(node)
+    ]
+    expected_tangents = sum(
+        _rw._tangent_meta_arg_count(meta)
+        for meta in spec.fw_metadata.subclass_tangent_meta
+    )
+    provably_zero_outputs: frozenset[int] = frozenset()
+    if len(tangent_placeholders) == expected_tangents:
+        flat_indices = _rw._undefined_tangent_flat_indices(
+            spec.fw_metadata, specializable_indices
+        )
+        provably_zero_outputs = _rw._provably_zero_backward_output_indices(
+            bw_gm, {tangent_placeholders[i] for i in flat_indices}
+        )
+    provably_zero_src = f"frozenset({tuple(sorted(provably_zero_outputs))!r})"
+    unique_backward_sources: list[str] = []
+    source_indices: dict[str, int] = {}
+    variant_source_indices: list[int] = []
+    for variant in backward_variants:
+        source_index = source_indices.get(variant.python_code)
+        if source_index is None:
+            source_index = len(unique_backward_sources)
+            source_indices[variant.python_code] = source_index
+            unique_backward_sources.append(variant.python_code)
+        variant_source_indices.append(source_index)
+    namespaced_sources = namespace_module_names([fw_python, *unique_backward_sources])
+    fw_ns = namespaced_sources[0]
+    backward_blocks = namespaced_sources[1:]
+    exact_variants: list[str] = []
+    default_variant = "None"
+    for variant, source_index in zip(
+        backward_variants, variant_source_indices, strict=True
+    ):
+        call_name = _inner_call_bw_name(source_index)
+        value = (
+            f"({call_name}, {variant.kept_arg_indices!r}, "
+            f"{variant.pruned_output_indices!r}, "
+            f"{variant.skip_materialize_grad_output_indices!r})"
+        )
+        if variant.undefined_grad_out_mask is None:
+            default_variant = value
+        else:
+            exact_variants.append(f"    {variant.undefined_grad_out_mask!r}: {value},")
+    variants_src = "\n".join([f"{AOT_BACKWARD_VARIANTS} = {{", *exact_variants, "}"])
+    imports |= {
+        "import contextlib",
+        "import torch",
+        "import weakref",
+        "from torch._functorch._aot_autograd.standalone_runtime import "
+        "_AutogradRngStateTracker, _AutogradSavedState, "
+        "_mask_pruned_backward_outputs, "
+        "_pruned_backward_output_indices_from_dependencies, "
+        "_snapshot_external_objects, index_to_external_object_weakref, "
+        "normalize_as_list",
+    }
+
+    # The artifact bakes aot_autograd_prune_unused_outputs=True at emission
+    # time instead of calling _set_grad_output_prototypes, which would re-read
+    # the ambient config wherever the artifact happens to be loaded. Like the
+    # runtime helper, prototypes are built even for a node with a single
+    # differentiable output: a downstream custom Function whose backward
+    # returns None hands that sole tangent in as undefined, and materializing
+    # it needs a prototype.
+    prototypes_expr = "_grad_output_prototypes(raw_returns, _fw_metadata)"
+    imports.add(
+        "from torch._functorch._aot_autograd.standalone_runtime import "
+        "_grad_output_prototypes"
+    )
+
+    glue = f"""
+_fw_metadata = {fw_metadata_src}
+# ViewAndMutationMeta.__post_init__ reads the ambient functionalize_rng_ops config.
+# Restore the values captured when this graph was traced.
+_fw_metadata.is_rng_op_functionalized = {spec.fw_metadata.is_rng_op_functionalized!r}
+_fw_metadata.num_outputs_rng_offset = {spec.fw_metadata.num_outputs_rng_offset!r}
+_fw_metadata.num_forward = {spec.fw_metadata.num_forward!r}
+_saved_state = _AutogradSavedState(metadata=_fw_metadata)
+_rng_state = {rng_src}
+_BACKWARD_OUTPUT_DEPENDENCIES = {backward_output_dependencies_src}
+_BACKWARD_OUTPUT_PROVABLY_ZERO = {provably_zero_src}
+_AOT_SPECIALIZABLE_GRAD_OUT_INDICES = {specializable_src}
+{AOT_OBSERVED_UNDEFINED_TANGENT_MASKS} = set()
+{AOT_BACKWARD_VARIANT_COMPILER} = None
+_NUM_FORWARD_RETURNS = {spec.fw_metadata.num_forward_returns}
+_DISABLE_AMP = {spec.disable_amp!r}
+
+
+def _finalize(ctx, fw_outs):
+    raw_returns = list(fw_outs[:_NUM_FORWARD_RETURNS])
+    # Prune-unused-outputs behavior is baked in at emission time; the ambient
+    # aot_autograd_prune_unused_outputs config must not change the artifact.
+    ctx._aot_prune_unused_outputs_enabled = True
+    ctx.set_materialize_grads(False)
+    protos = {prototypes_expr}
+    ctx._aot_grad_output_prototypes, ctx._aot_grad_output_prototype_objects = protos
+    ctx.mark_non_differentiable(*_transform_raw_returns(raw_returns))
+    ctx._materialize_non_diff_grads = False
+    _snapshot_external_objects(ctx)
+    return tuple(raw_returns)
+
+
+def _backward_impl(ctx, all_args):
+    ctx.maybe_clear_saved_tensors()
+    for idx, obj in getattr(ctx, "_external_objects", {{}}).items():
+        index_to_external_object_weakref[idx] = weakref.ref(obj)
+    inner_call_bw, kept_arg_indices, pruned, _ = ctx._aot_backward_variant
+    if kept_arg_indices is not None:
+        kept_args = [all_args[index] for index in kept_arg_indices]
+        all_args.clear()
+        all_args.extend(kept_args)
+    amp = torch._C._DisableAutocast if _DISABLE_AMP else contextlib.nullcontext
+    with amp():
+        out = inner_call_bw(all_args)
+    out = normalize_as_list(out)
+    if pruned is None:
+        # Dependency alone is not enough to null a grad: only outputs that are
+        # ALSO provably zero with their tangents undefined may be masked (an
+        # affine custom backward yields a nonzero grad from a zero tangent).
+        pruned = tuple(
+            index
+            for index in _pruned_backward_output_indices_from_dependencies(
+                _BACKWARD_OUTPUT_DEPENDENCIES,
+                ctx._undefined_grad_out_indices,
+            )
+            if index in _BACKWARD_OUTPUT_PROVABLY_ZERO
+        )
+    return _mask_pruned_backward_outputs(out, pruned)
+
+
+def _double_backward(ctx, impl_fn, all_args):
+    class _DoubleBackward(torch.autograd.Function):
+        @staticmethod
+        def forward(double_ctx, *unused_args):
+            return impl_fn(double_ctx)
+
+        @staticmethod
+        def backward(ctx, *args):
+            raise RuntimeError(
+                "torch.compile with aot_autograd does not currently support "
+                "double backward"
+            )
+
+    if not any(t.requires_grad for t in all_args if isinstance(t, torch.Tensor)):
+        all_args = [torch.empty(0, requires_grad=True)] + all_args
+    return _DoubleBackward.apply(*all_args)
+
+
+class _CompiledFunction(torch.autograd.Function):
+    boxed_grads_call = True
+
+    @staticmethod
+    def forward(ctx, *deduped_flat_tensor_args):
+        return _compiled_forward(
+            ctx,
+            deduped_flat_tensor_args,
+            _rng_state.add_forward_args,
+            _saved_state.save_from_forward,
+            _finalize,
+            {forward_call_name},
+        )
+
+    @staticmethod
+    def backward(ctx, *flat_args):
+        if len(flat_args) == 1 and isinstance(flat_args[0], list):
+            ctx._undefined_grad_out_indices = tuple(
+                index for index, grad in enumerate(flat_args[0]) if grad is None
+            )
+        else:
+            ctx._undefined_grad_out_indices = ()
+        # Canonical mask: only specializable (surviving user-output) indices
+        # key the variant table -- a non-differentiable output's tangent is
+        # always undefined and must not fork variants (mirrors the live
+        # runtime's _specializable_user_grad_output_mask).
+        mask = sum(
+            1 << index
+            for index in ctx._undefined_grad_out_indices
+            if index in _AOT_SPECIALIZABLE_GRAD_OUT_INDICES
+        )
+        if {AOT_BACKWARD_VARIANT_COMPILER} is not None:
+            {AOT_OBSERVED_UNDEFINED_TANGENT_MASKS}.add(mask)
+        variant = {AOT_BACKWARD_VARIANTS}.get(mask)
+        if variant is None and {AOT_BACKWARD_VARIANT_COMPILER} is not None:
+            variant = {AOT_BACKWARD_VARIANT_COMPILER}(mask)
+            {AOT_BACKWARD_VARIANTS}[mask] = variant
+        if variant is None:
+            variant = _AOT_DEFAULT_BACKWARD_VARIANT
+        if variant is None:
+            raise torch.compiler.PrecompileError(
+                "precompile artifact encountered an undefined-output-tangent "
+                f"bitmask that was not covered by example_inputs: {{mask:#b}}"
+            )
+        ctx._aot_backward_variant = variant
+        ctx._aot_skip_materialize_grad_output_indices = variant[3]
+        return _compiled_backward(
+            flat_args,
+            ctx,
+            _backward_prologue,
+            _rng_state.add_backward_args,
+            _backward_impl,
+            _backward_epilogue,
+            _double_backward,
+        )
+
+
+def _boxed_autograd_apply(args):
+    return _CompiledFunction.apply(*args)
+"""
+
+    if outer_wrappers:
+        entry = f"""
+def {entry_name}(args):
+    return {orch.fn_name}(
+        _boxed_autograd_apply, contextlib.nullcontext, lambda: None, args
+    )
+"""
+        outermost_name = fn_id_to_name[id(outer_wrappers[-1].fn)]
+        public_call = f"""
+def call(flat_inputs):  # noqa: F811
+    return {outermost_name}(list(flat_inputs))
+"""
+    else:
+        entry = ""
+        public_call = f"""
+def call(flat_inputs):  # noqa: F811
+    return {orch.fn_name}(
+        _boxed_autograd_apply, contextlib.nullcontext, lambda: None, list(flat_inputs)
+    )
+"""
+
+    parts = [
+        "# Generated by aot_autograd.compile_to_python (training) -- do not edit.",
+        "",
+        "import torch._dynamo",
+        *sorted(imports),
+        "",
+        "# === Inner Inductor output code: FORWARD ===",
+        fw_ns,
+        "_inner_call_fw = call_s0",
+        "",
+        *[
+            block
+            for index, source in enumerate(backward_blocks, 1)
+            for block in (
+                f"# === Inner Inductor output code: BACKWARD variant {index - 1} ===",
+                source,
+                f"{_inner_call_bw_name(index - 1)} = call_s{index}",
+                "",
+            )
+        ],
+        variants_src,
+        f"_AOT_DEFAULT_BACKWARD_VARIANT = {default_variant}",
+        "",
+        "# === AOTAutograd runtime wrappers ===",
+        *blocks,
+        orchestration_block,
+        glue,
+        entry,
+        *outer_blocks,
+        public_call,
+    ]
+    return "\n".join(parts)
+
+
+def _restride_backward_placeholders(
+    bw_gm: GraphModule,
+    fwd_output_strides: Sequence[tuple[str, ...] | None],
+    spec: Any,
+) -> None:
+    """Restride the backward's saved-activation inputs to what the forward chose.
+
+    Layout optimization lets the compiled forward hand back e.g. channels-last
+    saved activations, so the backward must be lowered against those strides
+    rather than the eager ones its joint trace carries. torch.compile does this
+    in ``_aot_stage2b_bw_compile`` with strides reported out of the forward's
+    lowering; this is the same restride against the strides
+    ``_inductor_compile_to_python`` now reports.
+
+    The rewrite lands on ``node.meta["val"]``, NOT on an example-inputs list:
+    ``inductor.compile_to_python`` rebuilds its fakes from the placeholders'
+    metadata and ignores the inputs it is handed, so restriding a list is a
+    silent no-op through that entry point.
+    """
+    import torch
+    from torch._inductor.utils import shape_env_from_inputs
+    from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+    if not fwd_output_strides:
+        return
+    # Which of the forward's outputs are the saved activations, and where they
+    # sit among the backward's inputs, are both recorded -- guessing positionally
+    # restrides the wrong placeholder and asserts (or miscomputes) at runtime.
+    meta = spec.fw_metadata
+    saved = list(fwd_output_strides[meta.tensors_saved_for_backwards_slice])
+    num_symints = spec.num_symints_saved_for_bw
+    placeholders = [n for n in bw_gm.graph.nodes if n.op == "placeholder"]
+    shape_env = shape_env_from_inputs([node.meta.get("val") for node in placeholders])
+    for index, node in enumerate(placeholders):
         val = node.meta.get("val")
-        if _is_symbolic(val):
-            return True
-        if isinstance(val, torch.Tensor) and (
-            any(_is_symbolic(s) for s in val.shape)
-            or any(_is_symbolic(s) for s in val.stride())
-            or _is_symbolic(val.storage_offset())
+        if not isinstance(val, torch.Tensor):
+            continue
+        offset = index - num_symints
+        if not (0 <= offset < len(saved)) or not saved[offset]:
+            continue
+        real = tuple(
+            cast("int | torch.SymInt", shape_env.deserialize_symexpr(s))
+            if shape_env is not None and isinstance(s, str)
+            else int(s)
+            for s in saved[offset]
+        )
+        if len(real) == val.dim() and not all(
+            statically_known_true(actual == expected)
+            for actual, expected in zip(val.stride(), real)
         ):
+            node.meta["val"] = val.as_strided(val.size(), real)
+
+
+def _graph_differentiates(gm: GraphModule) -> bool:
+    """Whether a dense graph contains a backward computation inline.
+
+    Scoped to call nodes and to the callable target's operator name, matched
+    against aten's ``*_backward`` naming convention (e.g. ``convolution_backward``,
+    ``threshold_backward``). Matching the suffix rather than any occurrence of
+    "backward" avoids a spurious hit on an op whose name merely contains the
+    substring, and avoids stringifying placeholders/get_attrs entirely.
+
+    This is a name heuristic, consulted only when the capture produced no joint
+    graph (``"bw" in dense`` is authoritative otherwise). The dense graph carries
+    no autograd metadata that could say more: functionalization has already
+    erased requires_grad from node values. Its one blind spot is a backward
+    expressed through a custom op whose name lacks the ``_backward`` suffix; such
+    a graph lowers with ``is_inference=True``, i.e. inductor's inference layout
+    heuristics and post-grad passes, which is a performance rather than a
+    correctness difference.
+    """
+    import torch
+
+    for node in gm.graph.nodes:
+        if node.op not in ("call_function", "call_method"):
+            continue
+        target = node.target
+        if isinstance(target, torch._ops.OpOverload):
+            name = target.overloadpacket.__name__
+        else:
+            name = getattr(target, "__name__", None) or str(target)
+        if name.endswith("_backward"):
             return True
     return False
 
 
-def compile_to_python(
+def _compile_to_python_with_state(
     gm: GraphModule,
     example_inputs: Sequence[Any],
     *,
     options: dict[str, Any] | None = None,
-) -> tuple[str, bytes | None]:
+    grad_enabled: bool = False,
+) -> tuple[str, bytes | None, _CompileToPythonState | None]:
     """Compile ``gm`` to ``(python_code, cache)``; see the module docstring.
+
+    ``grad_enabled`` runs the AOTAutograd capture pass under ``enable_grad`` instead of the
+    default ``no_grad``, and covers two different graphs. One performs autograd INTERNALLY
+    -- a Dynamo graph captured with ``trace_autograd_ops``, whose traced
+    ``torch.autograd.grad`` call needs a live autograd graph to differentiate and otherwise
+    fails the capture pass with "element 0 of tensors does not require grad"; that is still
+    an INFERENCE graph at the AOT boundary, since its backward lives inside the traced call.
+    The other has INPUTS that require grad, and AOTAutograd then emits a joint
+    forward+backward: two dense graphs, composed into a module whose ``call`` returns
+    outputs carrying ``grad_fn``, so the caller's ``.backward()`` runs the compiled
+    backward. Leaving it off pins the inference path, which is what you want for a forward
+    you will never differentiate.
 
     THREADING: serialized by a process-global lock (``_COMPILE_LOCK``). The wrapper-source
     capture is thread-local, but the AOTAutograd pass and the inner inductor compile both
@@ -867,6 +1813,7 @@ def compile_to_python(
     import copy
 
     import torch
+    from torch._functorch import config as functorch_config
     from torch._higher_order_ops.effects import _get_effect
     from torch._inductor import compile_to_python as _inductor_compile_to_python
     from torch._inductor.compile_fx import compile_fx
@@ -917,21 +1864,34 @@ def compile_to_python(
         # compile-time token and never runs.
         captured: list[GeneratedSource] = []
         dense: dict[str, Any] = {}
+        # The training compose needs AOTAutograd's own spec (fw_metadata, RNG
+        # state, disable_amp, the saved/symint counts). It is built during the
+        # capture pass and not otherwise reachable from out here.
+        from . import runtime_wrappers as _rw
+
+        specs: list[Any] = []
 
         def _capture_inner_compile(dense_gm, dense_inputs, **kwargs):
-            if "gm" in dense:
+            # A training graph reaches this TWICE -- once for the forward, once
+            # for the backward -- and inductor says which via is_backward. Keep
+            # the "only one of each" guard per slot; a third call is still
+            # something this layer does not model.
+            slot = "bw" if kwargs.get("is_backward") else "gm"
+            if slot in dense:
                 raise NotImplementedError(
                     "aot_autograd.compile_to_python does not support a graph whose "
-                    "AOTAutograd lowering emits more than one inner forward graph."
+                    f"AOTAutograd lowering emits more than one inner {slot} graph."
                 )
-            dense["gm"] = dense_gm
+            dense[slot] = dense_gm
+            dense[f"{slot}_inputs"] = list(dense_inputs)
             # Retain the placeholder's IDENTITY: it is the authoritative inner call the
             # runtime-wrapper chain closes over. The composer needs it to tell the inner
             # call apart from the orchestration's own outer closure (both surface as a
             # wrapper's inner-ref yet neither is a captured wrapper fn), which is what
             # separates INNER wrappers from the OUTER dedup / synthetic-base wrappers.
             placeholder = make_boxed_func(dense_gm.forward)
-            dense["placeholder"] = placeholder
+            if slot == "gm":
+                dense["placeholder"] = placeholder
             return placeholder
 
         # Drive inductor's own ``compile_fx`` (i.e. its exact AOTAutograd invocation --
@@ -942,26 +1902,43 @@ def compile_to_python(
         # the graph (there is no dynamic_shapes knob): a symbolically-traced graph uses
         # ``"from_graph"`` to stay dynamic, a static one ``"from_example_inputs"`` to
         # specialize -- matching what the composer can bake (symbolic view metadata is
-        # rejected downstream). no_grad pins the inference path (one forward module).
+        # rejected downstream). grad mode selects an inference forward or a joint
+        # forward/backward.
         # Deepcopy first so compile_fx cannot mutate the caller's gm (torchbind
         # ProcessGroups smuggled through as shared references). Note: the raw-collective /
         # torchbind rewrites are inductor-lowering prereqs and belong to the step-2 inductor
         # compile, which applies them to the dense graph -- not duplicated here.
         shapes_mode = (
-            "from_graph" if _graph_has_dynamic_shapes(gm) else "from_example_inputs"
+            "from_tracing_context"
+            if torch._guards.TracingContext.try_get() is not None
+            else (
+                "from_graph" if _graph_has_dynamic_shapes(gm) else "from_example_inputs"
+            )
         )
         with (
-            torch.no_grad(),
+            torch.enable_grad() if grad_enabled else torch.no_grad(),
             _standalone_context(gm, shapes_mode, aot=False),
+            functorch_config.patch(
+                enable_autograd_cache=False,
+                enable_remote_autograd_cache=False,
+                # The emitted training glue bakes the undefined-tangent
+                # specialization on (see _AOT_PRUNE_UNUSED_OUTPUTS below), so
+                # capture under it too: that records the autograd trace info
+                # the exact retrace needs, without which every partial-mask
+                # variant silently fell back to structural pruning.
+                aot_autograd_prune_unused_outputs=grad_enabled,
+            ),
             capture_generated_sources(captured),
+            _rw.capture_aot_dispatch_autograd_specs(specs),
         ):
             with _share_torchbind_and_process_group_on_deepcopy():
                 gm_owned = copy.deepcopy(gm)
             compile_fx(
                 gm_owned,
                 example_inputs,
-                # Placeholder returns a boxed callable, not a full OutputCode; AOTAutograd
-                # only wraps it (never inductor-post-compiles it), so this is fine at runtime.
+                # Placeholder returns a boxed callable, not a full OutputCode;
+                # AOTAutograd only wraps it (never inductor-post-compiles it), so
+                # this is fine at runtime.
                 inner_compile=_capture_inner_compile,  # pyrefly: ignore[bad-argument-type]
                 ignore_shape_env=_resolve_ignore_shape_env(shapes_mode),
             )
@@ -971,12 +1948,105 @@ def compile_to_python(
                 "forward compiler, so no dense graph was captured."
             )
 
-        inner_python, cache = _inductor_compile_to_python(
-            dense["gm"], example_inputs, options=options
+        # Lower the FORWARD first and take the strides inductor actually chose,
+        # then restride the backward's placeholders to match before lowering it.
+        # This is the fw->bw coupling torch.compile gets from
+        # TracingContext.report_output_strides (graph_compile.py:2841) and feeds
+        # to _aot_stage2b_bw_compile; a capture pass that never lowers cannot
+        # observe it, and two independently-lowered graphs then disagree about
+        # layout -- loudly on a conv net, silently if size asserts are off.
+        has_joint = "bw" in dense
+        differentiates = has_joint or _graph_differentiates(dense["gm"])
+        fwd_output_strides: list[tuple[str, ...] | None] = []
+        # The user-visible outputs of a training forward are its first
+        # num_forward outputs; the rest are saved activations inductor may
+        # re-lay-out freely (the backward is restrided to match below).
+        num_user_outputs = (
+            specs[0].fw_metadata.num_forward if has_joint and len(specs) == 1 else None
         )
-        source = _compose_standalone_module(
-            inner_python, captured, dense["placeholder"]
+        inner_python, forward_cache = _inductor_compile_to_python(
+            dense["gm"],
+            example_inputs,
+            options=options,
+            is_inference=not differentiates,
+            output_strides=fwd_output_strides,
+            num_user_visible_outputs=num_user_outputs,
         )
+        if not has_joint:
+            source = _compose_standalone_module(
+                inner_python, captured, dense["placeholder"]
+            )
+            return source, forward_cache, None
+
+        if len(specs) != 1:
+            raise NotImplementedError(
+                "aot_autograd.compile_to_python expected exactly one training "
+                f"autograd-function spec, captured {len(specs)}."
+            )
+        spec = specs[0]
+
+        _restride_backward_placeholders(dense["bw"], fwd_output_strides, spec)
+        bw_python, backward_cache = _inductor_compile_to_python(
+            dense["bw"],
+            [],
+            options=options,
+            is_inference=False,
+            is_backward=True,
+        )
+        from torch.compiler._cache import CacheArtifactManager
+
+        cache = CacheArtifactManager.merge((forward_cache, backward_cache))
+        source = _compose_training_module(
+            inner_python,
+            [
+                _StandaloneBackwardVariant(
+                    undefined_grad_out_mask=None,
+                    python_code=bw_python,
+                    pruned_output_indices=None,
+                )
+            ],
+            captured,
+            spec,
+            dense["bw"],
+            dense["placeholder"],
+        )
+        state = _CompileToPythonState(
+            forward_python=inner_python,
+            backward_python=bw_python,
+            captured=captured,
+            spec=spec,
+            backward_graph=dense["bw"],
+            backward_inputs=dense["bw_inputs"],
+            options=options,
+            forward_cache=forward_cache,
+            backward_cache=backward_cache,
+            forward_inner_call=dense["placeholder"],
+        )
+    return source, cache, state
+
+
+def compile_to_python(
+    gm: GraphModule,
+    example_inputs: Sequence[Any],
+    *,
+    options: dict[str, Any] | None = None,
+    grad_enabled: bool = False,
+) -> tuple[str, bytes | None]:
+    """Compile ``gm`` to standalone Python source and an optional cache bundle.
+
+    See the module documentation for the generated module's calling convention.
+    ``grad_enabled=True`` includes AOTAutograd's differentiable forward and backward.
+
+    When called inside an active ``TracingContext`` (i.e. from a torch.compile
+    backend), the graph's shapes are taken from that context's shape environment
+    rather than inferred from ``gm``; the emitted source is otherwise the same.
+    """
+    source, cache, _ = _compile_to_python_with_state(
+        gm,
+        example_inputs,
+        options=options,
+        grad_enabled=grad_enabled,
+    )
     return source, cache
 
 

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -4,6 +4,7 @@ import contextlib
 import copy
 import itertools
 import logging
+import math
 import os
 import pickle
 import shutil
@@ -612,7 +613,48 @@ class NoRunnableInductorModuleError(RuntimeError):
     """
 
 
-def _runnable_source(compiled_graph: OutputCode) -> str:
+def _passthrough_source(gm: GraphModule) -> str | None:
+    placeholders = {
+        node: index
+        for index, node in enumerate(gm.graph.nodes)
+        if node.op == "placeholder"
+    }
+    output = next((node for node in gm.graph.nodes if node.op == "output"), None)
+    if output is None or any(
+        node.op not in ("placeholder", "output") for node in gm.graph.nodes
+    ):
+        return None
+
+    def render(value: Any) -> str:
+        if isinstance(value, torch.fx.Node):
+            if value not in placeholders:
+                raise KeyError(value)
+            return f"args[{placeholders[value]}]"
+        if isinstance(value, tuple):
+            values = ", ".join(render(item) for item in value)
+            return f"({values},)" if len(value) == 1 else f"({values})"
+        if isinstance(value, list):
+            return f"[{', '.join(render(item) for item in value)}]"
+        if isinstance(value, float) and not math.isfinite(value):
+            return f"float({str(value)!r})"
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return repr(value)
+        raise TypeError
+
+    try:
+        result = render(output.args[0])
+    except (KeyError, TypeError):
+        return None
+    # Honor inductor's boxed-call contract of consuming the argument list so a
+    # backward's saved tensors are released as early as the real kernel would.
+    return (
+        f"def call(args):\n    result = {result}\n    args.clear()\n    return result\n"
+    )
+
+
+def _runnable_source(
+    compiled_graph: OutputCode, gm: GraphModule, *, allow_passthrough: bool = False
+) -> str:
     """Return the Inductor output-module source for a compiled inner graph.
 
     ``compile_fx_inner`` returns a ``CompiledFxGraph`` that carries the wrapper-module
@@ -621,6 +663,8 @@ def _runnable_source(compiled_graph: OutputCode) -> str:
     surface as ``NoRunnableInductorModuleError``.
     """
     source = getattr(compiled_graph, "source_code", None)
+    if not source and allow_passthrough:
+        source = _passthrough_source(gm)
     if not source:
         raise NoRunnableInductorModuleError(
             "the compiled graph produced no runnable Inductor output module: it has no "
@@ -698,6 +742,10 @@ def compile_to_python(
     example_inputs: Sequence[InputType],
     *,
     options: dict[str, Any] | None = None,
+    is_inference: bool = True,
+    is_backward: bool = False,
+    output_strides: list[tuple[str, ...] | None] | None = None,
+    num_user_visible_outputs: int | None = None,
 ) -> tuple[str, bytes | None]:
     """Compile ``gm`` and return ``(inner_python, cache)`` -- the INNER half of the
     backend contract behind ``torch.compiler.precompile``.
@@ -715,6 +763,15 @@ def compile_to_python(
     layer -- a companion change in ``torch._functorch.aot_autograd`` wraps this and
     composes AOTAutograd's codegen'd runtime wrappers around the result.
     Callers must run ``call`` under ``torch.no_grad()`` (the kernels use out= ops).
+    ``is_inference`` selects Inductor's inference or training layout heuristics, while
+    ``is_backward`` enables backward-specific lowering constraints. If ``output_strides``
+    is provided, it is extended with the layouts selected for the graph outputs so an
+    AOTAutograd backward can be lowered against the forward's actual saved-activation
+    layouts. The first ``num_user_visible_outputs`` outputs (all of them when None)
+    are marked user-visible, which under ``keep_output_stride`` (the default; honored
+    from ``config_patches`` as ``torch.compile`` honors ``options``) pins their strides
+    to the graph's instead of letting inductor pad or re-lay-out tensors the caller
+    will hand to autograd or return.
 
     Caller preconditions (this layer does not re-derive them):
 
@@ -812,7 +869,11 @@ def compile_to_python(
     from torch._guards import detect_fake_mode, tracing, TracingContext
     from torch.compiler._cache import CacheArtifactManager
 
-    from .compile_fx import compile_fx_inner
+    from .compile_fx import (
+        _cudagraph_trees_clone_live_user_outputs,
+        _recursive_record_user_visible_output_idxs,
+        compile_fx_inner,
+    )
     from .virtualized import V
 
     # Own a copy: the collective rewrites and inductor may mutate the graph, and ``gm`` may
@@ -831,6 +892,21 @@ def compile_to_python(
     # dims. A post-AOTAutograd graph's shapes are already baked into this metadata, so
     # there is no separate dynamic-shapes knob.
     fake_inputs = _placeholder_fake_inputs(gm)
+    output_node = gm.graph.find_nodes(op="output")[-1]
+    outputs = output_node.args[0] if output_node.args else ()
+    if isinstance(outputs, torch.fx.Node):
+        outputs = (outputs,)
+    outputs = list(outputs)
+    if num_user_visible_outputs is not None:
+        # The caller's prefix; for a training forward this is num_forward,
+        # which also spans mutated-input returns and intermediate bases (a
+        # superset of what compile_fx pins, so strictly more conservative).
+        outputs = outputs[:num_user_visible_outputs]
+    # Like compile_fx's marking, only tensor outputs are user visible; None and
+    # symbolic-int outputs carry no layout.
+    user_visible_output_idxs = [
+        idx for idx, out in enumerate(outputs) if isinstance(out, torch.fx.Node)
+    ]
     fake_mode = detect_fake_mode(fake_inputs)
     if fake_mode is None:
         raise RuntimeError(
@@ -848,16 +924,33 @@ def compile_to_python(
         V.set_fake_mode(fake_mode),
         CacheArtifactManager.with_fresh_cache(),
     ):
+        # Under the caller's config, as compile_fx does: the pin applies only
+        # with keep_output_stride (or cudagraph trees' live-output cloning), so
+        # options={"keep_output_stride": False} is honored here too. Nested
+        # invoke_subgraph subgraphs get the same treatment compile_fx gives them.
+        if config.keep_output_stride or _cudagraph_trees_clone_live_user_outputs():
+            output_node.meta["user_visible_output_idxs"] = user_visible_output_idxs
+        else:
+            output_node.meta["user_visible_output_idxs"] = []
+        _recursive_record_user_visible_output_idxs(gm)
         compiled_graph = compile_fx_inner(
             gm,
             fake_inputs,
             static_input_idxs=(),
             cudagraphs=BoxedBool(False),
-            is_inference=True,
+            is_inference=is_inference,
+            is_backward=is_backward,
             boxed_forward_device_index=BoxedDeviceIndex(None),
         )
         artifacts = torch.compiler.save_cache_artifacts()
-    inner_python = _runnable_source(compiled_graph)
+    if output_strides is not None:
+        # The strides Inductor CHOSE for this graph's outputs, which only exist
+        # once it has lowered. A training backward has to be compiled against
+        # the forward's actual choices -- layout optimization is free to hand
+        # back channels-last saved activations -- and this is the only channel
+        # for that, since the caller cannot see the CompiledFxGraph.
+        output_strides.extend(getattr(compiled_graph, "output_strides", None) or [])
+    inner_python = _runnable_source(compiled_graph, gm, allow_passthrough=is_backward)
     cache = _acceleration_cache_bytes(artifacts)
     return inner_python, cache
 

--- a/torch/compiler/_cache.py
+++ b/torch/compiler/_cache.py
@@ -3,7 +3,7 @@ import dataclasses
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from itertools import chain
 from typing import Any
@@ -314,6 +314,31 @@ class CacheArtifactManager:
             return None
 
         return artifacts
+
+    @staticmethod
+    def merge(serialized_artifacts: Iterable[bytes | None]) -> bytes | None:
+        """Combine serialized cache bundles, deduplicating identical artifacts."""
+        merged: CacheArtifactsResult = defaultdict(list)
+        seen: OrderedSet[CacheArtifact] = OrderedSet()
+        for serialized in serialized_artifacts:
+            if serialized is None:
+                continue
+            artifacts = CacheArtifactManager.deserialize(serialized)
+            if artifacts is None:
+                # The cache is only an accelerator; drop the unreadable bundle
+                # (deserialize already logged it) and keep the others.
+                continue
+            for artifact_type, values in artifacts.items():
+                for artifact in values:
+                    if artifact in seen:
+                        continue
+                    merged[artifact_type].append(artifact)
+                    seen.add(artifact)
+        if not merged:
+            return None
+        serializer = AppendingByteSerializer(serialize_fn=_serialize_single_cache)
+        serializer.extend(merged.items())
+        return serializer.to_bytes()
 
     @staticmethod
     def populate_caches(artifacts: CacheArtifactsResult) -> CacheInfo:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195288
* __->__ #195885
* #195884
* #195689
* #195688
* #195883
* #195882
* #195687
* #195686
* #195287
* #195286

compile_to_python / to_standalone_python can now emit the training (backward)
path, not just inference, on top of the undefined-tangent backward
specialization two commits below: a training artifact composes the forward,
the base backward and one backward variant per tangent mask observed at
capture, and serves the variant for the mask a backward call presents.

Differentiability of a generated graph is decided by scanning call nodes'
operator names (to_standalone_python._graph_differentiates), not by
substring-matching graph names.

Standalone artifacts. compile_to_python training artifacts import AOTAutograd
only through standalone_runtime: source_emit redirects every re-exported object
there by identity, and the surface holds the runtime helpers, the metadata
types, the whole closed set of descriptor classes, FunctionalTensor (the
raw_type baked into output metadata) and SymIntEqByExpr (baked MetadataKey
entries); BackwardState is bound into the forward only when the graph has
backward state, and the surface test matches every private torch path an
artifact could reach internals through. The direct compile_to_python path
captures under aot_autograd_prune_unused_outputs, matching the flag the emitted
glue bakes on, so the exact retrace is available and a declined retrace warns
instead of silently falling back to structural pruning; the standalone mask
compiler follows the live runtime's fallback policy and always serves mask 0.
standalone_compile marks user-visible outputs under keep_output_stride as
compile_fx does; module renaming converts ast byte offsets to str offsets; the
module names shared with torch._precompile are constants; the passthrough
backward consumes its argument list; a corrupt cache bundle does not discard
the good ones in a merge.

Suggested review order: to_standalone_python.py (the training composer),
standalone_runtime.py and source_emit.py (the stable import surface),
torch/_inductor/standalone_compile.py (user-visible output marking), then
torch/compiler/_cache.py.

Test Plan:

```
python test/functorch/test_compile_to_python.py
python test/inductor/test_compile_to_python.py
```

New tests: a training artifact loading in a fresh subprocess, the
stable-surface import assertion for training artifacts across private paths,
non-ASCII module renaming, passthrough argument release, and cache-merge
tolerance.

Authored with an AI assistant.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo