### PR TITLE
Run Auto PR Triage tests in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -236,7 +236,7 @@ jobs:
         PYTHONPATH=$(pwd) pytest tools/stats
         PYTHONPATH=$(pwd) pytest tools/test -o "python_files=test*.py"
         PYTHONPATH=$(pwd) pytest .github/scripts -o "python_files=test*.py"
-        PYTHONPATH=$(pwd)/scripts/auto_pr_triage pytest scripts/auto_pr_triage --import-mode=importlib
+        PYTHONPATH=$(pwd)/scripts/auto_pr_triage python -m unittest discover -s scripts/auto_pr_triage -p 'test_*.py' -b
 
   test_collect_env:
     if: ${{ github.repository == 'pytorch/pytorch' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -236,6 +236,7 @@ jobs:
         PYTHONPATH=$(pwd) pytest tools/stats
         PYTHONPATH=$(pwd) pytest tools/test -o "python_files=test*.py"
         PYTHONPATH=$(pwd) pytest .github/scripts -o "python_files=test*.py"
+        PYTHONPATH=$(pwd)/scripts/auto_pr_triage pytest scripts/auto_pr_triage --import-mode=importlib
 
   test_collect_env:
     if: ${{ github.repository == 'pytorch/pytorch' }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #195933
* #195778
* #195777

Add the Auto PR Triage test directory to the existing test-tools job. Setting `PYTHONPATH` to the script directory preserves the modules' sibling-import layout.

Use `unittest` discovery because the linter image lacks the repository `pytest_shard_custom` plugin that pytest 7 loads from the root configuration. Keeping this PyTorch-specific wiring in a separate commit leaves the reusable import below mechanically identical to ciforge.

Test Plan:

```bash
PYTHONPATH=$(pwd)/scripts/auto_pr_triage python -m unittest discover -s scripts/auto_pr_triage -p 'test_*.py' -b
python tools/linter/adapters/no_workflows_on_fork.py .github/workflows/lint.yml
UV_NO_CONFIG=1 lintrunner -a .github/workflows/lint.yml
git diff --check
```

All 227 Auto PR Triage tests pass locally.

Authored with an AI assistant.
