### PR TITLE
[Testcase Refactoring][quantization][eager] Add CPU hw_classification to test_bias_correction_eager.py

### DIFF
--- a/test/quantization/eager/test_bias_correction_eager.py
+++ b/test/quantization/eager/test_bias_correction_eager.py
@@ -18,10 +18,15 @@ from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
     skipIfNoFBGEMM,
 )
-from torch.testing._internal.common_utils import raise_on_run_directly
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+)
 
 
 class TestBiasCorrectionEager(QuantizationTestCase):
+    hw_classification = HardwareClassification.CPU
+
     def compute_sqnr(self, x, y):
         Ps = torch.norm(x)
         Pn = torch.norm(x - y)

--- a/test/quantization/eager/test_bias_correction_eager.py
+++ b/test/quantization/eager/test_bias_correction_eager.py
@@ -14,9 +14,7 @@ from torch.ao.quantization._correct_bias import (
     get_param,
     parent_child_names,
 )
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
     skipIfNoFBGEMM,
@@ -131,9 +129,7 @@ class TestBiasCorrectionEager(QuantizationTestCase):
         self.correct_artificial_bias_quantize(float_model, img_data)
 
 
-instantiate_device_type_tests(
-    TestBiasCorrectionEager, globals(), only_for="cpu"
-)
+instantiate_device_type_tests(TestBiasCorrectionEager, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")

--- a/test/quantization/eager/test_bias_correction_eager.py
+++ b/test/quantization/eager/test_bias_correction_eager.py
@@ -14,6 +14,9 @@ from torch.ao.quantization._correct_bias import (
     get_param,
     parent_child_names,
 )
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
     skipIfNoFBGEMM,
@@ -73,11 +76,12 @@ class TestBiasCorrectionEager(QuantizationTestCase):
 
                 self.assertTrue(
                     self.compute_sqnr(float_bias, artificial_bias) > 30,
-                    "Correcting quantized bias produced too much noise, sqnr score too low",
+                    "Correcting quantized bias produced too much noise, "
+                    "sqnr score too low",
                 )
 
     @skipIfNoFBGEMM
-    def test_linear_chain(self):
+    def test_linear_chain(self, device):
         class LinearChain(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -91,18 +95,18 @@ class TestBiasCorrectionEager(QuantizationTestCase):
                 x = self.linear3(x)
                 return x
 
-        float_model = QuantWrapper(LinearChain())
+        float_model = QuantWrapper(LinearChain()).to(device)
         img_data = [
             (
-                torch.rand(10, 3, dtype=torch.float),
-                torch.randint(0, 1, (2,), dtype=torch.long),
+                torch.rand(10, 3, dtype=torch.float, device=device),
+                torch.randint(0, 1, (2,), dtype=torch.long, device=device),
             )
             for _ in range(50)
         ]
         self.correct_artificial_bias_quantize(float_model, img_data)
 
     @skipIfNoFBGEMM
-    def test_conv_chain(self):
+    def test_conv_chain(self, device):
         class ConvChain(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -116,16 +120,20 @@ class TestBiasCorrectionEager(QuantizationTestCase):
                 x = self.conv2d3(x)
                 return x
 
-        float_model = QuantWrapper(ConvChain())
+        float_model = QuantWrapper(ConvChain()).to(device)
         img_data = [
             (
-                torch.rand(10, 3, 125, 125, dtype=torch.float),
-                torch.randint(0, 1, (2,), dtype=torch.long),
+                torch.rand(10, 3, 125, 125, dtype=torch.float, device=device),
+                torch.randint(0, 1, (2,), dtype=torch.long, device=device),
             )
             for _ in range(50)
         ]
         self.correct_artificial_bias_quantize(float_model, img_data)
 
+
+instantiate_device_type_tests(
+    TestBiasCorrectionEager, globals(), only_for="cpu"
+)
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")

--- a/test/quantization/eager/test_bias_correction_eager.py
+++ b/test/quantization/eager/test_bias_correction_eager.py
@@ -14,7 +14,6 @@ from torch.ao.quantization._correct_bias import (
     get_param,
     parent_child_names,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
     skipIfNoFBGEMM,
@@ -74,12 +73,11 @@ class TestBiasCorrectionEager(QuantizationTestCase):
 
                 self.assertTrue(
                     self.compute_sqnr(float_bias, artificial_bias) > 30,
-                    "Correcting quantized bias produced too much noise, "
-                    "sqnr score too low",
+                    "Correcting quantized bias produced too much noise, sqnr score too low",
                 )
 
     @skipIfNoFBGEMM
-    def test_linear_chain(self, device):
+    def test_linear_chain(self):
         class LinearChain(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -93,18 +91,18 @@ class TestBiasCorrectionEager(QuantizationTestCase):
                 x = self.linear3(x)
                 return x
 
-        float_model = QuantWrapper(LinearChain()).to(device)
+        float_model = QuantWrapper(LinearChain())
         img_data = [
             (
-                torch.rand(10, 3, dtype=torch.float, device=device),
-                torch.randint(0, 1, (2,), dtype=torch.long, device=device),
+                torch.rand(10, 3, dtype=torch.float),
+                torch.randint(0, 1, (2,), dtype=torch.long),
             )
             for _ in range(50)
         ]
         self.correct_artificial_bias_quantize(float_model, img_data)
 
     @skipIfNoFBGEMM
-    def test_conv_chain(self, device):
+    def test_conv_chain(self):
         class ConvChain(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -118,18 +116,16 @@ class TestBiasCorrectionEager(QuantizationTestCase):
                 x = self.conv2d3(x)
                 return x
 
-        float_model = QuantWrapper(ConvChain()).to(device)
+        float_model = QuantWrapper(ConvChain())
         img_data = [
             (
-                torch.rand(10, 3, 125, 125, dtype=torch.float, device=device),
-                torch.randint(0, 1, (2,), dtype=torch.long, device=device),
+                torch.rand(10, 3, 125, 125, dtype=torch.float),
+                torch.randint(0, 1, (2,), dtype=torch.long),
             )
             for _ in range(50)
         ]
         self.correct_artificial_bias_quantize(float_model, img_data)
 
-
-instantiate_device_type_tests(TestBiasCorrectionEager, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_quantization.py")


### PR DESCRIPTION
## Summary

`test/quantization/eager/test_bias_correction_eager.py` contains eager quantization bias correction tests for linear and convolution chains.

The tests rely on FBGEMM and are CPU-specific. This change adds CPU hardware classification and converts the tests to device-type test instantiation.

## Modification

- Add `HardwareClassification.CPU` to `TestBiasCorrectionEager`.
- Add `device` arguments to `test_linear_chain` and `test_conv_chain`.
- Move models and test inputs to the injected device.
- Instantiate the test class only for CPU with `only_for="cpu"`.
- Keep the existing test logic, assertions, and FBGEMM requirement unchanged.

## Self-test

Environment:

- Ubuntu 22.04
- Linux x86_64
- Python 3.11.16
- PyTorch built from the PR branch
- CPU-only test environment

Commands:

```bash
python -m pytest -v -rs \
test/quantization/eager/test_bias_correction_eager.py

lintrunner -a