### PR TITLE
[dynamo] model dict-subclass instance attributes, decline the __dict__ view

### DIFF
--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2616,8 +2616,9 @@ class DictTests(torch._dynamo.test_case.TestCase):
         remove_batch = graph.call_function(torch._remove_batch_dim, (x, x, x, x))
         self.assertFalse(_is_safe_to_reorder(remove_batch))
 
-    @staticmethod
-    def _make_dict_with_attr(kind):
+    # NB: not a staticmethod -- see the note in test_repros.py; the generated
+    # subclasses rebind copied staticmethods as instance methods.
+    def _make_dict_with_attr(self, kind):
         # Only a type with a non-zero tp_dictoffset can carry instance
         # attributes; a plain dict cannot. defaultdict is deliberately absent:
         # it is modelled by DefaultDictVariable(UserDefinedDictVariable), so it
@@ -2733,8 +2734,7 @@ class DictTests(torch._dynamo.test_case.TestCase):
         ),
     }
 
-    @staticmethod
-    def _seeded_ordered_dict():
+    def _seeded_ordered_dict(self):
         d = OrderedDict(a=1)
         d._metadata = OrderedDict([("", {"version": 1})])
         return d

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -2724,6 +2724,13 @@ class DictTests(torch._dynamo.test_case.TestCase):
         "setdefault": lambda d: d.__dict__.setdefault("m", 1),
         "init": lambda d: d.__dict__.__init__({"m": 1}),
         "vars_setitem": lambda d: vars(d).__setitem__("m", 1),
+        "getattr_setitem": lambda d: getattr(d, "__dict__").__setitem__("m", 1),  # noqa: B009
+        # The instance attribute is read as an attribute FIRST, so the tracker
+        # already exists when the __dict__ spelling reaches it.
+        "read_then_store": lambda d: (
+            dict(d._metadata),
+            d.__dict__.__setitem__("m", 1),
+        ),
     }
 
     @staticmethod
@@ -2763,12 +2770,15 @@ class DictTests(torch._dynamo.test_case.TestCase):
     def test_dunder_dict_write_declines(self, spelling):
         self._check_dunder_dict_declines(self._DUNDER_DICT_WRITES[spelling])
 
-    def test_dunder_dict_sourceless_declines(self):
+    @parametrize("spelling", ["store", "read"])
+    def test_dunder_dict_sourceless_declines(self, spelling):
         # A dict built in-frame has no source, so a store through its __dict__
-        # would be dropped on the floor rather than replayed.
+        # would be dropped on the floor rather than replayed. The read is
+        # declined too: the answer would come from a rebuilt copy.
         def fn(t):
             d = OrderedDict(a=1)
-            d.__dict__["m"] = 1
+            if spelling == "store":
+                d.__dict__["m"] = 1
             return t + 1, hasattr(d, "m"), dict(d.__dict__)
 
         x = torch.zeros(2)
@@ -2776,6 +2786,61 @@ class DictTests(torch._dynamo.test_case.TestCase):
             torch.compile(fn, backend="eager", fullgraph=True)(x)
         torch._dynamo.reset()
         self.assertEqual(torch.compile(fn, backend="eager")(x), fn(x))
+
+    def test_dict_instance_attr_sourceless_setattr_declines(self):
+        # Seeding an instance attribute on a dict built in-frame is a
+        # sourceless setattr on a dict subclass. There is nothing to replay it
+        # onto, so it graph-breaks rather than silently dropping the store --
+        # this is why an OrderedDict carrying _metadata cannot be BUILT inside
+        # a fullgraph region, only passed in.
+        def fn(t):
+            d = OrderedDict(a=1)
+            d._metadata = OrderedDict([("", {"version": 1})])
+            return t + 1, hasattr(d, "_metadata"), list(d._metadata.items())
+
+        x = torch.zeros(2)
+        with self.assertRaisesRegex(Unsupported, "setattr\\(\\) on unsupported"):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        torch._dynamo.reset()
+        self.assertEqual(torch.compile(fn, backend="eager")(x), fn(x))
+
+    @parametrize("fullgraph", [True, False])
+    @unittest.expectedFailure
+    def test_dunder_dict_descriptor_get_declines(self, fullgraph):
+        # PRE-EXISTING WRONG ANSWER, byte-identical before this change: calling
+        # the __dict__ getset descriptor directly bypasses the decline above
+        # and constant-folds through a rebuilt container, so it answers {} for
+        # an object whose instance dict is not empty. Every other spelling
+        # graph-breaks. When this is fixed the xfail flips loudly.
+        desc = OrderedDict.__dict__["__dict__"]
+
+        def fn(d, t):
+            return t + 1, dict(desc.__get__(d))
+
+        x = torch.zeros(2)
+        d_eager, d = self._seeded_ordered_dict(), self._seeded_ordered_dict()
+        expected = fn(d_eager, x)
+        if fullgraph:
+            with self.assertRaisesRegex(Unsupported, self.DUNDER_DICT_GB):
+                torch.compile(fn, backend="eager", fullgraph=True)(d, x)
+        else:
+            self.assertEqual(torch.compile(fn, backend="eager")(d, x), expected)
+
+    def test_issubclass_on_dict_instance_matches_eager(self):
+        # A dict tracker models no Python class, but issubclass() still has to
+        # raise the same TypeError eager does rather than answer from the type.
+        def fn(d, t):
+            try:
+                issubclass(d, dict)
+                return t + 1, "no-raise"
+            except TypeError as e:
+                return t + 1, str(e)
+
+        x = torch.zeros(2)
+        d = self._seeded_ordered_dict()
+        self.assertEqual(
+            torch.compile(fn, backend="eager", fullgraph=True)(d, x), fn(d, x)
+        )
 
     def test_dunder_dict_aliased_reverse_order_declines(self):
         # The same instance dict also reaches the frame as a GLOBAL, a locality

--- a/test/dynamo/test_dicts.py
+++ b/test/dynamo/test_dicts.py
@@ -4,6 +4,7 @@
 import enum
 import itertools
 import operator
+import string
 import types
 import unittest
 import weakref
@@ -62,6 +63,11 @@ class FakeMapping:
 
     def __getitem__(self, key: str) -> Any:
         return self._value
+
+
+# Holds the GLOBAL end of the instance-__dict__ aliasing test below, whose
+# whole point is a source pairing make_dupe_guard refuses to relate.
+_ALIASED_INSTANCE_DICT: Any = None
 
 
 class DictTests(torch._dynamo.test_case.TestCase):
@@ -2609,6 +2615,538 @@ class DictTests(torch._dynamo.test_case.TestCase):
 
         remove_batch = graph.call_function(torch._remove_batch_dim, (x, x, x, x))
         self.assertFalse(_is_safe_to_reorder(remove_batch))
