### PR TITLE
Emit a scale-config AMI variant prefix so Windows canary AMIs are reachable

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -93,17 +93,10 @@ META_LABEL_PREFIX = "mt-"
 META_CANARY_LABEL_PREFIX = "c-mt-"
 LF_LABEL_PREFIX = "lf-"
 
-# The EC2 autoscaler runners declared in test-infra's scale-config.yml hang
-# per-runner AMI `variants:` off an experiment name, reached by prefixing the
-# runner type with it: the wincanary variant of windows.12xlarge is
-# wincanary.windows.12xlarge. That is how a new Windows AMI gets exercised
-# before rollout, and the ARC prefixes above cannot express it.
-#
-# Deliberately limited to the AMI-variant experiments. Fleet selection is NOT
-# folded in: `lf` runs at a percentage rollout over ALL workflows, so deriving
-# a prefix from it would silently move Windows builds onto another fleet for
-# every run that happens to be sampled. Anything not listed here leaves the
-# prefix empty and the caller lands on the bare label it uses today.
+# Experiments naming a scale-config AMI variant, selected by prefixing the
+# runner type: wincanary.windows.12xlarge. Fleet experiments are excluded on
+# purpose -- lf rolls out over ALL workflows and would move Windows builds off
+# their fleet as a side effect.
 SCALE_CONFIG_VARIANT_EXPERIMENTS = frozenset({"wincanary", "wincanarylf"})
 
 AMD_SANDBOX_EXPERIMENT = "amd-sandbox"
@@ -136,8 +129,6 @@ class RunnerPrefixResult(NamedTuple):
     # Dedicated prefix for the amd-sandbox experiment, exposed via its own output
     # (amd-sandbox-label-type) instead of being folded into ``prefix``.
     amd_sandbox_prefix: str = ""
-    # Dot-scheme prefix for the scale-config (EC2) fleets, exposed via
-    # scale-config-label-type. Empty means the default Meta scale-config fleet.
     scale_config_prefix: str = ""
 
 
