### PR TITLE
Remove the unused BUILD_FUNCTORCH option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,7 +519,6 @@ cmake_dependent_option(
   BUILD_LAZY_TS_BACKEND
   "Build the lazy Torchscript backend, not compatible with mobile builds" ON
   "NOT INTERN_BUILD_MOBILE" OFF)
-cmake_dependent_option(BUILD_FUNCTORCH "Build Functorch" ON "BUILD_PYTHON" OFF)
 cmake_dependent_option(BUILD_BUNDLE_PTXAS "Bundle PTX into torch/bin folder"
                        OFF "USE_CUDA" OFF)
 cmake_dependent_option(
@@ -973,7 +972,6 @@ if(INTERN_BUILD_MOBILE)
     set(INTERN_DISABLE_AUTOGRAD ON)
   endif()
   set(BUILD_PYTHON OFF)
-  set(BUILD_FUNCTORCH OFF)
   set(USE_DISTRIBUTED OFF)
   set(NO_API ON)
   set(USE_FBGEMM OFF)


### PR DESCRIPTION
```
Deleting the functorch C extension (#163340) removed the only reader of this
option along with the `add_subdirectory(functorch)` it guarded. What is left is
a `cmake_dependent_option` nothing consults and a `set(BUILD_FUNCTORCH OFF)`
in the interned mobile build that turns off something already off, so the option
appears twice in the tree and does nothing in either place.

Test Plan:

git grep -c BUILD_FUNCTORCH

returns nothing after the change; before it, the only two hits in the repository
were the two lines removed here.
```

Drafted with AI assistance (Claude Code).