### PR TITLE
[CI] [Distribtued] Install nccl4py in distributed CI configs 

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -343,6 +343,14 @@ function install_torchcomms() {
   pip_build_and_install "git+https://github.com/meta-pytorch/torchcomms.git@${commit}" dist/torchcomms
 }
 
+function install_nccl4py() {
+  local extra=cu12
+  if [[ "${DESIRED_CUDA:-}" == 13.* || "${CUDA_VERSION:-}" == 13.* || "${BUILD_ENVIRONMENT:-}" == *cuda13* ]]; then
+    extra=cu13
+  fi
+  pip_install "nccl4py[${extra}]==0.5.0"
+}
+
 function install_spmd_types() {
   local commit
   commit=$(get_pinned_commit spmd_types)

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1784,6 +1784,7 @@ test_distributed_single_gpu() {
   # `default` config's Python tests.
   install_torchcomms
   install_spmd_types
+  install_nccl4py
   test_distributed not-multigpu
 }
 
@@ -2420,6 +2421,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
 elif [[ "$TEST_CONFIG" == distributed ]]; then
   install_torchcomms
   install_spmd_types
+  install_nccl4py
   # On CUDA and ROCm the single-process (single-GPU) distributed tests are hived
   # off to the `default` config's 1-GPU runner (see below), so this multi-GPU box
   # only runs the process-spawning ones. Elsewhere (e.g. CPU pull) there is no
@@ -2632,6 +2634,7 @@ elif [[ "${TEST_CONFIG}" == dtensor ]]; then
   test_dtensor
 elif [[ "${TEST_CONFIG}" == h100_distributed ]]; then
   install_torchcomms
+  install_nccl4py
   test_h100_distributed
 elif [[ "${TEST_CONFIG}" == "h100-symm-mem" ]]; then
   test_h100_symm_mem


### PR DESCRIPTION
### Summary 

Installs nccl4py into the distributed builds so CI for `NCCL4PyBackend` and `TokenSwitch` as well as other distributed functionalities that depend on it runs. 

The version is currently a manual pin, looking for suggestions to automate that. 