### PR TITLE
[MPS] Add register-resident Metal kernels for small-matrix inverse

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -67,16 +67,12 @@ struct EighParams {
   float tol;
 };
 
-// Per-thread small-matrix LU kernels: up to these sizes one thread inverts a
-// whole matrix (solves a whole right-hand-side column) from registers.
-// LinearAlgebra.metal instantiates exact sizes 1..8 for luInvSmall and NMAX
-// buckets {4, 8, 16} for luSolveSmall, and static_asserts those lists against
-// these constants.
-C10_METAL_CONSTEXPR int64_t kLUSmallInvMax = 8;
-C10_METAL_CONSTEXPR int64_t kLUSmallSolveMax = 16;
+// Per-thread small-matrix inverse kernel: up to this size one thread inverts a
+// whole matrix from registers. LinearAlgebra.metal instantiates exact sizes
+// 1..16 and static_asserts the list against this constant. Strides are in
+// elements.
+C10_METAL_CONSTEXPR int64_t kLUSmallInvMax = 16;
 
-// Strides are in elements; for the adjoint solve the host swaps
-// LU_rstride/LU_cstride so the kernel walks LU^T and only has to conjugate.
 template <typename index_t = int64_t>
 struct LUSmallInvParams {
   index_t A_bstride;
@@ -85,19 +81,6 @@ struct LUSmallInvParams {
   index_t X_bstride;
   index_t X_rstride;
   index_t X_cstride;
-};
-
-template <typename index_t = int64_t>
-struct LUSmallSolveParams {
-  index_t LU_bstride;
-  index_t LU_rstride;
-  index_t LU_cstride;
-  index_t X_bstride;
-  index_t X_rstride;
-  index_t X_cstride;
-  uint32_t n;
-  uint32_t k;
-  bool adjoint;
 };
 
 // for LU streaming-panel kernels

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -67,6 +67,54 @@ struct EighParams {
   float tol;
 };
 
+// Per-thread small-matrix LU kernels: up to these sizes one thread
+// factors/inverts a whole matrix (solves a whole right-hand-side column) from
+// registers. LinearAlgebra.metal instantiates NMAX buckets {4, 8} for
+// luFactorSmall, exact sizes 1..8 for luInvSmall and {4, 8, 16} for
+// luSolveSmall, and static_asserts those lists against these constants.
+C10_METAL_CONSTEXPR int64_t kLUSmallFactorMax = 8;
+C10_METAL_CONSTEXPR int64_t kLUSmallSolveMax = 16;
+
+// Strides are in elements; for the adjoint solve the host swaps
+// LU_rstride/LU_cstride so the kernel walks LU^T and only has to conjugate.
+template <typename index_t = int64_t>
+struct LUSmallFactorParams {
+  index_t A_bstride;
+  index_t A_rstride;
+  index_t A_cstride;
+  index_t LU_bstride;
+  index_t LU_rstride;
+  index_t LU_cstride;
+  uint32_t batch;
+  uint32_t m;
+  uint32_t n;
+};
+
+template <typename index_t = int64_t>
+struct LUSmallInvParams {
+  index_t A_bstride;
+  index_t A_rstride;
+  index_t A_cstride;
+  index_t X_bstride;
+  index_t X_rstride;
+  index_t X_cstride;
+  uint32_t batch;
+};
+
+template <typename index_t = int64_t>
+struct LUSmallSolveParams {
+  index_t LU_bstride;
+  index_t LU_rstride;
+  index_t LU_cstride;
+  index_t X_bstride;
+  index_t X_rstride;
+  index_t X_cstride;
+  uint32_t batch;
+  uint32_t n;
+  uint32_t k;
+  bool adjoint;
+};
+
 // for LU streaming-panel kernels
 C10_METAL_CONSTEXPR unsigned kLUStreamNT = 256;
 C10_METAL_CONSTEXPR unsigned kLUStreamWarpsPerTG =

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -85,7 +85,6 @@ struct LUSmallFactorParams {
   index_t LU_bstride;
   index_t LU_rstride;
   index_t LU_cstride;
-  uint32_t batch;
   uint32_t m;
   uint32_t n;
 };
@@ -98,7 +97,6 @@ struct LUSmallInvParams {
   index_t X_bstride;
   index_t X_rstride;
   index_t X_cstride;
-  uint32_t batch;
 };
 
 template <typename index_t = int64_t>
@@ -109,7 +107,6 @@ struct LUSmallSolveParams {
   index_t X_bstride;
   index_t X_rstride;
   index_t X_cstride;
-  uint32_t batch;
   uint32_t n;
   uint32_t k;
   bool adjoint;

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -67,28 +67,16 @@ struct EighParams {
   float tol;
 };
 
-// Per-thread small-matrix LU kernels: up to these sizes one thread
-// factors/inverts a whole matrix (solves a whole right-hand-side column) from
-// registers. LinearAlgebra.metal instantiates NMAX buckets {4, 8} for
-// luFactorSmall, exact sizes 1..8 for luInvSmall and {4, 8, 16} for
-// luSolveSmall, and static_asserts those lists against these constants.
-C10_METAL_CONSTEXPR int64_t kLUSmallFactorMax = 8;
+// Per-thread small-matrix LU kernels: up to these sizes one thread inverts a
+// whole matrix (solves a whole right-hand-side column) from registers.
+// LinearAlgebra.metal instantiates exact sizes 1..8 for luInvSmall and NMAX
+// buckets {4, 8, 16} for luSolveSmall, and static_asserts those lists against
+// these constants.
+C10_METAL_CONSTEXPR int64_t kLUSmallInvMax = 8;
 C10_METAL_CONSTEXPR int64_t kLUSmallSolveMax = 16;
 
 // Strides are in elements; for the adjoint solve the host swaps
 // LU_rstride/LU_cstride so the kernel walks LU^T and only has to conjugate.
-template <typename index_t = int64_t>
-struct LUSmallFactorParams {
-  index_t A_bstride;
-  index_t A_rstride;
-  index_t A_cstride;
-  index_t LU_bstride;
-  index_t LU_rstride;
-  index_t LU_cstride;
-  uint32_t m;
-  uint32_t n;
-};
-
 template <typename index_t = int64_t>
 struct LUSmallInvParams {
   index_t A_bstride;

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -2600,6 +2600,371 @@ kernel void luApplyPivotsRHS(
 INSTANTIATE_LU_APPLY_PIVOTS_RHS(float)
 INSTANTIATE_LU_APPLY_PIVOTS_RHS(float2)
 
+// Small-matrix LU (luFactorSmall / luInvSmall / luSolveSmall): one thread per
+// matrix (per right-hand-side column for the solve), the whole NMAX x NMAX
+// zero-padded matrix lives in registers. Every array index must stay a
+// compile-time constant after unrolling, so row swaps scan for r == p instead
+// of indexing a[p] directly.
+template <typename T, short NMAX>
+kernel void luFactorSmall(
+    device const T* A [[buffer(0)]],
+    device T* LU [[buffer(1)]],
+    device int* pivots [[buffer(2)]],
+    device int* info [[buffer(3)]],
+    constant LUSmallFactorParams<>& params [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (tid >= params.batch) {
+    return;
+  }
+  const uint m = params.m;
+  const uint n = params.n;
+  const uint mn = min(m, n);
+  device const T* Ab = A + long(tid) * params.A_bstride;
+  device T* Lb = LU + long(tid) * params.LU_bstride;
+  device int* pv = pivots + ulong(tid) * mn;
+
+  T a[NMAX][NMAX];
+#pragma unroll
+  for (short r = 0; r < NMAX; r++) {
+#pragma unroll
+    for (short c = 0; c < NMAX; c++) {
+      a[r][c] = (uint(r) < m && uint(c) < n)
+          ? Ab[long(r) * params.A_rstride + long(c) * params.A_cstride]
+          : T(0.0f);
+    }
+  }
+
+  int inf = 0;
+#pragma unroll
+  for (short j = 0; j < NMAX; j++) {
+    if (uint(j) < mn) {
+      float bv = -1.0f;
+      short p = -1;
+#pragma unroll
+      for (short r = 0; r < NMAX; r++) {
+        if (r >= j && uint(r) < m) {
+          const float v = luPivotMag(a[r][j]);
+          if (v > bv) {
+            bv = v;
+            p = r;
+          }
+        }
+      }
+      if (p < 0) {
+        p = j;
+      }
+      pv[j] = int(p) + 1;
+      if (bv == 0.0f && inf == 0) {
+        inf = j + 1;
+      }
+#pragma unroll
+      for (short r = 0; r < NMAX; r++) {
+        if (r > j && r == p) {
+#pragma unroll
+          for (short c = 0; c < NMAX; c++) {
+            const T t = a[j][c];
+            a[j][c] = a[r][c];
+            a[r][c] = t;
+          }
+        }
+      }
+      if (bv != 0.0f) {
+        const T rp = luRecip(a[j][j]);
+#pragma unroll
+        for (short r = 0; r < NMAX; r++) {
+          if (r > j) {
+            const T l = c10::metal::mul(a[r][j], rp);
+            a[r][j] = l;
+#pragma unroll
+            for (short c = 0; c < NMAX; c++) {
+              if (c > j) {
+                a[r][c] = c10::metal::fma(-l, a[j][c], a[r][c]);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  info[tid] = inf;
+
+#pragma unroll
+  for (short r = 0; r < NMAX; r++) {
+#pragma unroll
+    for (short c = 0; c < NMAX; c++) {
+      if (uint(r) < m && uint(c) < n) {
+        Lb[long(r) * params.LU_rstride + long(c) * params.LU_cstride] = a[r][c];
+      }
+    }
+  }
+}
+
+#define INSTANTIATE_LU_FACTOR_SMALL(T, NMAX)                \
+  template [[host_name("luFactorSmall_" #T "_" #NMAX)]]     \
+  kernel void luFactorSmall<T, NMAX>(                       \
+      device const T* A [[buffer(0)]],                      \
+      device T* LU [[buffer(1)]],                           \
+      device int* pivots [[buffer(2)]],                     \
+      device int* info [[buffer(3)]],                       \
+      constant LUSmallFactorParams<>& params [[buffer(4)]], \
+      uint tid [[thread_position_in_grid]]);
+
+// NMAX buckets picked by lu_factor_small_encode
+INSTANTIATE_LU_FACTOR_SMALL(float, 4)
+INSTANTIATE_LU_FACTOR_SMALL(float, 8)
+INSTANTIATE_LU_FACTOR_SMALL(float2, 4)
+INSTANTIATE_LU_FACTOR_SMALL(float2, 8)
+static_assert(kLUSmallFactorMax == 8, "update luFactorSmall instantiations");
+
+template <short N>
+kernel void luInvSmall(
+    device const float* A [[buffer(0)]],
+    device float* X [[buffer(1)]],
+    device int* info [[buffer(2)]],
+    constant LUSmallInvParams<>& params [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  if (tid >= params.batch) {
+    return;
+  }
+  device const float* Ab = A + long(tid) * params.A_bstride;
+  device float* Xb = X + long(tid) * params.X_bstride;
+
+  float a[N][N];
+  float x[N][N];
+#pragma unroll
+  for (short r = 0; r < N; r++) {
+#pragma unroll
+    for (short c = 0; c < N; c++) {
+      a[r][c] = Ab[long(r) * params.A_rstride + long(c) * params.A_cstride];
+      x[r][c] = (r == c) ? 1.0f : 0.0f;
+    }
+  }
+
+  int inf = 0;
+#pragma unroll
+  for (short j = 0; j < N; j++) {
+    float bv = -1.0f;
+    short p = -1;
+#pragma unroll
+    for (short r = 0; r < N; r++) {
+      if (r >= j) {
+        const float v = luPivotMag(a[r][j]);
+        if (v > bv) {
+          bv = v;
+          p = r;
+        }
+      }
+    }
+    if (p < 0) {
+      p = j;
+    }
+    if (bv == 0.0f && inf == 0) {
+      inf = j + 1;
+    }
+#pragma unroll
+    for (short r = 0; r < N; r++) {
+      if (r > j && r == p) {
+#pragma unroll
+        for (short c = 0; c < N; c++) {
+          const float ta = a[j][c];
+          a[j][c] = a[r][c];
+          a[r][c] = ta;
+          const float tx = x[j][c];
+          x[j][c] = x[r][c];
+          x[r][c] = tx;
+        }
+      }
+    }
+    if (bv != 0.0f) {
+      const float rp = luRecip(a[j][j]);
+#pragma unroll
+      for (short r = 0; r < N; r++) {
+        if (r > j) {
+          const float l = a[r][j] * rp;
+          a[r][j] = l;
+#pragma unroll
+          for (short c = 0; c < N; c++) {
+            if (c > j) {
+              a[r][c] = fma(-l, a[j][c], a[r][c]);
+            }
+            x[r][c] = fma(-l, x[j][c], x[r][c]);
+          }
+        }
+      }
+    }
+  }
+#pragma unroll
+  for (short c = N - 1; c >= 0; c--) {
+#pragma unroll
+    for (short k = 0; k < N; k++) {
+      x[c][k] = x[c][k] / a[c][c];
+    }
+#pragma unroll
+    for (short i = 0; i < N; i++) {
+      if (i < c) {
+#pragma unroll
+        for (short k = 0; k < N; k++) {
+          x[i][k] = fma(-a[i][c], x[c][k], x[i][k]);
+        }
+      }
+    }
+  }
+  info[tid] = inf;
+
+#pragma unroll
+  for (short r = 0; r < N; r++) {
+#pragma unroll
+    for (short c = 0; c < N; c++) {
+      Xb[long(r) * params.X_rstride + long(c) * params.X_cstride] = x[r][c];
+    }
+  }
+}
+
+#define INSTANTIATE_LU_INV_SMALL(N)                      \
+  template [[host_name("luInvSmall_float_" #N)]]         \
+  kernel void luInvSmall<N>(                             \
+      device const float* A [[buffer(0)]],               \
+      device float* X [[buffer(1)]],                     \
+      device int* info [[buffer(2)]],                    \
+      constant LUSmallInvParams<>& params [[buffer(3)]], \
+      uint tid [[thread_position_in_grid]]);
+
+// exact sizes 1..kLUSmallFactorMax picked by lu_inv_small_encode
+INSTANTIATE_LU_INV_SMALL(1)
+INSTANTIATE_LU_INV_SMALL(2)
+INSTANTIATE_LU_INV_SMALL(3)
+INSTANTIATE_LU_INV_SMALL(4)
+INSTANTIATE_LU_INV_SMALL(5)
+INSTANTIATE_LU_INV_SMALL(6)
+INSTANTIATE_LU_INV_SMALL(7)
+INSTANTIATE_LU_INV_SMALL(8)
+static_assert(kLUSmallFactorMax == 8, "update luInvSmall instantiations");
+
+template <typename T>
+inline T luSmallElem(
+    device const T* LU,
+    long i,
+    long j,
+    long rs,
+    long cs,
+    bool adjoint) {
+  const T v = LU[i * rs + j * cs];
+  return adjoint ? c10::metal::conj(v) : v;
+}
+
+template <typename T, short NMAX>
+kernel void luSolveSmall(
+    device const T* LU [[buffer(0)]],
+    device const int* pivots [[buffer(1)]],
+    device T* X [[buffer(2)]],
+    constant LUSmallSolveParams<>& params [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  const uint b = tid / params.k;
+  if (b >= params.batch) {
+    return;
+  }
+  const uint col = tid - b * params.k;
+  const uint n = params.n;
+  const bool adjoint = params.adjoint;
+  const long rs = params.LU_rstride;
+  const long cs = params.LU_cstride;
+  device const T* Lb = LU + long(b) * params.LU_bstride;
+  device const int* pv = pivots + ulong(b) * n;
+  device T* Xb = X + long(b) * params.X_bstride + long(col) * params.X_cstride;
+
+  T x[NMAX];
+#pragma unroll
+  for (short i = 0; i < NMAX; i++) {
+    x[i] = (uint(i) < n) ? Xb[long(i) * params.X_rstride] : T(0.0f);
+  }
+  if (!adjoint) {
+#pragma unroll
+    for (short s = 0; s < NMAX; s++) {
+      if (uint(s) < n) {
+        const int p = pv[s] - 1;
+#pragma unroll
+        for (short r = 0; r < NMAX; r++) {
+          if (r > s && r == p) {
+            const T t = x[s];
+            x[s] = x[r];
+            x[r] = t;
+          }
+        }
+      }
+    }
+  }
+#pragma unroll
+  for (short c = 0; c < NMAX; c++) {
+    if (uint(c) < n) {
+      if (adjoint) {
+        x[c] = c10::metal::div(x[c], luSmallElem(Lb, c, c, rs, cs, adjoint));
+      }
+#pragma unroll
+      for (short i = 0; i < NMAX; i++) {
+        if (i > c && uint(i) < n) {
+          const T l = luSmallElem(Lb, i, c, rs, cs, adjoint);
+          x[i] = c10::metal::fma(-l, x[c], x[i]);
+        }
+      }
+    }
+  }
+#pragma unroll
+  for (short c = NMAX - 1; c >= 0; c--) {
+    if (uint(c) < n) {
+      if (!adjoint) {
+        x[c] = c10::metal::div(x[c], luSmallElem(Lb, c, c, rs, cs, adjoint));
+      }
+#pragma unroll
+      for (short i = 0; i < NMAX; i++) {
+        if (i < c) {
+          const T u = luSmallElem(Lb, i, c, rs, cs, adjoint);
+          x[i] = c10::metal::fma(-u, x[c], x[i]);
+        }
+      }
+    }
+  }
+  if (adjoint) {
+#pragma unroll
+    for (short s = NMAX - 1; s >= 0; s--) {
+      if (uint(s) < n) {
+        const int p = pv[s] - 1;
+#pragma unroll
+        for (short r = 0; r < NMAX; r++) {
+          if (r > s && r == p) {
+            const T t = x[s];
+            x[s] = x[r];
+            x[r] = t;
+          }
+        }
+      }
+    }
+  }
+#pragma unroll
+  for (short i = 0; i < NMAX; i++) {
+    if (uint(i) < n) {
+      Xb[long(i) * params.X_rstride] = x[i];
+    }
+  }
+}
+
+#define INSTANTIATE_LU_SOLVE_SMALL(T, NMAX)                \
+  template [[host_name("luSolveSmall_" #T "_" #NMAX)]]     \
+  kernel void luSolveSmall<T, NMAX>(                       \
+      device const T* LU [[buffer(0)]],                    \
+      device const int* pivots [[buffer(1)]],              \
+      device T* X [[buffer(2)]],                           \
+      constant LUSmallSolveParams<>& params [[buffer(3)]], \
+      uint tid [[thread_position_in_grid]]);
+
+// NMAX buckets picked by lu_solve_small_encode
+INSTANTIATE_LU_SOLVE_SMALL(float, 4)
+INSTANTIATE_LU_SOLVE_SMALL(float, 8)
+INSTANTIATE_LU_SOLVE_SMALL(float, 16)
+INSTANTIATE_LU_SOLVE_SMALL(float2, 4)
+INSTANTIATE_LU_SOLVE_SMALL(float2, 8)
+INSTANTIATE_LU_SOLVE_SMALL(float2, 16)
+static_assert(kLUSmallSolveMax == 16, "update luSolveSmall instantiations");
+
 kernel void applyPivots(
     device float* P [[buffer(0)]],
     device const int* pivots [[buffer(1)]],

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -2600,11 +2600,10 @@ kernel void luApplyPivotsRHS(
 INSTANTIATE_LU_APPLY_PIVOTS_RHS(float)
 INSTANTIATE_LU_APPLY_PIVOTS_RHS(float2)
 
-// Small-matrix LU (luInvSmall / luSolveSmall): one thread per matrix (per
-// right-hand-side column for the solve), the whole matrix lives in registers,
-// zero-padded to NMAX for the solve. Every array index must stay a
-// compile-time constant after unrolling, so row swaps scan for r == p instead
-// of indexing a[p] directly.
+// Small-matrix inverse (luInvSmall): one thread per matrix, the matrix and
+// its inverse live in registers. Every array index must stay a compile-time
+// constant after unrolling, so row swaps scan for r == p instead of indexing
+// a[p] directly.
 template <short N>
 kernel void luInvSmall(
     device const float* A [[buffer(0)]],
@@ -2724,129 +2723,15 @@ INSTANTIATE_LU_INV_SMALL(5)
 INSTANTIATE_LU_INV_SMALL(6)
 INSTANTIATE_LU_INV_SMALL(7)
 INSTANTIATE_LU_INV_SMALL(8)
-static_assert(kLUSmallInvMax == 8, "update luInvSmall instantiations");
-
-template <typename T>
-inline T luSmallElem(
-    device const T* LU,
-    long i,
-    long j,
-    long rs,
-    long cs,
-    bool adjoint) {
-  const T v = LU[i * rs + j * cs];
-  return adjoint ? c10::metal::conj(v) : v;
-}
-
-template <typename T, short NMAX>
-kernel void luSolveSmall(
-    device const T* LU [[buffer(0)]],
-    device const int* pivots [[buffer(1)]],
-    device T* X [[buffer(2)]],
-    constant LUSmallSolveParams<>& params [[buffer(3)]],
-    uint tid [[thread_position_in_grid]]) {
-  const uint b = tid / params.k;
-  const uint col = tid - b * params.k;
-  const uint n = params.n;
-  const bool adjoint = params.adjoint;
-  const long rs = params.LU_rstride;
-  const long cs = params.LU_cstride;
-  device const T* Lb = LU + long(b) * params.LU_bstride;
-  device const int* pv = pivots + ulong(b) * n;
-  device T* Xb = X + long(b) * params.X_bstride + long(col) * params.X_cstride;
-
-  T x[NMAX];
-#pragma unroll
-  for (short i = 0; i < NMAX; i++) {
-    x[i] = (uint(i) < n) ? Xb[long(i) * params.X_rstride] : T(0.0f);
-  }
-  if (!adjoint) {
-#pragma unroll
-    for (short s = 0; s < NMAX; s++) {
-      if (uint(s) < n) {
-        const int p = pv[s] - 1;
-#pragma unroll
-        for (short r = 0; r < NMAX; r++) {
-          if (r > s && r == p) {
-            const T t = x[s];
-            x[s] = x[r];
-            x[r] = t;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (short c = 0; c < NMAX; c++) {
-    if (uint(c) < n) {
-      if (adjoint) {
-        x[c] = c10::metal::div(x[c], luSmallElem(Lb, c, c, rs, cs, adjoint));
-      }
-#pragma unroll
-      for (short i = 0; i < NMAX; i++) {
-        if (i > c && uint(i) < n) {
-          const T l = luSmallElem(Lb, i, c, rs, cs, adjoint);
-          x[i] = c10::metal::fma(-l, x[c], x[i]);
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (short c = NMAX - 1; c >= 0; c--) {
-    if (uint(c) < n) {
-      if (!adjoint) {
-        x[c] = c10::metal::div(x[c], luSmallElem(Lb, c, c, rs, cs, adjoint));
-      }
-#pragma unroll
-      for (short i = 0; i < NMAX; i++) {
-        if (i < c) {
-          const T u = luSmallElem(Lb, i, c, rs, cs, adjoint);
-          x[i] = c10::metal::fma(-u, x[c], x[i]);
-        }
-      }
-    }
-  }
-  if (adjoint) {
-#pragma unroll
-    for (short s = NMAX - 1; s >= 0; s--) {
-      if (uint(s) < n) {
-        const int p = pv[s] - 1;
-#pragma unroll
-        for (short r = 0; r < NMAX; r++) {
-          if (r > s && r == p) {
-            const T t = x[s];
-            x[s] = x[r];
-            x[r] = t;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (short i = 0; i < NMAX; i++) {
-    if (uint(i) < n) {
-      Xb[long(i) * params.X_rstride] = x[i];
-    }
-  }
-}
-
-#define INSTANTIATE_LU_SOLVE_SMALL(T, NMAX)                \
-  template [[host_name("luSolveSmall_" #T "_" #NMAX)]]     \
-  kernel void luSolveSmall<T, NMAX>(                       \
-      device const T* LU [[buffer(0)]],                    \
-      device const int* pivots [[buffer(1)]],              \
-      device T* X [[buffer(2)]],                           \
-      constant LUSmallSolveParams<>& params [[buffer(3)]], \
-      uint tid [[thread_position_in_grid]]);
-
-// NMAX buckets picked by lu_solve_small_encode
-INSTANTIATE_LU_SOLVE_SMALL(float, 4)
-INSTANTIATE_LU_SOLVE_SMALL(float, 8)
-INSTANTIATE_LU_SOLVE_SMALL(float, 16)
-INSTANTIATE_LU_SOLVE_SMALL(float2, 4)
-INSTANTIATE_LU_SOLVE_SMALL(float2, 8)
-INSTANTIATE_LU_SOLVE_SMALL(float2, 16)
-static_assert(kLUSmallSolveMax == 16, "update luSolveSmall instantiations");
+INSTANTIATE_LU_INV_SMALL(9)
+INSTANTIATE_LU_INV_SMALL(10)
+INSTANTIATE_LU_INV_SMALL(11)
+INSTANTIATE_LU_INV_SMALL(12)
+INSTANTIATE_LU_INV_SMALL(13)
+INSTANTIATE_LU_INV_SMALL(14)
+INSTANTIATE_LU_INV_SMALL(15)
+INSTANTIATE_LU_INV_SMALL(16)
+static_assert(kLUSmallInvMax == 16, "update luInvSmall instantiations");
 
 kernel void applyPivots(
     device float* P [[buffer(0)]],

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -2815,7 +2815,7 @@ kernel void luInvSmall(
 }
 
 #define INSTANTIATE_LU_INV_SMALL(N)                      \
-  template [[host_name("luInvSmall_float_" #N)]]         \
+  template [[host_name("luInvSmall_" #N)]]               \
   kernel void luInvSmall<N>(                             \
       device const float* A [[buffer(0)]],               \
       device float* X [[buffer(1)]],                     \

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -2629,7 +2629,7 @@ kernel void luInvSmall(
 #pragma unroll
   for (short j = 0; j < N; j++) {
     float bv = -1.0f;
-    short p = -1;
+    short p = j;
 #pragma unroll
     for (short r = 0; r < N; r++) {
       if (r >= j) {
@@ -2639,9 +2639,6 @@ kernel void luInvSmall(
           p = r;
         }
       }
-    }
-    if (p < 0) {
-      p = j;
     }
     if (bv == 0.0f && inf == 0) {
       inf = j + 1;
@@ -2666,7 +2663,6 @@ kernel void luInvSmall(
       for (short r = 0; r < N; r++) {
         if (r > j) {
           const float l = a[r][j] * rp;
-          a[r][j] = l;
 #pragma unroll
           for (short c = 0; c < N; c++) {
             if (c > j) {

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -2613,9 +2613,6 @@ kernel void luFactorSmall(
     device int* info [[buffer(3)]],
     constant LUSmallFactorParams<>& params [[buffer(4)]],
     uint tid [[thread_position_in_grid]]) {
-  if (tid >= params.batch) {
-    return;
-  }
   const uint m = params.m;
   const uint n = params.n;
   const uint mn = min(m, n);
@@ -2723,9 +2720,6 @@ kernel void luInvSmall(
     device int* info [[buffer(2)]],
     constant LUSmallInvParams<>& params [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
-  if (tid >= params.batch) {
-    return;
-  }
   device const float* Ab = A + long(tid) * params.A_bstride;
   device float* Xb = X + long(tid) * params.X_bstride;
 
@@ -2860,9 +2854,6 @@ kernel void luSolveSmall(
     constant LUSmallSolveParams<>& params [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   const uint b = tid / params.k;
-  if (b >= params.batch) {
-    return;
-  }
   const uint col = tid - b * params.k;
   const uint n = params.n;
   const bool adjoint = params.adjoint;

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -2600,119 +2600,11 @@ kernel void luApplyPivotsRHS(
 INSTANTIATE_LU_APPLY_PIVOTS_RHS(float)
 INSTANTIATE_LU_APPLY_PIVOTS_RHS(float2)
 
-// Small-matrix LU (luFactorSmall / luInvSmall / luSolveSmall): one thread per
-// matrix (per right-hand-side column for the solve), the whole NMAX x NMAX
-// zero-padded matrix lives in registers. Every array index must stay a
+// Small-matrix LU (luInvSmall / luSolveSmall): one thread per matrix (per
+// right-hand-side column for the solve), the whole matrix lives in registers,
+// zero-padded to NMAX for the solve. Every array index must stay a
 // compile-time constant after unrolling, so row swaps scan for r == p instead
 // of indexing a[p] directly.
-template <typename T, short NMAX>
-kernel void luFactorSmall(
-    device const T* A [[buffer(0)]],
-    device T* LU [[buffer(1)]],
-    device int* pivots [[buffer(2)]],
-    device int* info [[buffer(3)]],
-    constant LUSmallFactorParams<>& params [[buffer(4)]],
-    uint tid [[thread_position_in_grid]]) {
-  const uint m = params.m;
-  const uint n = params.n;
-  const uint mn = min(m, n);
-  device const T* Ab = A + long(tid) * params.A_bstride;
-  device T* Lb = LU + long(tid) * params.LU_bstride;
-  device int* pv = pivots + ulong(tid) * mn;
-
-  T a[NMAX][NMAX];
-#pragma unroll
-  for (short r = 0; r < NMAX; r++) {
-#pragma unroll
-    for (short c = 0; c < NMAX; c++) {
-      a[r][c] = (uint(r) < m && uint(c) < n)
-          ? Ab[long(r) * params.A_rstride + long(c) * params.A_cstride]
-          : T(0.0f);
-    }
-  }
-
-  int inf = 0;
-#pragma unroll
-  for (short j = 0; j < NMAX; j++) {
-    if (uint(j) < mn) {
-      float bv = -1.0f;
-      short p = -1;
-#pragma unroll
-      for (short r = 0; r < NMAX; r++) {
-        if (r >= j && uint(r) < m) {
-          const float v = luPivotMag(a[r][j]);
-          if (v > bv) {
-            bv = v;
-            p = r;
-          }
-        }
-      }
-      if (p < 0) {
-        p = j;
-      }
-      pv[j] = int(p) + 1;
-      if (bv == 0.0f && inf == 0) {
-        inf = j + 1;
-      }
-#pragma unroll
-      for (short r = 0; r < NMAX; r++) {
-        if (r > j && r == p) {
-#pragma unroll
-          for (short c = 0; c < NMAX; c++) {
-            const T t = a[j][c];
-            a[j][c] = a[r][c];
-            a[r][c] = t;
-          }
-        }
-      }
-      if (bv != 0.0f) {
-        const T rp = luRecip(a[j][j]);
-#pragma unroll
-        for (short r = 0; r < NMAX; r++) {
-          if (r > j) {
-            const T l = c10::metal::mul(a[r][j], rp);
-            a[r][j] = l;
-#pragma unroll
-            for (short c = 0; c < NMAX; c++) {
-              if (c > j) {
-                a[r][c] = c10::metal::fma(-l, a[j][c], a[r][c]);
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  info[tid] = inf;
-
-#pragma unroll
-  for (short r = 0; r < NMAX; r++) {
-#pragma unroll
-    for (short c = 0; c < NMAX; c++) {
-      if (uint(r) < m && uint(c) < n) {
-        Lb[long(r) * params.LU_rstride + long(c) * params.LU_cstride] = a[r][c];
-      }
-    }
-  }
-}
-
-#define INSTANTIATE_LU_FACTOR_SMALL(T, NMAX)                \
-  template [[host_name("luFactorSmall_" #T "_" #NMAX)]]     \
-  kernel void luFactorSmall<T, NMAX>(                       \
-      device const T* A [[buffer(0)]],                      \
-      device T* LU [[buffer(1)]],                           \
-      device int* pivots [[buffer(2)]],                     \
-      device int* info [[buffer(3)]],                       \
-      constant LUSmallFactorParams<>& params [[buffer(4)]], \
-      uint tid [[thread_position_in_grid]]);
-
-// NMAX buckets picked by lu_factor_small_encode
-INSTANTIATE_LU_FACTOR_SMALL(float, 4)
-INSTANTIATE_LU_FACTOR_SMALL(float, 8)
-INSTANTIATE_LU_FACTOR_SMALL(float2, 4)
-INSTANTIATE_LU_FACTOR_SMALL(float2, 8)
-static_assert(kLUSmallFactorMax == 8, "update luFactorSmall instantiations");
-
 template <short N>
 kernel void luInvSmall(
     device const float* A [[buffer(0)]],
@@ -2823,7 +2715,7 @@ kernel void luInvSmall(
       constant LUSmallInvParams<>& params [[buffer(3)]], \
       uint tid [[thread_position_in_grid]]);
 
-// exact sizes 1..kLUSmallFactorMax picked by lu_inv_small_encode
+// exact sizes 1..kLUSmallInvMax picked by lu_inv_small_encode
 INSTANTIATE_LU_INV_SMALL(1)
 INSTANTIATE_LU_INV_SMALL(2)
 INSTANTIATE_LU_INV_SMALL(3)
@@ -2832,7 +2724,7 @@ INSTANTIATE_LU_INV_SMALL(5)
 INSTANTIATE_LU_INV_SMALL(6)
 INSTANTIATE_LU_INV_SMALL(7)
 INSTANTIATE_LU_INV_SMALL(8)
-static_assert(kLUSmallFactorMax == 8, "update luInvSmall instantiations");
+static_assert(kLUSmallInvMax == 8, "update luInvSmall instantiations");
 
 template <typename T>
 inline T luSmallElem(

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -62,6 +62,7 @@
 #include <c10/util/TypeCast.h>
 #include <c10/util/env.h>
 #include <algorithm>
+#include <bit>
 #include <limits>
 #include <string>
 #include <string_view>
@@ -896,6 +897,37 @@ static void lu_factor_panel_encode(const Tensor& LU,
   }
 }
 
+static void lu_factor_small_encode(const Tensor& A, const Tensor& LU, const Tensor& pivots, const Tensor& info) {
+  const auto m = A.size(-2);
+  const auto n = A.size(-1);
+  const auto batch = c10::multiply_integers(A.sizes().begin(), A.sizes().end() - 2);
+  const auto A_ = A.reshape({batch, m, n});
+  const auto LU_ = LU.reshape({batch, m, n});
+  const LUSmallFactorParams<> params{.A_bstride = A_.stride(0),
+                                     .A_rstride = A_.stride(1),
+                                     .A_cstride = A_.stride(2),
+                                     .LU_bstride = LU_.stride(0),
+                                     .LU_rstride = LU_.stride(1),
+                                     .LU_cstride = LU_.stride(2),
+                                     .batch = c10::checked_convert<uint32_t>(batch, "uint32_t"),
+                                     .m = static_cast<uint32_t>(m),
+                                     .n = static_cast<uint32_t>(n)};
+  const auto nmax = std::bit_ceil(static_cast<uint32_t>(std::max({m, n, int64_t{4}})));
+  auto pso = lib.getPipelineStateForFunc(fmt::format("luFactorSmall_{}_{}", mps::scalarToMetalTypeString(A), nmax));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto enc = stream->commandEncoder();
+      [enc setComputePipelineState:pso];
+      mtl_setArgs(enc, A_, LU_, pivots, info, params);
+      mtl_dispatch1DJob(enc, pso, batch);
+    }
+  });
+  if (!LU_.is_alias_of(LU)) {
+    LU.copy_(LU_);
+  }
+}
+
 static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
                                              bool pivot,
                                              const Tensor& LU,
@@ -922,26 +954,29 @@ static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
     return;
   }
 
-  // kernels factor row-major, the LU output is column-major: square factors
-  // in the LU.mT() view and transposes in place, the rest go via a scratch
   resize_output(LU, A.sizes());
-  const bool inPlace = aRows == aCols && !LU.is_same(A) && LU.mT().is_contiguous();
-  Tensor work_full;
-  if (inPlace) {
-    work_full = LU.mT();
-  } else {
-    work_full = at::empty(A.sizes(), A.options());
-  }
-  work_full.copy_(A);
-  Tensor work = work_full.dim() > 3 ? work_full.flatten(0, -3) : work_full;
-  TORCH_INTERNAL_ASSERT(work.is_contiguous())
-  int64_t batchSize = work.dim() > 2 ? work.size(0) : 1;
-
   Tensor pivots_ = pivots.is_contiguous() ? pivots : at::empty(pivots.sizes(), pivots.options());
   Tensor info_ = info.is_contiguous() ? info : at::empty(info.sizes(), info.options());
-  lu_factor_panel_encode(work, pivots_, info_, aRows, aCols, batchSize, inPlace);
-  if (!inPlace) {
-    LU.copy_(work_full);
+  if (std::max(aRows, aCols) <= kLUSmallFactorMax) {
+    lu_factor_small_encode(A, LU, pivots_, info_);
+  } else {
+    // kernels factor row-major, the LU output is column-major: square factors
+    // in the LU.mT() view and transposes in place, the rest go via a scratch
+    const bool inPlace = aRows == aCols && !LU.is_same(A) && LU.mT().is_contiguous();
+    Tensor work_full;
+    if (inPlace) {
+      work_full = LU.mT();
+    } else {
+      work_full = at::empty(A.sizes(), A.options());
+    }
+    work_full.copy_(A);
+    Tensor work = work_full.dim() > 3 ? work_full.flatten(0, -3) : work_full;
+    TORCH_INTERNAL_ASSERT(work.is_contiguous())
+    int64_t batchSize = work.dim() > 2 ? work.size(0) : 1;
+    lu_factor_panel_encode(work, pivots_, info_, aRows, aCols, batchSize, inPlace);
+    if (!inPlace) {
+      LU.copy_(work_full);
+    }
   }
   if (!pivots_.is_same(pivots)) {
     pivots.copy_(pivots_);
@@ -1049,6 +1084,41 @@ static void lu_solve_encode(const Tensor& W, const Tensor& pivots, int64_t n, in
   }
 }
 
+static void lu_solve_small_encode(const Tensor& LU,
+                                  const Tensor& pivots,
+                                  const Tensor& B,
+                                  int64_t Bnum,
+                                  int64_t n,
+                                  int64_t k,
+                                  bool adjoint) {
+  const auto X = B.reshape({Bnum, n, k});
+  const auto threads = c10::checked_convert<uint32_t>(Bnum * k, "uint32_t");
+  const LUSmallSolveParams<> params{.LU_bstride = LU.stride(0),
+                                    .LU_rstride = adjoint ? LU.stride(2) : LU.stride(1),
+                                    .LU_cstride = adjoint ? LU.stride(1) : LU.stride(2),
+                                    .X_bstride = X.stride(0),
+                                    .X_rstride = X.stride(1),
+                                    .X_cstride = X.stride(2),
+                                    .batch = static_cast<uint32_t>(Bnum),
+                                    .n = static_cast<uint32_t>(n),
+                                    .k = static_cast<uint32_t>(k),
+                                    .adjoint = adjoint};
+  const auto nmax = std::bit_ceil(static_cast<uint32_t>(std::max<int64_t>(n, 4)));
+  auto pso = lib.getPipelineStateForFunc(fmt::format("luSolveSmall_{}_{}", mps::scalarToMetalTypeString(B), nmax));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto enc = stream->commandEncoder();
+      [enc setComputePipelineState:pso];
+      mtl_setArgs(enc, LU, pivots, X, params);
+      mtl_dispatch1DJob(enc, pso, threads);
+    }
+  });
+  if (!X.is_alias_of(B)) {
+    B.copy_(X);
+  }
+}
+
 static void mps_lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
   using namespace mps;
   TORCH_CHECK(LU.scalar_type() == kFloat || LU.scalar_type() == kComplexFloat,
@@ -1072,6 +1142,10 @@ static void mps_lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Te
   auto piv_shape = batch;
   piv_shape.push_back(n);
   auto piv_b = pivots.expand(piv_shape).contiguous().reshape({Bnum, n});
+  if (n <= kLUSmallSolveMax) {
+    lu_solve_small_encode(LU.expand(with_mat(n, n)).reshape({Bnum, n, n}), piv_b, B, Bnum, n, k, adjoint);
+    return;
+  }
 
   auto W = at::empty({Bnum, n, n + k}, LU.options());
   auto factor = adjoint ? LU.expand(with_mat(n, n)).mH() : LU.expand(with_mat(n, n));
@@ -1102,13 +1176,51 @@ static void linalg_solve_out_mps_impl(const Tensor& A,
   at::linalg_lu_solve_out(result_, LU, pivots, B_, left, false);
 }
 
+static void lu_inv_small_encode(const Tensor& A, const Tensor& result, const Tensor& info) {
+  const auto n = A.size(-1);
+  const auto batch = c10::multiply_integers(A.sizes().begin(), A.sizes().end() - 2);
+  const auto A_ = A.reshape({batch, n, n});
+  const auto X = result.reshape({batch, n, n});
+  const LUSmallInvParams<> params{.A_bstride = A_.stride(0),
+                                  .A_rstride = A_.stride(1),
+                                  .A_cstride = A_.stride(2),
+                                  .X_bstride = X.stride(0),
+                                  .X_rstride = X.stride(1),
+                                  .X_cstride = X.stride(2),
+                                  .batch = c10::checked_convert<uint32_t>(batch, "uint32_t")};
+  auto pso = lib.getPipelineStateForFunc(fmt::format("luInvSmall_{}_{}", mps::scalarToMetalTypeString(A), n));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto enc = stream->commandEncoder();
+      [enc setComputePipelineState:pso];
+      mtl_setArgs(enc, A_, X, info, params);
+      mtl_dispatch1DJob(enc, pso, batch);
+    }
+  });
+  if (!X.is_alias_of(result)) {
+    result.copy_(X);
+  }
+}
+
 static void linalg_inv_ex_out_mps_impl(const Tensor& A, bool check_errors, const Tensor& result, const Tensor& info) {
   using namespace mps;
   TORCH_CHECK(result.is_mps(), "Output tensor is not MPS");
   TORCH_CHECK(!A.is_complex(), "linalg_inv: not supported for complex types yet!");
 
-  info.zero_();
   if (A.numel() == 0) {
+    info.zero_();
+    return;
+  }
+  if (A.size(-1) <= kLUSmallFactorMax) {
+    Tensor info_ = info.is_contiguous() ? info : at::empty(info.sizes(), info.options());
+    lu_inv_small_encode(A, result, info_);
+    if (!info_.is_same(info)) {
+      info.copy_(info_);
+    }
+    if (check_errors) {
+      at::_linalg_check_errors(info, "linalg.inv_ex", A.dim() == 2);
+    }
     return;
   }
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1121,7 +1121,10 @@ static void lu_inv_small_encode(const Tensor& A, const Tensor& result, const Ten
       auto enc = stream->commandEncoder();
       [enc setComputePipelineState:pso];
       mtl_setArgs(enc, A_, X, info, params);
-      mtl_dispatch1DJob(enc, pso, threads);
+      // using mtl_dispatch1DJob would launch a single threadgroup of up to 1024 threads
+      // all of which would be pinned to one GPU core, which is not ideal for such work
+      [enc dispatchThreads:MTLSizeMake(threads, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(c10::metal::simdgroup_size, 1, 1)];
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -902,14 +902,14 @@ static void lu_factor_small_encode(const Tensor& A, const Tensor& LU, const Tens
   const auto n = A.size(-1);
   const auto batch = c10::multiply_integers(A.sizes().begin(), A.sizes().end() - 2);
   const auto A_ = A.reshape({batch, m, n});
-  const auto LU_ = LU.reshape({batch, m, n});
+  const auto LU_ = LU.view({batch, m, n});
+  const auto threads = c10::checked_convert<uint32_t>(batch, "uint32_t");
   const LUSmallFactorParams<> params{.A_bstride = A_.stride(0),
                                      .A_rstride = A_.stride(1),
                                      .A_cstride = A_.stride(2),
                                      .LU_bstride = LU_.stride(0),
                                      .LU_rstride = LU_.stride(1),
                                      .LU_cstride = LU_.stride(2),
-                                     .batch = c10::checked_convert<uint32_t>(batch, "uint32_t"),
                                      .m = static_cast<uint32_t>(m),
                                      .n = static_cast<uint32_t>(n)};
   const auto nmax = std::bit_ceil(static_cast<uint32_t>(std::max({m, n, int64_t{4}})));
@@ -920,12 +920,9 @@ static void lu_factor_small_encode(const Tensor& A, const Tensor& LU, const Tens
       auto enc = stream->commandEncoder();
       [enc setComputePipelineState:pso];
       mtl_setArgs(enc, A_, LU_, pivots, info, params);
-      mtl_dispatch1DJob(enc, pso, batch);
+      mtl_dispatch1DJob(enc, pso, threads);
     }
   });
-  if (!LU_.is_alias_of(LU)) {
-    LU.copy_(LU_);
-  }
 }
 
 static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
@@ -1091,7 +1088,7 @@ static void lu_solve_small_encode(const Tensor& LU,
                                   int64_t n,
                                   int64_t k,
                                   bool adjoint) {
-  const auto X = B.reshape({Bnum, n, k});
+  const auto X = B.view({Bnum, n, k});
   const auto threads = c10::checked_convert<uint32_t>(Bnum * k, "uint32_t");
   const LUSmallSolveParams<> params{.LU_bstride = LU.stride(0),
                                     .LU_rstride = adjoint ? LU.stride(2) : LU.stride(1),
@@ -1099,7 +1096,6 @@ static void lu_solve_small_encode(const Tensor& LU,
                                     .X_bstride = X.stride(0),
                                     .X_rstride = X.stride(1),
                                     .X_cstride = X.stride(2),
-                                    .batch = static_cast<uint32_t>(Bnum),
                                     .n = static_cast<uint32_t>(n),
                                     .k = static_cast<uint32_t>(k),
                                     .adjoint = adjoint};
@@ -1114,9 +1110,6 @@ static void lu_solve_small_encode(const Tensor& LU,
       mtl_dispatch1DJob(enc, pso, threads);
     }
   });
-  if (!X.is_alias_of(B)) {
-    B.copy_(X);
-  }
 }
 
 static void mps_lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
@@ -1180,14 +1173,14 @@ static void lu_inv_small_encode(const Tensor& A, const Tensor& result, const Ten
   const auto n = A.size(-1);
   const auto batch = c10::multiply_integers(A.sizes().begin(), A.sizes().end() - 2);
   const auto A_ = A.reshape({batch, n, n});
-  const auto X = result.reshape({batch, n, n});
+  const auto X = result.view({batch, n, n});
+  const auto threads = c10::checked_convert<uint32_t>(batch, "uint32_t");
   const LUSmallInvParams<> params{.A_bstride = A_.stride(0),
                                   .A_rstride = A_.stride(1),
                                   .A_cstride = A_.stride(2),
                                   .X_bstride = X.stride(0),
                                   .X_rstride = X.stride(1),
-                                  .X_cstride = X.stride(2),
-                                  .batch = c10::checked_convert<uint32_t>(batch, "uint32_t")};
+                                  .X_cstride = X.stride(2)};
   auto pso = lib.getPipelineStateForFunc(fmt::format("luInvSmall_{}_{}", mps::scalarToMetalTypeString(A), n));
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
@@ -1195,12 +1188,9 @@ static void lu_inv_small_encode(const Tensor& A, const Tensor& result, const Ten
       auto enc = stream->commandEncoder();
       [enc setComputePipelineState:pso];
       mtl_setArgs(enc, A_, X, info, params);
-      mtl_dispatch1DJob(enc, pso, batch);
+      mtl_dispatch1DJob(enc, pso, threads);
     }
   });
-  if (!X.is_alias_of(result)) {
-    result.copy_(X);
-  }
 }
 
 static void linalg_inv_ex_out_mps_impl(const Tensor& A, bool check_errors, const Tensor& result, const Tensor& info) {
@@ -1213,11 +1203,7 @@ static void linalg_inv_ex_out_mps_impl(const Tensor& A, bool check_errors, const
     return;
   }
   if (A.size(-1) <= kLUSmallFactorMax) {
-    Tensor info_ = info.is_contiguous() ? info : at::empty(info.sizes(), info.options());
-    lu_inv_small_encode(A, result, info_);
-    if (!info_.is_same(info)) {
-      info.copy_(info_);
-    }
+    lu_inv_small_encode(A, result, info);
     if (check_errors) {
       at::_linalg_check_errors(info, "linalg.inv_ex", A.dim() == 2);
     }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -897,34 +897,6 @@ static void lu_factor_panel_encode(const Tensor& LU,
   }
 }
 
-static void lu_factor_small_encode(const Tensor& A, const Tensor& LU, const Tensor& pivots, const Tensor& info) {
-  const auto m = A.size(-2);
-  const auto n = A.size(-1);
-  const auto batch = c10::multiply_integers(A.sizes().begin(), A.sizes().end() - 2);
-  const auto A_ = A.reshape({batch, m, n});
-  const auto LU_ = LU.view({batch, m, n});
-  const auto threads = c10::checked_convert<uint32_t>(batch, "uint32_t");
-  const LUSmallFactorParams<> params{.A_bstride = A_.stride(0),
-                                     .A_rstride = A_.stride(1),
-                                     .A_cstride = A_.stride(2),
-                                     .LU_bstride = LU_.stride(0),
-                                     .LU_rstride = LU_.stride(1),
-                                     .LU_cstride = LU_.stride(2),
-                                     .m = static_cast<uint32_t>(m),
-                                     .n = static_cast<uint32_t>(n)};
-  const auto nmax = std::bit_ceil(static_cast<uint32_t>(std::max({m, n, int64_t{4}})));
-  auto pso = lib.getPipelineStateForFunc(fmt::format("luFactorSmall_{}_{}", mps::scalarToMetalTypeString(A), nmax));
-  auto stream = getCurrentMPSStream();
-  dispatch_sync_with_rethrow(stream->queue(), ^() {
-    @autoreleasepool {
-      auto enc = stream->commandEncoder();
-      [enc setComputePipelineState:pso];
-      mtl_setArgs(enc, A_, LU_, pivots, info, params);
-      mtl_dispatch1DJob(enc, pso, threads);
-    }
-  });
-}
-
 static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
                                              bool pivot,
                                              const Tensor& LU,
@@ -951,29 +923,26 @@ static void linalg_lu_factor_ex_out_mps_impl(const Tensor& A,
     return;
   }
 
+  // kernels factor row-major, the LU output is column-major: square factors
+  // in the LU.mT() view and transposes in place, the rest go via a scratch
   resize_output(LU, A.sizes());
+  const bool inPlace = aRows == aCols && !LU.is_same(A) && LU.mT().is_contiguous();
+  Tensor work_full;
+  if (inPlace) {
+    work_full = LU.mT();
+  } else {
+    work_full = at::empty(A.sizes(), A.options());
+  }
+  work_full.copy_(A);
+  Tensor work = work_full.dim() > 3 ? work_full.flatten(0, -3) : work_full;
+  TORCH_INTERNAL_ASSERT(work.is_contiguous())
+  int64_t batchSize = work.dim() > 2 ? work.size(0) : 1;
+
   Tensor pivots_ = pivots.is_contiguous() ? pivots : at::empty(pivots.sizes(), pivots.options());
   Tensor info_ = info.is_contiguous() ? info : at::empty(info.sizes(), info.options());
-  if (std::max(aRows, aCols) <= kLUSmallFactorMax) {
-    lu_factor_small_encode(A, LU, pivots_, info_);
-  } else {
-    // kernels factor row-major, the LU output is column-major: square factors
-    // in the LU.mT() view and transposes in place, the rest go via a scratch
-    const bool inPlace = aRows == aCols && !LU.is_same(A) && LU.mT().is_contiguous();
-    Tensor work_full;
-    if (inPlace) {
-      work_full = LU.mT();
-    } else {
-      work_full = at::empty(A.sizes(), A.options());
-    }
-    work_full.copy_(A);
-    Tensor work = work_full.dim() > 3 ? work_full.flatten(0, -3) : work_full;
-    TORCH_INTERNAL_ASSERT(work.is_contiguous())
-    int64_t batchSize = work.dim() > 2 ? work.size(0) : 1;
-    lu_factor_panel_encode(work, pivots_, info_, aRows, aCols, batchSize, inPlace);
-    if (!inPlace) {
-      LU.copy_(work_full);
-    }
+  lu_factor_panel_encode(work, pivots_, info_, aRows, aCols, batchSize, inPlace);
+  if (!inPlace) {
+    LU.copy_(work_full);
   }
   if (!pivots_.is_same(pivots)) {
     pivots.copy_(pivots_);
@@ -1202,7 +1171,7 @@ static void linalg_inv_ex_out_mps_impl(const Tensor& A, bool check_errors, const
     info.zero_();
     return;
   }
-  if (A.size(-1) <= kLUSmallFactorMax) {
+  if (A.size(-1) <= kLUSmallInvMax) {
     lu_inv_small_encode(A, result, info);
     if (check_errors) {
       at::_linalg_check_errors(info, "linalg.inv_ex", A.dim() == 2);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -62,7 +62,6 @@
 #include <c10/util/TypeCast.h>
 #include <c10/util/env.h>
 #include <algorithm>
-#include <bit>
 #include <limits>
 #include <string>
 #include <string_view>
@@ -1050,37 +1049,6 @@ static void lu_solve_encode(const Tensor& W, const Tensor& pivots, int64_t n, in
   }
 }
 
-static void lu_solve_small_encode(const Tensor& LU,
-                                  const Tensor& pivots,
-                                  const Tensor& B,
-                                  int64_t Bnum,
-                                  int64_t n,
-                                  int64_t k,
-                                  bool adjoint) {
-  const auto X = B.view({Bnum, n, k});
-  const auto threads = c10::checked_convert<uint32_t>(Bnum * k, "uint32_t");
-  const LUSmallSolveParams<> params{.LU_bstride = LU.stride(0),
-                                    .LU_rstride = adjoint ? LU.stride(2) : LU.stride(1),
-                                    .LU_cstride = adjoint ? LU.stride(1) : LU.stride(2),
-                                    .X_bstride = X.stride(0),
-                                    .X_rstride = X.stride(1),
-                                    .X_cstride = X.stride(2),
-                                    .n = static_cast<uint32_t>(n),
-                                    .k = static_cast<uint32_t>(k),
-                                    .adjoint = adjoint};
-  const auto nmax = std::bit_ceil(static_cast<uint32_t>(std::max<int64_t>(n, 4)));
-  auto pso = lib.getPipelineStateForFunc(fmt::format("luSolveSmall_{}_{}", mps::scalarToMetalTypeString(B), nmax));
-  auto stream = getCurrentMPSStream();
-  dispatch_sync_with_rethrow(stream->queue(), ^() {
-    @autoreleasepool {
-      auto enc = stream->commandEncoder();
-      [enc setComputePipelineState:pso];
-      mtl_setArgs(enc, LU, pivots, X, params);
-      mtl_dispatch1DJob(enc, pso, threads);
-    }
-  });
-}
-
 static void mps_lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
   using namespace mps;
   TORCH_CHECK(LU.scalar_type() == kFloat || LU.scalar_type() == kComplexFloat,
@@ -1104,10 +1072,6 @@ static void mps_lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Te
   auto piv_shape = batch;
   piv_shape.push_back(n);
   auto piv_b = pivots.expand(piv_shape).contiguous().reshape({Bnum, n});
-  if (n <= kLUSmallSolveMax) {
-    lu_solve_small_encode(LU.expand(with_mat(n, n)).reshape({Bnum, n, n}), piv_b, B, Bnum, n, k, adjoint);
-    return;
-  }
 
   auto W = at::empty({Bnum, n, n + k}, LU.options());
   auto factor = adjoint ? LU.expand(with_mat(n, n)).mH() : LU.expand(with_mat(n, n));

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1181,7 +1181,7 @@ static void lu_inv_small_encode(const Tensor& A, const Tensor& result, const Ten
                                   .X_bstride = X.stride(0),
                                   .X_rstride = X.stride(1),
                                   .X_cstride = X.stride(2)};
-  auto pso = lib.getPipelineStateForFunc(fmt::format("luInvSmall_{}_{}", mps::scalarToMetalTypeString(A), n));
+  auto pso = lib.getPipelineStateForFunc(fmt::format("luInvSmall_{}", n));
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9202,11 +9202,9 @@ class TestMPS(TestCaseMPS):
         helper(2)
         helper(6)
         helper(3)
-        # register-kernel cutoffs: inv n <= 8, then lu_factor panel + lu_solve n <= 16
+        # both sides of the n <= 8 register-kernel cutoff
         helper(8)
         helper(9)
-        helper(16)
-        helper(17)
         helper(1025, atol=1e-4)
 
     # Test tril

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2741,8 +2741,8 @@ class TestMPS(TestCaseMPS):
             check(input_cpu, input_mps)
             check(input_cpu.mT, input_mps.mT)
 
-        # test with different even/odd matrix sizes
-        matrix_sizes = [1, 2, 3, 4]
+        # even/odd matrix sizes plus both sides of the n <= 8 register-kernel cutoff
+        matrix_sizes = [1, 2, 3, 4, 8, 9]
         # even/odd batch sizes
         batch_sizes = [1, 2, 4]
 
@@ -2827,8 +2827,9 @@ class TestMPS(TestCaseMPS):
                 X_mps_t = torch.linalg.solve(A_mps.mT, b_mps, left=left)
                 self.assertEqual(X_cpu_t, X_mps_t)
 
-        # test with different even/odd matrix sizes
-        matrix_sizes = [1, 2, 3, 4]
+        # even/odd matrix sizes plus both sides of the register-kernel cutoffs
+        # (lu_factor n <= 8, lu_solve n <= 16)
+        matrix_sizes = [1, 2, 3, 4, 8, 9, 16, 17]
         # even/odd batch sizes
         batch_sizes = [1, 2, 4]
 
@@ -2949,7 +2950,10 @@ class TestMPS(TestCaseMPS):
                     mat = (n, k) if left else (k, n)
                     check(A, make_B(*b_batch, *mat), left, adjoint)
 
-        # multi-block (n > 32) path
+        # both sides of the n <= 16 register-kernel cutoff, then the multi-block (n > 32) path
+        for size in (16, 17):
+            for adjoint in [True, False]:
+                check(make_A(2, size, size), make_B(2, size, k), left=True, adjoint=adjoint)
         check(make_A(2, 40, 40), make_B(2, 40, 5), left=True, adjoint=False)
 
     def test_linalg_lu_backed_complex_backward(self):
@@ -9201,7 +9205,11 @@ class TestMPS(TestCaseMPS):
         helper(2)
         helper(6)
         helper(3)
+        # register-kernel cutoffs: inv n <= 8, then lu_factor panel + lu_solve n <= 16
         helper(8)
+        helper(9)
+        helper(16)
+        helper(17)
         helper(1025, atol=1e-4)
 
     # Test tril

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2827,8 +2827,8 @@ class TestMPS(TestCaseMPS):
                 X_mps_t = torch.linalg.solve(A_mps.mT, b_mps, left=left)
                 self.assertEqual(X_cpu_t, X_mps_t)
 
-        # even/odd matrix sizes plus both sides of the lu_solve n <= 16 register-kernel cutoff
-        matrix_sizes = [1, 2, 3, 4, 16, 17]
+        # test with different even/odd matrix sizes
+        matrix_sizes = [1, 2, 3, 4]
         # even/odd batch sizes
         batch_sizes = [1, 2, 4]
 
@@ -9201,9 +9201,10 @@ class TestMPS(TestCaseMPS):
         helper(2)
         helper(6)
         helper(3)
-        # both sides of the n <= 8 register-kernel cutoff
         helper(8)
-        helper(9)
+        # both sides of the n <= 16 register-kernel cutoff
+        helper(16)
+        helper(17)
         helper(1025, atol=1e-4)
 
     # Test tril

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2950,10 +2950,7 @@ class TestMPS(TestCaseMPS):
                     mat = (n, k) if left else (k, n)
                     check(A, make_B(*b_batch, *mat), left, adjoint)
 
-        # both sides of the n <= 16 register-kernel cutoff, then the multi-block (n > 32) path
-        for size in (16, 17):
-            for adjoint in [True, False]:
-                check(make_A(2, size, size), make_B(2, size, k), left=True, adjoint=adjoint)
+        # multi-block (n > 32) path
         check(make_A(2, 40, 40), make_B(2, 40, 5), left=True, adjoint=False)
 
     def test_linalg_lu_backed_complex_backward(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2741,8 +2741,8 @@ class TestMPS(TestCaseMPS):
             check(input_cpu, input_mps)
             check(input_cpu.mT, input_mps.mT)
 
-        # even/odd matrix sizes plus both sides of the n <= 8 register-kernel cutoff
-        matrix_sizes = [1, 2, 3, 4, 8, 9]
+        # test with different even/odd matrix sizes
+        matrix_sizes = [1, 2, 3, 4]
         # even/odd batch sizes
         batch_sizes = [1, 2, 4]
 
@@ -2827,9 +2827,8 @@ class TestMPS(TestCaseMPS):
                 X_mps_t = torch.linalg.solve(A_mps.mT, b_mps, left=left)
                 self.assertEqual(X_cpu_t, X_mps_t)
 
-        # even/odd matrix sizes plus both sides of the register-kernel cutoffs
-        # (lu_factor n <= 8, lu_solve n <= 16)
-        matrix_sizes = [1, 2, 3, 4, 8, 9, 16, 17]
+        # even/odd matrix sizes plus both sides of the lu_solve n <= 16 register-kernel cutoff
+        matrix_sizes = [1, 2, 3, 4, 16, 17]
         # even/odd batch sizes
         batch_sizes = [1, 2, 4]
 


### PR DESCRIPTION
Idea from a report from @ducha-aiki here:
https://x.com/ducha_aiki/status/2095512336027001133

Batched small matrix inverses are used in kornia library, so adding coverage for this makes sense imo. This PR introduces `luInvSmall` fused kernel which does factorization and solve in one kernel launch if N <= 16

Reason for specializing for N <= 16 matrices is that we want to keep everything in registers. When I measured on M5 Pro for N > 16 it dropped in performance across all batch sizes after N >= 24 but there were more regressions for smaller batches as well, so I left this nice round number. 

<details>
<summary> Performance across shapes </summary> 

| shape | CPU ms | MPS pipelined `inv_ex(check_errors=False)` ms | vs CPU |
| --- | --: | --: | --: |
| 10x2x2 | 0.0210 | 0.0098 | 2.2x |
| 100x2x2 | 0.0248 | 0.0050 | 5.0x |
| 1000x2x2 | 0.0634 | 0.0051 | 12.4x |
| 10000x2x2 | 0.337 | 0.006 | 58.7x |
| 100000x2x2 | 2.814 | 0.012 | 239.0x |
| 10x3x3 | 0.0206 | 0.0061 | 3.4x |
| 100x3x3 | 0.0245 | 0.0060 | 4.1x |
| 1000x3x3 | 0.0704 | 0.0055 | 12.8x |
| 10000x3x3 | 0.404 | 0.007 | 61.2x |
| 100000x3x3 | 3.501 | 0.023 | 153.1x |
| 10x4x4 | 0.0212 | 0.0084 | 2.5x |
| 100x4x4 | 0.0261 | 0.0076 | 3.4x |
| 1000x4x4 | 0.0800 | 0.0078 | 10.3x |
| 10000x4x4 | 0.516 | 0.010 | 50.4x |
| 100000x4x4 | 4.163 | 0.048 | 86.8x |
| 10x8x8 | 0.0215 | 0.0375 | 0.6x |
| 100x8x8 | 0.0391 | 0.0386 | 1.0x |
| 1000x8x8 | 0.158 | 0.039 | 4.1x |
| 10000x8x8 | 1.192 | 0.112 | 10.6x |
| 100000x8x8 | 9.781 | 0.856 | 11.4x |
| 1000x16x16 | 0.405 | 0.227 | 1.8x |
| 10000x16x16 | 3.697 | 1.431 | 2.6x |
| 100000x16x16 | 36.908 | 11.508 | 3.2x |

</details>

<details> 
<summary> Script for producing the above numbers: </summary>

```python
import statistics, time, torch

sync = torch.mps.synchronize


def cpu_median_ms(fn, warmup, iters):
    for _ in range(warmup): fn()
    times = []
    for _ in range(iters):
        t0 = time.perf_counter(); fn(); times.append(time.perf_counter() - t0)
    return statistics.median(times) * 1e3


def mps_pipelined_ms(fn, warmup, iters, warm_seconds=0.5):
    t0 = time.perf_counter()
    while time.perf_counter() - t0 < warm_seconds:
        for _ in range(warmup): fn()
        sync()
    t0 = time.perf_counter()
    for _ in range(iters): fn()
    sync()
    return (time.perf_counter() - t0) / iters * 1e3


torch.manual_seed(0)
print("| shape | CPU ms | MPS pipelined `inv_ex(check_errors=False)` ms | vs CPU |\n| --- | --: | --: | --: |")
for n in (2, 3, 4, 8, 16):
    for batch in (10, 100, 1000, 10000, 100000) if n < 16 else (1000, 10000, 100000):
        a_cpu = torch.randn(batch, n, n) + 3 * torch.eye(n)
        a_mps = a_cpu.to("mps")
        warmup, iters = (20, 60) if batch * n * n <= 2_000_000 else (5, 20)
        cpu_ms = cpu_median_ms(lambda: torch.linalg.inv_ex(a_cpu, check_errors=False), warmup, iters)
        mps_ms = mps_pipelined_ms(lambda: torch.linalg.inv_ex(a_mps, check_errors=False), warmup, iters)
        digits = 4 if cpu_ms < 0.1 else 3
        print(f"| {batch}x{n}x{n} | {cpu_ms:.{digits}f} | {mps_ms:.{digits}f} | {cpu_ms / mps_ms:.1f}x |", flush=True)
```

</details>

<details>

<summary> To instantiate or not to instantiate, that is the question:
</summary>

| n | batch | templated `luInvSmall_<n>` | runtime-n  | slowdown |
| --- | --: | --: | --: | --: |
| 1 | 1000 | 0.0025 | 0.0036 | 1.42x |
| 1 | 10000 | 0.0025 | 0.0034 | 1.38x |
| 1 | 100000 | 0.0041 | 0.0081 | 1.95x |
| 2 | 1000 | 0.0024 | 0.0040 | 1.68x |
| 2 | 10000 | 0.0031 | 0.0052 | 1.69x |
| 2 | 100000 | 0.0078 | 0.0248 | 3.16x |
| 3 | 1000 | 0.0029 | 0.0065 | 2.26x |
| 3 | 10000 | 0.0040 | 0.0088 | 2.19x |
| 3 | 100000 | 0.0200 | 0.0558 | 2.79x |
| 4 | 1000 | 0.0045 | 0.0107 | 2.39x |
| 4 | 10000 | 0.0072 | 0.0147 | 2.06x |
| 4 | 100000 | 0.0417 | 0.1131 | 2.71x |
| 6 | 1000 | 0.0174 | 0.0263 | 1.51x |
| 6 | 10000 | 0.0247 | 0.0405 | 1.64x |
| 6 | 100000 | 0.2695 | 0.3670 | 1.36x |
| 8 | 1000 | 0.0339 | 0.0536 | 1.58x |
| 8 | 10000 | 0.0969 | 0.1327 | 1.37x |
| 8 | 100000 | 0.7558 | 1.0775 | 1.43x |
| 10 | 1000 | 0.0587 | 0.0976 | 1.66x |
| 10 | 10000 | 0.2249 | 0.3153 | 1.40x |
| 10 | 100000 | 1.7760 | 2.5669 | 1.45x |
| 12 | 1000 | 0.0935 | 0.1596 | 1.71x |
| 12 | 10000 | 0.4326 | 0.6205 | 1.43x |
| 12 | 100000 | 3.6089 | 5.0861 | 1.41x |
| 14 | 1000 | 0.1438 | 0.2461 | 1.71x |
| 14 | 10000 | 0.7627 | 1.1022 | 1.45x |
| 14 | 100000 | 6.3115 | 9.1537 | 1.45x |
| 16 | 1000 | 0.2094 | 0.3560 | 1.70x |
| 16 | 10000 | 1.2935 | 1.7959 | 1.39x |
| 16 | 100000 | 10.2404 | 14.8026 | 1.45x |


</details>