### PR TITLE
Avoid mutating state_dict metadata in `load_state_dict(assign=True)`

### DIFF
--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -438,6 +438,25 @@ class TestLoadStateDict(NNTestCase):
             net2.load_state_dict(state_dict, strict=False, assign=True)
 
     @swap([True, False])
+    def test_load_state_dict_assign_does_not_mutate_metadata(self):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.p = torch.nn.Parameter(torch.ones(1))
+
+        sd = M().state_dict()
+        orig_metadata = deepcopy(sd._metadata)
+
+        M().load_state_dict(sd, assign=True)
+
+        self.assertEqual(sd._metadata, orig_metadata)
+
+        m = M()
+        old_param = m.p
+        m.load_state_dict(sd)
+        self.assertIs(m.p, old_param)
+
+    @swap([True, False])
     def test_load_state_dict_warn_assign(self):
         with torch.device("meta"):
             m = torch.nn.Linear(3, 5)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2591,7 +2591,11 @@ class Module:
             state_dict._metadata = metadata  # type: ignore[attr-defined]
 
         def load(module, local_state_dict, prefix="") -> None:
-            local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
+            # Copy so assign_to_params_buffers is not written into the
+            # caller's state_dict._metadata.
+            local_metadata = (
+                {} if metadata is None else metadata.get(prefix[:-1], {}).copy()
+            )
             if assign:
                 local_metadata["assign_to_params_buffers"] = assign
             module._load_from_state_dict(


### PR DESCRIPTION
Fixes #188166

`load_state_dict(assign=True)` wrote `assign_to_params_buffers` into the caller's `state_dict._metadata` because `metadata.get(...)` returns that dict by reference. A later default load from the same object then swapped Parameter instances, and the flag survived `torch.save` / `torch.load`. Copy the per-module metadata before injecting the flag.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```
python test/nn/test_load_state_dict.py TestLoadStateDict.test_load_state_dict_assign_does_not_mutate_metadata
```