### PR TITLE
[dynamo] Look up SideEffects through OutputGraph in SideEffectsProxyDict

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2332,6 +2332,28 @@ def forward(self):
         ):
             mod_for_compile(torch.tensor(True), torch.tensor(5))
 
+    def test_cond_dunder_dict_read_then_outer_mutation(self):
+        # The first __dict__ access on `inner` happens inside the cond body,
+        # whose side effects table is discarded after tracing. The later
+        # mutation outside the cond must still be recorded and replayed.
+        def fn(pred, x):
+            def inner():
+                return x + 1
+
+            def branch():
+                return x + len(inner.__dict__)
+
+            out = control_flow.cond(pred, branch, branch)
+            inner.tag = 42
+            return out, inner
+
+        x = torch.randn(4)
+        out, inner = torch.compile(fn, backend="eager", fullgraph=True)(
+            torch.tensor(True), x
+        )
+        self.assertEqual(out, x)
+        self.assertEqual(inner.tag, 42)
+
     def test_cond_with_constant_pred(self):
         def test(pred, x):
             def true_fn(x):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7452,6 +7452,29 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         del x
         self.assertTrue(p_ref() is None)
 
+    @skipIfWindows(msg="Tensor lifetime checks are unreliable on Windows")
+    def test_release_input_memory_hop_dunder_dict(self):
+        # Accessing a nested function's __dict__ inside a HOP body used to
+        # create a reference cycle through the speculated SideEffects table,
+        # keeping the frame's input tensors alive until a full gc.collect().
+        def fn(pred, x):
+            def branch():
+                def inner():
+                    return x + 1
+
+                inner.attr = 1
+                return inner()
+
+            return torch.cond(pred, branch, branch)
+
+        x = torch.randn(4)
+        x_ref = weakref.ref(x)
+        pred = torch.tensor(True)
+        out = torch.compile(fn, backend="eager", fullgraph=True)(pred, x)
+        self.assertEqual(out, x + 1)
+        del x, out
+        self.assertIsNone(x_ref())
+
     def test_update_locals_and_stack_uses_shared_cache(self):
         def fn(x):
             perm = [0, 3, 5]

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -21,6 +21,7 @@ import collections
 import functools
 import sys
 import types
+import weakref
 from collections.abc import Callable, Iterator
 from typing import Any, cast, TYPE_CHECKING, Union
 
