### PR TITLE
[dynamo] Fix --skip-fp64-check in benchmark accuracy runs

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2389,6 +2389,8 @@ class BenchmarkRunner:
                 accuracy_status = "eager_two_runs_differ"
                 return record_status(accuracy_status, dynamo_start_stats=start_stats)
 
+            correct_rerun_result = None
+
             # Support multiple accuracy check runs for flaky models
             accuracy_check_runs = self.get_accuracy_check_runs(name)
             pass_count = 0

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2279,34 +2279,35 @@ class BenchmarkRunner:
         with self.pick_grad(name, self.args.training):
             # Collect the fp64 reference outputs to be used later for accuracy checking.
             fp64_outputs = None
-            model_fp64 = None
-            inputs_fp64 = None
-            try:
-                model_fp64, inputs_fp64 = cast_to_fp64(
-                    self.deepcopy_and_maybe_parallelize(model),
-                    clone_inputs(example_inputs),
-                )
-                self.init_optimizer(name, current_device, model_fp64.parameters())
-                fp64_outputs = self.run_n_iterations(
-                    model_fp64, inputs_fp64, self.model_iter_fn
-                )
-                fp64_outputs = tree_map(
-                    lambda x: x.to(torch.float64)
-                    if isinstance(x, torch.Tensor) and x.is_floating_point()
-                    else x,
-                    fp64_outputs,
-                )
-            except Exception:
-                log.warning(
-                    "fp64 golden ref were not generated for %s. Setting accuracy check to cosine",
-                    name,
-                    exc_info=True,
-                )
-                self.args.cosine = True
-                fp64_outputs = None
-            finally:
-                del model_fp64, inputs_fp64
-                empty_gpu_cache(current_device)
+            if not self.args.skip_fp64_check:
+                model_fp64 = None
+                inputs_fp64 = None
+                try:
+                    model_fp64, inputs_fp64 = cast_to_fp64(
+                        self.deepcopy_and_maybe_parallelize(model),
+                        clone_inputs(example_inputs),
+                    )
+                    self.init_optimizer(name, current_device, model_fp64.parameters())
+                    fp64_outputs = self.run_n_iterations(
+                        model_fp64, inputs_fp64, self.model_iter_fn
+                    )
+                    fp64_outputs = tree_map(
+                        lambda x: x.to(torch.float64)
+                        if isinstance(x, torch.Tensor) and x.is_floating_point()
+                        else x,
+                        fp64_outputs,
+                    )
+                except Exception:
+                    log.warning(
+                        "fp64 golden ref were not generated for %s. Setting accuracy check to cosine",
+                        name,
+                        exc_info=True,
+                    )
+                    self.args.cosine = True
+                    fp64_outputs = None
+                finally:
+                    del model_fp64, inputs_fp64
+                    empty_gpu_cache(current_device)
 
             tolerance, cos_similarity = self.get_tolerance_and_cosine_flag(
                 self.args.training, current_device, name
@@ -2388,8 +2389,6 @@ class BenchmarkRunner:
                 accuracy_status = "eager_two_runs_differ"
                 return record_status(accuracy_status, dynamo_start_stats=start_stats)
 
-            correct_rerun_result = None
-
             # Support multiple accuracy check runs for flaky models
             accuracy_check_runs = self.get_accuracy_check_runs(name)
             pass_count = 0
@@ -2464,7 +2463,8 @@ class BenchmarkRunner:
                         ):
                             correct_result = process_fn(correct_result)
                             new_result = process_fn(new_result)
-                            fp64_outputs = process_fn(fp64_outputs)
+                            if fp64_outputs is not None:
+                                fp64_outputs = process_fn(fp64_outputs)
 
                     if (
                         self.args.save_model_outputs_to


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/195979

## Motivation
The Dynamo benchmark harness exposes a `--skip-fp64-check` flag, but `BenchmarkRunner.check_accuracy` currently ignores it.

## Solution
Two changes in `BenchmarkRunner.check_accuracy`:
1.  When `self.args.skip_fp64_check` is enabled, the FP64 model/input copy and the extra computation are skipped, leaving `fp64_outputs = None`.
2. Only invoke `process_fn(fp64_outputs)` when `fp64_outputs is not None`, preventing a skipped reference from being passed into the process function.

## Test Plan
Verified manually using the following command:

```bash
python benchmarks/dynamo/torchbench.py \
    --accuracy \
    --inference \
    --backend inductor \
    --only <model> \
    --skip-fp64-check
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @gujinghui @fengyuan14 @guangyey