+
+    @staticmethod
+    def _make_dict_with_attr(kind):
+        # Only a type with a non-zero tp_dictoffset can carry instance
+        # attributes; a plain dict cannot. defaultdict is deliberately absent:
+        # it is modelled by DefaultDictVariable(UserDefinedDictVariable), so it
+        # would not exercise ConstDictVariable at all.
+        if kind == "dict":
+            return {"a": 1}
+        d = OrderedDict(a=1)
+        if kind == "ordered_dict_attr":
+            d._metadata = OrderedDict([("", {"version": 1})])
+        return d
+
+    @parametrize("kind", ["dict", "ordered_dict", "ordered_dict_attr"])
+    def test_dict_instance_attr_hasattr(self, kind):
+        def fn(d, t):
+            return t + 1, hasattr(d, "_metadata"), getattr(d, "_metadata", None)
+
+        d = self._make_dict_with_attr(kind)
+        x = torch.zeros(2)
+        self.assertEqual(
+            torch.compile(fn, backend="eager", fullgraph=True)(d, x), fn(d, x)
+        )
+
+    def test_dict_instance_attr_mutation_replays(self):
+        def fn(d, t):
+            d._metadata["module"] = d._metadata.pop("")
+            return t + 1
+
+        d = self._make_dict_with_attr("ordered_dict_attr")
+        expected = OrderedDict([("module", {"version": 1})])
+        torch.compile(fn, backend="eager", fullgraph=True)(d, torch.zeros(2))
+        self.assertEqual(list(d._metadata.items()), list(expected.items()))
+
+    def test_dict_instance_attr_guarded(self):
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(d, t):
+            return t + (1 if hasattr(d, "_metadata") else 0)
+
+        d = OrderedDict(a=1)
+        x = torch.zeros(2)
+        self.assertEqual(fn(d, x), x)
+        self.assertEqual(cnt.frame_count, 1)
+
+        d._metadata = {}
+        self.assertEqual(fn(d, x), x + 1)
+        self.assertEqual(cnt.frame_count, 2)
+
+        del d._metadata
+        self.assertEqual(fn(d, x), x)
+        self.assertEqual(cnt.frame_count, 2)
+
+    def test_dict_instance_attr_sourceless(self):
+        # A dict built inside the frame starts with an empty instance dict.
+        def fn(t):
+            d = OrderedDict(a=1)
+            return t + 1, hasattr(d, "_metadata"), hasattr(d, "keys")
+
+        x = torch.zeros(2)
+        self.assertEqual(torch.compile(fn, backend="eager", fullgraph=True)(x), fn(x))
+
+    def test_dict_instance_attr_nonconst_keys(self):
+        # Non-constant keys put the dict source behind a DictGuardManager;
+        # the instance-attribute guard has to survive that.
+        def fn(d, t):
+            return t + 1, hasattr(d, "_metadata"), d._metadata["version"]
+
+        key = torch.zeros(1)
+        d = OrderedDict([(key, 1)])
+        d._metadata = {"version": 3}
+        x = torch.zeros(2)
+        self.assertEqual(
+            torch.compile(fn, backend="eager", fullgraph=True)(d, x), fn(d, x)
+        )
+
+    DUNDER_DICT_GB = "unsupported __dict__ access on a dict subclass"
+    # Stock breaks on hasattr for ANY OrderedDict, so a bare assertRaises here
+    # passes without the source-usability check. Pin the reason instead.
+    UNUSABLE_SOURCE_GB = "instance __dict__ could not be read under a guard"
+
+    # Dynamo never models a dict subclass's instance __dict__ as a view: reuse
+    # of an already-tracked dict under a source of mismatching locality is
+    # unguarded, so the view's stores can replay onto the wrong object. Every
+    # spelling therefore has to graph-break, and to match eager once the break
+    # is allowed -- never a silent divergence.
+    _DUNDER_DICT_READS = {
+        "attr": lambda d: dict(d.__dict__),
+        "vars": lambda d: dict(vars(d)),
+        "getattr": lambda d: dict(getattr(d, "__dict__")),  # noqa: B009
+        "getattr_default": lambda d: dict(getattr(d, "__dict__", {})),
+        "getattribute": lambda d: dict(d.__getattribute__("__dict__")),
+        "attrgetter": lambda d: dict(operator.attrgetter("__dict__")(d)),
+        "len": lambda d: len(d.__dict__),
+        "bool": lambda d: bool(d.__dict__),
+    }
+    _DUNDER_DICT_WRITES = {
+        "setitem": lambda d: d.__dict__.__setitem__("m", 1),
+        "delitem": lambda d: d.__dict__.__delitem__("_metadata"),
+        "update": lambda d: d.__dict__.update({"m": 1}),
+        "ior": lambda d: d.__dict__.__ior__({"m": 1}),
+        "clear": lambda d: d.__dict__.clear(),
+        "pop": lambda d: d.__dict__.pop("_metadata"),
+        "popitem": lambda d: d.__dict__.popitem(),
+        "setdefault": lambda d: d.__dict__.setdefault("m", 1),
+        "init": lambda d: d.__dict__.__init__({"m": 1}),
+        "vars_setitem": lambda d: vars(d).__setitem__("m", 1),
+    }
+
+    @staticmethod
+    def _seeded_ordered_dict():
+        d = OrderedDict(a=1)
+        d._metadata = OrderedDict([("", {"version": 1})])
+        return d
+
+    def _check_dunder_dict_declines(self, body, gb_regex=None):
+        # The graph-break message is asserted, not just its type: seeding an
+        # instance attribute is itself an unsupported setattr, so a bare
+        # assertRaises(Unsupported) passes even when the body never touches
+        # __dict__ at all.
+        gb_regex = gb_regex or self.DUNDER_DICT_GB
+        mk = self._seeded_ordered_dict
+        x = torch.zeros(2)
+
+        def fn(d, t):
+            return t + 1, body(d)
+
+        with self.assertRaisesRegex(Unsupported, gb_regex):
+            torch.compile(fn, backend="eager", fullgraph=True)(mk(), x)
+
+        torch._dynamo.reset()
+        d_eager, d = mk(), mk()
+        expected = fn(d_eager, x)
+        self.assertEqual(torch.compile(fn, backend="eager")(d, x), expected)
+        self.assertEqual(d.__dict__, d_eager.__dict__)
+        self.assertEqual(list(d.__dict__), list(d_eager.__dict__))
+        self.assertEqual(list(d.keys()), list(d_eager.keys()))
+
+    @parametrize("spelling", sorted(_DUNDER_DICT_READS))
+    def test_dunder_dict_read_declines(self, spelling):
+        self._check_dunder_dict_declines(self._DUNDER_DICT_READS[spelling])
+
+    @parametrize("spelling", sorted(_DUNDER_DICT_WRITES))
+    def test_dunder_dict_write_declines(self, spelling):
+        self._check_dunder_dict_declines(self._DUNDER_DICT_WRITES[spelling])
+
+    def test_dunder_dict_sourceless_declines(self):
+        # A dict built in-frame has no source, so a store through its __dict__
+        # would be dropped on the floor rather than replayed.
+        def fn(t):
+            d = OrderedDict(a=1)
+            d.__dict__["m"] = 1
+            return t + 1, hasattr(d, "m"), dict(d.__dict__)
+
+        x = torch.zeros(2)
+        with self.assertRaisesRegex(Unsupported, self.DUNDER_DICT_GB):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        torch._dynamo.reset()
+        self.assertEqual(torch.compile(fn, backend="eager")(x), fn(x))
+
+    def test_dunder_dict_aliased_reverse_order_declines(self):
+        # The same instance dict also reaches the frame as a GLOBAL, a locality
+        # pairing make_dupe_guard refuses to relate. A view would leave the
+        # aliasing an unguarded compile-time id() coincidence, so the second
+        # call keeps the first call's code and replays its store onto the first
+        # object. The view is built BEFORE the global is wrapped, so no
+        # build-time check on the view can see this.
+        def fn(d, t):
+            d.__dict__["_x"] = 5
+            _ALIASED_INSTANCE_DICT["_y"] = 7
+            return t + 1
+
+        x = torch.zeros(2)
+
+        def run(f):
+            global _ALIASED_INSTANCE_DICT
+            first, second = OrderedDict(a=1), OrderedDict(a=1)
+            _ALIASED_INSTANCE_DICT = first.__dict__
+            f(first, x)
+            f(second, x)
+            return dict(first.__dict__), dict(second.__dict__)
+
+        with self.assertRaisesRegex(Unsupported, self.DUNDER_DICT_GB):
+            run(torch.compile(fn, backend="eager", fullgraph=True))
+
+        torch._dynamo.reset()
+        expected = run(fn)
+        self.assertEqual(run(torch.compile(fn, backend="eager")), expected)
+
+    def test_dunder_dict_export_strict_declines(self):
+        # torch.export(strict=True) has no graph-break fallback, so the decline
+        # is a hard failure there rather than a slow path. Stock answered from
+        # the rebuilt copy -- right by accident while the instance dict is
+        # empty, silently wrong the moment the object carries an attribute.
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.d = OrderedDict(a=1)
+
+            def forward(self, t):
+                return t + 1, len(self.d.__dict__)
+
+        with self.assertRaisesRegex(Unsupported, self.DUNDER_DICT_GB):
+            torch.export.export(Mod(), (torch.zeros(2),), strict=True)
+
+    def test_dict_instance_attr_unguardable_source_graph_breaks(self):
+        # An answer that cannot be guarded must not be returned: a
+        # ConstantSource cannot carry a HASATTR guard, so hasattr has to break
+        # rather than assume the attribute is absent.
+        d = OrderedDict(a=1)
+        d._metadata = {"v": 1}
+
+        @torch._dynamo.assume_constant_result
+        def get_d():
+            return d
+
+        def fn(t):
+            return t + (1 if hasattr(get_d(), "_metadata") else 0)
+
+        def fn_read(t):
+            return t + get_d()._metadata["v"]
+
+        x = torch.zeros(2)
+        with self.assertRaisesRegex(Unsupported, self.UNUSABLE_SOURCE_GB):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        torch._dynamo.reset()
+        self.assertEqual(torch.compile(fn, backend="eager")(x), fn(x))
+
+        # The read path defers to a GetAttrVariable instead of answering
+        # "absent", so it still produces the right value after a graph break.
+        torch._dynamo.reset()
+        self.assertEqual(torch.compile(fn_read, backend="eager")(x), fn_read(x))
+
+    @parametrize("method", ["init", "clear"])
+    def test_immutable_dict_mutation_breaks(self, method):
+        # functools.partial(...).keywords is a user-reachable immutable dict
+        # tracker. __init__ and clear() were the two mutating dict entry points
+        # missing the is_mutable() gate their siblings have, so they reached
+        # side_effects.mutation() and died with an internal AssertionError
+        # instead of graph-breaking.
+        def base(a=0, b=0):
+            return a + b
+
+        def fn(p, t):
+            if method == "init":
+                p.keywords.__init__({"a": 5})
+            else:
+                p.keywords.clear()
+            return t + 1
+
+        x = torch.zeros(2)
+        with self.assertRaises(Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(partial(base, b=1), x)
+
+        torch._dynamo.reset()
+        p_eager, p_compiled = partial(base, b=1), partial(base, b=1)
+        fn(p_eager, x)
+        torch.compile(fn, backend="eager")(p_compiled, x)
+        self.assertEqual(dict(p_compiled.keywords), dict(p_eager.keywords))
+
+    @parametrize("method", ["move_to_end", "popitem"])
+    def test_immutable_ordered_dict_mutation_breaks(self, method):
+        # nn.Module hook dicts are NNModuleHooksDictVariable, built with no
+        # mutation_type, so they are immutable OrderedDict trackers. The two
+        # odict-only mutators were missing the is_mutable() gate their dict
+        # siblings have and died with an internal AssertionError.
+        def fn(mod, t):
+            if method == "move_to_end":
+                mod._forward_hooks.move_to_end(next(iter(mod._forward_hooks)))
+            else:
+                mod._forward_hooks.popitem()
+            return t + 1
+
+        def mk():
+            m = torch.nn.Linear(3, 3)
+            m.register_forward_hook(lambda mod, i, o: o)
+            m.register_forward_hook(lambda mod, i, o: o)
+            return m
+
+        x = torch.zeros(2)
+        with self.assertRaises(Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)(mk(), x)
+
+        # Hook keys are globally unique ints, so compare the permutation of the
+        # original key order rather than the keys themselves.
+        torch._dynamo.reset()
+        m_eager, m_compiled = mk(), mk()
+        before_eager, before_compiled = (
+            list(m_eager._forward_hooks),
+            list(m_compiled._forward_hooks),
+        )
+        self.assertEqual(
+            torch.compile(fn, backend="eager")(m_compiled, x), fn(m_eager, x)
+        )
+        self.assertEqual(
+            [before_compiled.index(k) for k in m_compiled._forward_hooks],
+            [before_eager.index(k) for k in m_eager._forward_hooks],
+        )
+
+    def test_dict_instance_attr_stale_alias_all_spellings(self):
+        # dir(), hasattr() and a plain read of the same object must agree that
+        # the live instance dict is behind the traced stores, and say so: the
+        # hasattr spelling used to blame the source instead.
+        def dir_body(d, alias, t):
+            alias["_metadata"] = {"v": 8}
+            return t + 1, "_metadata" in dir(d)
+
+        def hasattr_body(d, alias, t):
+            alias["_metadata"] = {"v": 8}
+            return t + 1, hasattr(d, "_metadata")
+
+        x = torch.zeros(2)
+
+        def mk():
+            d = OrderedDict(a=1)
+            d._metadata = {"v": 1}
+            return d, d.__dict__, x
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(Unsupported, "dir\\(\\) on a rebuilt container"):
+            torch.compile(dir_body, backend="eager", fullgraph=True)(*mk())
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(Unsupported, "stale instance __dict__ read"):
+            torch.compile(hasattr_body, backend="eager", fullgraph=True)(*mk())
+
+        for body in (dir_body, hasattr_body):
+            torch._dynamo.reset()
+            expected = body(*mk())[1:]
+            self.assertEqual(torch.compile(body, backend="eager")(*mk())[1:], expected)
+
+        # Same shape on an object whose real instance dict is EMPTY: only the
+        # aliased tracker knows about the store, so a helper that looked at the
+        # live object alone would answer "no attributes" and be wrong.
+        def dir_body_empty(d, alias, t):
+            alias["m"] = 1
+            return t + 1, "m" in dir(d)
+
+        def mk_empty():
+            d = OrderedDict(a=1)
+            return d, d.__dict__, x
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(Unsupported, "dir\\(\\) on a rebuilt container"):
+            torch.compile(dir_body_empty, backend="eager", fullgraph=True)(*mk_empty())
+        torch._dynamo.reset()
+        expected = dir_body_empty(*mk_empty())[1:]
+        self.assertEqual(
+            torch.compile(dir_body_empty, backend="eager")(*mk_empty())[1:], expected
+        )
+
+    @parametrize("kind", ["plain_dict", "ordered_dict"])
+    def test_dict_instance_attr_hasattr_dunder_dict(self, kind):
+        # hasattr(d, "__dict__") must answer from the instance, not the class:
+        # every class has a __dict__, a plain dict instance does not. The plain
+        # dict can also be READ, since there is no instance dict to model.
+        def has(d, t):
+            return t + 1, hasattr(d, "__dict__")
+
+        def read(d, t):
+            return t + 1, getattr(d, "__dict__", None)
+
+        d = {"a": 1} if kind == "plain_dict" else OrderedDict(a=1)
+        x = torch.zeros(2)
+        self.assertEqual(
+            torch.compile(has, backend="eager", fullgraph=True)(d, x), has(d, x)
+        )
+        if kind == "plain_dict":
+            self.assertEqual(
+                torch.compile(read, backend="eager", fullgraph=True)(d, x), read(d, x)
+            )
+
+    def test_dict_instance_attr_dir_empty_is_guarded(self):
+        # dir() answering from an empty instance dict bakes that emptiness in
+        # just as tp_getattro_impl does, so it needs the same keys guard.
+        def fn(d, t):
+            return t + 1, "_metadata" in dir(d)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        cf = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.zeros(2)
+        d = OrderedDict(a=1)
+        self.assertEqual(cf(d, x)[1], fn(d, x)[1])
+
+        d._metadata = 5
+        with self.assertRaisesRegex(Unsupported, "dir\\(\\) on a rebuilt container"):
+            cf(d, x)
+
+    def test_dict_instance_attr_aliased_stale_read_breaks(self):
+        # An aliased instance-dict tracker with pending stores makes the live
+        # dict stale. Deferring the read is not enough: restore_stack rebuilds
+        # the GetAttrVariable BEFORE codegen_update_mutated replays the stores,
+        # so it would still observe the pre-replay value. It has to break.
+        def fn(d, alias, t):
+            alias["_metadata"] = {"v": 8}
+            return t + 1, d._metadata
+
+        x = torch.zeros(2)
+        d = OrderedDict(a=1)
+        d._metadata = {"v": 1}
+        expected = fn(d, d.__dict__, x)[1:]
+
+        d2 = OrderedDict(a=1)
+        d2._metadata = {"v": 1}
+        with self.assertRaisesRegex(Unsupported, "stale instance __dict__ read"):
+            torch.compile(fn, backend="eager", fullgraph=True)(d2, d2.__dict__, x)
+
+        torch._dynamo.reset()
+        d3 = OrderedDict(a=1)
+        d3._metadata = {"v": 1}
+        got = torch.compile(fn, backend="eager")(d3, d3.__dict__, x)[1:]
+        self.assertEqual(got, expected)
+
+    def test_dict_instance_attr_dir(self):
+        # dir() is built from as_python_constant(), i.e. a rebuilt object, so
+        # it would report the attribute absent while hasattr reports it present
+        # -- Dynamo contradicting itself within one frame.
+        self._check_dunder_dict_declines(
+            lambda d: ("_metadata" in dir(d), hasattr(d, "_metadata")),
+            gb_regex="dir\\(\\) on a rebuilt container",
+        )
+
+    def test_dict_instance_attr_skip_guard_source_graph_breaks(self):
+        # A global read from a stdlib-module frame gets a SkipGuardSource, whose
+        # guards install_guard drops on the floor. Answering from the instance
+        # dict there would bake in an unguarded answer.
+        probe_src = (
+            "def probe():\n"
+            "    return 1 if hasattr(_dynamo_test_probe, '_metadata') else 0\n"
+        )
+        ns = {}
+        exec(compile(probe_src, "<probe>", "exec"), ns)  # noqa: P204
+        probe = types.FunctionType(ns["probe"].__code__, string.__dict__, "probe")
+
+        d = OrderedDict(a=1)
+        d._metadata = {"v": 1}
+        string._dynamo_test_probe = d
+
+        def fn(t):
+            return t + probe()
+
+        x = torch.zeros(2)
+        try:
+            with self.assertRaisesRegex(Unsupported, self.UNUSABLE_SOURCE_GB):
+                torch.compile(fn, backend="eager", fullgraph=True)(x)
+            torch._dynamo.reset()
+            self.assertEqual(torch.compile(fn, backend="eager")(x), fn(x))
+        finally:
+            del string._dynamo_test_probe
+
+    def test_dict_instance_attr_skip_guard_install_graph_breaks(self):
+        # Inside reuse_hash_fn, install_guard no-ops, so an instance-attribute
+        # answer would be baked in unguarded. It has to decline instead, which
+        # surfaces as reuse_hash_fn's own "not fully traceable" error.
+        from torch.compiler import nested_compile_region
+
+        def hash_fn(d, x):
+            return 1 if hasattr(d, "_metadata") else 0
+
+        @nested_compile_region(reuse_hash_fn=hash_fn)
+        def region(d, x):
+            return x.sin() + len(d)
+
+        def fn(d, x):
+            return region(d, x)
+
+        d = OrderedDict(a=1)
+        d._metadata = {"v": 1}
+        with self.assertRaisesRegex(
+            RuntimeError, "reuse_hash_fn must be fully traceable"
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(d, torch.randn(4))
+
+    @parametrize("kind", ["plain_dict", "instance_dict", "empty_ordered_dict"])
+    def test_dir_on_dict_without_instance_dict(self, kind):
+        # dir() must only decline when the REAL object carries an instance
+        # attribute the rebuilt copy would miss. A plain dict cannot hold one,
+        # an object's __dict__ is itself a plain dict, and an OrderedDict that
+        # simply has none is just as safe -- gating on the type instead would
+        # break every OrderedDict, including nn.Module's hook dicts.
+        class Obj:
+            def __init__(self):
+                self.a = 1
+
+        if kind == "plain_dict":
+
+            def fn(t):
+                return t + 1, "keys" in dir({"a": 1})
+
+            args = ()
+        elif kind == "empty_ordered_dict":
+
+            def fn(d, t):  # type: ignore[misc]
+                return t + 1, "keys" in dir(d), "_metadata" in dir(d)
+
+            args = (OrderedDict(a=1),)  # type: ignore[assignment]
+        else:
+            # obj.__dict__ is a plain dict reached through a DunderDictVariable,
+            # a different VT from the plain-dict literal above.
+            def fn(o, t):  # type: ignore[misc]
+                return t + 1, "a" in dir(o.__dict__), "keys" in dir(o.__dict__)
+
+            args = (Obj(),)  # type: ignore[assignment]
+
+        x = torch.zeros(2)
+        self.assertEqual(
+            torch.compile(fn, backend="eager", fullgraph=True)(*args, x), fn(*args, x)
+        )
+
+    def test_dict_instance_attr_skip_guard_install_getattr_spelling(self):
+        # Same decline, spelled with getattr-and-default instead of hasattr.
+        # That spelling reaches the constant-fold fallback, which used to
+        # swallow the decline and hash a rebuilt (empty) instance dict.
+        from torch.compiler import nested_compile_region
+
+        def hash_fn(d, x):
+            return 1 if getattr(d, "_metadata", None) is not None else 0
+
+        @nested_compile_region(reuse_hash_fn=hash_fn)
+        def region(d, x):
+            return x.sin() + len(d)
+
+        def fn(d, x):
+            return region(d, x)
+
+        d = OrderedDict(a=1)
+        d._metadata = {"v": 1}
+        with self.assertRaisesRegex(
+            RuntimeError, "reuse_hash_fn must be fully traceable"
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(d, torch.randn(4))
 
 
 instantiate_parametrized_tests(DictTests)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2681,6 +2681,95 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         res = fn()
         self.assertEqual(((3, 5), (3, 5)), res)
 
+    @staticmethod
+    def _consume_prefix_state_dict(kind, t):
+        items = [("module.w", t), ("keep", t + 1), ("module.b", t + 2)]
+        if kind == "dict":
+            return dict(items)
+        sd = collections.OrderedDict(items)
+        if kind == "metadata":
+            sd._metadata = collections.OrderedDict(
+                [("", {"version": 1}), ("module", {"version": 2})]
+            )
+        return sd
+
+    @staticmethod
+    def _consume_prefix_snapshot(sd):
+        # pop+reinsert deliberately reorders, so the key ORDER is part of the
+        # contract (eager pins it in test/test_nn.py TestUtils).
+        meta = getattr(sd, "_metadata", None)
+        return (
+            list(sd.keys()),
+            sd["w"] + sd["b"] + sd["keep"],
+            None if meta is None else list(meta.items()),
+        )
+
+    @parametrize("kind", ["dict", "ordered_dict", "metadata"])
+    def test_consume_prefix_in_state_dict_caller_owned(self, kind):
+        # The helper strips a prefix from its state_dict argument in place, so
+        # it cannot be a graph node: FX hands the call an immutable_dict and
+        # fake propagation raises, and when it does not the mutation is
+        # silently dropped. It was bulk-added to the in-graph function list by
+        # #114196 rather than deliberately classified. The dict here is owned
+        # by the caller, so the mutation has to survive side-effect replay.
+        def fn(t, sd):
+            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
+                sd, "module."
+            )
+            return t + 1
+
+        x = torch.zeros(2)
+        sd_eager = self._consume_prefix_state_dict(kind, x)
+        fn(x, sd_eager)
+
+        sd_compiled = self._consume_prefix_state_dict(kind, x)
+        torch.compile(fn, backend="eager", fullgraph=True)(x, sd_compiled)
+        self.assertEqual(
+            self._consume_prefix_snapshot(sd_compiled),
+            self._consume_prefix_snapshot(sd_eager),
+        )
+
+    @parametrize("fullgraph", [True, False])
+    def test_consume_prefix_in_state_dict_metadata_only(self, fullgraph):
+        # No state_dict key matches the prefix, but the _metadata half of the
+        # helper still rewrites keys. As a single graph node the call returned
+        # None, its result was unused, and the rewrite was silently dropped.
+        def fn(t, sd):
+            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
+                sd, "module."
+            )
+            return t + 1
+
+        def make():
+            sd = collections.OrderedDict(w=torch.zeros(2))
+            sd._metadata = collections.OrderedDict(
+                [("", {"version": 1}), ("module.w", {"version": 2})]
+            )
+            return sd
+
+        x = torch.zeros(2)
+        sd_eager = make()
+        fn(x, sd_eager)
+
+        sd_compiled = make()
+        torch.compile(fn, backend="eager", fullgraph=fullgraph)(x, sd_compiled)
+        self.assertEqual(
+            list(sd_compiled._metadata.items()), list(sd_eager._metadata.items())
+        )
+        self.assertEqual(list(sd_compiled.keys()), list(sd_eager.keys()))
+
+    @parametrize("kind", ["dict", "ordered_dict"])
+    def test_consume_prefix_in_state_dict_built_in_frame(self, kind):
+        def fn(t):
+            sd = self._consume_prefix_state_dict(kind, t)
+            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
+                sd, "module."
+            )
+            return self._consume_prefix_snapshot(sd)
+
+        x = torch.zeros(2)
+        self.assertEqual(torch.compile(fn, backend="eager", fullgraph=True)(x), fn(x))
+
     def test_missing_attr_on_skipped_function_is_catchable(self):
         # A missing attribute on a skipped callable used to become a deferred
         # GetAttrVariable, which the graph break below materialized where the

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2681,8 +2681,11 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         res = fn()
         self.assertEqual(((3, 5), (3, 5)), res)
 
