### PR TITLE
[ROCm][c10d] Unskip nccl2 expandable all-gather

### DIFF
--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -25,7 +25,6 @@ from torch.testing._internal.common_distributed import (
     requires_nccl,
     requires_nccl_version,
     skip_if_lt_x_gpu,
-    skip_if_rocm_ver_atleast_multiprocess,
 )
 from torch.testing._internal.common_utils import (
     IS_FBCODE,
@@ -804,7 +803,6 @@ class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_large_in_place_all_gather(self) -> None:
         numel = 16 * 1024 * 1024
         output = torch.empty(


### PR DESCRIPTION
## Summary
- Drop `@skip_if_rocm_ver_atleast_multiprocess([7, 14])` from `ProcessGroupNCCL2ExpandableSegmentsTest.test_large_in_place_all_gather`.
- That skip is `>= 7.14`, so it also hides the test on ROCm 10.0 trunk. This is a probe: no RCCL staging workaround, just run it.

Not the same as #192814 (`test_cuda.py` expandable OOM tests).

## CI Validation


  Commit: `e284b654` — removes `@skip_if_rocm_ver_atleast_multiprocess([7, 14])` from
  `test/distributed/test_c10d_nccl2.py::ProcessGroupNCCL2ExpandableSegmentsTest::test_large_in_place_all_gather`

  | Workflow | Job link | Shard | Result |
  |---|---|---|---|
  | mi200 (`periodic-rocm-mi200`) | https://github.com/pytorch/pytorch/actions/runs/34380035880/job/102569640363 | distributed 1/3 | PASSED [5.5268s] [ 56%] |
  | mi300 (`periodic-rocm-mi300`) | https://github.com/pytorch/pytorch/actions/runs/34380035427/job/102570063136 | distributed 1/5 | PASSED [7.6727s] [ 56%] |
  | preview (`rocm-preview`) | https://github.com/pytorch/pytorch/actions/runs/34380178171/job/102579135460 | distributed 1/3 | PASSED [3.2646s] [ 56%] |
  | trunk (`trunk`, mi350) | https://github.com/pytorch/pytorch/actions/runs/34380178369/job/102570883269 | distributed 1/3 | PASSED [3.4859s] [ 56%] |


  ### Caveat
  mi200 `distributed` shard 2/3 failed on this run, but its artifact contains a different- set of test files entirely (fsdp/, checkpoint/, tensor/, etc.) — no `test_c10d_nccl2` log present. That failure is unrelated to the unskipped test.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang