### PR TITLE
[Inductor] Autotune bounded structural outer-reduction plans

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19143,12 +19143,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         if torch.cuda.get_device_capability()[0] < 10:
             self.skipTest("experimental large OUTER plan is restricted to SM100+")
 
-        x = torch.randn(
-            5247, 96, 128, device=self.device, dtype=torch.bfloat16
-        )
-        y = torch.randn(
-            5247, 96, 128, device=self.device, dtype=torch.bfloat16
-        )
+        x = torch.randn(5247, 96, 128, device=self.device, dtype=torch.bfloat16)
+        y = torch.randn(5247, 96, 128, device=self.device, dtype=torch.bfloat16)
         stats = torch.rand(5247, 96, 1, device=self.device, dtype=torch.float32)
 
         def f(x, y, stats):
@@ -19179,6 +19175,108 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         simple_code = simple_source_codes[0]
         self.assertIn("ReductionHint.OUTER_NO_SPLIT", simple_code)
         self.assertEqual(simple_code.count("@triton_heuristics.reduction("), 1)
+
+    @config.patch(
+        {
+            "max_autotune": True,
+            "compile_threads": 1,
+            "force_disable_caches": True,
+            "triton.autotune_experimental_large_output_outer_reductions": True,
+        }
+    )
+    @unittest.mock.patch.dict(
+        os.environ, {"TORCHINDUCTOR_DISABLE_MULTI_KERNEL_CACHE": "1"}
+    )
+    @skipIfRocm
+    @skipIfXpu
+    @xfail_if_mps
+    def test_autotune_large_outer_reduction_plans(self):
+        if self.device == "cpu":
+            self.skipTest("Skip for CPU device")
+        if torch.cuda.get_device_capability()[0] < 10:
+            self.skipTest("experimental large OUTER plans are restricted to SM100+")
+
+        x = torch.randn(5247, 96, 128, device=self.device, dtype=torch.bfloat16)
+        y = torch.randn_like(x)
+        stats = torch.rand(5247, 96, 1, device=self.device, dtype=torch.float32)
+
+        def f(x, y, stats):
+            return (x.float() * y.float() * torch.rsqrt(stats + 1e-5)).sum(dim=0)
+
+        expected = f(x, y, stats)
+        actual, source_codes = run_and_get_code(
+            torch.compile(f, fullgraph=True), x, y, stats
+        )
+        self.assertEqual(expected, actual, atol=0.125, rtol=0.01)
+        code = source_codes[0]
+        self.assertIn("async_compile.multi_kernel_plan(", code)
+        self.assertIn("ReductionHint.OUTER_NO_SPLIT", code)
+        self.assertGreaterEqual(code.count("ReductionHint.OUTER"), 3)
+        # Exactly one one-pass kernel competes with one partial+final plan.
+        # Do not accidentally expand this into a split/config cross-product.
+        self.assertEqual(code.count("async_compile.triton("), 3)
+
+        def multi_output(x, y, stats):
+            producer = x.float() * y.float() * torch.rsqrt(stats + 1e-5)
+            return producer.sum(dim=0), (producer * y.float()).sum(dim=0)
+
+        multi_expected = multi_output(x, y, stats)
+        with config.patch({"triton.multi_kernel": 3}):
+            multi_actual, multi_source_codes = run_and_get_code(
+                torch.compile(multi_output, fullgraph=True), x, y, stats
+            )
+        self.assertEqual(multi_expected, multi_actual, atol=0.125, rtol=0.01)
+        self.assertEqual(
+            multi_source_codes[0].count("async_compile.multi_kernel_plan("), 1
+        )
+        # Both logical outputs remain fused in the partial and final stages, so
+        # the two-output case is still exactly three kernels total.
+        self.assertEqual(multi_source_codes[0].count("async_compile.triton("), 3)
+
+        # OUTER also names pre-existing split-reduction schedules.  Do not
+        # accidentally wrap those in the experimental whole-plan selector.
+        ordinary_x = torch.randn(16384, 128, device=self.device, dtype=torch.bfloat16)
+
+        def ordinary_outer(x):
+            return x.float().sum(dim=0)
+
+        ordinary_expected = ordinary_outer(ordinary_x)
+        ordinary_actual, ordinary_source_codes = run_and_get_code(
+            torch.compile(ordinary_outer, fullgraph=True), ordinary_x
+        )
+        self.assertEqual(ordinary_expected, ordinary_actual, atol=0.125, rtol=0.01)
+        ordinary_code = ordinary_source_codes[0]
+        self.assertIn("ReductionHint.OUTER", ordinary_code)
+        self.assertNotIn("async_compile.multi_kernel_plan(", ordinary_code)
+
+        # A graph-192-like trailing reduction must remain outside this leading-
+        # dimension schedule family even when it has the same large R/X extents.
+        trailing_x = torch.randn(12288, 5247, device=self.device, dtype=torch.bfloat16)
+
+        def trailing_reduction(x):
+            return x.float().sum(dim=1)
+
+        trailing_expected = trailing_reduction(trailing_x)
+        trailing_actual, trailing_source_codes = run_and_get_code(
+            torch.compile(trailing_reduction, fullgraph=True), trailing_x
+        )
+        self.assertEqual(trailing_expected, trailing_actual, atol=0.125, rtol=0.01)
+        self.assertNotIn("async_compile.multi_kernel_plan(", trailing_source_codes[0])
+
+        # Whole-plan selection replaces the direct mode's producer-complexity
+        # profitability guess.  A simple but shape-eligible producer must still
+        # receive the bounded choice so runtime timing can keep one-pass.
+        simple_x = torch.randn(5247, 12288, device=self.device, dtype=torch.bfloat16)
+
+        def simple_large_outer(x):
+            return x.float().sum(dim=0)
+
+        simple_expected = simple_large_outer(simple_x)
+        simple_actual, simple_source_codes = run_and_get_code(
+            torch.compile(simple_large_outer, fullgraph=True), simple_x
+        )
+        self.assertEqual(simple_expected, simple_actual, atol=0.125, rtol=0.01)
+        self.assertIn("async_compile.multi_kernel_plan(", simple_source_codes[0])
 
     @config.patch(force_disable_caches=True)
     @xfail_if_mps  # MPS codegen does not emit ReductionHint.OUTER

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -224,6 +224,9 @@ class CUDACombinedScheduling(BaseScheduling):
     def codegen_staged_reduction(self, node):
         return self._triton_scheduling.codegen_staged_reduction(node)
 