-    @staticmethod
-    def _consume_prefix_state_dict(kind, prefix_case, t):
+    # NB: not a staticmethod -- make_test_cls_with_patches copies non-test
+    # attributes with getattr(cls, name), which unwraps a staticmethod into a
+    # plain function and rebinds it as an instance method on the generated
+    # class (test_dynamic_shapes, test_nested_graph_breaks_wrapped).
+    def _consume_prefix_state_dict(self, kind, prefix_case, t):
         if prefix_case == "empty":
             items = []
         elif prefix_case == "no_match":
@@ -2698,8 +2701,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             )
         return sd
 
-    @staticmethod
-    def _consume_prefix_snapshot(sd):
+    def _consume_prefix_snapshot(self, sd):
         # pop+reinsert deliberately reorders, so the key ORDER is part of the
         # contract (eager pins it in test/test_nn.py TestUtils).
         meta = getattr(sd, "_metadata", None)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2682,8 +2682,13 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(((3, 5), (3, 5)), res)
 
     @staticmethod
-    def _consume_prefix_state_dict(kind, t):
-        items = [("module.w", t), ("keep", t + 1), ("module.b", t + 2)]
+    def _consume_prefix_state_dict(kind, prefix_case, t):
+        if prefix_case == "empty":
+            items = []
+        elif prefix_case == "no_match":
+            items = [("w", t), ("keep", t + 1)]
+        else:
+            items = [("module.w", t), ("keep", t + 1), ("module.b", t + 2)]
         if kind == "dict":
             return dict(items)
         sd = collections.OrderedDict(items)