@@ -75,6 +76,7 @@ from .object_protocol import (
 
 if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
+    from torch._dynamo.side_effects import SideEffects
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
 
     from .functions import UserFunctionVariable
@@ -1607,8 +1609,22 @@ class SideEffectsProxyDict(collections.abc.MutableMapping[kV, VariableTracker]):
 
     def __init__(self, item: VariableTracker, tx: "InstructionTranslatorBase") -> None:
         self.item = item
-        self.side_effects = tx.output.side_effects
+        self.output_graph_weakref = weakref.ref(tx.output)
         self.item_dict = self.get_value___dict__(tx, item)
+
+    @property
+    def side_effects(self) -> "SideEffects":
+        """
+        Resolved per access, not captured in __init__: speculate_subgraph
+        replaces the table after tracing a HOP body, so a captured one would
+        be stale and its mutations never replayed. It would also form a cycle
+        (the table owns this proxy via store_attr_mutations) that keeps
+        keepalive tensors alive until a full GC.
+        """
+        output_graph = self.output_graph_weakref()
+        if output_graph is None:
+            raise AssertionError("output_graph weakref is dead")
+        return output_graph.side_effects
 
     def _maybe_unwrap_key(self, key: kV) -> str:
         Hasher = HashableTracker


### PR DESCRIPTION
## Human Note
We were holding a strong ref; matches what we do here ->  https://github.com/pytorch/pytorch/blob/7e1c35ebdb7015a89ecdb99030893a767550eef1/torch/_dynamo/side_effects.py#L269

## Agent Report
# Report: pytorch#195866

## What changed

`SideEffectsProxyDict` (`torch/_dynamo/variables/dicts.py`) held a strong reference to the `SideEffects` table current at construction. That table transitively owns the proxy (`store_attr_mutations -> VT.dict_vt -> DunderDictVariable.items -> proxy`), forming a cycle. Inside HOP bodies, `speculate_subgraph` restores a pre-speculation clone and discards the traced table, which `OutputGraph.cleanup()` never clears, so its `keepalive` list pinned the frame's input tensors until a full `gc.collect()`.

The proxy now keeps `weakref.ref(tx.output)` and resolves `side_effects` through the `OutputGraph` on each access. This breaks the cycle and also makes the proxy consult the table `speculate_subgraph` actually installs.

The snapshot was also a correctness bug: a `__dict__` first read inside a HOP body followed by an attribute mutation outside it (`inner.tag = 42`) was silently dropped on baseline, since the mutation landed in the discarded table.

Tests added: `test_release_input_memory_hop_dunder_dict` (`test_misc.py`, memory) and `test_cond_dunder_dict_read_then_outer_mutation` (`test_higher_order_ops.py`, dropped side effect). Both fail before and pass after.

## Validation

- Repro scripts (cond, wrap, checkpoint, flex_attention, `inner.attr = 1`, `functools.wraps`): inputs released immediately after `del`.
- `test_dicts.py` + `test_functions.py` (884), `test_higher_order_ops.py` (234), `test_misc.py -k "dict or release or side_effect or wraps or attr"` (112), `test_repros.py` subset (42), `test_flat_apply.py` + `test_autograd_function.py` (105): all pass.
- `lintrunner` clean.

## Remaining uncertainty

- The issue's exact `torch.cond` snippet did not reproduce on this checkout (already fixed by something else upstream); the fix here targets the `flex_attention` path the reporter hit and the general `__dict__`-in-HOP pattern.
- The property asserts if the `OutputGraph` weakref is dead. This cannot happen in practice (VTs are created and consumed within the root `InstructionTranslator.run()`, which owns the graph), and `SideEffects.store_attr` already asserts the same on the proxy's write path.

Commit: `5eb1b9548ca`. PR title in `pr_title.txt`, label `release notes: dynamo` in `pr_labels.txt`.


Fixes #195866


<details>
<summary>Agent Worklog</summary>

# Worklog: pytorch#195866

Issue: `torch.compile` keeps a reference to a frame's input tensor when the frame contains `torch.cond` / `flex_attention`; only `gc.collect()` releases it.

## Investigation

- Checkout `7e1c35ebdb7` (2.15.0a0). The issue's exact `torch.cond` snippet no longer reproduces, but `flex_attention` does (`agent_space/repro2.py`).
- `gc.get_referrers` chain (`agent_space/refs3.py`): tensor <- `SideEffects.keepalive` <- `SideEffects` <- `SideEffectsProxyDict.side_effects` <- `DunderDictVariable.items` <- `NestedUserFunctionVariable.dict_vt` <- `CellVariable` <- `SideEffects.store_attr_mutations`. A pure cycle, so freed only by cyclic GC.
- Why HOPs specifically: `speculate_subgraph(restore_side_effects=True)` traces into the *original* `SideEffects`, then installs a pre-speculation clone and drops the original. `OutputGraph.cleanup()` only clears the current table, so the dropped one (with a copy of `keepalive`) stays alive via the cycle.
- Minimal repro without flex (`agent_space/repro3.py`): any `__dict__` access on a nested function inside a `torch.cond` branch (`inner.attr = 1` or `functools.wraps`). Outside a HOP the same code does not leak because `cleanup()` clears `keepalive` on the current table.

## Fix

`torch/_dynamo/variables/dicts.py`: `SideEffectsProxyDict` now stores `weakref.ref(tx.output)` and resolves `side_effects` via a property (`output_graph.side_effects`). No strong back-reference, so no cycle. Side benefit: the proxy follows the table `speculate_subgraph` swaps in when restoring, rather than a discarded one.

## Is the proxy the right layer? (follow-up question)

- Checked whether snapshotting the table is wrong on its own terms: `agent_space/stale_table.py` reads `inner.__dict__` inside a cond branch, then does `inner.tag = 42` after the cond. Baseline: `tag` is silently missing after the compiled call (mutation recorded into the discarded table, never replayed). With fix: 42. So this is a correctness bug, not only a leak; the proxy should read the live table like every other VT does via `tx.output.side_effects`.
- Can `output_graph_weakref()` be None when `side_effects` is invoked? No in practice: one `OutputGraph` per root `InstructionTranslator`, all VTs are created and consumed inside `run()`, and the graph outlives them. `SideEffects.store_attr` already derefs the same weakref (with the same assertion) on the proxy's write path, so no new liveness assumption is added. Added `test_cond_dunder_dict_read_then_outer_mutation` to `test_higher_order_ops.py` (baseline: `AttributeError: 'function' object has no attribute 'tag'`).

## Validation

- New test `test/dynamo/test_misc.py::test_release_input_memory_hop_dunder_dict` fails before the fix (`tensor(...) is not None`) and passes after (verified with a patch file, not stash).
- `agent_space/repro2.py` / `repro3.py`: all variants (cond, cond w/ args, wrap, checkpoint, flex_attention, setattr, functools.wraps) release immediately.
- `pytest test/dynamo/test_dicts.py test/dynamo/test_functions.py`: 884 passed.
- `pytest test/dynamo/test_higher_order_ops.py`: 234 passed.
- `pytest test/dynamo/test_misc.py -k "dict or release or side_effect or wraps or attr"`: 112 passed.
- `pytest test/dynamo/test_repros.py -k "dict or wraps or attr or nested or cond"`: 42 passed; `test_flat_apply.py test_autograd_function.py`: 105 passed.
- `lintrunner` clean on both files.

## Status

Committed as `5eb1b9548ca` on the job worktree (detached HEAD). `pr_title.txt` / `pr_labels.txt` written. Not submitted.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98