### PR TITLE
[inductor] Tighten formatting helper annotations

### DIFF
--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -43,6 +43,7 @@ from .registry import CompiledFn, CompilerFn, register_debug_backend as register
 
 
 if TYPE_CHECKING:
+    from torch._inductor.triton_bundler import TritonBundle
     from torch.fx.node import Target
 
 
@@ -314,7 +315,7 @@ class AOTEagerOutputCode(OutputCode):
             self.gm.recompile()
             self._serialized_gm = None
 
-    def set_triton_bundle(self, triton_bundle: Any) -> None:
+    def set_triton_bundle(self, triton_bundle: "TritonBundle") -> None:
         pass
 
 

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -509,7 +509,7 @@ class SubgraphTemplate(KernelTemplate):
         if not kwargs:
             return base_name
 
-        def sanitize_value(v: Any) -> str:
+        def sanitize_value(v: object) -> str:
             """Convert a value to a valid Python identifier component."""
             s = str(v)
             # Replace invalid characters with underscores

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -119,7 +119,7 @@ def _rewrite_symbol_solution_for_int_codegen(expr: sympy.Expr) -> sympy.Expr:
     return CleanDiv(numerator, denominator)
 
 
-def _sanitize_for_repr(obj: Any) -> Any:
+def _sanitize_for_repr(obj: object) -> object:
     """Convert Enum values to their underlying value for valid Python repr in code generation."""
     if isinstance(obj, Enum):
         return _sanitize_for_repr(obj.value)

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -840,7 +840,7 @@ def log_runtime_and_tensor_meta(node_runtimes: Sequence[tuple[Any, float]]) -> N
         def to_list(x: Sequence[Any] | None) -> list[Any]:
             return list(to_optimization_hints(x)) if x is not None else []
 
-        def dtype_to_str(dtype: Any) -> str | None:
+        def dtype_to_str(dtype: torch.dtype | None) -> str | None:
             if dtype is None:
                 return None
             s = str(dtype)
@@ -1369,7 +1369,7 @@ def save_args_for_compile_fx_inner(*args: Any, **kwargs: Any) -> None:
     if not os.path.exists(folder):
         os.mkdir(folder)
 
-    def python_value(value: Any) -> int | float | bool | None:
+    def python_value(value: object) -> int | float | bool | None:
         if value is None:
             return None
         if isinstance(value, bool):
@@ -1378,11 +1378,11 @@ def save_args_for_compile_fx_inner(*args: Any, **kwargs: Any) -> None:
             return value
         # SymPy numbers expose is_integer as a tri-state property.
         if getattr(value, "is_integer", None) is False:
-            return float(value)
+            return float(value)  # pyrefly: ignore[bad-argument-type]
         try:
-            return int(value)
+            return int(value)  # pyrefly: ignore[bad-argument-type]
         except (TypeError, ValueError):
-            return float(value)
+            return float(value)  # pyrefly: ignore[bad-argument-type]
 
     def handle_sym_expr(x: Any, pytype: str) -> SymExprMetadataHolder:
         node = x.node

--- a/torch/_inductor/kernel/flex_gemm/debug.py
+++ b/torch/_inductor/kernel/flex_gemm/debug.py
@@ -12,6 +12,7 @@ from typing import Any, TYPE_CHECKING
 import torch
 from torch._inductor.kernel.gemm_epilogue import (
     NormalizedGetItem,
+    NormalizedNode,
     NormalizedPrepareSoftmax,
     NormalizedReduction,
     NormalizedSelect,
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
     from torch._inductor.kernel.flex_gemm.fx_cutedsl_codegen import (
         FlexGemmEpilogueAnalysis,
     )
+
+    from .constraints import FlexGemmLocalReduceGeometry, FlexGemmOutputContraction
 
 
 flex_gemm_log = logging.getLogger(__name__)
@@ -139,13 +142,13 @@ def _format_fx_tensor(node: torch.fx.Node) -> str:
     )
 
 
-def _format_geometry(geometry: Any) -> str:
+def _format_geometry(geometry: "FlexGemmLocalReduceGeometry") -> str:
     """Format grouped GEMM geometry in logical M/N terms."""
     axis = "M" if geometry.axis == 0 else "N"
     return f"axis={axis}, group={geometry.group}"
 
 
-def _format_output_contraction(contraction: Any | None) -> str:
+def _format_output_contraction(contraction: "FlexGemmOutputContraction | None") -> str:
     """Format the logical contraction applied to the main output."""
     if contraction is None:
         return "none"
@@ -153,7 +156,7 @@ def _format_output_contraction(contraction: Any | None) -> str:
     return f"N-axis, group={contraction.group}, layout={layout}"
 
 