@@ -2700,34 +2705,70 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         meta = getattr(sd, "_metadata", None)
         return (
             list(sd.keys()),
-            sd["w"] + sd["b"] + sd["keep"],
+            dict(sd),
             None if meta is None else list(meta.items()),
         )
 
     @parametrize("kind", ["dict", "ordered_dict", "metadata"])
-    def test_consume_prefix_in_state_dict_caller_owned(self, kind):
+    @parametrize("owner", ["caller", "in_frame"])
+    def test_consume_prefix_in_state_dict(self, kind, owner):
         # The helper strips a prefix from its state_dict argument in place, so
         # it cannot be a graph node: FX hands the call an immutable_dict and
         # fake propagation raises, and when it does not the mutation is
         # silently dropped. It was bulk-added to the in-graph function list by
-        # #114196 rather than deliberately classified. The dict here is owned
-        # by the caller, so the mutation has to survive side-effect replay.
-        def fn(t, sd):
-            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
-                sd, "module."
-            )
+        # #114196 rather than deliberately classified. A caller-owned dict
+        # additionally needs the mutation to survive side-effect replay.
+        cp = torch.nn.modules.utils.consume_prefix_in_state_dict_if_present
+
+        def caller_fn(t, sd):
+            cp(sd, "module.")
             return t + 1
 
