### PR TITLE
[TokenSwitch] Hold `topk_idx` in `torch.int64`

### DIFF
--- a/test/distributed/test_token_switch.py
+++ b/test/distributed/test_token_switch.py
@@ -150,7 +150,9 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         received = out_tokens[:NUM_TOKENS].float()
         self.assertTrue(
             received.eq(expected_val).all(),
-            lambda msg: f"{msg}\nrank {self.rank}: expected {expected_val}, got {received[0, 0].item()}",
+            lambda msg: (
+                f"{msg}\nrank {self.rank}: expected {expected_val}, got {received[0, 0].item()}"
+            ),
         )
 
     @skip_if_lt_x_gpu(2)
@@ -225,6 +227,7 @@ class TokenSwitchNCCLTest(MultiProcContinuousTest):
         )
         out_tokens.sum().backward()
         torch.cuda.synchronize()
+        self.assertEqual(_out_idx.dtype, torch.int64)
 
         # grad_out_tokens is all-ones; combine routes them back: each token gets 1.0 per top-k slot
         self.assertIsNotNone(tokens.grad)

--- a/torch/distributed/_token_switch.py
+++ b/torch/distributed/_token_switch.py
@@ -360,7 +360,7 @@ class TokenSwitchNCCL(TokenSwitch):
         return (
             tokens.new_zeros(max_recv_tokens, H),
             topk_weights.new_zeros(max_recv_tokens, K),
-            tokens.new_zeros(max_recv_tokens, K, dtype=torch.int32),
+            tokens.new_zeros(max_recv_tokens, K, dtype=torch.int64),
         )
 
     def create_routing(


### PR DESCRIPTION
because NCCL_EP_ALGO_HIGH_THROUGHPUT is hardcoded at https://github.com/pytorch/pytorch/blob/5405e96f56b2caf08548e7c614d0e9c576bcc8dc/torch/csrc/distributed/c10d/symm_mem/nccl_ep.cu#L134 and the algorithm seems to expect topk_idx to be int64 as per https://github.com/NVIDIA/nccl-extensions/blob/850d97a66ab6882ed0fca3856ce620f0d0ed7f93/nccl_ep/nccl_ep.cc#L4339.