@@ -548,8 +539,6 @@ def get_runner_prefix(
 
     lf_enabled = False
     amd_sandbox_prefix = ""
-    # Non-fleet experiments enabled for this run, in the order encountered.
-    # These name scale-config AMI `variants:` (e.g. wincanary).
     scale_config_experiments: list[str] = []
     for experiment_name, experiment_settings in settings.experiments.items():
         if not experiment_settings.all_branches and is_exception_branch(branch):
@@ -675,8 +664,8 @@ def get_runner_prefix(
             elif experiment_name in SCALE_CONFIG_VARIANT_EXPERIMENTS:
                 scale_config_experiments.append(experiment_name)
                 log.info(
-                    f"Experiment '{experiment_name}' enabled; it names a scale-config "
-                    "AMI variant and is offered on scale-config-label-type."
+                    f"Experiment '{experiment_name}' enabled; offering it on "
+                    "scale-config-label-type."
                 )
             else:
                 log.info(
@@ -691,8 +680,6 @@ def get_runner_prefix(
     else:
         prefix = META_CANARY_LABEL_PREFIX if is_canary else META_LABEL_PREFIX
 
-    # AMI-variant prefix: "" when no variant experiment is enabled, otherwise
-    # "<variant>.", e.g. "wincanary." -> wincanary.windows.12xlarge.
     if len(scale_config_experiments) > 1:
         log.error(
             "Only one scale-config AMI variant can be enabled for a job at any time. "

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -93,15 +93,18 @@ META_LABEL_PREFIX = "mt-"
 META_CANARY_LABEL_PREFIX = "c-mt-"
 LF_LABEL_PREFIX = "lf-"
 
-# Scale-config fleets (the EC2 autoscaler runners declared in test-infra's
-# {,canary-,lf-,lf-canary-}scale-config.yml) name their labels with a dot
-# scheme -- "", "lf.", "lf.c." -- and hang per-runner AMI `variants:` off the
-# experiment name, e.g. the wincanary variant of lf.windows.12xlarge is
-# reached as wincanary.lf.windows.12xlarge. Windows never moved to ARC, so it
-# needs this scheme rather than the ARC prefixes above; it is published on its
-# own output so ARC consumers keep seeing mt-/c-mt-/lf- unchanged.
-SCALE_CONFIG_LF_PREFIX = "lf"
-SCALE_CONFIG_CANARY_SUFFIX = ".c"
+# The EC2 autoscaler runners declared in test-infra's scale-config.yml hang
+# per-runner AMI `variants:` off an experiment name, reached by prefixing the
+# runner type with it: the wincanary variant of windows.12xlarge is
+# wincanary.windows.12xlarge. That is how a new Windows AMI gets exercised
+# before rollout, and the ARC prefixes above cannot express it.
+#
+# Deliberately limited to the AMI-variant experiments. Fleet selection is NOT
+# folded in: `lf` runs at a percentage rollout over ALL workflows, so deriving
+# a prefix from it would silently move Windows builds onto another fleet for
+# every run that happens to be sampled. Anything not listed here leaves the
+# prefix empty and the caller lands on the bare label it uses today.
+SCALE_CONFIG_VARIANT_EXPERIMENTS = frozenset({"wincanary", "wincanarylf"})
 
 AMD_SANDBOX_EXPERIMENT = "amd-sandbox"
 AMD_SANDBOX_LABEL_PREFIX = "amd-sandbox-"
@@ -669,13 +672,16 @@ def get_runner_prefix(
             elif experiment_name == LF_FLEET_EXPERIMENT:
                 lf_enabled = True
                 log.info("lf experiment enabled. Using the Linux Foundation fleet.")
-            else:
-                # Not an ARC fleet selector, but it may name a scale-config AMI
-                # variant, which is how Windows canary AMIs are reached.
+            elif experiment_name in SCALE_CONFIG_VARIANT_EXPERIMENTS:
                 scale_config_experiments.append(experiment_name)
                 log.info(
-                    f"Experiment '{experiment_name}' enabled; it does not affect the "
-                    "ARC label prefix but is offered on scale-config-label-type."
+                    f"Experiment '{experiment_name}' enabled; it names a scale-config "
+                    "AMI variant and is offered on scale-config-label-type."
+                )
+            else:
+                log.info(
+                    f"Experiment '{experiment_name}' enabled but no longer affects "
+                    "the runner label prefix; ignoring."
                 )
 
     # Fleet selection: the Meta (OSDC) fleet is the default; the lf experiment
@@ -685,22 +691,17 @@ def get_runner_prefix(
     else:
         prefix = META_CANARY_LABEL_PREFIX if is_canary else META_LABEL_PREFIX
 
-    # Scale-config scheme, assembled fleet-first and dot-joined with a trailing
-    # dot, e.g. "" / "lf." / "lf.c." / "wincanary." / "lf.wincanary.".
+    # AMI-variant prefix: "" when no variant experiment is enabled, otherwise
+    # "<variant>.", e.g. "wincanary." -> wincanary.windows.12xlarge.
     if len(scale_config_experiments) > 1:
         log.error(
-            "Only a fleet and one other experiment can be enabled for a job at any "
-            f"time. Enabling {scale_config_experiments[0]} and ignoring the rest, "
-            f"which are {', '.join(scale_config_experiments[1:])}"
+            "Only one scale-config AMI variant can be enabled for a job at any time. "
+            f"Enabling {scale_config_experiments[0]} and ignoring the rest, which "
+            f"are {', '.join(scale_config_experiments[1:])}"
         )
         del scale_config_experiments[1:]
-    if lf_enabled:
-        fleet = SCALE_CONFIG_LF_PREFIX + (
-            SCALE_CONFIG_CANARY_SUFFIX if is_canary else ""
-        )
-        scale_config_experiments.insert(0, fleet)
     scale_config_prefix = (
-        ".".join(scale_config_experiments) + "." if scale_config_experiments else ""
+        f"{scale_config_experiments[0]}." if scale_config_experiments else ""
     )
 
     return RunnerPrefixResult(

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -695,7 +695,9 @@ def get_runner_prefix(
         )
         del scale_config_experiments[1:]
     if lf_enabled:
-        fleet = SCALE_CONFIG_LF_PREFIX + (SCALE_CONFIG_CANARY_SUFFIX if is_canary else "")
+        fleet = SCALE_CONFIG_LF_PREFIX + (
+            SCALE_CONFIG_CANARY_SUFFIX if is_canary else ""
+        )
         scale_config_experiments.insert(0, fleet)
     scale_config_prefix = (
         ".".join(scale_config_experiments) + "." if scale_config_experiments else ""

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -77,6 +77,7 @@ GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
 GH_OUTPUT_KEY_AMI = "runner-ami"
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
 GH_OUTPUT_KEY_AMD_SANDBOX_LABEL_TYPE = "amd-sandbox-label-type"
+GH_OUTPUT_KEY_SCALE_CONFIG_LABEL_TYPE = "scale-config-label-type"
 OPT_OUT_LABEL = "no-runner-experiments"
 
 SETTING_EXPERIMENTS = "experiments"
@@ -91,6 +92,16 @@ LF_FLEET_EXPERIMENT = "lf"
 META_LABEL_PREFIX = "mt-"
 META_CANARY_LABEL_PREFIX = "c-mt-"
 LF_LABEL_PREFIX = "lf-"
+
+# Scale-config fleets (the EC2 autoscaler runners declared in test-infra's
+# {,canary-,lf-,lf-canary-}scale-config.yml) name their labels with a dot
+# scheme -- "", "lf.", "lf.c." -- and hang per-runner AMI `variants:` off the
+# experiment name, e.g. the wincanary variant of lf.windows.12xlarge is
+# reached as wincanary.lf.windows.12xlarge. Windows never moved to ARC, so it
+# needs this scheme rather than the ARC prefixes above; it is published on its
+# own output so ARC consumers keep seeing mt-/c-mt-/lf- unchanged.
+SCALE_CONFIG_LF_PREFIX = "lf"
+SCALE_CONFIG_CANARY_SUFFIX = ".c"
 
 AMD_SANDBOX_EXPERIMENT = "amd-sandbox"
 AMD_SANDBOX_LABEL_PREFIX = "amd-sandbox-"
@@ -122,6 +133,9 @@ class RunnerPrefixResult(NamedTuple):
     # Dedicated prefix for the amd-sandbox experiment, exposed via its own output
     # (amd-sandbox-label-type) instead of being folded into ``prefix``.
     amd_sandbox_prefix: str = ""
+    # Dot-scheme prefix for the scale-config (EC2) fleets, exposed via
+    # scale-config-label-type. Empty means the default Meta scale-config fleet.
+    scale_config_prefix: str = ""
 
 
 class Settings(NamedTuple):
@@ -531,6 +545,9 @@ def get_runner_prefix(
 
     lf_enabled = False
     amd_sandbox_prefix = ""
+    # Non-fleet experiments enabled for this run, in the order encountered.
+    # These name scale-config AMI `variants:` (e.g. wincanary).
+    scale_config_experiments: list[str] = []
     for experiment_name, experiment_settings in settings.experiments.items():
         if not experiment_settings.all_branches and is_exception_branch(branch):
             log.info(
@@ -653,9 +670,12 @@ def get_runner_prefix(
                 lf_enabled = True
                 log.info("lf experiment enabled. Using the Linux Foundation fleet.")
             else:
+                # Not an ARC fleet selector, but it may name a scale-config AMI
+                # variant, which is how Windows canary AMIs are reached.
+                scale_config_experiments.append(experiment_name)
                 log.info(
-                    f"Experiment '{experiment_name}' enabled but no longer affects "
-                    "the runner label prefix; ignoring."
+                    f"Experiment '{experiment_name}' enabled; it does not affect the "
+                    "ARC label prefix but is offered on scale-config-label-type."
                 )
 
     # Fleet selection: the Meta (OSDC) fleet is the default; the lf experiment
@@ -664,7 +684,28 @@ def get_runner_prefix(
         prefix = LF_LABEL_PREFIX
     else:
         prefix = META_CANARY_LABEL_PREFIX if is_canary else META_LABEL_PREFIX
-    return RunnerPrefixResult(prefix=prefix, amd_sandbox_prefix=amd_sandbox_prefix)
+
+    # Scale-config scheme, assembled fleet-first and dot-joined with a trailing
+    # dot, e.g. "" / "lf." / "lf.c." / "wincanary." / "lf.wincanary.".
+    if len(scale_config_experiments) > 1:
+        log.error(
+            "Only a fleet and one other experiment can be enabled for a job at any "
+            f"time. Enabling {scale_config_experiments[0]} and ignoring the rest, "
+            f"which are {', '.join(scale_config_experiments[1:])}"
+        )
+        del scale_config_experiments[1:]
+    if lf_enabled:
+        fleet = SCALE_CONFIG_LF_PREFIX + (SCALE_CONFIG_CANARY_SUFFIX if is_canary else "")
+        scale_config_experiments.insert(0, fleet)
+    scale_config_prefix = (
+        ".".join(scale_config_experiments) + "." if scale_config_experiments else ""
+    )
+
+    return RunnerPrefixResult(
+        prefix=prefix,
+        amd_sandbox_prefix=amd_sandbox_prefix,
+        scale_config_prefix=scale_config_prefix,
+    )
 
 
 def get_rollout_state_from_issue(github_token: str, repo: str, issue_num: int) -> str:
@@ -728,6 +769,7 @@ def main() -> None:
 
     runner_label_prefix = META_LABEL_PREFIX
     amd_sandbox_label_prefix = ""
+    scale_config_label_prefix = ""
 
     # no-runner-experiments means "use Meta, not LF": opt out of the lf
     # experiment, so the run stays on the default Meta fleet.
@@ -770,6 +812,7 @@ def main() -> None:
         )
         runner_label_prefix = result.prefix
         amd_sandbox_label_prefix = result.amd_sandbox_prefix
+        scale_config_label_prefix = result.scale_config_prefix
 
     except Exception as e:
         log.error(
@@ -778,6 +821,7 @@ def main() -> None:
 
     set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, runner_label_prefix)
     set_github_output(GH_OUTPUT_KEY_AMD_SANDBOX_LABEL_TYPE, amd_sandbox_label_prefix)
+    set_github_output(GH_OUTPUT_KEY_SCALE_CONFIG_LABEL_TYPE, scale_config_label_prefix)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -862,8 +862,8 @@ if __name__ == "__main__":
 
 
 class TestScaleConfigPrefix(TestCase):
-    """The scale-config (EC2) fleets use a dot scheme and AMI variants, unlike
-    the ARC prefixes on label-type. Windows binary builds consume this."""
+    """scale-config-label-type names a scale-config AMI variant. Only the
+    wincanary/wincanarylf experiments drive it; fleet selection must not."""
 
     SETTINGS = """
 experiments:
@@ -876,39 +876,40 @@ experiments:
 ---
 @lfuser,lf
 @wcuser,wincanary
+@wclfuser,wincanarylf
 @bothuser,lf,wincanarylf
 @plainuser,
 """
     ALL = frozenset({"lf", "wincanary", "wincanarylf"})
 
-    def _prefix(self, user: str, is_canary: bool = False) -> str:
+    def _result(self, user: str, is_canary: bool = False) -> rd.RunnerPrefixResult:
         return rd.get_runner_prefix(
             self.SETTINGS, (user, user), "somebranch", self.ALL, frozenset(), is_canary
-        ).scale_config_prefix
+        )
 
-    def test_default_is_bare(self) -> None:
-        # scale-config.yml declares windows.12xlarge with no prefix
-        self.assertEqual("", self._prefix("plainuser"))
+    def test_no_variant_means_no_prefix(self) -> None:
+        self.assertEqual("", self._result("plainuser").scale_config_prefix)
 
-    def test_lf(self) -> None:
-        # lf-scale-config.yml declares lf.windows.12xlarge
-        self.assertEqual("lf.", self._prefix("lfuser"))
+    def test_lf_alone_does_not_set_a_prefix(self) -> None:
+        # lf runs at a percentage rollout over ALL workflows; it must not move
+        # Windows builds onto another fleet as a side effect.
+        self.assertEqual("", self._result("lfuser").scale_config_prefix)
+        self.assertEqual("", self._result("lfuser", is_canary=True).scale_config_prefix)
 
-    def test_lf_canary(self) -> None:
-        # lf-canary-scale-config.yml declares lf.c.windows.12xlarge
-        self.assertEqual("lf.c.", self._prefix("lfuser", is_canary=True))
-
-    def test_ami_variant(self) -> None:
+    def test_wincanary(self) -> None:
         # wincanary is an AMI variant of windows.12xlarge
-        self.assertEqual("wincanary.", self._prefix("wcuser"))
+        self.assertEqual("wincanary.", self._result("wcuser").scale_config_prefix)
 
-    def test_fleet_comes_first(self) -> None:
-        self.assertEqual("lf.wincanarylf.", self._prefix("bothuser"))
+    def test_wincanarylf(self) -> None:
+        self.assertEqual("wincanarylf.", self._result("wclfuser").scale_config_prefix)
+
+    def test_lf_does_not_compose_with_the_variant(self) -> None:
+        # Opting into both yields the variant alone, never "lf.wincanarylf."
+        self.assertEqual("wincanarylf.", self._result("bothuser").scale_config_prefix)
 
     def test_arc_label_type_is_untouched(self) -> None:
         # label-type keeps the ARC scheme so Linux workflows are unaffected
-        for user, expected in (("plainuser", "mt-"), ("lfuser", "lf-")):
-            result = rd.get_runner_prefix(
-                self.SETTINGS, (user, user), "somebranch", self.ALL, frozenset(), False
-            )
-            self.assertEqual(expected, result.prefix)
+        self.assertEqual("mt-", self._result("plainuser").prefix)
+        self.assertEqual("lf-", self._result("lfuser").prefix)
+        self.assertEqual("c-mt-", self._result("plainuser", is_canary=True).prefix)
+        self.assertEqual("lf-", self._result("bothuser").prefix)

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -862,8 +862,7 @@ if __name__ == "__main__":
 
 
 class TestScaleConfigPrefix(TestCase):
-    """scale-config-label-type names a scale-config AMI variant. Only the
-    wincanary/wincanarylf experiments drive it; fleet selection must not."""
+    """Only wincanary/wincanarylf drive scale-config-label-type."""
 
     SETTINGS = """
 experiments:
@@ -891,24 +890,21 @@ experiments:
         self.assertEqual("", self._result("plainuser").scale_config_prefix)
 
     def test_lf_alone_does_not_set_a_prefix(self) -> None:
-        # lf runs at a percentage rollout over ALL workflows; it must not move
-        # Windows builds onto another fleet as a side effect.
+        # lf rolls out over ALL workflows; it must not relocate Windows builds.
         self.assertEqual("", self._result("lfuser").scale_config_prefix)
         self.assertEqual("", self._result("lfuser", is_canary=True).scale_config_prefix)
 
     def test_wincanary(self) -> None:
-        # wincanary is an AMI variant of windows.12xlarge
         self.assertEqual("wincanary.", self._result("wcuser").scale_config_prefix)
 
     def test_wincanarylf(self) -> None:
         self.assertEqual("wincanarylf.", self._result("wclfuser").scale_config_prefix)
 
     def test_lf_does_not_compose_with_the_variant(self) -> None:
-        # Opting into both yields the variant alone, never "lf.wincanarylf."
+        # never "lf.wincanarylf."
         self.assertEqual("wincanarylf.", self._result("bothuser").scale_config_prefix)
 
     def test_arc_label_type_is_untouched(self) -> None:
-        # label-type keeps the ARC scheme so Linux workflows are unaffected
         self.assertEqual("mt-", self._result("plainuser").prefix)
         self.assertEqual("lf-", self._result("lfuser").prefix)
         self.assertEqual("c-mt-", self._result("plainuser", is_canary=True).prefix)

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -859,3 +859,56 @@ class TestRunnerDeterminatorNoRunnerExperimentsLabel(TestCase):
 
 if __name__ == "__main__":
     main()
+
+
+class TestScaleConfigPrefix(TestCase):
+    """The scale-config (EC2) fleets use a dot scheme and AMI variants, unlike
+    the ARC prefixes on label-type. Windows binary builds consume this."""
+
+    SETTINGS = """
+experiments:
+  lf:
+    rollout_perc: 0
+  wincanary:
+    rollout_perc: 0
+  wincanarylf:
+    rollout_perc: 0
+---
+@lfuser,lf
+@wcuser,wincanary
+@bothuser,lf,wincanarylf
+@plainuser,
+"""
+    ALL = frozenset({"lf", "wincanary", "wincanarylf"})
+
+    def _prefix(self, user: str, is_canary: bool = False) -> str:
+        return rd.get_runner_prefix(
+            self.SETTINGS, (user, user), "somebranch", self.ALL, frozenset(), is_canary
+        ).scale_config_prefix
+
+    def test_default_is_bare(self) -> None:
+        # scale-config.yml declares windows.12xlarge with no prefix
+        self.assertEqual("", self._prefix("plainuser"))
+
+    def test_lf(self) -> None:
+        # lf-scale-config.yml declares lf.windows.12xlarge
+        self.assertEqual("lf.", self._prefix("lfuser"))
+
+    def test_lf_canary(self) -> None:
+        # lf-canary-scale-config.yml declares lf.c.windows.12xlarge
+        self.assertEqual("lf.c.", self._prefix("lfuser", is_canary=True))
+
+    def test_ami_variant(self) -> None:
+        # wincanary is an AMI variant of windows.12xlarge
+        self.assertEqual("wincanary.", self._prefix("wcuser"))
+
+    def test_fleet_comes_first(self) -> None:
+        self.assertEqual("lf.wincanarylf.", self._prefix("bothuser"))
+
+    def test_arc_label_type_is_untouched(self) -> None:
+        # label-type keeps the ARC scheme so Linux workflows are unaffected
+        for user, expected in (("plainuser", "mt-"), ("lfuser", "lf-")):
+            result = rd.get_runner_prefix(
+                self.SETTINGS, (user, user), "somebranch", self.ALL, frozenset(), False
+            )
+            self.assertEqual(expected, result.prefix)

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -61,11 +61,7 @@ on:
         description: Runner prefix for the "amd-sandbox" experiment (empty when not enabled)
         value: ${{ jobs.runner-determinator.outputs.amd-sandbox-label-type }}
       scale-config-label-type:
-        description: >-
-          Runner prefix for the scale-config (EC2) fleets, which use a dot scheme
-          ("", "lf.", "lf.c.") and expose AMI variants keyed by experiment name.
-          Windows binary builds consume this instead of label-type, which carries
-          the ARC prefixes (mt-/c-mt-/lf-).
+        description: Scale-config AMI variant prefix, e.g. "wincanary." (empty when none)
         value: ${{ jobs.runner-determinator.outputs.scale-config-label-type }}
       # Deprecated empty-string alias kept only so the MI350/gfx950 workflows that
       # still reference amd-do-label-type resolve to a bare (unprefixed) label,

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -60,6 +60,13 @@ on:
       amd-sandbox-label-type:
         description: Runner prefix for the "amd-sandbox" experiment (empty when not enabled)
         value: ${{ jobs.runner-determinator.outputs.amd-sandbox-label-type }}
+      scale-config-label-type:
+        description: >-
+          Runner prefix for the scale-config (EC2) fleets, which use a dot scheme
+          ("", "lf.", "lf.c.") and expose AMI variants keyed by experiment name.
+          Windows binary builds consume this instead of label-type, which carries
+          the ARC prefixes (mt-/c-mt-/lf-).
+        value: ${{ jobs.runner-determinator.outputs.scale-config-label-type }}
       # Deprecated empty-string alias kept only so the MI350/gfx950 workflows that
       # still reference amd-do-label-type resolve to a bare (unprefixed) label,
       # matching the old inactive amd-do experiment. Removed once #191249 drops
@@ -82,6 +89,7 @@ jobs:
       runner-type: ${{ steps.set-runner-info.outputs.runner-type }}
       runner-label: ${{ steps.set-runner-info.outputs.runner-label }}
       amd-sandbox-label-type: ${{ steps.set-condition.outputs.amd-sandbox-label-type }}
+      scale-config-label-type: ${{ steps.set-condition.outputs.scale-config-label-type }}
       ci-docker-hash: ${{ steps.ci-docker-hash.outputs.ci-docker-hash }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Windows canary AMIs cannot currently be tested: the AMIs are provisioned and the experiments are live, but nothing can emit a runner label that reaches them. See pytorch/test-infra#8734.

Split out of #195863 (landed) -- those workflows already reference `scale-config-label-type`, which does not exist on `main` yet, so it resolves to the empty string and Windows lands on the bare labels it used before. This adds the output.

## Why the existing prefixes don't work

`label-type` carries the ARC prefixes, which compose with ARC runner names:

```
mt-l-x86iavx512-16-128        <- what Linux binary builds run on today
```

Windows never moved to ARC. Its runners live in test-infra's scale configs and expose per-runner AMI `variants:` keyed by experiment name:

```yaml
windows.12xlarge:
  variants:
    wincanary:   { ami: Windows 2019 GHA CI - 20250812161628|... }
    wincanarylf: { ami: Windows 2019 GHA CI - 20260826001402|... }
```

A variant is selected by prefixing the runner type with its name -- `wincanary.windows.12xlarge`. Since #186663 and #189219 the determinator has had no way to emit that, so `wincanary` / `wincanarylf` are evaluated and then discarded:

```python
log.info(f"Experiment '{experiment_name}' enabled but no longer affects "
         "the runner label prefix; ignoring.")
```

`c-mt-` doesn't help either: it is gated on [`is_canary`](https://github.com/pytorch/pytorch/blob/main/.github/scripts/runner_determinator.py#L760), which is `github_repo == "pytorch/pytorch-canary"` -- the canary *repo*, not a canary AMI -- and `c-mt-windows.12xlarge` is not declared in any scale config.

## Change

Add `scale-config-label-type` next to `label-type`, driven only by the AMI-variant experiments:

```python
SCALE_CONFIG_VARIANT_EXPERIMENTS = frozenset({"wincanary", "wincanarylf"})
```

| opted into | `label-type` | `scale-config-label-type` | Windows label |
| --- | --- | --- | --- |
| nothing | `mt-` | `""` | `windows.12xlarge` |
| `lf` | `lf-` | `""` | `windows.12xlarge` |
| `lf`, canary repo | `lf-` | `""` | `windows.12xlarge` |
| `wincanary` | `mt-` | `wincanary.` | `wincanary.windows.12xlarge` |
| `wincanarylf` | `mt-` | `wincanarylf.` | `wincanarylf.windows.12xlarge` |
| `lf` + `wincanarylf` | `lf-` | `wincanarylf.` | `wincanarylf.windows.12xlarge` |

**Fleet selection is deliberately excluded.** An earlier revision folded `lf` in and emitted `lf.` / `lf.c.`, but `lf` runs at `rollout_perc: 15` over `workflows: ALL`, so 15% of Windows binary builds would have moved onto the LF fleet as a side effect of enabling AMI testing. Limiting the output to the variant experiments keeps the change to runs that explicitly opt in; everything else keeps the label it uses today.

That also removes fleet+variant composition, and with it the question of whether the autoscaler wants `lf.wincanarylf.` or `wincanarylf.lf.` -- the prefix is now just the variant name, matching how the variant is keyed under each runner type.

`label-type` and `amd-sandbox-label-type` are unchanged; this only adds an output.

## Test plan

`python -m pytest .github/scripts/test_runner_determinator.py` -> 50 passed, covering every row above plus an assertion that `label-type` still returns `mt-` / `c-mt-` / `lf-`.

```
user (opt-ins)              label-type  scale-config    windows label
plainuser  (none)           mt-         (empty)         windows.12xlarge
lfuser     (lf)             lf-         (empty)         windows.12xlarge
lfuser     (lf, canary)     lf-         (empty)         windows.12xlarge
wcuser     (wincanary)      mt-         wincanary.      wincanary.windows.12xlarge
wclfuser   (wincanarylf)    mt-         wincanarylf.    wincanarylf.windows.12xlarge
bothuser   (lf+wincanarylf) lf-         wincanarylf.    wincanarylf.windows.12xlarge
```

## Open question

`wincanarylf` now resolves to `wincanarylf.windows.12xlarge` -- the Meta-fleet runner carrying the LF canary AMI -- rather than anything on the LF fleet. That matches where the variant is declared in `scale-config.yml`, and the AMI values are identical across all four configs, but if the intent was specifically *LF fleet + canary AMI* then that combination is no longer expressible. @huydhn does the naming imply a fleet?

AI assistance (Claude) was used for this change.