+        # Seeding _metadata on a dict built in the frame is a sourceless
+        # setattr on a dict subclass, which Dynamo declines; that decline is
+        # the seeding, not the helper.
+        declines = kind == "metadata" and owner == "in_frame"
         x = torch.zeros(2)
-        sd_eager = self._consume_prefix_state_dict(kind, x)
-        fn(x, sd_eager)
 
-        sd_compiled = self._consume_prefix_state_dict(kind, x)
-        torch.compile(fn, backend="eager", fullgraph=True)(x, sd_compiled)
-        self.assertEqual(
-            self._consume_prefix_snapshot(sd_compiled),
-            self._consume_prefix_snapshot(sd_eager),
-        )
+        for prefix_case in ("match", "no_match", "empty"):
+
+            def in_frame_fn(t, _case=prefix_case):
+                sd = self._consume_prefix_state_dict(kind, _case, t)
+                cp(sd, "module.")
+                return self._consume_prefix_snapshot(sd)
+
+            for fullgraph in (True, False):
+                with self.subTest(prefix_case=prefix_case, fullgraph=fullgraph):
+                    # Without a reset the fullgraph=True run below reuses the
+                    # cache entry from the fullgraph=False run and never
+                    # re-traces.
+                    torch._dynamo.reset()
+                    if owner == "caller":
+                        sd_eager = self._consume_prefix_state_dict(kind, prefix_case, x)
+                        caller_fn(x, sd_eager)
+                        sd = self._consume_prefix_state_dict(kind, prefix_case, x)
+                        torch.compile(caller_fn, backend="eager", fullgraph=fullgraph)(
+                            x, sd
+                        )
+                        self.assertEqual(
+                            self._consume_prefix_snapshot(sd),
+                            self._consume_prefix_snapshot(sd_eager),
+                        )
+                    elif declines and fullgraph:
+                        with self.assertRaisesRegex(
+                            torch._dynamo.exc.Unsupported,
+                            "setattr\\(\\) on unsupported",
+                        ):
+                            torch.compile(in_frame_fn, backend="eager", fullgraph=True)(
+                                x
+                            )
+                    else:
+                        self.assertEqual(
+                            torch.compile(
+                                in_frame_fn, backend="eager", fullgraph=fullgraph
+                            )(x),
+                            in_frame_fn(x),
+                        )
 
     @parametrize("fullgraph", [True, False])
     def test_consume_prefix_in_state_dict_metadata_only(self, fullgraph):
@@ -2757,18 +2798,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             list(sd_compiled._metadata.items()), list(sd_eager._metadata.items())
         )
         self.assertEqual(list(sd_compiled.keys()), list(sd_eager.keys()))
-
-    @parametrize("kind", ["dict", "ordered_dict"])
-    def test_consume_prefix_in_state_dict_built_in_frame(self, kind):
-        def fn(t):
-            sd = self._consume_prefix_state_dict(kind, t)
-            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
-                sd, "module."
-            )
-            return self._consume_prefix_snapshot(sd)
-
-        x = torch.zeros(2)
-        self.assertEqual(torch.compile(fn, backend="eager", fullgraph=True)(x), fn(x))
 
     def test_missing_attr_on_skipped_function_is_catchable(self):
         # A missing attribute on a skipped callable used to become a deferred

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2419,6 +2419,37 @@
       ]
     }
   ],
