### PR TITLE
[NumPy] Fix ZeroDivisionError on num=1 and forward dtype in geomspace

### DIFF
--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -692,6 +692,41 @@ class TestCtorNested(TestCase):
         assert_equal(w.asarray(lst), [[1, 2], [3, 4]])
 
 
+class TestGeomspace(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_geomspace_num_one_and_zero(self):
+        res1 = w.geomspace(1, 1000, num=1)
+        assert_equal(res1, w.array([1.0]))
+        assert_equal(res1.dtype, w.float64)
+
+        res0 = w.geomspace(1, 1000, num=0)
+        assert_equal(res0.shape, (0,))
+        assert_equal(res0.dtype, w.float64)
+
+    def test_geomspace_dtype(self):
+        res32 = w.geomspace(1, 1000, num=4, dtype=w.float32)
+        assert_equal(res32.dtype, w.float32)
+
+        res64 = w.geomspace(1, 1000, num=4, dtype=w.float64)
+        assert_equal(res64.dtype, w.float64)
+
+        res_int = w.geomspace(1, 1000, num=4, dtype=w.int64)
+        assert_equal(res_int.dtype, w.int64)
+        assert_equal(res_int, w.array([1, 10, 100, 1000]))
+
+    def test_geomspace_negative(self):
+        res_neg = w.geomspace(-1, -1000, num=4)
+        assert_allclose(res_neg, w.array([-1.0, -10.0, -100.0, -1000.0]))
+        assert_equal(w.geomspace(-1, -1000, num=1), w.array([-1.0]))
+
+    def test_geomspace_zero_raises(self):
+        with self.assertRaises(ValueError):
+            w.geomspace(0, 1000, num=4)
+        with self.assertRaises(ValueError):
+            w.geomspace(1, 0, num=4)
+
+
 class TestMisc(TestCase):
     hw_classification = HardwareClassification.GENERIC
 

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -726,6 +726,11 @@ class TestGeomspace(TestCase):
         with self.assertRaises(ValueError):
             w.geomspace(1, 0, num=4)
 
+    def test_geomspace_complex(self):
+        res = w.geomspace(1j, 1000j, num=4)
+        assert_allclose(res, w.array([1j, 10j, 100j, 1000j]))
+        assert_equal(res.dtype, w.complex128)
+
 
 class TestMisc(TestCase):
     hw_classification = HardwareClassification.GENERIC

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -362,12 +362,15 @@ def geomspace(
     if bool(torch.any(start == 0)) or bool(torch.any(stop == 0)):
         raise ValueError("Geometric sequence cannot include zero")
     if dtype is None:
-        dtype = _dtypes_impl.default_dtypes().float_dtype
+        if start.is_complex() or stop.is_complex():
+            dtype = _dtypes_impl.default_dtypes().complex_dtype
+        else:
+            dtype = _dtypes_impl.default_dtypes().float_dtype
     elif not isinstance(dtype, torch.dtype):
         from . import _dtypes
 
         dtype = _dtypes.dtype(dtype).torch_dtype
-    out_sign = torch.sign(start)
+    out_sign = torch.sgn(start)
     start = start / out_sign
     stop = stop / out_sign
     log_start = torch.log10(start)

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -355,15 +355,37 @@ def geomspace(
 ) -> torch.Tensor:
     if axis != 0 or not endpoint:
         raise NotImplementedError
-    base = torch.pow(stop / start, 1.0 / (num - 1))
-    logbase = torch.log(base)
-    # torch.logspace accepts tensor start/end/base at runtime.
-    return torch.logspace(  # pyrefly: ignore[no-matching-overload]
-        torch.log(start) / logbase,
-        torch.log(stop) / logbase,
+    if not isinstance(start, torch.Tensor):
+        start = torch.as_tensor(start)
+    if not isinstance(stop, torch.Tensor):
+        stop = torch.as_tensor(stop)
+    if bool(torch.any(start == 0)) or bool(torch.any(stop == 0)):
+        raise ValueError("Geometric sequence cannot include zero")
+    if dtype is None:
+        dtype = _dtypes_impl.default_dtypes().float_dtype
+    elif not isinstance(dtype, torch.dtype):
+        from . import _dtypes
+
+        dtype = _dtypes.dtype(dtype).torch_dtype
+    out_sign = torch.sign(start)
+    start = start / out_sign
+    stop = stop / out_sign
+    log_start = torch.log10(start)
+    log_stop = torch.log10(stop)
+    # torch.logspace accepts tensor start/end at runtime.
+    res = torch.logspace(  # pyrefly: ignore[no-matching-overload]
+        log_start,
+        log_stop,
         num,
-        base=base,
+        base=10.0,
+        dtype=dtype,
     )
+    res = (res * out_sign).to(dtype)
+    if num > 0:
+        res[0] = start * out_sign
+        if num > 1:
+            res[-1] = stop * out_sign
+    return res
 
 
 def logspace(


### PR DESCRIPTION
Fixes #195978

### Description

This PR fixes three bugs in `torch._numpy.geomspace`:

1. **`num=1` ZeroDivisionError**: `torch._numpy.geomspace(start, stop, num=1)` crashed with `ZeroDivisionError: float division by zero` because the step ratio was computed as `1.0 / (num - 1)`. In NumPy, `num=1` returns a 1-element array containing `start` (or `start` converted to `dtype`).
2. **Ignored `dtype`**: While `dtype` was accepted in the argument signature, it was never forwarded to `torch.logspace`, and default float dtype handling was omitted. As a result, requesting any `dtype` (e.g. `dtype='float64'` or `dtype='int64'`) silently returned `float32`.
3. **Negative range failure**: Calling `geomspace` with negative values (e.g. `start=-1, stop=-1000`) produced `NaN`s because `torch.log` was taken on negative numbers.

### Root Cause & Why These Changes Are Applied

Geometric progression points in log-space are mathematically invariant to the logarithm base:
for any base $B > 0$, the points are generated by interpolating between $\log_B(\text{start})$ and $\log_B(\text{stop})$.

Computing `base = (stop / start) ** (1.0 / (num - 1))` was unnecessary and created a division-by-zero singularity at `num = 1`.

By adopting NumPy's reference approach (`base=10.0` with `torch.log10`):
- `torch.logspace(torch.log10(start), torch.log10(stop), num, base=10.0, dtype=dtype)` natively handles `num=1` (returning `[start]`) and `num=0` (returning `[]`) without any division by `num - 1`.
- `dtype` is properly resolved (defaulting to `_dtypes_impl.default_dtypes().float_dtype` when `None`) and forwarded to `torch.logspace`.
- Negative ranges are handled via sign rotation (`out_sign = torch.sign(start)`), matching NumPy semantics.
- Sequences containing zero raise `ValueError("Geometric sequence cannot include zero")`, matching NumPy.
- Exact endpoints are preserved for `num > 0` to prevent log/pow floating-point precision drift.

### Test Plan

Added unit tests in `TestGeomspace` in `test/torch_np/test_basic.py`:
- `test_geomspace_num_one_and_zero`: verifies `num=1` returns `[start]` with float64 dtype, and `num=0` returns empty array.
- `test_geomspace_dtype`: verifies `float32`, `float64`, and `int64` dtypes are respected.
- `test_geomspace_negative`: verifies negative ranges produce correct geometric sequences.
- `test_geomspace_zero_raises`: verifies `ValueError` is raised if sequence includes zero.

Ran tests locally:
```bash
python -m unittest test.torch_np.test_basic.TestGeomspace
```
All 4 tests pass.


cc @mruberry @rgommers