### PR TITLE
[Profiler] Fix up test_python_export_envelope_matches_kineto 

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4608,9 +4608,15 @@ class TestPythonChromeTraceExport(TestCase):
             with open(py_path) as f:
                 py_trace = json.load(f)
 
-        for key in ("cuda_driver_version", "cuda_runtime_version"):
-            self.assertIn(key, py_trace)
-            self.assertEqual(py_trace[key], kineto_trace[key])
+        self.assertEqual(
+            py_trace["cuda_runtime_version"], kineto_trace["cuda_runtime_version"]
+        )
+        # The Python exporter omits the driver version when the optional cuda-bindings
+        # package is unavailable or cannot query its CUDA runtime.
+        if "cuda_driver_version" in py_trace:
+            self.assertEqual(
+                py_trace["cuda_driver_version"], kineto_trace["cuda_driver_version"]
+            )
         # regsPerBlock is the one field torch's device properties do not carry, so the
         # exporter omits it; everything else must match what kineto wrote.
         for py_device, kineto_device in zip(


### PR DESCRIPTION
This is failing in Kineto CI because cuda_driver_version is not present in the python exported json. The logic that adds the driver key to the trace is:

```
try:
        versions["cuda_driver_version"] = _check_cuda_bindings(
            _cuda_bindings_runtime.cudaDriverGetVersion()
        )
    except RuntimeError:
        # cuda.bindings drives its own CUDART, not the one torch initialized, so this can
        # fail where torch is fine. Losing a version key beats aborting the export.
        pass
```

Kineto CI min version is 12.6 and doesn't install the right bindings for this. The comments say that this field isn't guaranteed anyways so just check for parity if it does exist in the python trace.