+    def codegen_outer_reduction_plans(self, node):
+        return self._triton_scheduling.codegen_outer_reduction_plans(node)
+
     def codegen_node(self, node: FusedSchedulerNode | SchedulerNode) -> None:
         return self._triton_scheduling.codegen_node(node)
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -50,7 +50,7 @@ from ..optimize_indexing import (
     indexing_dtype_strength_reduction,
 )
 from ..runtime.coordinate_descent_tuner import CoordescTuner
-from ..runtime.hints import DeviceProperties, InductorMeta
+from ..runtime.hints import DeviceProperties, InductorMeta, ReductionHint
 from ..runtime.runtime_utils import (
     green_text,
     last_power_of_2,
@@ -75,7 +75,7 @@ from ..utils import (
 from ..virtualized import ops, OpsWrapper, V
 from .block_analysis import BlockPatternMatcher
 from .common import CSEVariable, index_prevent_reordering, Kernel, PythonPrinter
-from .multi_kernel import MultiKernel, SizeHintMultiKernel
+from .multi_kernel import MultiKernel, MultiKernelPlan, SizeHintMultiKernel
 from .simd_kernel_features import (
     DisableReduction,
     EnableReduction,
@@ -3190,6 +3190,128 @@ class SIMDScheduling(BaseScheduling):
         if plan is None:
             raise AssertionError("sub-parent reduction plan was lost before codegen")
         return self._codegen_reduction_with_sub_parent_epilogue(nodes, plan)
+
+    def _codegen_single_kernel_for_plan(self, node):
+        """Generate one SIMD kernel without emitting its wrapper call."""
+        nodes = list(node.get_nodes())
+        _, (numel, rnumel) = max(nodes, key=lambda x: int(x.is_reduction())).group
+        node_schedule = self.generate_node_schedule(nodes, numel, rnumel)
+        kernel_features = SIMDKernelFeatures(node_schedule, numel, rnumel)
+        tiling, tiling_score = self.get_tiling_and_scores(
+            node_schedule,
+            kernel_features.numel,
+            kernel_features.reduction_numel,
+            kernel_features.coalesce_analysis,
+        )
+        kernels = self.create_kernel_choices(
+            kernel_features,
+            [tiling],
+            {
+                "features": kernel_features,
+                "tiling_scores": tiling_score,
+                "disable_multi_kernel": True,
+            },
+        )
+        if len(kernels) != 1:
+            raise AssertionError(
+                f"expected one bounded kernel choice, got {len(kernels)}"
+            )
+        kernel = kernels[0]
+        self.codegen_node_schedule_with_kernel(node_schedule, kernel)
+        config_patches = self._collect_config_patches(node_schedule)
+        with V.set_kernel_handler(kernel), config.patch(**config_patches):
+            src_code = kernel.codegen_kernel()
+        kernel.kernel_name = self.define_kernel(src_code, node_schedule, kernel)
+        kernel.code_hash = code_hash(src_code)
+        return kernel, node_schedule
+
+    def codegen_outer_reduction_plans(self, node):
+        """Emit one one-pass kernel and one partial+final reduction plan."""
+        if not isinstance(node, scheduler.FusedOuterReductionPlans):
+            raise AssertionError(f"unexpected outer reduction plan type: {type(node)}")
+        partials = node.partial_reductions
+        finals = node.final_reductions
+        if len(partials) != len(finals) or not all(
+            isinstance(snode.node, ir.ComputedBuffer) for snode in (*partials, *finals)
+        ):
+            raise AssertionError(
+                "outer reduction plans require paired computed buffers"
+            )
+
+        # The structural kernels use the IR selected by Reduction.create().
+        partial_kernel, partial_schedule = self._codegen_single_kernel_for_plan(
+            node.partial_node
+        )
+        final_kernels_and_schedules = [
+            self._codegen_single_kernel_for_plan(final_node)
+            for final_node in node.final_nodes
+        ]
+
+        # Reconstruct the original reduction in a temporary scheduler node and
+        # make it write the structural plan's externally visible output.
+        with contextlib.ExitStack() as stack:
+            original_names = []
+            one_pass_nodes = []
+            try:
+                for partial, final in zip(partials, finals):
+                    partial_buffer = partial.node
+                    final_buffer = final.node
+                    if not (
+                        isinstance(partial_buffer, ir.ComputedBuffer)
+                        and isinstance(final_buffer, ir.ComputedBuffer)
+                    ):
+                        raise AssertionError("expected computed reduction buffers")
+                    original_names.append((partial_buffer, partial_buffer.name))
+                    stack.enter_context(partial_buffer.with_original_inner_fn())
+                    partial_buffer.name = final_buffer.name
+                    partial_buffer.layout = final_buffer.layout
+                    if not isinstance(partial_buffer.data, ir.Reduction):
+                        raise AssertionError("expected reconstructed Reduction")
+                    partial_buffer.data = dataclasses.replace(
+                        partial_buffer.data,
+                        reduction_hint=ReductionHint.OUTER_NO_SPLIT,
+                    )
+                    one_pass_node = scheduler.SchedulerNode(
+                        self.scheduler, partial_buffer
+                    )
+                    # These temporary nodes are created after scheduler
+                    # initialization; inherit the ordering metadata required
+                    # to form a fused codegen-only owner.
+                    for attr in (
+                        "min_order",
+                        "max_order",
+                        "min_input_distance",
+                        "max_input_distance",
+                    ):
+                        setattr(one_pass_node, attr, getattr(partial, attr))
+                    one_pass_nodes.append(one_pass_node)
+                one_pass_owner = (
+                    one_pass_nodes[0]
+                    if len(one_pass_nodes) == 1
+                    else scheduler.FusedSchedulerNode(self.scheduler, one_pass_nodes)
+                )
+                one_pass_kernel, _ = self._codegen_single_kernel_for_plan(
+                    one_pass_owner
+                )
+            finally:
+                for partial_buffer, original_name in original_names:
+                    partial_buffer.name = original_name
+
+        final_kernels = [kernel for kernel, _schedule in final_kernels_and_schedules]
+        plan = MultiKernelPlan([[one_pass_kernel], [partial_kernel, *final_kernels]])
+        with V.set_kernel_handler(plan):
+            structural_schedules = [partial_schedule] + [
+                schedule for _kernel, schedule in final_kernels_and_schedules
+            ]
+            for scheduled_node in itertools.chain.from_iterable(structural_schedules):
+                if isinstance(scheduled_node, BaseSchedulerNode):
+                    scheduled_node.mark_run()
+        self._launch_kernel_and_cleanup(
+            plan,
+            list(node.get_nodes()),
+            free_buffers=False,
+        )
+        self.free_buffers_in_scheduler()
 
     def _codegen_nested_reduction(self, node, plan):
         """

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7161,7 +7161,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         if (
             config.max_autotune
-            and config.triton.enable_experimental_large_output_outer_reductions
+            and (
+                config.triton.enable_experimental_large_output_outer_reductions
+                or config.triton.autotune_experimental_large_output_outer_reductions
+            )
             and not config.deterministic
             and not config.batch_invariant
             and not torch.are_deterministic_algorithms_enabled()

--- a/torch/_inductor/codegen/xpu/xpu_combined_scheduling.py
+++ b/torch/_inductor/codegen/xpu/xpu_combined_scheduling.py
@@ -104,6 +104,9 @@ class XPUCombinedScheduling(BaseScheduling):
     def codegen_staged_reduction(self, node):
         return self._triton_scheduling.codegen_staged_reduction(node)
 
+    def codegen_outer_reduction_plans(self, node):
+        return self._triton_scheduling.codegen_outer_reduction_plans(node)
+
     def codegen_node(self, node: FusedSchedulerNode | SchedulerNode) -> None:
         return self._triton_scheduling.codegen_node(node)
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1962,6 +1962,17 @@ class triton:
         == "1"
     )
 
+    # Benchmark the one-pass OUTER_NO_SPLIT plan against exactly one structural
+    # plan selected by the experimental heuristic above.  This is separate from
+    # the structural-plan gate while sequence-plan codegen is being validated.
+    autotune_experimental_large_output_outer_reductions = (
+        os.environ.get(
+            "TORCHINDUCTOR_AUTOTUNE_EXPERIMENTAL_LARGE_OUTPUT_OUTER_REDUCTIONS",
+            "0",
+        )
+        == "1"
+    )
+
     # torchTLX enablement. None (the default) means TLX is never considered
     # (standard Inductor behavior); "allow" lets TLX compete via autotuning;
     # "force" uses only TLX templates plus forced epilogue fusion. Also a

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -380,10 +380,9 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         if (
             inductor_meta.get("max_autotune")
             and (
-                inductor_meta.get(
-                    "enable_experimental_large_output_outer_reductions"
-                )
+                inductor_meta.get("enable_experimental_large_output_outer_reductions")
                 or config.triton.enable_experimental_large_output_outer_reductions
+                or config.triton.autotune_experimental_large_output_outer_reductions
             )
             and not inductor_meta.get("deterministic")
             and not inductor_meta.get("are_deterministic_algorithms_enabled")
@@ -396,9 +395,7 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             and size_hints["x"] >= 8192
             and rnumel >= 128
         ):
-            result_configs.append(
-                make_config(128, 8, num_warps=1, min_num_warps=1)
-            )
+            result_configs.append(make_config(128, 8, num_warps=1, min_num_warps=1))
 
         return self._finalize_configs(
             result_configs, make_config, size_hints, inductor_meta
@@ -643,8 +640,8 @@ class ReductionHeuristic(CodegenConfigHeuristics):
                 inductor_meta=inductor_meta,
                 triton_meta=triton_meta,
             )
-        for config in configs:
-            config.kwargs["RSPLIT"] = split  # type: ignore[union-attr]
+        for candidate_config in configs:
+            candidate_config.kwargs["RSPLIT"] = split  # type: ignore[union-attr]
         return configs
 
     def apply_rsplit_size(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1675,7 +1675,14 @@ class Reduction(Loops):
         )
         split_large_outer = (
             preserve_large_outer_hint
-            and config.triton.enable_experimental_large_output_outer_reductions
+            and (
+                config.triton.enable_experimental_large_output_outer_reductions
+                or (
+                    config.triton.autotune_experimental_large_output_outer_reductions
+                    and not V.graph.cpp_wrapper
+                    and not V.graph.aot_mode
+                )
+            )
             and not config.deterministic
             and not config.batch_invariant
             and not torch.are_deterministic_algorithms_enabled()
@@ -1827,12 +1834,10 @@ class Reduction(Loops):
                 producer_profitable = False
                 if split_large_outer:
                     opcount = r.inner_fn_opcount()
-                    producer_profitable = (
-                        Reduction._is_experimental_large_output_outer_producer_profitable(
-                            opcount.num_ops,
-                            opcount.nontrivial_read_count,
-                            has_partial_output_broadcast_read,
-                        )
+                    producer_profitable = Reduction._is_experimental_large_output_outer_producer_profitable(
+                        opcount.num_ops,
+                        opcount.nontrivial_read_count,
+                        has_partial_output_broadcast_read,
                     )
                 if (
                     split_large_outer
@@ -1841,7 +1846,14 @@ class Reduction(Loops):
                         dtype in (torch.bfloat16, torch.float32)
                         for dtype in source_dtypes
                     )
-                    and producer_profitable
+                    # The direct structural mode keeps the conservative
+                    # producer guard.  Whole-plan autotuning can safely admit
+                    # the broader shape-eligible family because it benchmarks
+                    # the complete structural sequence against one-pass.
+                    and (
+                        config.triton.autotune_experimental_large_output_outer_reductions
+                        or producer_profitable
+                    )
                 ):
                     split = Reduction._experimental_large_output_outer_split_factor(
                         reduction_numel_hint, numel_hint, num_sm
@@ -2161,7 +2173,11 @@ class Reduction(Loops):
 
             # Find the reduction that get split
             split_reduction = None
-            if config.triton.mix_order_reduction and isinstance(out, TensorBox):
+            needs_original_reduction = (
+                config.triton.mix_order_reduction
+                or config.triton.autotune_experimental_large_output_outer_reductions
+            )
+            if needs_original_reduction and isinstance(out, TensorBox):
 
                 def _find_split_reduction(
                     cur_node: TensorBox,
@@ -2199,6 +2215,29 @@ class Reduction(Loops):
                 split_reduction._original_inner_fn = inner_fn
                 split_reduction._original_ranges = ranges
                 split_reduction._original_reduction_ranges = reduction_ranges
+                split_reduction._whole_plan_outer_reduction = False
+                if (
+                    config.triton.autotune_experimental_large_output_outer_reductions
+                    and hint == ReductionHint.OUTER
+                ):
+                    numel_hint = V.graph.sizevars.optimization_hint(
+                        sympy_product(ranges)
+                    )
+                    reduction_numel_hint = V.graph.sizevars.optimization_hint(
+                        reduction_numel
+                    )
+                    # OUTER also names pre-existing split reductions.  Only
+                    # preserve a one-pass alternative when num_splits selected
+                    # the experimental large-output path above.
+                    split_reduction._whole_plan_outer_reduction = (
+                        numel_hint
+                        >= DeviceProperties.create(device).multi_processor_count
+                        * 2
+                        * 32
+                        and Reduction._should_use_experimental_large_output_outer_plan(
+                            reduction_numel_hint, numel_hint, int(split)
+                        )
+                    )
             return out
 
         out = TensorBox.create(
@@ -5711,6 +5750,9 @@ class ComputedBuffer(OperationBuffer):
     _original_inner_fn: Callable[..., Any] | None = None
     _original_ranges: Sequence[_IntLike] | None = None
     _original_reduction_ranges: Sequence[_IntLike] | None = None
+    # Request a bounded runtime choice between the original one-pass reduction
+    # and this buffer's generated partial+final structural plan.
+    _whole_plan_outer_reduction: bool = False
 
     @contextlib.contextmanager
     def with_original_inner_fn(self) -> Iterator[None]:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3683,6 +3683,34 @@ class FusedStagedReduction(FusedSchedulerNode):
     """A fused reduction group that requires staged SIMD codegen."""
 
 
+class FusedOuterReductionPlans(FusedSchedulerNode):
+    """One logical reduction represented by one-pass and structural plans.
+
+    ``partial_node`` and ``final_node`` retain the existing two-kernel IR.  The
+    backend additionally reconstructs the original one-pass reduction from the
+    metadata on ``partial_reduction`` and benchmarks the two complete plans.
+    This node is deliberately formed after ordinary fusion, and is not itself
+    eligible for further fusion while the bounded plan selector is experimental.
+    """
+
+    def __init__(
+        self,
+        partial_node: BaseSchedulerNode,
+        final_nodes: list[BaseSchedulerNode],
+        partial_reductions: list[SchedulerNode],
+        final_reductions: list[SchedulerNode],
+    ) -> None:
+        self.partial_node = partial_node
+        self.final_nodes = final_nodes
+        self.partial_reductions = partial_reductions
+        self.final_reductions = final_reductions
+        super().__init__(
+            partial_node.scheduler,
+            list(partial_node.get_nodes())
+            + [leaf for owner in final_nodes for leaf in owner.get_nodes()],
+        )
+
+
 class FusedNestedReductions(FusedStagedReduction):
     """
     Fused node for two dependent reductions over the same logical elements.
@@ -5018,6 +5046,8 @@ class Scheduler:
         if config._post_fusion_custom_pass is not None:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 
+        self.create_outer_reduction_plan_nodes()
+
         if any(
             isinstance(node, FusedExternTritonKernelSchedulerNode)
             for node in self.nodes
@@ -6046,6 +6076,138 @@ class Scheduler:
                 node.unpack() if isinstance(node, GroupedSchedulerNode) else [node]
             )
         self.nodes = new_nodes
+
+    def create_outer_reduction_plan_nodes(self) -> None:
+        """Group one eligible partial+final reduction into a bounded plan choice.
+
+        The structural heuristic has already selected exactly one split.  This
+        pass does not add split/config candidates; it only preserves the current
+        two-kernel plan alongside its original one-pass form.  Keep the initial
+        implementation to standalone reductions so both choices have exactly
+        the same externally visible output and no hidden fused epilogues.
+        """
+        if (
+            not config.triton.autotune_experimental_large_output_outer_reductions
+            or V.graph.cpp_wrapper
+            or V.graph.aot_mode
+        ):
+            return
+
+        replacements: list[
+            tuple[
+                BaseSchedulerNode,
+                list[BaseSchedulerNode],
+                FusedOuterReductionPlans,
+            ]
+        ] = []
+        claimed = OrderedSet[BaseSchedulerNode]()
+        for partial_owner in self.nodes:
+            if partial_owner in claimed:
+                continue
+            partial_candidates = [
+                sn
+                for sn in partial_owner.get_nodes()
+                if isinstance(sn, SchedulerNode)
+                and isinstance(sn.node, ir.ComputedBuffer)
+                and sn.node._whole_plan_outer_reduction
+            ]
+            if not partial_candidates or len(partial_candidates) != len(
+                partial_owner.get_nodes()
+            ):
+                continue
+            final_owners = OrderedSet[BaseSchedulerNode]()
+            final_by_partial: list[SchedulerNode] = []
+            valid = True
+            for partial in partial_candidates:
+                outputs = partial.get_outputs()
+                if len(outputs) != 1:
+                    valid = False
+                    break
+                users = [
+                    user.node
+                    for user in outputs[0].users
+                    if not user.is_weak and isinstance(user.node, BaseSchedulerNode)
+                ]
+                if len(users) != 1:
+                    valid = False
+                    break
+                final = users[0]
+                final_owner = self.get_fused_node(final)
+                final_owners.add(final_owner)
+                if not (
+                    isinstance(final, SchedulerNode)
+                    and isinstance(final.node, ir.ComputedBuffer)
+                    and isinstance(final.node.data, ir.Reduction)
+                    and any(
+                        dep.name == outputs[0].get_name()
+                        for dep in final.read_writes.reads
+                    )
+                ):
+                    valid = False
+                    break
+                final_by_partial.append(final)
+            if not valid or not final_owners:
+                continue
+            if partial_owner in final_owners or any(
+                owner in claimed for owner in final_owners
+            ):
+                continue
+            if any(
+                {
+                    final
+                    for final in final_by_partial
+                    if self.get_fused_node(final) is owner
+                }
+                != set(owner.get_nodes())
+                for owner in final_owners
+            ):
+                continue
+            if any(
+                self.get_node_stream(partial_owner) != self.get_node_stream(owner)
+                for owner in final_owners
+            ):
+                continue
+            if any(
+                self.node_to_mempool.get(partial_owner)
+                != self.node_to_mempool.get(owner)
+                for owner in final_owners
+            ):
+                continue
+
+            grouped = FusedOuterReductionPlans(
+                partial_owner,
+                list(final_owners),
+                partial_candidates,
+                final_by_partial,
+            )
+            replacements.append((partial_owner, list(final_owners), grouped))
+            claimed.add(partial_owner)
+            claimed.update(final_owners)
+
+        if not replacements:
+            return
+
+        replacement_by_node = {
+            old: grouped
+            for partial, finals, grouped in replacements
+            for old in (partial, *finals)
+        }
+        emitted = OrderedSet[FusedOuterReductionPlans]()
+        new_nodes: list[BaseSchedulerNode] = []
+        for node in self.nodes:
+            grouped = replacement_by_node.get(node)
+            if grouped is None:
+                new_nodes.append(node)
+            elif grouped not in emitted:
+                new_nodes.append(grouped)
+                emitted.add(grouped)
+        self.nodes = self.topological_sort_schedule(new_nodes)
+
+        for partial, _finals, grouped in replacements:
+            for leaf in grouped.get_nodes():
+                self.name_to_fused_node[leaf.get_name()] = grouped
+            self.node_to_stream[grouped] = self.get_node_stream(partial)
+            self.node_to_mempool[grouped] = self.node_to_mempool.get(partial)
 
     def benchmark_fused_nodes(
         self, nodes: Sequence[BaseSchedulerNode]
@@ -11206,6 +11368,9 @@ class Scheduler:
             elif isinstance(node, FusedStagedReduction):
                 # pyrefly: ignore [unbound-name]
                 self.get_backend(device).codegen_staged_reduction(node)
+            elif isinstance(node, FusedOuterReductionPlans):
+                # pyrefly: ignore [unbound-name]
+                self.get_backend(device).codegen_outer_reduction_plans(node)
             elif isinstance(node, FusedMixOrderReductions):
                 # pyrefly: ignore [unbound-name]
                 self.get_backend(device).codegen_mix_order_reduction(node)
@@ -11593,6 +11758,9 @@ class BaseScheduling:  # noqa: docstring_linter
         raise NotImplementedError
 
     def codegen_staged_reduction(self, node: FusedStagedReduction) -> None:
+        raise NotImplementedError
+
+    def codegen_outer_reduction_plans(self, node: FusedOuterReductionPlans) -> None:
         raise NotImplementedError
 
     def codegen_sync(self) -> None:


### PR DESCRIPTION
Stack (oldest at bottom):
* __->__ #195942
* #195941
* #195606

Under a default-off config, compare one one-pass OUTER reduction against one heuristic-generated partial-plus-final structural plan and cache the complete-plan winner.