### PR TITLE
[Testcase Refactoring] Add proper hw_classification to test_distribution

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -5725,6 +5725,8 @@ class TestDistributionShapes(DistributionsTestCase):
 
 @skipIfTorchDynamo("Not a TorchDynamo suitable test")
 class TestKL(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
 
@@ -6250,6 +6252,8 @@ class TestKL(DistributionsTestCase):
 
 
 class TestConstraints(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_params_constraints(self):
         normalize_probs_dists = (
             Categorical,
@@ -6307,6 +6311,8 @@ class TestConstraints(DistributionsTestCase):
 
 @skipIfTorchDynamo("Not a TorchDynamo suitable test")
 class TestNumericalStability(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _test_pdf_score(
         self,
         dist_class,
@@ -6588,6 +6594,8 @@ class TestNumericalStability(DistributionsTestCase):
 
 # TODO: make this a pytest parameterized test
 class TestLazyLogitsInitialization(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # ContinuousBernoulli is not tested because log_prob is not computed simply
@@ -6992,6 +7000,8 @@ class TestFunctors(DistributionsTestCase):
 
 
 class TestValidation(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_valid(self):
         for Dist, params in _get_examples():
             for param in params:
@@ -7082,6 +7092,8 @@ class TestValidation(DistributionsTestCase):
 
 
 class TestJit(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _examples(self):
         for Dist, params in _get_examples():
             for param in params:

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4813,6 +4813,8 @@ class TestDistributionsGPU(DistributionsTestCase):
 # the reparameterization trick and do not need to be tested for accuracy.
 @skipIfTorchDynamo("Not a TorchDynamo suitable test")
 class TestRsample(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_gamma(self):
         num_samples = 100
@@ -6648,6 +6650,8 @@ class TestLazyLogitsInitialization(DistributionsTestCase):
 @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
 @skipIfTorchDynamo("FIXME: Tries to trace through SciPy and fails")
 class TestAgainstScipy(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         positive_var = torch.randn(20, dtype=torch.double).exp()
@@ -6857,6 +6861,8 @@ class TestAgainstScipy(DistributionsTestCase):
 
 
 class TestFunctors(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
+    
     def test_cat_transform(self):
         x1 = -1 * torch.arange(1, 101, dtype=torch.float).view(-1, 100)
         x2 = (torch.arange(1, 101, dtype=torch.float).view(-1, 100) - 1) / 100

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -119,6 +119,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import (
     gradcheck,
+    HardwareClassification,
     load_tests,
     run_tests,
     set_default_dtype,
@@ -5098,6 +5099,7 @@ class TestRsample(DistributionsTestCase):
 
 
 class TestDistributionShapes(DistributionsTestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         self.scalar_sample = 1


### PR DESCRIPTION
### Summary
- Add "GENERIC" `hw_classification`  in `test_distributions.py`.

### Changes
- Add `"GENERIC"` `hw_classification` to `TestDistributionShapes`,  `TestRsample`,  `TestKL`,  `TestConstraints`,  `TestNumericalStability`,  `TestLazyLogitsInitialization`,  `TestAgainstScipy`,  `TestFunctors`,  `TestValidation`, `TestJit` in `test/distributions/test_distributions.py`.
- Import `HardwareClassification` from `torch.testing._internal.common_utils`.

### Test Plan
- Run `pytest test/distributions/test_distributions.py` to verify all tests pass.