### PR TITLE
[Testcase Refactoring] Classify sparsity parametrization tests by hardware

### DIFF
--- a/test/ao/sparsity/test_parametrization.py
+++ b/test/ao/sparsity/test_parametrization.py
@@ -5,7 +5,11 @@ import torch
 from torch import nn
 from torch.ao.pruning.sparsifier import utils
 from torch.nn.utils import parametrize
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 class ModelUnderTest(nn.Module):
@@ -32,6 +36,8 @@ class ModelUnderTest(nn.Module):
 
 
 class TestFakeSparsity(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_masking_logic(self):
         model = nn.Linear(16, 16, bias=False)
         model.weight = nn.Parameter(torch.eye(16))


### PR DESCRIPTION
## Description

Classify `TestFakeSparsity` in `test/ao/sparsity/test_parametrization.py` as
`HardwareClassification.GENERIC`.

The tests in this class cover generic sparsity parametrization behavior,
including masking logic, parametrization registration, state dict
preservation, and JIT tracing. They do not test accelerator-specific
behavior and do not require device instantiation.

This change only adds the hardware classification to the existing test
class. It does not change the test logic, test signatures, device placement,
or test discovery.

## Testing

- Verified that the `TestFakeSparsity` test set is unchanged before and after
  the modification: 4 tests with identical test IDs.
- CPU:
  `python test/test_ao_sparsity.py -k TestFakeSparsity -v`
  - 4 passed
  - 0 failed
  - 0 skipped
- Hardware classification:
  - `GENERIC`: all 4 `TestFakeSparsity` tests were selected and passed.
  - `ACCELERATOR`: no `TestFakeSparsity` tests were selected.
- `git diff --check` passed.
- Targeted lint passed.