### PR TITLE
[ROCm] Enable test_cholesky_solve_batched_many_batches for ROCm >= 10.1

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_utils import \
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, subtest, skipIfTorchDynamo,
-     skipIfRocmArch, skipIfRocmVersionAtLeast, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
+     skipIfRocmArch, getRocmVersion, lazy_skip_if, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
      skipIfNoNvmath)
 from torch.testing._internal.common_device_type import \
@@ -3133,7 +3133,9 @@ class TestLinalg(TestCase):
 
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
-    @skipIfRocmVersionAtLeast([7, 14])
+    # rocBLAS trsm regression: introduced in 7.14, fixed in 10.1 (rocm-libraries#10503)
+    @lazy_skip_if(lambda: TEST_WITH_ROCM and (7, 14) <= getRocmVersion() < (10, 1),
+                  "rocBLAS trsm regression (ROCm 7.14-10.0)")
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})


### PR DESCRIPTION
The test test_cholesky_solve_batched_many_batches already runs on legacy ROCm. This PR enabled this test for ROCm >= 10.1. Since the rocBLAS trsm large-batch regression was introduced in ROCm 7.14 and
fixed in ROCm 10.1 (rocm-libraries#10503).

The test was verified by running locally with docker image **rocm/frameworks-internal:rocm10.1.0a20260901_ubuntu22.04_py3.10_pytorch_2.13.0_c41047d**

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang