### PR TITLE
Fix syntax error in torch.profiler documentation (#190202)

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -608,10 +608,10 @@ class _KinetoProfile:
                 ]
             ) as p:
                 code_to_profile_0()
-                // turn off collection of all CUDA activity
+                # turn off collection of all CUDA activity
                 p.toggle_collection_dynamic(False, [torch.profiler.ProfilerActivity.CUDA])
                 code_to_profile_1()
-                // turn on collection of all CUDA activity
+                # turn on collection of all CUDA activity
                 p.toggle_collection_dynamic(True, [torch.profiler.ProfilerActivity.CUDA])
                 code_to_profile_2()
             print(p.key_averages().table(


### PR DESCRIPTION
This PR fixes issue #190202 - syntax error in torch.profiler documentation.

## Problem
The documentation example for toggle_collection_dynamic used C++ style comments (//) instead of Python comments (#), causing a SyntaxError when users copy and paste the example code.

## Solution
Replace the C++ style comments with Python comments.

## Changes
- Fixed comments in torch/profiler/profiler.py documentation

## Testing
- Verified that the fixed code is valid Python syntax

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.