### PR TITLE
Fix hardcoded rendezvous ports in distributed tests

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -143,6 +143,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
 
@@ -176,6 +177,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
@@ -215,6 +217,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(
                 4, 4, dtype=torch.float, device=device_type
@@ -313,6 +316,7 @@ graph():
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             func_c = functools.partial(func, **self.get_world_trs())
@@ -361,6 +365,7 @@ graph():
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
@@ -408,7 +413,11 @@ graph():
             return grad3, grad2, grad1
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, self.backend(device_type), fake_pg=True
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=True,
+            rdvz_file=self.file_name,
         ):
             # all_reduces remain in order!
             # note: this isn't actually invariant of pass currently..
@@ -442,6 +451,7 @@ graph():
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
 
@@ -508,6 +518,7 @@ graph():
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             q = torch.randn(1, 1, 128, 16, device=device_type, requires_grad=True)
             k = torch.randn(1, 1, 128, 16, device=device_type, requires_grad=True)
@@ -565,6 +576,7 @@ graph():
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs_a = (
                 torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
@@ -628,6 +640,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs_a = (
                 torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
@@ -666,6 +679,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs_a = torch.ones(8, 4, dtype=torch.float, device=device_type)
             inputs_b = torch.ones(8, 4, dtype=torch.float, device=device_type) * 2
@@ -707,6 +721,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs_a = torch.ones(4, 4, dtype=torch.float, device=device_type)
             inputs_b = torch.ones(4, 4, dtype=torch.float, device=device_type)
@@ -746,6 +761,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type)
             ranks = list(range(self.world_size))
@@ -799,6 +815,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -862,6 +879,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -915,6 +933,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -983,6 +1002,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
                 self.world_size,
                 self.backend(device_type),
                 fake_pg=not at_least_x_gpu(2),
+                rdvz_file=self.file_name,
             ),
             torch._inductor.config.patch(
                 "aten_distributed_optimizations.insert_overlap_deps", True
@@ -1055,6 +1075,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs_a = torch.ones(4, 4, dtype=torch.float, device=device_type)
             inputs_b = torch.ones(4, 4, dtype=torch.float, device=device_type) * 2
@@ -1102,6 +1123,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(8, 8, dtype=torch.float, device=device_type) + self.rank
 
@@ -1143,6 +1165,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(4, 4, dtype=torch.float32, device=device_type)
             b = torch.ones(4, 4, dtype=torch.float16, device=device_type) * 2
@@ -1180,6 +1203,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             b = torch.ones(4, 4, dtype=torch.float, device=device_type) * 2
@@ -1224,6 +1248,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -1285,6 +1310,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(4, 4, dtype=torch.float32, device=device_type)
             b = torch.ones(4, 4, dtype=torch.float64, device=device_type) * 2
@@ -1343,6 +1369,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             import torch.distributed as dist
             from torch._subclasses.fake_tensor import unset_fake_temporarily
@@ -1405,6 +1432,7 @@ class TestComputeCommReorderingBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             world_size = self.world_size
             full_chunk = (7 + world_size - 1) // world_size
@@ -1602,6 +1630,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -1647,6 +1676,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -1881,6 +1911,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -2053,6 +2084,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -2093,6 +2125,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             with FakeTensorMode():
                 a_val = torch.empty(8, 8, device=device_type)
@@ -2223,6 +2256,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -2277,6 +2311,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -2318,6 +2353,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -2373,6 +2409,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
@@ -2439,6 +2476,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             a = torch.ones(8, 8, dtype=torch.float, device=device_type)
             b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2

--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2183,6 +2183,17 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
         except OSError:
             pass
 
+    def _init_process_group(self, backend):
+        # Rendezvous over the per-test temp file rather than a fixed TCP port,
+        # so concurrently running test processes cannot collide.
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend,
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
     def test_get_backend_name(self):
         dpg = DummyProcessGroup(0, 1)
         self.assertEqual("Dummy", dpg.name())
@@ -2207,9 +2218,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             "dummy", PythonProcessGroupExtensionTest.create_dummy
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group("dummy", rank=self.rank, world_size=self.world_size)
+        self._init_process_group("dummy")
 
         backend = dist.get_backend_impl()
         self.assertIsInstance(backend, DummyProcessGroup)
@@ -2229,9 +2238,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             "dummy", PythonProcessGroupExtensionTest.create_dummy
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group("dummy", rank=self.rank, world_size=self.world_size)
+        self._init_process_group("dummy")
 
         dpg = DummyProcessGroup(0, 124)
         from torch.distributed.distributed_c10d import _canonicalize_group_rank
@@ -2379,11 +2386,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             "dummy", PythonProcessGroupExtensionTest.create_dummy
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group(
-            "cpu:dummy,cuda:dummy,xpu:dummy", rank=self.rank, world_size=self.world_size
-        )
+        self._init_process_group("cpu:dummy,cuda:dummy,xpu:dummy")
 
         # test all_gather
         input_tensor = torch.ones(2, 2) * 7
@@ -2418,9 +2421,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             "dummy", PythonProcessGroupExtensionTest.create_dummy
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group("dummy", rank=self.rank, world_size=self.world_size)
+        self._init_process_group("dummy")
 
         # test all_gather
         input_tensor = torch.ones(2, 2) * 7
@@ -2454,9 +2455,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             "dummy", PythonProcessGroupExtensionTest.create_dummy
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group("dummy", rank=self.rank, world_size=self.world_size)
+        self._init_process_group("dummy")
 
         # test send
         input_tensor = torch.zeros(2, 2)
@@ -2489,9 +2488,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             "dummy", PythonProcessGroupExtensionTest.create_dummy
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group("dummy", rank=self.rank, world_size=self.world_size)
+        self._init_process_group("dummy")
 
         pg = c10d._get_default_group()
 
@@ -2504,9 +2501,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             "dummy", PythonProcessGroupExtensionTest.create_dummy
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group("dummy", rank=self.rank, world_size=self.world_size)
+        self._init_process_group("dummy")
 
         pg = c10d._get_default_group()
 
@@ -2548,11 +2543,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             extended_api=True,
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group(
-            "delegating", rank=self.rank, world_size=self.world_size
-        )
+        self._init_process_group("delegating")
 
         try:
             sub_pg = dist.new_group(ranks=[0])
@@ -2607,11 +2598,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             devices=["cpu", "cuda"],
         )
 
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = "6789"
-        dist.init_process_group(
-            "delegating", rank=self.rank, world_size=self.world_size
-        )
+        self._init_process_group("delegating")
 
         try:
             backend = "cpu:delegating,cuda:delegating"

