### PR TITLE
[Test] Fix PrivateUse1 filtering with PYTORCH_TESTING_DEVICE_FOR_CUSTOM

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1158,8 +1158,22 @@ def get_desired_device_type_test_bases(
         os.getenv(PYTORCH_TESTING_DEVICE_FOR_CUSTOM_KEY, "")
     )
     if env_custom_only_for:
+        # Replace privateuse1 backend name with 'privateuse1' to ensure
+        # consistent device type filtering
+        if _is_privateuse1_backend_available():
+            privateuse1_backend_name = torch._C._get_privateuse1_backend_name()
+
+            def func_replace(x: str) -> str:
+                return x.replace(privateuse1_backend_name, "privateuse1")
+        else:
+
+            def func_replace(x: str) -> str:
+                return x
+
+        normalized_custom = [func_replace(x) for x in env_custom_only_for]
         desired_device_type_test_bases += filter(
-            lambda x: x.device_type in env_custom_only_for, test_bases
+            lambda x: func_replace(x.device_type) in normalized_custom,
+            test_bases,
         )
         desired_device_type_test_bases = list(set(desired_device_type_test_bases))
 


### PR DESCRIPTION
## Summary

Fix device-type filtering issues when `PYTORCH_TESTING_DEVICE_FOR_CUSTOM` is used with tests instantiated via `instantiate_device_type_tests` with `only_for`.

When a PrivateUse1 backend such as OpenReg is registered, `PrivateUse1TestBase.device_type` is initially `"privateuse1"` and is updated to the registered backend name `"openreg"` the first time `PrivateUse1TestBase.setUpClass` is executed.

This caused two matching issues:

- With `PYTORCH_TESTING_DEVICE_FOR_CUSTOM=privateuse1`, a base whose `device_type` had already been updated to `"openreg"` could not match.
- With `PYTORCH_TESTING_DEVICE_FOR_CUSTOM=openreg`, a base whose `device_type` was still `"privateuse1"` could not match.

This fix normalizes both the environment value and the test base's `device_type` to `"privateuse1"` before matching.

