### PR TITLE
[xpu] Compensate for UMD headroom in free_memory on SYCL 2026.2

### DIFF
--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -1517,20 +1517,8 @@ class DeviceCachingAllocator {
              alloc_block(params, true, context))));
     }
     if (!block_found) {
-      const auto& raw_device = c10::xpu::get_raw_device(device);
-      const auto device_total =
-          raw_device.get_info<sycl::info::device::global_mem_size>();
-      // Estimate the available device memory when the SYCL runtime does not
-      // support the corresponding aspect (ext_intel_free_memory).
-      size_t device_free = device_total -
-          stats.reserved_bytes[static_cast<size_t>(StatType::AGGREGATE)]
-              .current;
-      // TODO: Remove the aspect check once the SYCL runtime bug is fixed on
-      // affected devices.
-      if (raw_device.has(sycl::aspect::ext_intel_free_memory)) {
-        device_free =
-            raw_device.get_info<sycl::ext::intel::info::device::free_memory>();
-      }
+      const auto [device_free, device_total] = getMemoryInfo();
+
       std::string allowed_info;
       if (set_fraction) {
         allowed_info = format_size(allowed_memory_maximum) + " allowed; ";
@@ -1849,8 +1837,56 @@ class DeviceCachingAllocator {
         ") doesn't support querying the available free memory. ",
         "You can file an issue at https://github.com/pytorch/pytorch/issues ",
         "to help us prioritize its implementation.");
-    const size_t free =
+    size_t free =
         device.get_info<sycl::ext::intel::info::device::free_memory>();
+
+    /**
+     * Note [UMD Headroom]
+     *
+     * `global_mem_size` is the total usable memory size reported by L0 Sysman,
+     * corresponding to the KMD-reported `.physicalSize`.
+     *
+     * Starting with SYCL compiler 2026.2, `free_memory` on certain Intel GPUs
+     * (Xe2 and later) uses the L0 `.currUsableMemSize` API. Its accounting is
+     * based on the UMD-advertised memory size, which reserves a fixed fraction
+     * of `global_mem_size` as UMD headroom. Add this fraction back to keep
+     * `free_memory` consistent with `global_mem_size`.
+     *
+     * In earlier compiler versions `free_memory` use the L0 Sysman `.free` API,
+     * which is already based on `global_mem_size`.
+     *
+     * The static_assert below forces this workaround to be revalidated when
+     * upgrading the compiler beyond this version.
+     */
+#if SYCL_COMPILER_VERSION > 20260200
+    static_assert(
+        false,
+        "Re-validate the free-memory workaround above for this SYCL compiler version.");
+#elif SYCL_COMPILER_VERSION == 20260200
+    const auto arch = device.get_info<sycl::info::device::architecture>();
+    if (arch >=
+        sycl::ext::oneapi::experimental::architecture::intel_gpu_bmg_g21) {
+      // Fraction differs by GPU type and, for discrete GPUs, by OS, see
+      // https://github.com/intel/compute-runtime/blob/master/programmers-guide/DEVICE_MEMORY_ACCOUNTING.md#umd-headroom.
+      constexpr double kIntegratedGpuUsableFraction = 0.94;
+#ifdef _WIN32
+      constexpr double kDiscreteGpuUsableFraction = 0.98;
+#else
+      constexpr double kDiscreteGpuUsableFraction = 0.95;
+#endif
+      const bool is_integrated_gpu =
+          device.has(sycl::aspect::ext_oneapi_is_integrated_gpu);
+      const double usable_fraction = is_integrated_gpu
+          ? kIntegratedGpuUsableFraction
+          : kDiscreteGpuUsableFraction;
+      free += (1 - usable_fraction) * total;
+      TORCH_CHECK(
+          free <= total, "Calculated free memory exceeds total memory.");
+    }
+#else
+    // SYCL_COMPILER_VERSION < 20260200: the driver does not withhold memory,
+    // so no adjustment is needed.
+#endif
     return {free, total};
   }
 
@@ -2525,3 +2561,4 @@ int getPoolUseCount(c10::DeviceIndex device, MempoolId_t mempool_id) {
 }
 
 } // namespace c10::xpu::XPUCachingAllocator
+ 

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -2561,4 +2561,3 @@ int getPoolUseCount(c10::DeviceIndex device, MempoolId_t mempool_id) {
 }
 
 } // namespace c10::xpu::XPUCachingAllocator
- 

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -1109,6 +1109,34 @@ print(torch.xpu.is_initialized())
         self.assertGreaterEqual(before_free_bytes, after_free_bytes)
         self.assertEqual(before_total_bytes, after_total_bytes)
 
+    @unittest.skipIf(not HAS_PYZES, "requires pyzes")
+    @unittest.skipIf(not Xe2_Or_Later, "not available")
+    @serialTest()
+    def test_mem_get_info_with_pyzes(self):
+        torch.xpu.synchronize()
+        torch.xpu.empty_cache()
+        free_bytes, total_bytes = torch.xpu.mem_get_info()
+        memory_handle = torch.xpu._zes_get_memory_handle()
+
+        from ctypes import byref
+
+        import pyzes
+
+        mem_state = pyzes.zes_mem_state_t()
+        rc = pyzes.zesMemoryGetState(memory_handle, byref(mem_state))
+        if rc != pyzes.ZE_RESULT_SUCCESS:
+            self.fail("Failed to get memory state from Level Zero Sysman")
+
+        mem_props = pyzes.zes_mem_properties_t()
+        mem_props.stype = pyzes.ZES_STRUCTURE_TYPE_MEM_PROPERTIES
+
+        rc = pyzes.zesMemoryGetProperties(memory_handle, byref(mem_props))
+        if rc != pyzes.ZE_RESULT_SUCCESS:
+            self.fail("Failed to get memory properties from Level Zero Sysman")
+
+        self.assertEqual(free_bytes, mem_state.free)
+        self.assertEqual(total_bytes, mem_props.physicalSize)
+
     def test_get_arch_list(self):
         arch_list = torch.xpu.get_arch_list()
         if not arch_list:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #197412
* __->__ #195987

# Motivation
`global_mem_size` is the total usable memory size reported by L0 Sysman, corresponding to the KMD-reported `.physicalSize`. Starting with SYCL compiler 2026.2, `free_memory` on certain Intel GPUs (Xe2 and later) uses the L0 `.currUsableMemSize` API. Its accounting is based on the UMD-advertised memory size, which reserves a fixed fraction of `global_mem_size` as UMD headroom. Add this fraction back to keep `free_memory` consistent with `global_mem_size`. In earlier compiler versions `free_memory` use the L0 Sysman `.free` API, which is already based on `global_mem_size`.

So we could use the following formula to calculate free size based on KMD-reproted:
```
fraction = 0.95; // e.g.
free = L0.currUsableMemSize + (1-fraction) * L0.physicalSize;
```

# Additional Context
<img width="2227" height="659" alt="image" src="https://github.com/user-attachments/assets/71e0895a-151a-47d5-b927-3b8b6941a092" />


## Test
I am already validating this change on Arc770, PVC, and BMG on Linux.
I am NOT validating this change on iGPU, this is the risk.
UT passed on BMG with 2026.1;
<img width="1549" height="312" alt="image" src="https://github.com/user-attachments/assets/943016a3-bd79-4bd5-836a-971e0308fab1" />
UT passed on BMG with 2026.2;
<img width="1536" height="430" alt="image" src="https://github.com/user-attachments/assets/7d4a8075-fc78-4e3c-8742-cb88af358ed1" />