+  "GB7765": [
+    {
+      "Gb_type": "stale instance __dict__ read",
+      "Context": "{self.python_type()}.{name}",
+      "Explanation": "The instance __dict__ of this object has pending stores that only replay when the compiled region exits, so reading the attribute now would see a stale value.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
+  "GB9739": [
+    {
+      "Gb_type": "unsupported __dict__ access on a dict subclass",
+      "Context": "{self.python_type()}.__dict__",
+      "Explanation": "Dynamo cannot model the instance __dict__ of a dict subclass as a view; stores through it are not guaranteed to reach the right object.",
+      "Hints": [
+        "Use attribute access instead of the __dict__ mapping.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
+  "GB6985": [
+    {
+      "Gb_type": "unsupported dir() on a rebuilt container",
+      "Context": "dir({arg.python_type_name()})",
+      "Explanation": "Dynamo models this value by rebuilding it, so dir() would miss the instance attributes the real object has.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB0156": [
     {
       "Gb_type": "Unsupported method call",
@@ -3547,6 +3578,15 @@
     }
   ],
   "GB0217": [
+    {
+      "Gb_type": "unsupported hasattr operation",
+      "Context": "hasattr({cls.__name__}, {name}): {reason}",
+      "Explanation": "hasattr on {cls} is not supported: {reason}",
+      "Hints": [
+        "Consider using a regular dictionary instead",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
     {
       "Gb_type": "unsupported hasattr operation",
       "Context": "Class {cls}",

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -198,6 +198,7 @@ from .variables.misc import (
 )
 from .variables.nn_module import NNModuleVariable, UnspecializedNNModuleVariable
 from .variables.object_protocol import (
+    constant_fold_getattr_allowed,
     generic_delitem,
     generic_getattr,
     generic_getiter,
@@ -3365,7 +3366,7 @@ class InstructionTranslatorBase(
         try:
             result = generic_getattr(self, obj, attr)
         except Unsupported:
-            if not obj.is_python_constant():
+            if not obj.is_python_constant() or not constant_fold_getattr_allowed(obj):
                 raise
             source = AttrSource(obj.source, attr) if obj.source else None
             result = VariableTracker.build(

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -2967,7 +2967,6 @@ torch_non_c_binding_in_graph_functions = dict.fromkeys(
         "torch.nn.modules.utils._ntuple",
         "torch.nn.modules.utils._quadruple",
         "torch.nn.modules.utils._reverse_repeat_tuple",
-        "torch.nn.modules.utils.consume_prefix_in_state_dict_if_present",
         "torch.nn.parameter.is_lazy",
         "torch.norm",
         "torch.quantization.default_eval_fn",

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -104,6 +104,7 @@ from .object_protocol import (
     _NO_DEFAULT,
     binary_iop,
     binary_op,
+    constant_fold_getattr_allowed,
     generic_delitem,
     generic_getattr,
     generic_getitem,
@@ -2380,6 +2381,20 @@ class BuiltinVariable(BaseBuiltinVariable):
             return VariableTracker.build(tx, dir(arg.fn))
         # Enable specialized VTs for constants to work with dir()
         if arg.is_python_constant():
+            is_dict = isinstance(arg, ConstDictVariable)
+            if is_dict and arg.rebuild_misses_instance_attrs(tx):
+                # as_python_constant() rebuilds the dict, so dir() of it omits
+                # every instance attribute -- which would contradict what
+                # hasattr() reports for the same name.
+                unimplemented(
+                    gb_type="unsupported dir() on a rebuilt container",
+                    context=f"dir({arg.python_type_name()})",
+                    explanation=(
+                        "Dynamo models this value by rebuilding it, so dir() "
+                        "would miss the instance attributes the real object has."
+                    ),
+                    hints=[*graph_break_hints.SUPPORTABLE],
+                )
             return VariableTracker.build(tx, dir(arg.as_python_constant()))
         return None
 
@@ -3482,6 +3497,8 @@ class GetAttrBuiltinVariable(BaseBuiltinVariable):
             # if all args are python constants, evaluate getattr() directly rather
             # than propagating a graph break from tp_getattro_impl.
             if not check_unspec_or_constant_args(args, kwargs):
+                raise
+            if not constant_fold_getattr_allowed(args[0]):
                 raise
             try:
                 result = getattr(*[a.as_python_constant() for a in args])

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -22,7 +22,7 @@ import functools
 import sys
 import types
 from collections.abc import Callable, Iterator
-from typing import Any, cast, TYPE_CHECKING, Union
+from typing import Any, cast, NoReturn, TYPE_CHECKING, Union
 
 from torch.utils._pytree import MappingKey
 
@@ -33,13 +33,19 @@ from ..bytecode_transformation import (
     create_dup_top,
     create_instruction,
 )
-from ..exc import raise_observed_exception, raise_type_error, unimplemented
+from ..exc import (
+    raise_observed_exception,
+    raise_type_error,
+    TorchDynamoException,
+    unimplemented,
+)
 from ..guards import GuardBuilder, install_guard
 from ..source import (
     AttrSource,
     DictGetItemSource,
     is_constant_source,
     is_from_local_source,
+    is_from_skip_guard_source,
 )
 from ..utils import (
     _item_debug_repr,
@@ -84,6 +90,10 @@ if TYPE_CHECKING:
 # - Implement hash_impl(self, tx) on the VariableTracker subclass (or rely on the
 #   base class default which uses get_real_python_backed_value())
 # - Implement tp_richcompare_impl() for key equality
+
+
+class _StaleInstanceDict(NotImplementedError):
+    """The live instance __dict__ is behind stores Dynamo has already traced."""
 
 
 def pydict_check(obj: VariableTracker) -> bool:
@@ -500,6 +510,11 @@ class ConstDictVariable(VariableTracker):
     ) -> VariableTracker:
         from . import DictBuiltinVariable
 
+        if not self.is_mutable():
+            # Mirrors mp_ass_subscript_impl: a slot cannot decline by returning
+            # None, so hand back to the base, which graph-breaks. Without this
+            # the mutation below asserts internally.
+            return super().tp_init_impl(tx, args, kwargs)
         temp_dict_vt = DictBuiltinVariable.call_custom_dict(tx, dict, *args, **kwargs)
         tx.output.side_effects.mutation(self)
         self.items.update(temp_dict_vt.items)  # type: ignore[attr-defined]
@@ -621,7 +636,9 @@ class ConstDictVariable(VariableTracker):
         tx: "InstructionTranslatorBase",
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
+    ) -> VariableTracker | None:
+        if not self.is_mutable():
+            return None
         self.should_reconstruct_all = True
         tx.output.side_effects.mutation(self)
         self.items.clear()
@@ -790,25 +807,184 @@ class ConstDictVariable(VariableTracker):
         self.install_dict_keys_match_guard()
         return VariableTracker.build(tx, len(self.items))
 
+    def _instance_dict(self, tx: "InstructionTranslatorBase") -> dict[str, Any]:
+        """The real object's instance __dict__.
+
+        Returns an empty dict when this object cannot hold instance attributes
+        or holds none. Raises NotImplementedError when that cannot be
+        established, and _StaleInstanceDict when Dynamo has already traced
+        stores into an aliased tracker for the very same dict. Never conflate
+        the three: "empty" gets baked into the trace, the others must not be.
+        Sole resolver, so every caller applies one policy on which sources are
+        usable.
+        """
+        if self.python_type().__dictoffset__ == 0 or self.source is None:
+            # No tp_dictoffset means no instance attributes are possible. A
+            # sourceless tracker has no source to guard, so it can only be
+            # treated as empty; that is exact for the sites that build a fresh
+            # dict, and unobserved-but-approximate for SourcelessBuilder's
+            # OrderedDict handler, which wraps a pre-existing object.
+            return {}
+
+        # install_guard silently drops a SkipGuardSource guard and no-ops
+        # entirely under skip_guard_install, so a successful call is not proof
+        # that a guard exists. An answer that cannot be guarded must not be
+        # baked into the trace.
+        if (
+            is_from_skip_guard_source(self.source)
+            or tx.output.tracing_context.guards_context.skip_install
+        ):
+            raise NotImplementedError
+
+        try:
+            obj = tx.output.resolve_source_value(self.source)
+            instance_dict = object.__getattribute__(obj, "__dict__")
+        except TorchDynamoException:
+            raise
+        except Exception as e:
+            raise NotImplementedError from e
+
+        # The same dict can also arrive as an ordinary dict argument (e.g. as
+        # the resume function's local after a graph break). Stores into such a
+        # tracker replay only at region exit, so the live dict read above is
+        # stale for the purpose of reading an attribute off the object.
+        aliased = tx.output.side_effects.id_to_variable.get(id(instance_dict))
+        if aliased is not None and tx.output.side_effects.is_modified(aliased):
+            raise _StaleInstanceDict
+        return instance_dict
+
+    def _instance_dict_lookup(self, tx: "InstructionTranslatorBase", name: str) -> Any:
+        """Read *name* out of the real object's instance __dict__ under a guard.
+
+        Returns NO_SUCH_SUBOBJ when the attribute is absent; raises whatever
+        _instance_dict raises. The HASATTR guard covers the absent answer too:
+        that is what makes defining the attribute later recompile.
+        """
+        instance_dict = self._instance_dict(tx)
+        if self.source is not None and self.python_type().__dictoffset__ != 0:
+            try:
+                install_guard(
+                    self.source.make_guard(
+                        functools.partial(GuardBuilder.HASATTR, attr=name)
+                    )
+                )
+            except TorchDynamoException:
+                raise
+            except Exception as e:
+                # make_guard raises for an unguardable source (CONSTANT,
+                # ephemeral) and install_guard for TempLocalSource.
+                raise NotImplementedError from e
+        return instance_dict.get(name, NO_SUCH_SUBOBJ)
+
+    def rebuild_misses_instance_attrs(self, tx: "InstructionTranslatorBase") -> bool:
+        """Whether as_python_constant() would drop instance attributes.
+
+        The rebuilt dict carries none, so this is just "does the real object
+        have any" -- asked of the instance, not the type: an OrderedDict that
+        holds none is reproduced exactly, and gating on the type instead would
+        break every OrderedDict, including nn.Module's hook dicts. Shares
+        _instance_dict's taxonomy rather than repeating it, so this and
+        _instance_dict_lookup can never disagree about which sources are usable
+        or about a stale aliased dict. A False answer gets baked into the
+        trace, so it is only given once the instance dict's key set is guarded.
+        """
+        try:
+            if self._instance_dict(tx):
+                return True
+            self._install_instance_dict_keys_guard()
+            return False
+        except NotImplementedError:
+            # Includes _StaleInstanceDict. Cannot establish it is safe, so
+            # assume the worst; every attribute query on this tracker declines
+            # too, so no frame ends up with two contradictory answers.
+            return True
+
+    def _install_instance_dict_keys_guard(self) -> None:
+        """Guard the key set of this object's instance __dict__, so that the
+        object gaining an attribute recompiles. Raises NotImplementedError when
+        the source cannot carry the guard, like _instance_dict_lookup, so the
+        caller declines instead of baking in an unguarded answer.
+        """
+        if self.source is None or self.python_type().__dictoffset__ == 0:
+            return
+        try:
+            install_guard(
+                AttrSource(self.source, "__dict__").make_guard(
+                    GuardBuilder.DICT_KEYS_MATCH
+                )
+            )
+        except TorchDynamoException:
+            raise
+        except Exception as e:
+            raise NotImplementedError from e
+
+    def _unimplemented_stale_read(self, name: str) -> NoReturn:
+        unimplemented(
+            gb_type="stale instance __dict__ read",
+            context=f"{self.python_type()}.{name}",
+            explanation=(
+                "The instance __dict__ of this object has pending stores that "
+                "only replay when the compiled region exits, so reading the "
+                "attribute now would see a stale value."
+            ),
+            hints=[*graph_break_hints.SUPPORTABLE],
+        )
+
+    def lookup_instance_dict(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker | None:
+        try:
+            subobj = self._instance_dict_lookup(tx, name)
+        except _StaleInstanceDict:
+            # Deferring here would be a wrong answer, not a deferral:
+            # restore_stack rebuilds a GetAttrVariable BEFORE
+            # codegen_update_mutated replays the pending stores, so the read
+            # would still observe the pre-replay dict.
+            self._unimplemented_stale_read(name)
+        except NotImplementedError:
+            # Undeterminable (unguardable source, guards suppressed): fall
+            # through to generic_getattr's GetAttrVariable, i.e. what dicts did
+            # before this hook existed. That defers the read to runtime rather
+            # than answering "absent".
+            return None
+        if subobj is NO_SUCH_SUBOBJ or self.source is None:
+            return None
+        return VariableTracker.build(tx, subobj, AttrSource(self.source, name))
+
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> ConstantVariable:
-        # dict not allow setting arbitrary attributes.  OrderedDict and
-        # defaultdict allow arbitrary setattr, but not deletion of default attrs
+        # No _hasattr_check_side_effects() here: it needs is_attribute_mutation,
+        # and dict trackers carry ValueMutation, so it can never fire. This is
+        # only safe while setattr on a dict tracker always graph-breaks; if that
+        # gains support, hasattr will silently disagree with getattr unless a
+        # pending-store consult is added here.
+        #
+        # Only a type with a non-zero tp_dictoffset (OrderedDict) can hold
+        # instance attributes; for a plain dict the class alone decides.
+        # collections.defaultdict is absent on purpose: it is modelled by
+        # DefaultDictVariable(UserDefinedDictVariable) and never reaches here.
         cls = self.python_type()
-        if any(
-            cls is t for t in (dict, collections.OrderedDict, collections.defaultdict)
-        ):
-            if hasattr(cls, name):
-                return ConstantVariable.create(True)
-            if cls is dict:
-                return ConstantVariable.create(False)
+        if name == "__dict__":
+            # Asking the class would answer from type.__dict__, which every
+            # class has; the instance only has one when tp_dictoffset != 0.
+            return ConstantVariable.create(cls.__dictoffset__ != 0)
+        if hasattr(cls, name):
+            return ConstantVariable.create(True)
+        try:
+            found = self._instance_dict_lookup(tx, name) is not NO_SUCH_SUBOBJ
+        except _StaleInstanceDict:
+            self._unimplemented_stale_read(name)
+        except NotImplementedError:
+            pass
+        else:
+            return ConstantVariable.create(found)
 
-        msg = f"hasattr on {cls} is not supported"
+        reason = "the instance __dict__ could not be read under a guard"
         unimplemented(
             gb_type="unsupported hasattr operation",
-            context=f"Class {cls}",
-            explanation=msg,
+            context=f"hasattr({cls.__name__}, {name!r}): {reason}",
+            explanation=f"hasattr on {cls} is not supported: {reason}",
             hints=[
                 "Consider using a regular dictionary instead",
                 *graph_break_hints.SUPPORTABLE,
@@ -857,6 +1033,28 @@ class ConstDictVariable(VariableTracker):
         return eq_result
 
     def tp_getattro_impl(self, tx: "InstructionTranslatorBase", name: str):
+        if name == "__dict__" and self.python_type().__dictoffset__ != 0:
+            # Dynamo cannot soundly model the instance __dict__ as a view: reuse
+            # of an already-tracked dict under a source of mismatching locality
+            # is unguarded (make_dupe_guard's TODO(voz), guards.py:5769), so the
+            # view's stores can replay onto the wrong object.
+            # NB: bespoke dispatch rather than a tp_getset entry, because the
+            # tp_getset/tp_members migration has not reached ConstDictVariable
+            # yet (MappingProxyVariable below already has a table).
+            unimplemented(
+                gb_type="unsupported __dict__ access on a dict subclass",
+                context=f"{self.python_type()}.__dict__",
+                explanation=(
+                    "Dynamo cannot model the instance __dict__ of a dict "
+                    "subclass as a view; stores through it are not guaranteed "
+                    "to reach the right object."
+                ),
+                hints=[
+                    "Use attribute access instead of the __dict__ mapping.",
+                    *graph_break_hints.SUPPORTABLE,
+                ],
+            )
+
         # DictGuardManager does not support getattr_manager for plain dicts,
         # so AttrSource chains through a dict source break guard creation.
         # Return CallMethodVariable directly for methods, bypassing the
@@ -875,12 +1073,19 @@ class OrderedDictVariable(ConstDictVariable):
     # OrderedDict exposes no tp_getset / tp_members.
     # https://github.com/python/cpython/blob/v3.13.0/Objects/odictobject.c
 
+    # NB: both mutators below need the is_mutable() gate their dict siblings
+    # have. Immutable OrderedDictVariables are reachable, e.g. nn.Module hook
+    # dicts (nn_module.py builds NNModuleHooksDictVariable with no
+    # mutation_type); without the gate they assert inside
+    # side_effects.mutation() instead of graph-breaking.
     def move_to_end(
         self: "OrderedDictVariable",
         tx: "InstructionTranslatorBase",
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
+    ) -> VariableTracker | None:
+        if not self.is_mutable():
+            return None
         self.install_dict_keys_match_guard()
         tx.output.side_effects.mutation(self)
         if args[0] not in self:
@@ -900,7 +1105,9 @@ class OrderedDictVariable(ConstDictVariable):
         tx: "InstructionTranslatorBase",
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
+    ) -> VariableTracker | None:
+        if not self.is_mutable():
+            return None
         if not self.items:
             raise_observed_exception(
                 KeyError, tx, args=["popitem(): dictionary is empty"]

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -2261,6 +2261,25 @@ def object_generic_getattr(
     )
 
 
+def constant_fold_getattr_allowed(obj: VariableTracker) -> bool:
+    """Whether reading an attribute off ``obj.as_python_constant()`` is a sound
+    substitute when the VT itself declines the attribute.
+
+    Both getattr entry points -- `GetAttrBuiltinVariable.call_function` and
+    `InstructionTranslatorBase._load_attr` -- fall back to that read on an
+    `Unsupported`, which swallows the decline.  For a dict tracker that read is
+    never sound: ``as_python_constant()`` REBUILDS the dict, so an attribute
+    backed by per-instance storage is read off a throwaway object -- and every
+    decline the dict tracker makes (unguardable source, suppressed guards, a
+    stale aliased instance dict) would be silently converted into an answer.
+    Both call sites must apply this, or the unpatched one silently reinstates
+    the bug.  Refusing here is never a wrong answer, only a graph break.
+    """
+    from .dicts import ConstDictVariable
+
+    return not isinstance(obj, ConstDictVariable)
+
+
 def generic_getattr(
     tx: "InstructionTranslatorBase",
     obj: VariableTracker,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #171826
* #163503
* #185524
* #186100
* #191389
* __->__ #195958
* #195494
* #192863

torch.nn.modules.utils.consume_prefix_in_state_dict_if_present was in
torch_non_c_binding_in_graph_functions, a bulk auto-dump from #114196. It
mutates its state_dict argument in place, so as a graph node fake propagation
handed it an immutable_dict and raised TypeError. Inlining it instead requires
Dynamo to model instance attributes on dict subclasses, since the helper does
hasattr(state_dict, "_metadata") and nn.Module.state_dict() returns an
OrderedDict carrying _metadata.

Root cause of the harder half: ConstDictVariable.as_python_constant() REBUILDS
the container, so any consumer recovering a "real" object silently substituted
a freshly materialized copy with an empty instance dict. This change reads
instance attributes off the live object through lookup_instance_dict, gated on
a guard actually being installable, and declines otherwise.

An earlier revision also modelled the instance __dict__ itself as a view. That
is dropped. VariableBuilder._reuse_tracked_variable reuses a tracked tracker
with no guard whenever make_dupe_guard declines, which it does whenever two
sources disagree on locality (guards.py, TODO(voz)), so the view traced an
aliasing assumption nothing re-checked and replayed stores onto the wrong
object. A build-time gate cannot close this: the aliasing wrap can happen after
the view is built. Measuring settled it -- always declining the view scored
identically to the full machinery on both correctness matrices below, so the
modelling was carrying no weight. Declining is sound; a graph break is not a
wrong answer.

Two intentional behavior changes. Reading __dict__ off a dict subclass now
graph-breaks rather than constant-folding: stock returns 0 where eager returns
1 for any non-empty instance dict, so the old answer was right only by accident
on empty ones. Under export(strict=True) there is no fallback, so that becomes
a hard error. Separately, move_to_end/popitem on an immutable OrderedDict
tracker now graph-break instead of dying in an internal AssertionError; nn
module hook dicts are such trackers (nn_module.py builds
NNModuleHooksDictVariable with no mutation_type).

Review in order: the trace_rules.py deletion is the whole motivation; then
lookup_instance_dict and the guard gating in dicts.py; then the __dict__
decline; then the tests.

Test Plan:

test_consume_prefix_in_state_dict covers the helper over {plain dict,
OrderedDict, OrderedDict with _metadata} x {prefix matches, no match, empty}
x {dict built in-frame, dict passed in by the caller} x {fullgraph True,
False}, asserting list(sd.keys()) ORDER (the helper pops and reinserts, and
eager pins that ordering at test/test_nn.py:16561), the full mapping, and
_metadata contents against eager. The in-frame _metadata cells assert a
deliberate decline: seeding _metadata inside the traced frame is itself an
unsupported setattr, unrelated to the helper.

test_dicts.py covers the __dict__ surface: read and write spellings
(setitem/update/delitem/pop/clear/vars/getattr/read-then-store), sourceless
trackers, the reverse-order aliasing case, export(strict=True), and
issubclass. Reading __dict__ through a descriptor is pinned as an
expectedFailure -- it is a pre-existing wrong answer that reproduces
byte-identically on the parent commit, so a future fix flips it loudly.

```
python test/dynamo/test_repros.py -k consume_prefix
python test/dynamo/test_dicts.py
python test/dynamo/test_dynamic_shapes.py
python test/dynamo/test_nested_graph_breaks_wrapped.py
python test/dynamo/test_export.py
python test/dynamo/test_misc.py
python test/dynamo/test_functions.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_nn.py -k consume_prefix_in_state_dict_if_present
```

The last two are the generated mirrors of the first two. Test helpers on
these classes must not be @staticmethod: make_test_cls_with_patches copies
non-test attributes with getattr(cls, name), which unwraps the descriptor
and rebinds it as an instance method on the generated class.

Reverting torch/_dynamo/trace_rules.py and torch/_dynamo/variables/dicts.py to
the parent commit turns the first two green runs into 6 failures + 12 errors
and 32 failures + 12 errors respectively, so the tests discriminate. The
expectedFailure count stays at 3 across the revert, which is what establishes
the descriptor case as pre-existing.

Measured separately over the same two matrices, compiled-vs-eager: wrong
answers go 6 -> 0 on the consume_prefix matrix and 21 -> 3 on the dict-subclass
matrix, with zero cells regressing from correct to incorrect. The 3 residual
wrong answers are the descriptor case above.

test_modules.py test_save_and_load_inductor and test_hooks.py
test_no_recompile_on_same_hook fail identically on the parent commit in this
checkout (inductor_vec_mask_cast build issue); test_repros.py has 6
pre-existing environmental CUDA/LAPACK errors.

Authored with the assistance of an AI coding agent.