-def _format_normalized_dataflow(node: torch.fx.Node, normalized: Any) -> str:
+def _format_normalized_dataflow(node: torch.fx.Node, normalized: NormalizedNode) -> str:
     """Render one normalized FX operation as compact dataflow."""
     match normalized:
         case NormalizedView(shape=shape):
@@ -179,6 +182,7 @@ def _format_normalized_dataflow(node: torch.fx.Node, normalized: Any) -> str:
         case NormalizedUnsupportedReduction():
             operation = f"unsupported_reduction({node.target})"
         case _:
+            # NormalizedDtypeView keeps its full dataclass repr for dtype details.
             return repr(normalized)
     return f"{normalized.source.name} -> {operation}"
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -126,7 +126,7 @@ class OutputCode:
         raise NotImplementedError(type(self))
 
     # TODO: Get rid of this
-    def set_triton_bundle(self, triton_bundle: Any) -> None:
+    def set_triton_bundle(self, triton_bundle: TritonBundle) -> None:
         raise NotImplementedError(type(self))
 
 
@@ -993,7 +993,7 @@ class CompiledFxGraph(OutputCode):
 
             self.current_callable = wrapped_callable
 
-    def set_triton_bundle(self, triton_bundle: Any) -> None:
+    def set_triton_bundle(self, triton_bundle: TritonBundle) -> None:
         self._triton_bundle = triton_bundle
 
     def prepare_for_serialization(self) -> None:
@@ -1164,7 +1164,7 @@ class CompiledAOTI(OutputCode):
         if self.current_callable is None:
             self.__post_init__()
 
-    def set_triton_bundle(self, triton_bundle: Any) -> None:
+    def set_triton_bundle(self, triton_bundle: TritonBundle) -> None:
         pass
 
 
@@ -1186,7 +1186,7 @@ class MockFXGraphCacheOutput(OutputCode):
     def __call__(self, inputs: Sequence[Any]) -> Any:
         return self.gm(inputs)
 
-    def set_triton_bundle(self, triton_bundle: Any) -> None:
+    def set_triton_bundle(self, triton_bundle: TritonBundle) -> None:
         pass
 
 
@@ -1321,7 +1321,7 @@ class RegionalOutputCode(OutputCode):
             gm = fn(gm, **kwargs)
         self._graph_module = gm
 
-    def set_triton_bundle(self, triton_bundle: Any) -> None:
+    def set_triton_bundle(self, triton_bundle: TritonBundle) -> None:
         """Regional inductor doesn't use triton bundles directly."""
 
     def prepare_for_serialization(self) -> None:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3534,7 +3534,7 @@ class WhyNoFuse:
         )
 
 
-def pformat(obj: Any) -> str:
+def pformat(obj: object) -> str:
     if isinstance(obj, (OrderedSet, set)):  # noqa: set_linter
         # pformat has trouble with sets of sympy exprs
         obj = sorted(obj, key=str)


### PR DESCRIPTION
Tightens broad annotations for repr, formatting, and pass-through helpers. Values that are only narrowed, stringified, or recursively sanitized now use `object`; helpers with known caller contracts use their existing domain types (`TritonBundle`, `NormalizedNode`, FlexGEMM geometry, and `torch.dtype`). The dynamically convertible symbolic value remains `object`, with checker exceptions scoped to its three built-in conversion calls.

## Test plan

```bash
PATH=/home/bobren/local/b/pytorch-env/bin:$PATH pyrefly check torch/_inductor/scheduler.py torch/_inductor/codegen/wrapper.py torch/_inductor/codegen/subgraph.py torch/_inductor/debug.py torch/_inductor/output_code.py torch/_inductor/kernel/flex_gemm/debug.py torch/_dynamo/backends/debugging.py
```

```bash
PATH=/home/bobren/local/b/pytorch-env/bin:$PATH lintrunner -a --skip PYREFLY torch/_inductor/scheduler.py torch/_inductor/codegen/wrapper.py torch/_inductor/codegen/subgraph.py torch/_inductor/debug.py torch/_inductor/output_code.py torch/_inductor/kernel/flex_gemm/debug.py torch/_dynamo/backends/debugging.py
```

```bash
PATH=/home/bobren/local/b/pytorch-env/bin:$PATH PYTHONPYCACHEPREFIX=/home/bobren/local/b/pytorch/agent_space/type-rider-pycache python -m py_compile torch/_inductor/scheduler.py torch/_inductor/codegen/wrapper.py torch/_inductor/codegen/subgraph.py torch/_inductor/debug.py torch/_inductor/output_code.py torch/_inductor/kernel/flex_gemm/debug.py torch/_dynamo/backends/debugging.py
```

Authored with AI assistance.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98