### PR TITLE
[Testcase Refactoring] Move Triton activation-checkpoint flop test to accelerator harness

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -13,14 +13,19 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
-from torch.testing._internal.common_device_type import e4m3_type
+from torch.testing._internal.common_device_type import (
+    e4m3_type,
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.utils._triton import has_triton
 from torch.utils.flop_counter import sdpa_backward_flop_count, sdpa_flop_count
 
 
@@ -1121,102 +1126,6 @@ class TestFlopCounter(TestCase):
             torch.ops.mylib.trig_op()
         self.assertExpectedInline(get_total_flops(m2), """2""")
 
-    @requires_cuda_and_triton
-    @torch._functorch.config.patch("activation_memory_budget", 0.1)
-    @torch._functorch.config.patch("activation_memory_budget_solver", "dp")
-    @torch._functorch.config.patch("is_non_builtin_to_include", True)
-    def test_flop_counter_custom_triton_op_two_kernels_auto_ac(self):
-        import triton
-        import triton.language as tl
-
-        from torch.utils.flop_counter import register_flop_formula
-
-        @triton.jit
-        def sin_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(x_ptr + offsets, mask=mask)
-            out = tl.sin(x)
-            tl.store(out_ptr + offsets, out, mask=mask)
-
-        @triton.jit
-        def cos_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(x_ptr + offsets, mask=mask)
-            out = tl.cos(x)
-            tl.store(out_ptr + offsets, out, mask=mask)
-
-        n_elements = int(1e7)
-        x = torch.randn(n_elements, device="cuda", requires_grad=True)
-
-        cos_flops_recorded, sin_flops_recorded = 0, 0
-
-        @register_flop_formula(sin_kernel)
-        def compute_sin_kernel_flops(*args, **kwargs) -> int:
-            # dummy implementation
-            nonlocal sin_flops_recorded
-            sin_flops_recorded += 1
-            return 1
-
-        @register_flop_formula(cos_kernel)
-        def compute_cos_kernel_flops(*args, **kwargs) -> int:
-            # dummy implementation
-            nonlocal cos_flops_recorded
-            cos_flops_recorded += 1
-            return 1
-
-        def sin_grid(meta):
-            return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-
-        def cos_grid(meta):
-            return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-
-        @torch._library.triton.triton_op("mylib::trig_op", mutates_args=())
-        def trig_op(x_inp: torch.Tensor) -> torch.Tensor:
-            output = torch.empty_like(x_inp)
-            torch.library.wrap_triton(sin_kernel)[sin_grid](
-                x_inp, output, n_elements, 256
-            )
-            torch.library.wrap_triton(cos_kernel)[cos_grid](
-                x_inp, output, n_elements, 256
-            )
-            return output
-
-        # Register a backward
-        def trig_op_backward(ctx, grad_output):
-            (out,) = ctx.saved_tensors
-            return grad_output * out
-
-        def trig_op_setup_context(ctx, inputs, output):
-            ctx.save_for_backward(output)
-
-        trig_op.register_autograd(trig_op_backward, setup_context=trig_op_setup_context)
-
-        def fn(x_inp: torch.Tensor):
-            y1 = torch.ops.mylib.trig_op(x_inp)
-            y2 = torch.ops.mylib.trig_op(y1)
-            y3 = torch.ops.mylib.trig_op(y2)
-            return y3
-
-        torch.compile(fn, backend="aot_eager_decomp_partition", fullgraph=True)(x)
-
-        # Since we decompose, we will call the formula 3 times
-        self.assertEqual(
-            sin_flops_recorded,
-            3,
-            "Custom formula for sin_kernel not recorded during partitioning",
-        )
-        self.assertEqual(
-            cos_flops_recorded,
-            3,
-            "Custom formula for cos_kernel not recorded during partitioning",
-        )
-
     @skipIfNoTorchVision
     def test_inference_mode(self):
         def get_flops(model):
@@ -1349,6 +1258,89 @@ class TestFlopCounter(TestCase):
         # fw=2 bmms, bw=5 bmms (flash recomputes scores), fw+bw = fw * 7/2
         self.assertEqual(fw_bw_flops, fw_flops * 7 // 2)
         self.assertExpectedInline(str(fw_bw_flops), """146800640""")
+
+
+@unittest.skipIf(
+    TEST_WITH_TORCHDYNAMO, "torchdynamo doesn't work with __torch_dispatch__ right now"
+)
+class TestFlopCounterAutoACTritonDeviceType(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @unittest.skipIf(not has_triton(), "requires Triton")
+    @torch._functorch.config.patch("activation_memory_budget", 0.1)
+    @torch._functorch.config.patch("activation_memory_budget_solver", "dp")
+    @torch._functorch.config.patch("is_non_builtin_to_include", True)
+    def test_flop_counter_custom_triton_op_two_kernels_auto_ac(self, device):
+        import triton
+        import triton.language as tl
+
+        from torch.utils.flop_counter import register_flop_formula
+
+        @triton.jit
+        def sin_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            tl.store(out_ptr + offsets, tl.sin(x), mask=mask)
+
+        @triton.jit
+        def cos_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+            offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            tl.store(out_ptr + offsets, tl.cos(x), mask=mask)
+
+        n_elements = int(1e7)
+        x = torch.randn(n_elements, device=device, requires_grad=True)
+        cos_flops_recorded, sin_flops_recorded = 0, 0
+
+        @register_flop_formula(sin_kernel)
+        def compute_sin_kernel_flops(*args, **kwargs) -> int:
+            nonlocal sin_flops_recorded
+            sin_flops_recorded += 1
+            return 1
+
+        @register_flop_formula(cos_kernel)
+        def compute_cos_kernel_flops(*args, **kwargs) -> int:
+            nonlocal cos_flops_recorded
+            cos_flops_recorded += 1
+            return 1
+
+        def grid(meta):
+            return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+        @torch._library.triton.triton_op("mylib::trig_op", mutates_args=())
+        def trig_op(x_inp: torch.Tensor) -> torch.Tensor:
+            output = torch.empty_like(x_inp)
+            torch.library.wrap_triton(sin_kernel)[grid](x_inp, output, n_elements, 256)
+            torch.library.wrap_triton(cos_kernel)[grid](x_inp, output, n_elements, 256)
+            return output
+
+        def backward(ctx, grad_output):
+            (out,) = ctx.saved_tensors
+            return grad_output * out
+
+        def setup(ctx, inputs, output):
+            ctx.save_for_backward(output)
+
+        trig_op.register_autograd(backward, setup_context=setup)
+
+        def fn(x_inp: torch.Tensor):
+            y1 = torch.ops.mylib.trig_op(x_inp)
+            y2 = torch.ops.mylib.trig_op(y1)
+            return torch.ops.mylib.trig_op(y2)
+
+        torch.compile(fn, backend="aot_eager_decomp_partition", fullgraph=True)(x)
+        self.assertEqual(sin_flops_recorded, 3)
+        self.assertEqual(cos_flops_recorded, 3)
+
+
+instantiate_device_type_tests(
+    TestFlopCounterAutoACTritonDeviceType,
+    globals(),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True,
+)
 
 
 class TestFlexAttentionEstimation(TestCase):


### PR DESCRIPTION
I reviewed the code and the quoted PR draft below, verified the reported results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
>
> Part of #185590.
>
> ## Summary
>
> Part of #185590.
>
> This Draft isolates the Triton activation-checkpoint flop-counter test split from #193564.
>
> ## Changes
>
> - Move `test_flop_counter_custom_triton_op_two_kernels_auto_ac` into the uniquely named `TestFlopCounterAutoACTritonDeviceType` accelerator test class.
> - Use the device injected by the device-test harness.
> - Keep Triton availability as an independent `torch.utils._triton.has_triton()` gate.
> - Preserve the activation-checkpoint partitioning behavior and existing assertions.
>
> ## Motivation
>
> The activation-checkpoint and flop-count semantics are accelerator-generic when Triton is available. Device-type instantiation allows capable accelerator backends to exercise the same test without weakening its runtime requirements.
>
> ## Test Plan
>
> Commands executed in the local WSL CUDA environment:
>
> ```bash
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/test_flop_counter.py
> git diff --check
> LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/usr/lib/wsl/lib:$LD_LIBRARY_PATH /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python test/test_flop_counter.py -k TestFlopCounterAutoACTritonDeviceTypeCUDA.test_flop_counter_custom_triton_op_two_kernels_auto_ac
> ```
>
> Results:
>
> - `py_compile`: PASS.
> - `git diff --check`: PASS.
> - Focused CUDA test: SKIP; selected 1, executed 0, passed 0, failed 0, skipped 1 because Triton is unavailable locally.
> - Accelerator: CUDA; device count 1; distributed backend not applicable.
> - XPU/XCCL validation was not run.
> - `spin fixlint`: not run because `uvx` is unavailable.
> - Overall validation status: PARTIAL because the focused runtime test skipped and XPU was not validated.
>
> ## Notes
>
> - Split from #193564.
> - Head: `6a8b2f954f20c86f2cb24784cf4402897b246544`.
> - Base: `main` at `e8430bed0fd5e742b51c1164b8cc8f5da7a038ea`.
> - Files Changed contains only `test/test_flop_counter.py`.
> - The standalone diff is 89 additions and 97 deletions.
> - This PR remains Draft pending Triton runtime and hardware-specific CI validation.
>
> ## Checklist
>
> - [ ] Passes lint (`spin fixlint`) — not run because `uvx` is unavailable
> - [x] Added/updated tests
> - [x] Updated documentation (not applicable: test-only refactor)
> - [x] Included benchmark results (not applicable: no performance behavior changes)
>
> ## BC-breaking?
>
> No.