### PR TITLE
[TEST] Bump tolerances for `TestNN.test_Embedding_discontiguous_cuda`

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3549,7 +3549,9 @@ class ModuleTest(TestBase):
 
                 test_case.assertEqual(out, output)
                 test_case.assertEqual(grad, d_input, atol=1e-4, rtol=0)
-                test_case.assertEqual(test_case._get_parameters(module)[1], d_param)
+                test_case.assertEqual(
+                    test_case._get_parameters(module)[1], d_param, atol=1e-4, rtol=0
+                )
 
     def test_cuda(self, test_case):
         if not TEST_CUDA or not self.should_test_cuda:


### PR DESCRIPTION
parameters already had the higher tol, otherwise it's flaky due to sensitivity from atomic ops
authored with codex

cc @mruberry