### PR TITLE
Fix the kaiser and nuttall window docstring examples

### DIFF
--- a/torch/signal/windows/windows.py
+++ b/torch/signal/windows/windows.py
@@ -360,10 +360,10 @@ Examples::
 
     >>> # Generates a symmetric Kaiser window with a shape parameter of 12.0.
     >>> torch.signal.windows.kaiser(5)
-    tensor([4.0065e-05, 2.1875e-03, 4.3937e-02, 3.2465e-01, 8.8250e-01, 8.8250e-01, 3.2465e-01, 4.3937e-02, 2.1875e-03, 4.0065e-05])
+    tensor([5.2773e-05, 2.1567e-01, 1.0000e+00, 2.1567e-01, 5.2773e-05])
     >>> # Generates a periodic Kaiser window and shape parameter equal to 0.9.
     >>> torch.signal.windows.kaiser(5, sym=False, beta=0.9)
-    tensor([1.9858e-07, 5.1365e-05, 3.8659e-03, 8.4658e-02, 5.3941e-01, 1.0000e+00, 5.3941e-01, 8.4658e-02, 3.8659e-03, 5.1365e-05])
+    tensor([0.8244, 0.9348, 0.9926, 0.9926, 0.9348])
 """.format(
         **window_common_args,
     ),
@@ -855,11 +855,11 @@ References::
 Examples::
 
     >>> # Generates a symmetric Nuttall window.
-    >>> torch.signal.windows.general_hamming(5, sym=True)
+    >>> torch.signal.windows.nuttall(5, sym=True)
     tensor([3.6280e-04, 2.2698e-01, 1.0000e+00, 2.2698e-01, 3.6280e-04])
 
     >>> # Generates a periodic Nuttall window.
-    >>> torch.signal.windows.general_hamming(5, sym=False)
+    >>> torch.signal.windows.nuttall(5, sym=False)
     tensor([3.6280e-04, 1.1052e-01, 7.9826e-01, 7.9826e-01, 1.1052e-01])
 """.format(**window_common_args),
 )


### PR DESCRIPTION
### What is wrong

Two `Examples::` blocks in `torch/signal/windows/windows.py` print output the functions never produce.

**`kaiser`** shows `gaussian`'s output: ten values for a `kaiser(5)` call that returns five, and the exact two tensors printed in the `gaussian` docstring above it.

**`nuttall`** prints nuttall's values but calls `general_hamming`, which returns something else.

### Why

Both blocks were copied from a neighbouring window and only partly updated. `kaiser` already had its comments and its `std=` keyword corrected to `beta=`; the tensors were left behind.

### What changed

`kaiser`: the two printed tensors now match what `kaiser(5)` and `kaiser(5, sym=False, beta=0.9)` return.
`nuttall`: the calls now say `nuttall` instead of `general_hamming`. The printed values were already right.

Docs only, no code change.

### Test

Extracted every `>>>` example in the file and ran them under `doctest`:

| | attempted | failed |
|---|---|---|
| main | 22 | 4 |
| this PR | 22 | 0 |