### PR TITLE
[MPS] Fix svd_jacobi Metal compiler crash

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -3324,10 +3324,13 @@ kernel void svd_jacobi(
           }
         }
       }
-      threadgroup_barrier(
-          params.stage_v
-              ? mem_flags::mem_threadgroup
-              : (mem_flags::mem_threadgroup | mem_flags::mem_device));
+      // Barrier scope must be a compile-time constant (runtime mem_flags
+      // crashes the AGX compiler)
+      if (params.stage_v) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      } else {
+        threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+      }
     }
 
     threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12356,6 +12356,35 @@ class TestLinalgMPS(TestCaseMPS):
         self.assertEqual(mps.rank.cpu(), cpu.rank)
         self.assertEqual(mps.singular_values.cpu(), cpu.singular_values)
 
+    def test_linalg_svd_large_batch(self, device="mps"):
+        # Regression test for https://github.com/pytorch/pytorch/issues/195937:
+        # batches whose numel exceeds 8192 take the native on-device Jacobi
+        # kernel rather than the CPU fallback. That kernel used to crash the
+        # Metal compiler (a runtime mem_flags argument to threadgroup_barrier
+        # fails AGX instruction selection), so nothing above the threshold ran.
+        # Small OpInfo samples stay under the gate, so this is the only coverage
+        # of the kernel itself.
+        for dtype in (torch.float32, torch.complex64):
+            A = torch.randn(4096, 3, 3, dtype=dtype)  # 36864 elements, over the gate
+            Am = A.to(device)
+            U, S, Vh = torch.linalg.svd(Am, full_matrices=False)
+            # Singular values and reconstruction are gauge invariant; the raw
+            # U/Vh differ between the Jacobi solver and LAPACK.
+            self.assertEqual(S.cpu(), torch.linalg.svdvals(A), atol=1e-4, rtol=1e-4)
+            self.assertEqual(((U * S.unsqueeze(-2)) @ Vh).cpu(), A, atol=1e-4, rtol=1e-4)
+            # svdvals shares the same kernel.
+            self.assertEqual(torch.linalg.svdvals(Am).cpu(), torch.linalg.svdvals(A), atol=1e-4, rtol=1e-4)
+
+    def test_linalg_lstsq_large_batch(self, device="mps", dtype=torch.float32):
+        # lstsq is built on the native SVD; exercise a batch above the 8192 gate.
+        A = torch.randn(4096, 6, 3, dtype=dtype)  # overdetermined, well conditioned
+        B = torch.randn(4096, 6, 2, dtype=dtype)
+        xm = torch.linalg.lstsq(A.to(device), B.to(device)).solution.cpu()
+        xc = torch.linalg.lstsq(A, B).solution
+        # Fitted values A@x are unique for full column rank even where the raw
+        # solution is sensitive to conditioning of individual batch members.
+        self.assertEqual(A @ xm, A @ xc, atol=1e-4, rtol=1e-4)
+
     @dtypes(torch.float32, torch.complex64, torch.float16, torch.bfloat16)
     @parametrize("out", ["none", "zeros", "ones"])
     @parametrize("m, n, data, noncontig", [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195950
* __->__ #195949

Attempts to launch SVD kernel (linalg.svd/svdvals/lstsq) failed with

  Failed to created pipeline state object, error: ... AGXMetal Code=2 Compilation failed due to an interrupted connection: XPC_ERROR_CONNECTION_INTERRUPTED

Root caused to
```metal
  threadgroup_barrier(params.stage_v
                          ? mem_flags::mem_threadgroup
                          : (mem_flags::mem_threadgroup | mem_flags::mem_device));
```

The barrier scope must be a compile-time constant. The Metal front-end accepts the ternary and lowers it to the barrier intrinsic with a non-constant scope operand, but the AGX back-end cannot select @llvm.agx2.threadgroup.barrier.with.scope with a runtime operand and report_fatal_error() , taking down MTLCompilerService (surfacing as the XPC connection error).

This kernel had zero test coverage: every linalg OpInfo sample and the existing lstsq test sit under the 8192 gate, so they all took the CPU fallback and never built the pipeline.
Add above-gate regression tests for svd/svdvals (float32 and complex64) and batched lstsq that force the native kernel and check results gauge-invariantly against CPU.

Authored with assistance from Claude Code.

Fixes #195937