--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -135,6 +135,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
@@ -179,6 +180,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
@@ -233,6 +235,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
@@ -294,6 +297,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
@@ -354,6 +358,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             self.world_size,
             self.backend(device_type),
             fake_pg=not at_least_x_gpu(2),
+            rdvz_file=self.file_name,
         ):
             inputs = torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
             compiled = torch.compile(func)
@@ -412,6 +417,7 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
                 self.world_size,
                 self.backend(device_type),
                 fake_pg=not at_least_x_gpu(2),
+                rdvz_file=self.file_name,
             ):
                 inputs = (
                     torch.ones(4, 4, dtype=torch.float, device=device_type) + self.rank
@@ -481,7 +487,11 @@ graph():
             return grad3, grad2, grad1
 
         with _dynamo_dist_per_rank_init(
-            self.rank, self.world_size, self.backend(device_type), fake_pg=True
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=True,
+            rdvz_file=self.file_name,
         ):
             fn(g1, g2, g3)
 

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -886,7 +886,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @skip_if_lt_x_gpu(2)
     @config.patch(optimize_ddp=False, enable_compiler_collectives=True)
     def test_ddp_baseline_aot_eager_multiprocess(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             self.assertFalse(config.optimize_ddp)
             m, inputs, correct_outputs = get_model(f"{self.device_type}:{self.rank}")
             m = DDP(m, device_ids=[self.rank])
@@ -895,7 +897,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
             self.assertTrue(same(correct_outputs, outputs))
 
     def _test_hf_bert_ddp_inductor(self, static_graph):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             model, inputs = get_hf_bert(self.rank)
             model = DDP(model, static_graph=static_graph)
             run_hf_bert_ddp(self, model, inputs, "inductor")
@@ -919,7 +923,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
         self._test_hf_bert_ddp_inductor(static_graph=True)
 
     def _test_hf_bert_aot_eager(self, static_graph):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             model, inputs = get_hf_bert(self.rank)
             model = DDP(model, static_graph=static_graph)
             run_hf_bert_ddp(self, model, inputs, "aot_eager")
@@ -958,7 +964,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
             def forward(self, inp):
                 return self.fc3(self.fc2(self.fc1(inp)))
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             self.assertFalse(config.optimize_ddp)
             model = MyModel().to(device=self.device_type)
 
@@ -985,7 +993,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @config.patch(enable_compiler_collectives=True)
     @skip_if_lt_x_gpu(1)
     def test_fsdp_aot_eager(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             # Test with basic FSDP wrapping (outer wrap around whole model)
             m, inputs, correct_outputs = get_model(f"{self.device_type}:{self.rank}")
             fsdp_m = FSDP(m, use_orig_params=True)
@@ -1027,7 +1037,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
                 x = self.convp(x)
                 return x
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             net = Net().to(self.rank)
             optimizer = torch.optim.SGD(
                 net.parameters(),
@@ -1054,7 +1066,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @config.patch(enable_compiler_collectives=True)
     @skip_if_lt_x_gpu(1)
     def test_fsdp_setattr(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             # Test with basic FSDP wrapping (outer wrap around whole model)
             from torch._dynamo.utils import counters
 
@@ -1073,7 +1087,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @config.patch(enable_compiler_collectives=True)
     @skip_if_lt_x_gpu(1)
     def test_fsdp_unspecialized_forced_getattr_inline(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             # Test with basic FSDP wrapping (outer wrap around whole model)
             from torch._dynamo.utils import counters
 
@@ -1091,7 +1107,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @skip_if_lt_x_gpu(1)
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     def test_fsdp_inductor(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             # Test with basic FSDP wrapping (outer wrap around whole model)
             m, inputs, correct_outputs = get_model(f"{self.device_type}:{self.rank}")
             fsdp_m = FSDP(m, use_orig_params=True)
@@ -1116,7 +1134,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @skip_if_lt_x_gpu(1)
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     def test_fsdp_activation_checkpointing(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             model, inputs = get_toy_model_for_activation_checkpointing(
                 f"{self.device_type}:{self.rank}"
             )
@@ -1152,7 +1172,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
             )
             return model
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             for wrap_policy, test_instance in (
                 (None, "FSDP without recursive wrapping"),
             ):
@@ -1190,7 +1212,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     def test_hf_bert_fsdp_activation_checkpointing(self):
         from transformers.models.bert.modeling_bert import BertLayer
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             for wrap_policy, test_instance in (
                 (
                     functools.partial(
@@ -1234,7 +1258,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_automatic_dynamic_tensor(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
 
             class SimpleModel(nn.Module):
                 def __init__(self, input_size, output_size):
@@ -1279,7 +1305,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_automatic_dynamic_scalar(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             # TODO: This should be possible to do inside the function, but
@@ -1307,7 +1335,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_automatic_dynamic_speculation_divergence(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1337,7 +1367,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_graph_break_empty_graph_still_collective(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1369,7 +1401,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_dim_mismatch(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1398,7 +1432,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_missing_source(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1420,7 +1456,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_scalar_missing_source(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1442,7 +1480,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)
     def test_compiler_collectives_type_mismatch(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1478,7 +1518,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @enable_guard_collectives()
     def test_guard_collective(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1505,7 +1547,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @patch.object(torch._inductor.config, "max_autotune_gemm", True)
     @patch.object(torch._inductor.config, "distributed_max_autotune_gemm", True)
     def test_multiproc_autotune(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1541,7 +1585,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     @patch.object(torch._inductor.config, "max_autotune_gemm", True)
     @patch.object(torch._inductor.config, "distributed_max_autotune_gemm", True)
     def test_multiproc_autotune_dynamic_shapes(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             @torch.compile()
@@ -1612,7 +1658,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     def test_get_pg_attr(self):
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             pg = dist.distributed_c10d._get_default_group()
 
             device = f"{self.device_type}:{self.rank}"
@@ -1637,7 +1685,9 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     def test_asymmetric_compilation(self):
         from torch._dynamo.comptime import comptime
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             device = f"{self.device_type}:{self.rank}"
@@ -1690,7 +1740,12 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
         from torch._dynamo.utils import counters
         from torch._inductor.utils import fresh_cache
 
-        with fresh_cache(), _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with (
+            fresh_cache(),
+            _dynamo_dist_per_rank_init(
+                self.rank, self.world_size, rdvz_file=self.file_name
+            ),
+        ):
             torch._dynamo.utils.clear_compilation_metrics()
 
             device = f"{self.device_type}:{self.rank}"

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -319,7 +319,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             graph = make_fx(func)(*example_inputs)
             return inductor_compile_fx(graph, example_inputs)
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             example = functools.partial(
                 example,
                 **self.get_world_trs(),
@@ -357,7 +359,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             graph = make_fx(func)(*example_inputs)
             return inductor_compile_fx(graph, example_inputs)
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             matmul_cat_col = functools.partial(
                 matmul_cat_col,
                 **self.get_world_trs(),
@@ -396,7 +400,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             "triton.cudagraph_trees": True,
         }
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             compiled_func = torch.compile(
                 func, backend="inductor", fullgraph=True, options=options, dynamic=None
             )
@@ -420,7 +426,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
         # failed its "not tracked as outputs" pool check. The gathered buffer is
         # an intermediate here (consumed by + 1), so the leak is not masked by
         # being a graph output.
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             group_name = (
                 torch.distributed.distributed_c10d._get_default_group().group_name
             )
@@ -472,7 +480,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             graph = make_fx(func)(*example_inputs)
             return inductor_compile_fx(graph, example_inputs)
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             eager_func = functools.partial(
                 eager_func,
                 **self.get_world_trs(),
@@ -511,7 +521,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             graph = make_fx(func)(*example_inputs)
             return inductor_compile_fx(graph, example_inputs)
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             inductor_func = functools.partial(
                 inductor_func,
                 **self.get_world_trs(),
@@ -553,7 +565,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             # will not match eager.
             return y * y
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             x = torch.ones(12800, 12800, device=self.device) + self.rank
             self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
 
@@ -624,7 +638,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             e = d + ar
             return (e,)
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             inputs = torch.ones(4, 4, device=self.device) + self.rank
             compiled = torch.compile(func)
             out = compiled(inputs, **self.get_world_trs())
@@ -639,7 +655,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 tensor, src_dst_pairs, ranks, tag
             )
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             inputs = (
                 # rank0: [0., 1.], rank1: [2., 3.]
                 torch.arange(2, dtype=torch.float32, device=self.device)
@@ -674,7 +692,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 out = torch.cat(torch.chunk(res, world_size, dim=0), dim=last_dim)
                 return out
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             model = Model().to(self.device)
             model_compiled = torch.compile(model)
             inp = torch.tensor([[2, 1, 3, 0]], dtype=torch.long, device=self.device)
@@ -690,7 +710,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             torch.distributed.all_gather(tensor_list, tensor)
             return tensor_list
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             func_compiled = torch.compile(func)
             inp = torch.tensor(self.rank, dtype=torch.long, device=self.device)
             out = func_compiled(inp, self.world_size)
@@ -704,7 +726,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             torch.distributed.reduce_scatter(output, inputs)
             return output
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             inputs = [
                 torch.ones(4, 4, device=self.device) * (self.rank + i)
                 for i in range(self.world_size)
@@ -732,7 +756,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 out = y.transpose_(0, last_dim).contiguous()
                 return out
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             model = Model().to(self.device)
             model_compiled = torch.compile(model)
             inp = torch.tensor([[2, 1, 3, 0]], dtype=torch.long, device=self.device)
@@ -759,7 +785,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             graph = make_fx(func)(*example_inputs)
             return inductor_compile_fx(graph, example_inputs)
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             example = functools.partial(
                 example,
                 **self.get_world_trs(),
@@ -786,7 +814,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             graph = make_fx(func)(*example_inputs)
             return inductor_compile_fx(graph, example_inputs)
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             example = functools.partial(
                 example,
                 **self.get_world_trs(),
@@ -826,7 +856,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             return out
 
         with (
-            _dynamo_dist_per_rank_init(self.rank, self.world_size),
+            _dynamo_dist_per_rank_init(
+                self.rank, self.world_size, rdvz_file=self.file_name
+            ),
             torch._dynamo.config.patch(
                 dynamic_shapes=True,
                 capture_dynamic_output_shape_ops=True,
@@ -986,7 +1018,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             return torch.ops.custom_ns.foo(a2a)
 
         with (
-            _dynamo_dist_per_rank_init(self.rank, self.world_size),
+            _dynamo_dist_per_rank_init(
+                self.rank, self.world_size, rdvz_file=self.file_name
+            ),
             torch._dynamo.config.patch(
                 dynamic_shapes=True,
                 capture_dynamic_output_shape_ops=True,
@@ -1071,7 +1105,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             out = a2a / a2a.sum(dim=0)
             return out
 
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             inputs = (
                 torch.ones(self.world_size, self.world_size, device=self.device)
                 * (self.rank + 1),
@@ -1103,7 +1139,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
         # recompile on the tensor-class guard: the two produce an equivalent
         # graph (the runtime wrapper unwraps ACT). See
         # VariableBuilder.wrap_tensor / UnwrapCollectiveTensorSource.
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.reset()
             cnt = CompileCounter()
 
@@ -1141,7 +1179,9 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
         # across the ACT/Tensor alternation and not recompile on the class change.
         # Uses a real collective because grad flows through the all-gather autograd,
         # not through a directly-constructed ACT wrapper.
-        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+        with _dynamo_dist_per_rank_init(
+            self.rank, self.world_size, rdvz_file=self.file_name
+        ):
             torch._dynamo.reset()
             cnt = CompileCounter()
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -25,7 +25,6 @@ from enum import Enum
 from functools import partial, reduce, wraps
 from io import StringIO
 from typing import Any, NamedTuple
-from unittest.mock import patch
 
 import torch
 import torch._dynamo.test_case
@@ -1731,7 +1730,7 @@ class SaveForwardInputsModel(nn.Module):
 
 @contextmanager
 def _dynamo_dist_per_rank_init(
-    rank, world_size, backend=None, init_pg=True, fake_pg=False
+    rank, world_size, backend=None, init_pg=True, fake_pg=False, *, rdvz_file=None
 ):
     # To avoid multiple inheritance from _dynamo.test_case.TestCase and MultiProcessTestCase,
     # Just manually implement the most important part of the dynamo behavior to reset/clear.
@@ -1744,8 +1743,6 @@ def _dynamo_dist_per_rank_init(
     if backend is None:
         backend = c10d.get_default_backend_for_device(device_type)
 
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "6789"
     if init_pg:
         if fake_pg:
             store = torch.testing._internal.distributed.fake_pg.FakeStore()
@@ -1756,7 +1753,18 @@ def _dynamo_dist_per_rank_init(
                 store=store,
             )
         else:
-            c10d.init_process_group(backend=backend, rank=rank, world_size=world_size)
+            if rdvz_file is None:
+                # Legacy env:// rendezvous. Every rank must derive the same
+                # port here, so it cannot be allocated dynamically; pass
+                # rdvz_file instead to avoid colliding with concurrent runs.
+                os.environ["MASTER_ADDR"] = "localhost"
+                os.environ["MASTER_PORT"] = "6789"
+            c10d.init_process_group(
+                backend=backend,
+                store=c10d.FileStore(rdvz_file, world_size) if rdvz_file else None,
+                rank=rank,
+                world_size=world_size,
+            )
     torch._dynamo.reset()
     torch._dynamo.utils.counters.clear()
     try:
@@ -1779,27 +1787,26 @@ class DynamoDistributedSingleProcTestCase(torch._dynamo.test_case.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # _exit_stack is set up in TestCase
-        cls._exit_stack.enter_context(
-            patch.dict(
-                os.environ,
-                {
-                    "MASTER_ADDR": "localhost",
-                    "MASTER_PORT": "12355",
-                },
-            )
-        )
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            cls.rdvz_file = f.name
         cls.rank = 0
         device = torch.accelerator.current_accelerator().type
         cls.device = f"{device}:{cls.rank}"
         cls.device_ids = None if device in cls.device else [cls.rank]
         c10d.init_process_group(
-            c10d.get_default_backend_for_device(device), rank=cls.rank, world_size=1
+            c10d.get_default_backend_for_device(device),
+            store=c10d.FileStore(cls.rdvz_file, 1),
+            rank=cls.rank,
+            world_size=1,
         )
 
     @classmethod
     def tearDownClass(cls):
         c10d.destroy_process_group()
+        try:
+            os.remove(cls.rdvz_file)
+        except OSError:
+            pass
         super().tearDownClass()
 
 


### PR DESCRIPTION
## Summary

Three paths in the distributed test infrastructure hardcode a rendezvous port, so any two distributed test processes on the same host contend for it. `PythonProcessGroupExtensionTest` in `test_c10d_common.py` and `_dynamo_dist_per_rank_init` in `common_distributed.py` both pin `MASTER_PORT=6789`, and `DynamoDistributedSingleProcTestCase` pins 12355. The `_dynamo_dist_per_rank_init` path is the widest: it backs roughly a hundred tests across `test_dynamo_distributed.py`, `test_inductor_collectives.py`, `test_compute_comm_reordering.py`, and `test_aten_comm_compute_reordering.py`. A sequential run never sees the collision. The ROCm full-suite executor runs 16 tasks in parallel, and the loser either dies with `DistNetworkError ... port: 6789 ... EADDRINUSE` or attaches to the other run's TCPStore and hangs until the 300s harness timeout.

Every path now rendezvouses over a file rather than a TCP port. `PythonProcessGroupExtensionTest` uses the per-test temp file that `MultiProcessTestCase` already creates and propagates to every rank, wrapped in `dist.FileStore(self.file_name, self.world_size)` and passed as `store=`; `ProcessGroupWithDispatchedCollectivesTests` in the same file and `DistributedTestBase.create_pg` already do exactly this, and the `store=` form sidesteps the win32 `file://` URL quirk that `_init_methods` works around. `_dynamo_dist_per_rank_init` gains an `rdvz_file` keyword and builds its `FileStore` from that; its context manager has no access to the harness state, so each call site passes `self.file_name` explicitly. `DynamoDistributedSingleProcTestCase` allocates its own temp file in `setUpClass` and drops the `MASTER_ADDR`/`MASTER_PORT` patch entirely.

`find_free_port` was considered and rejected for both paths. It binds and closes, so another of the parallel tasks can still claim the port in the window before the store binds it, and keeping the reservation alive does not work either: TCPStore would have to bind that same port itself, and its `master_listen_fd` cannot be inherited through spawn under an `env://` rendezvous. The file rendezvous has no such gap.

The `env://` fallback in `_dynamo_dist_per_rank_init` is kept for callers that pass no `rdvz_file`, so out-of-tree users of the helper keep their current behavior. No in-tree caller takes it.

The nine `PythonProcessGroupExtensionTest` tests that rendezvous no longer exercise TCPStore. That is acceptable: they test the Python process-group extension API, and TCPStore has dedicated coverage elsewhere in the same file.

## Test Plan

Reproduction requires concurrency; every affected test passes when run on its own. Which instance fails is nondeterministic, and a losing instance may report the 300s timeout rather than EADDRINUSE.

Concurrent instances of the `test_c10d_common.py` tests. Before the change one instance fails with EADDRINUSE on port 6789 while the other completes in ~336s because of the 300s hang; after it both pass in ~39s, and a four-way stress passes in every instance:

```
cd test/distributed
for i in 1 2 3 4; do python -m pytest test_c10d_common.py -q -k PythonProcessGroupExtensionTest & done; wait
```

Same for the dynamo path, on disjoint GPUs so the port is the only shared resource. Otherwise NCCL resource exhaustion from oversubscribing the GPUs masks the port conflict with a different failure. One instance fails with EADDRINUSE before the change; both pass after it:

```
cd test/distributed
HIP_VISIBLE_DEVICES=0,1 python -m pytest test_dynamo_distributed.py -q -k test_ddp_baseline_aot_eager_multiprocess &
HIP_VISIBLE_DEVICES=2,3 python -m pytest test_dynamo_distributed.py -q -k test_ddp_baseline_aot_eager_multiprocess &
wait
```

No regressions. On 8x MI300-class GPUs with 2.13.0+rocm10.0.0rc4, giving 32 passed, 11 passed, and 21 passed / 7 skipped respectively:

```
cd test/distributed
PYTORCH_TEST_WITH_ROCM=1 python -m pytest test_c10d_common.py -q
PYTORCH_TEST_WITH_ROCM=1 python -m pytest test_c10d_object_collectives.py test_c10d_logger.py -q
PYTORCH_TEST_WITH_ROCM=1 python -m pytest test_dynamo_distributed.py -q -k TestMultiProc
```

On 4x gfx90a with HIP 7.14, covering the rewritten single-process harness, giving 32 passed:

```
cd test/distributed
python -m pytest test_dynamo_distributed.py -q -k TestSingleProc
```

Authored with the assistance of an AI coding assistant.
