### PR TITLE
Fix CUDA 13 DSA `cudaMemAdvise` host location (cudaErrorInvalidValue) (#195899)

### DIFF
--- a/c10/cuda/CUDADeviceAssertionHost.cpp
+++ b/c10/cuda/CUDADeviceAssertionHost.cpp
@@ -301,9 +301,12 @@ DeviceAssertionsData* CUDAKernelLaunchRegistry::
       cudaMallocManaged(&uvm_assertions_ptr, sizeof(DeviceAssertionsData)));
 
 #if CUDART_VERSION >= 13000 && !defined(USE_ROCM)
-  cudaMemLocation cpuDevice;
-  cpuDevice.type = cudaMemLocationTypeDevice;
-  cpuDevice.id = cudaCpuDeviceId;
+  // The CPU is addressed via cudaMemLocationTypeHost; a device location with
+  // id == cudaCpuDeviceId is rejected with cudaErrorInvalidValue, since ids are
+  // only validated as device ordinals. The id field is ignored for host
+  // locations.
+  cudaMemLocation cpuDevice{};
+  cpuDevice.type = cudaMemLocationTypeHost;
 #else
   // hipMemAdvise_v2 with hipMemLocationTypeDevice + hipCpuDeviceId fails on
   // ROCm; the v1 int API maps to Host semantics and works.


### PR DESCRIPTION
Summary:

Under CUDA 13, device-side assertions (DSA) were broken: every DSA kernel
launch threw `CUDA error: invalid argument` (`cudaErrorInvalidValue`) instead
of reporting the actual device-side assertion.

Root cause: CUDA 13 changed `cudaMemAdvise` to take a `cudaMemLocation` struct
instead of an `int` device id. D86578286 ported
`get_uvm_assertions_ptr_for_current_device()` to the new signature by encoding
the CPU as `{type = cudaMemLocationTypeDevice, id = cudaCpuDeviceId}`. 