### PR TITLE
[XPU][Refactor] Refactor test decoupling and device-agnostic in test_dynamo_decompositions.py and test_wrap_inductor_compiled_regions.py

### DIFF
--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -1,13 +1,12 @@
 # Owner(s): ["module: dynamo"]
 
-import unittest
-
 import torch
 import torch._dynamo.config
 import torch._dynamo.test_case
 from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skipIfCrossRef,
     TestCase,
@@ -22,6 +21,8 @@ class TestDynamoDecompositions(torch._dynamo.test_case.TestCase):
     into their constituent ops to avoid item() graph breaks.
     When False, the original ops are preserved.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfCrossRef
     def test_addcmul_inplace_decomposition_enabled(self):
@@ -611,6 +612,8 @@ class GraphModule(torch.nn.Module):
 class TestDynamoDecompositionsNumerics(TestCase):
     """Numerics tests for dynamo decompositions across devices."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_addcmul_tensor_value_numerics(self, device):
@@ -860,9 +863,30 @@ class TestDynamoDecompositionsNumerics(TestCase):
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    def test_addcdiv_scalar_value_cuda(self, device):
-        """Compiled addcdiv_ with scalar value matches eager on CUDA.
+    def test_add_scalar_alpha(self, device):
+        """Compiled add_ with scalar alpha matches eager."""
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device=device)
+        other = torch.randn(64, 64, device=device)
+
+        def fn(x, other):
+            return x.add_(other, alpha=2.3)
+
+        expected = fn(x.clone(), other)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other)  # noqa: UNSPECIFIED_BACKEND
+        self.assertEqual(expected, actual)
+
+
+@xfailIfNoAcceleratorTriton
+class TestDynamoDecompositionsNumericsDevice(TestCase):
+    """Accelerator numerics tests for dynamo decompositions."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcdiv_scalar_value(self, device):
+        """Compiled addcdiv_ with scalar value matches eager on accelerators.
 
         Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
         which nvcc can optimize differently than separate div + fma kernels.
@@ -881,9 +905,8 @@ class TestDynamoDecompositionsNumerics(TestCase):
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    def test_addcdiv_tensor_value_cuda(self, device):
-        """Compiled addcdiv_ with tensor value matches eager on CUDA.
+    def test_addcdiv_tensor_value(self, device):
+        """Compiled addcdiv_ with tensor value matches eager on accelerators.
 
         Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
         which nvcc can optimize differently than separate div + fma kernels.
@@ -901,23 +924,14 @@ class TestDynamoDecompositionsNumerics(TestCase):
         actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
-    @skipIfCrossRef
-    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    def test_add_scalar_alpha(self, device):
-        """Compiled add_ with scalar alpha matches eager."""
-        torch.manual_seed(42)
-        x = torch.randn(64, 64, device=device)
-        other = torch.randn(64, 64, device=device)
 
-        def fn(x, other):
-            return x.add_(other, alpha=2.3)
-
-        expected = fn(x.clone(), other)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), other)  # noqa: UNSPECIFIED_BACKEND
-        self.assertEqual(expected, actual)
-
-
-instantiate_device_type_tests(TestDynamoDecompositionsNumerics, globals())
+instantiate_device_type_tests(TestDynamoDecompositionsNumerics, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestDynamoDecompositionsNumericsDevice,
+    globals(),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -925,7 +925,9 @@ class TestDynamoDecompositionsNumericsDevice(TestCase):
         self.assertEqual(expected, actual)
 
 
-instantiate_device_type_tests(TestDynamoDecompositionsNumerics, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestDynamoDecompositionsNumerics, globals(), allow_xpu=True
+)
 instantiate_device_type_tests(
     TestDynamoDecompositionsNumericsDevice,
     globals(),

--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -4,7 +4,10 @@ import torch
 import torch._dynamo.config
 import torch._dynamo.test_case
 from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyOn,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -609,10 +612,10 @@ class GraphModule(torch.nn.Module):
 
 
 @xfailIfNoAcceleratorTriton
-class TestDynamoDecompositionsNumerics(TestCase):
+class TestDynamoDecompositionsNumericsDevice(TestCase):
     """Numerics tests for dynamo decompositions across devices."""
 
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
@@ -861,6 +864,49 @@ class TestDynamoDecompositionsNumerics(TestCase):
         actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
+    @onlyOn(["cuda", "xpu"])
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcdiv_scalar_value(self, device):
+        """Compiled addcdiv_ with scalar value matches eager on CUDA/XPU.
+
+        Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
+        which nvcc/icpx can optimize differently than separate div + fma kernels.
+        """
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device=device)
+        t1 = torch.randn(64, 64, device=device)
+        t2 = torch.randn(64, 64, device=device) + 0.1
+
+        def fn(x, t1, t2):
+            return x.addcdiv_(t1, t2, value=-0.01)
+
+        expected = fn(x.clone(), t1, t2)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)  # noqa: UNSPECIFIED_BACKEND
+        self.assertEqual(expected, actual)
+
+    @onlyOn(["cuda", "xpu"])
+    @skipIfCrossRef
+    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
+    def test_addcdiv_tensor_value(self, device):
+        """Compiled addcdiv_ with tensor value matches eager on CUDA/XPU.
+
+        Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
+        which nvcc/icpx can optimize differently than separate div + fma kernels.
+        """
+        torch.manual_seed(42)
+        x = torch.randn(64, 64, device=device)
+        t1 = torch.randn(64, 64, device=device)
+        t2 = torch.randn(64, 64, device=device) + 0.1
+        value = torch.tensor(-0.01, device=device)
+
+        def fn(x, t1, t2, value):
+            return x.addcdiv_(t1, t2, value=value)
+
+        expected = fn(x.clone(), t1, t2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)  # noqa: UNSPECIFIED_BACKEND
+        self.assertEqual(expected, actual)
+
     @skipIfCrossRef
     @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
     def test_add_scalar_alpha(self, device):
@@ -877,62 +923,8 @@ class TestDynamoDecompositionsNumerics(TestCase):
         self.assertEqual(expected, actual)
 
 
-@xfailIfNoAcceleratorTriton
-class TestDynamoDecompositionsNumericsDevice(TestCase):
-    """Accelerator numerics tests for dynamo decompositions."""
-
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    @skipIfCrossRef
-    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    def test_addcdiv_scalar_value(self, device):
-        """Compiled addcdiv_ with scalar value matches eager on accelerators.
-
-        Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
-        which nvcc can optimize differently than separate div + fma kernels.
-        """
-        torch.manual_seed(42)
-        x = torch.randn(64, 64, device=device)
-        t1 = torch.randn(64, 64, device=device)
-        t2 = torch.randn(64, 64, device=device) + 0.1
-
-        def fn(x, t1, t2):
-            return x.addcdiv_(t1, t2, value=-0.01)
-
-        expected = fn(x.clone(), t1, t2)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)  # noqa: UNSPECIFIED_BACKEND
-        self.assertEqual(expected, actual)
-
-    @skipIfCrossRef
-    @torch._dynamo.config.patch(enable_dynamo_decompositions=True)
-    def test_addcdiv_tensor_value(self, device):
-        """Compiled addcdiv_ with tensor value matches eager on accelerators.
-
-        Not bitwise: ATen inlines the division into fma(alpha, t1/t2, input)
-        which nvcc can optimize differently than separate div + fma kernels.
-        """
-        torch.manual_seed(42)
-        x = torch.randn(64, 64, device=device)
-        t1 = torch.randn(64, 64, device=device)
-        t2 = torch.randn(64, 64, device=device) + 0.1
-        value = torch.tensor(-0.01, device=device)
-
-        def fn(x, t1, t2, value):
-            return x.addcdiv_(t1, t2, value=value)
-
-        expected = fn(x.clone(), t1, t2, value)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)  # noqa: UNSPECIFIED_BACKEND
-        self.assertEqual(expected, actual)
-
-
 instantiate_device_type_tests(
-    TestDynamoDecompositionsNumerics, globals(), allow_xpu=True
-)
-instantiate_device_type_tests(
-    TestDynamoDecompositionsNumericsDevice,
-    globals(),
-    only_for=("cuda", "xpu"),
-    allow_xpu=True,
+    TestDynamoDecompositionsNumericsDevice, globals(), allow_xpu=True
 )
 
 if __name__ == "__main__":

--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -12,7 +12,9 @@ from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._inductor import config as inductor_config
 from torch.nn.attention.flex_attention import flex_attention, flex_attention_hop
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.triton_utils import requires_gpu_and_triton
 from torch.utils._debug_mode import DebugMode
 from torch.utils.checkpoint import (
     checkpoint,
@@ -71,11 +73,13 @@ def count_ops(
     return gm
 
 
-class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
+class TestWrapInductorCompiledRegionsDevice(torch._dynamo.test_case.TestCase):
     """Tests for wrap_inductor_compiled_regions option"""
 
-    @requires_cuda_and_triton
-    def test_wrap_enabled_visible_in_debug_mode(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_gpu_and_triton
+    def test_wrap_enabled_visible_in_debug_mode(self, device):
         """Test that compiled regions are wrapped when option is enabled"""
 
         @torch.compile(
@@ -86,8 +90,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -101,8 +105,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
-    def test_wrap_name_visible_in_debug_mode(self):
+    @requires_gpu_and_triton
+    def test_wrap_name_visible_in_debug_mode(self, device):
         """Test that named compiled regions surface their name in DebugMode"""
 
         @torch.compile(
@@ -114,8 +118,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -128,8 +132,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
-    def test_wrap_disabled_not_visible_in_debug_mode(self):
+    @requires_gpu_and_triton
+    def test_wrap_disabled_not_visible_in_debug_mode(self, device):
         """Test that compiled regions are not wrapped when option is disabled"""
 
         @torch.compile(
@@ -140,8 +144,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -155,16 +159,16 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
-    def test_wrap_default_disabled(self):
+    @requires_gpu_and_triton
+    def test_wrap_default_disabled(self, device):
         """Test that wrapping is disabled by default"""
 
         @torch.compile(backend="inductor", fullgraph=True)
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -178,8 +182,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = torch.matmul(x, y)
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
-    def test_wrap_with_backward(self):
+    @requires_gpu_and_triton
+    def test_wrap_with_backward(self, device):
         """Test that wrapping works correctly with backward pass"""
 
         @torch.compile(
@@ -190,8 +194,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         # Clone for eager comparison
         x_eager = x.detach().clone().requires_grad_(True)
@@ -218,8 +222,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
-    def test_wrap_with_multiple_ops(self):
+    @requires_gpu_and_triton
+    def test_wrap_with_multiple_ops(self, device):
         """Test wrapping with a function that has multiple operations"""
 
         @torch.compile(
@@ -233,8 +237,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             c = b + x
             return c
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         with DebugMode() as debug_mode:
             result = fn(x, y)
@@ -250,8 +254,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         expected = b + x
         self.assertEqual(result, expected)
 
-    @requires_cuda_and_triton
-    def test_wrap_option_type_validation(self):
+    @requires_gpu_and_triton
+    def test_wrap_option_type_validation(self, device):
         """Test that wrap_inductor_compiled_regions validates type correctly"""
 
         # Should accept bool
@@ -269,7 +273,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn_false(x):
             return x + 1
 
-        x = torch.randn(4, device="cuda")
+        x = torch.randn(4, device=device)
         _ = fn_true(x)
         _ = fn_false(x)
 
@@ -285,8 +289,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         self.assertIn("Unexpected type", str(cm.exception))
 
-    @requires_cuda_and_triton
-    def test_wrap_per_compilation(self):
+    @requires_gpu_and_triton
+    def test_wrap_per_compilation(self, device):
         """Test that wrap option is per-compilation, not global"""
 
         @torch.compile(
@@ -305,8 +309,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn_not_wrapped(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # First function should be wrapped
         with DebugMode() as debug_mode1:
@@ -318,11 +322,11 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             _ = fn_not_wrapped(x, y)
         self.assertNotIn("inductor_compiled_code", debug_mode2.debug_string())
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_wrap_with_cache(self):
+    def test_wrap_with_cache(self, device):
         """
         Test that wrap_inductor_compiled_regions works correctly with caching.
         Verify that the wrapper is properly applied when loading from cache by
@@ -334,8 +338,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # Clear all caches and counters
         counters.clear()
@@ -398,11 +402,11 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(result1, expected)
         self.assertEqual(result2, expected)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_wrap_config_affects_cache_key(self):
+    def test_wrap_config_affects_cache_key(self, device):
         """
         Test that wrap_inductor_compiled_regions is part of the cache key.
         Changing this option should cause a cache miss because it produces
@@ -413,8 +417,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         def fn(x, y):
             return torch.matmul(x, y)
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=device)
+        y = torch.randn(4, 4, device=device)
 
         # Clear all caches and counters
         counters.clear()
@@ -490,8 +494,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         # Unwrapped version should not
         self.assertNotIn("inductor_compiled_code", debug_unwrapped.debug_string())
 
-    @requires_cuda_and_triton
-    def test_flex_attention_with_wrapper_basic(self):
+    @requires_gpu_and_triton
+    def test_flex_attention_with_wrapper_basic(self, device):
         """Test that flex_attention works with wrap_inductor_compiled_regions=True"""
 
         def causal_score_mod(score, b, h, q_idx, k_idx):
@@ -506,9 +510,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return flex_attention(q, k, v, score_mod=causal_score_mod)
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Test forward pass
         output = fn(q, k, v)
@@ -526,8 +530,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         output_unwrapped = fn_unwrapped(q, k, v)
         torch.testing.assert_close(output, output_unwrapped, rtol=1e-3, atol=1e-3)
 
-    @requires_cuda_and_triton
-    def test_flex_attention_wrapper_visible_in_debug_mode(self):
+    @requires_gpu_and_triton
+    def test_flex_attention_wrapper_visible_in_debug_mode(self, device):
         """Test that inductor_compiled_code HOP is visible to DebugMode when wrapper is enabled"""
 
         def score_mod(score, b, h, q_idx, k_idx):
@@ -550,9 +554,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return flex_attention(q, k, v, score_mod=score_mod)
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Test with wrapper enabled - should see inductor_compiled_code HOP
         with DebugMode() as debug_wrapped:
@@ -576,8 +580,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             "inductor_compiled_code HOP should not be visible when wrapper is disabled",
         )
 
-    @requires_cuda_and_triton
-    def test_flex_attention_wrapper_with_backward(self):
+    @requires_gpu_and_triton
+    def test_flex_attention_wrapper_with_backward(self, device):
         """Test that wrapper works correctly with backward pass"""
 
         def score_mod(score, b, h, q_idx, k_idx):
@@ -593,13 +597,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward and backward
@@ -633,11 +637,11 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @inductor_config.patch("fx_graph_cache", True)
     @inductor_config.patch("fx_graph_remote_cache", False)
     @functorch_config.patch({"enable_autograd_cache": True})
-    def test_flex_attention_wrapper_with_cache(self):
+    def test_flex_attention_wrapper_with_cache(self, device):
         """Test that wrapper works correctly with caching"""
         from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 
@@ -656,9 +660,9 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             return fn
 
         B, H, S, D = 2, 4, 128, 64
-        q = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device="cuda", dtype=torch.float16)
+        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
         # Clear all caches
         counters.clear()
@@ -702,8 +706,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         # Verify correctness
         torch.testing.assert_close(result1, result2)
 
-    @requires_cuda_and_triton
-    def test_flex_attention_with_sac_must_save(self):
+    @requires_gpu_and_triton
+    def test_flex_attention_with_sac_must_save(self, device):
         """
         Test that SAC policy MUST_SAVE for flex_attention_hop
         prevents recomputation during backward when used with wrapper.
@@ -739,13 +743,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward compiler: should see flex_attention_hop once
@@ -786,8 +790,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(k.grad)
         self.assertIsNotNone(v.grad)
 
-    @requires_cuda_and_triton
-    def test_flex_attention_with_sac_prefer_recompute(self):
+    @requires_gpu_and_triton
+    def test_flex_attention_with_sac_prefer_recompute(self, device):
         """
         Test that SAC policy PREFER_RECOMPUTE for flex_attention_hop
         causes recomputation during backward when used with wrapper.
@@ -824,13 +828,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Forward compiler: should see flex_attention_hop once
@@ -871,8 +875,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertIsNotNone(k.grad)
         self.assertIsNotNone(v.grad)
 
-    @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_basic(self):
+    @requires_gpu_and_triton
+    def test_sac_outer_compile_inner_basic(self, device):
         """
         Test SAC(compile(foo)) pattern - SAC on eager code with inner compiled region.
 
@@ -909,8 +913,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             b = torch.relu(a)
             return b
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         # Clone for comparison
         x_eager = x.detach().clone().requires_grad_(True)
@@ -951,8 +955,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_name_visible_to_policy(self):
+    @requires_gpu_and_triton
+    def test_sac_outer_compile_inner_name_visible_to_policy(self, device):
         """Test that SAC policies can inspect torch.compile region names"""
 
         @torch.compile(
@@ -977,8 +981,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             a = inner_compiled_matmul(x, y)
             return torch.relu(a)
 
-        x = torch.randn(4, 4, device="cuda", requires_grad=True)
-        y = torch.randn(4, 4, device="cuda", requires_grad=True)
+        x = torch.randn(4, 4, device=device, requires_grad=True)
+        y = torch.randn(4, 4, device=device, requires_grad=True)
 
         x_eager = x.detach().clone().requires_grad_(True)
         y_eager = y.detach().clone().requires_grad_(True)
@@ -1005,8 +1009,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         self.assertEqual(x.grad, x_eager.grad)
         self.assertEqual(y.grad, y_eager.grad)
 
-    @requires_cuda_and_triton
-    def test_wrap_no_dispatch_mode_no_hop_invoked(self):
+    @requires_gpu_and_triton
+    def test_wrap_no_dispatch_mode_no_hop_invoked(self, device):
         """
         Test that without TorchDispatchMode, the HOP is NOT invoked.
 
@@ -1032,8 +1036,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             def fn(x, y):
                 return torch.matmul(x, y)
 
-            x = torch.randn(4, 4, device="cuda")
-            y = torch.randn(4, 4, device="cuda")
+            x = torch.randn(4, 4, device=device)
+            y = torch.randn(4, 4, device=device)
             expected = torch.matmul(x, y)
 
             result_without = fn(x, y)
@@ -1057,8 +1061,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             def fn2(x, y):
                 return torch.matmul(x, y)
 
-            x2 = torch.randn(4, 4, device="cuda")
-            y2 = torch.randn(4, 4, device="cuda")
+            x2 = torch.randn(4, 4, device=device)
+            y2 = torch.randn(4, 4, device=device)
             expected2 = torch.matmul(x2, y2)
 
             with DebugMode():
@@ -1068,8 +1072,8 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             mock_hop.assert_called()
             self.assertEqual(result_with, expected2)
 
-    @requires_cuda_and_triton
-    def test_sac_outer_compile_inner_flex_attention(self):
+    @requires_gpu_and_triton
+    def test_sac_outer_compile_inner_flex_attention(self, device):
         """
         Test SAC(compile(foo)) with flex_attention - the key motivating use case.
 
@@ -1103,13 +1107,13 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         B, H, S, D = 2, 4, 128, 64
         q = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         k = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
         v = torch.randn(
-            B, H, S, D, device="cuda", dtype=torch.float16, requires_grad=True
+            B, H, S, D, device=device, dtype=torch.float16, requires_grad=True
         )
 
         # Enable wrapping at the inductor config level so that flex_attention's
@@ -1150,6 +1154,86 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         torch.testing.assert_close(q.grad, q2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(k.grad, k2.grad, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(v.grad, v2.grad, rtol=1e-3, atol=1e-3)
+
+    @unittest.skipIf(not torch.accelerator.is_available(), "requires GPU")
+    def test_hop_codegen_releases_multiple_boxed_inputs_before_dispatch(self, device):
+        from torch._higher_order_ops.wrap import (
+            inductor_code_side_table,
+            inductor_compiled_code,
+            InductorCompiledCallable,
+        )
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        dtype = torch.uint8
+        num_saved = 2
+        saved_size = 8 * 1024 * 1024
+        iterations = 3
+        live_before_scratch = []
+        peak_during_backward = []
+        baseline_memory = 0
+        track_memory = False
+
+        def cleanup():
+            torch.accelerator.empty_cache()
+            torch.accelerator.reset_peak_memory_stats()
+
+        def fw_callable(inputs):
+            x = inputs[0]
+            return (x + 1, x + 2)
+
+        def bw_callable(inputs):
+            if track_memory:
+                inputs.clear()
+                live_before_scratch.append(
+                    torch.accelerator.memory_allocated() - baseline_memory
+                )
+                scratch = torch.empty((saved_size,), device=device, dtype=dtype)
+                peak_during_backward.append(
+                    torch.accelerator.max_memory_allocated() - baseline_memory
+                )
+                del scratch
+                return (torch.empty((), device=device, dtype=dtype),)
+            return (inputs[0] + inputs[1],)
+
+        inductor_code_side_table.reset_table()
+        fw = InductorCompiledCallable(fw_callable)
+        bw = InductorCompiledCallable(bw_callable)
+
+        def wrapper(x):
+            out = inductor_compiled_code(fw, [x], name="minimal_fw")
+            return inductor_compiled_code(
+                bw,
+                [out[i] for i in range(num_saved)],
+                name="minimal_bw",
+            )
+
+        gm = make_fx(wrapper)(torch.empty((saved_size,), dtype=dtype))
+        track_memory = True
+
+        try:
+            for _ in range(iterations):
+                cleanup()
+                inp = torch.empty((saved_size,), device=device, dtype=dtype)
+                baseline_memory = torch.accelerator.memory_allocated()
+                out = gm(inp)
+                torch.accelerator.synchronize()
+                del out, inp
+                cleanup()
+        finally:
+            inductor_code_side_table.reset_table()
+
+        max_live_before_scratch = max(live_before_scratch)
+        max_peak_during_backward = max(peak_during_backward)
+        self.assertLess(max_live_before_scratch, saved_size // 4)
+        self.assertLess(
+            max_peak_during_backward, num_saved * saved_size + saved_size // 2
+        )
+
+
+class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
+    """Device-agnostic tests for wrap_inductor_compiled_regions."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_fake_tensor_mode_works(self):
         """Test that running compiled code inside FakeTensorMode works with FX graph fallback"""
@@ -1312,81 +1396,6 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(alive_during_call, [False])
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_hop_codegen_releases_multiple_boxed_inputs_before_dispatch(self):
-        from torch._higher_order_ops.wrap import (
-            inductor_code_side_table,
-            inductor_compiled_code,
-            InductorCompiledCallable,
-        )
-        from torch.fx.experimental.proxy_tensor import make_fx
-
-        device = torch.device("cuda")
-        dtype = torch.uint8
-        num_saved = 2
-        saved_size = 8 * 1024 * 1024
-        iterations = 3
-        live_before_scratch = []
-        peak_during_backward = []
-        baseline_memory = 0
-        track_memory = False
-
-        def cleanup():
-            torch.cuda.empty_cache()
-            torch.cuda.reset_peak_memory_stats()
-
-        def fw_callable(inputs):
-            x = inputs[0]
-            return (x + 1, x + 2)
-
-        def bw_callable(inputs):
-            if track_memory:
-                inputs.clear()
-                live_before_scratch.append(
-                    torch.cuda.memory_allocated() - baseline_memory
-                )
-                scratch = torch.empty((saved_size,), device=device, dtype=dtype)
-                peak_during_backward.append(
-                    torch.cuda.max_memory_allocated() - baseline_memory
-                )
-                del scratch
-                return (torch.empty((), device=device, dtype=dtype),)
-            return (inputs[0] + inputs[1],)
-
-        inductor_code_side_table.reset_table()
-        fw = InductorCompiledCallable(fw_callable)
-        bw = InductorCompiledCallable(bw_callable)
-
-        def wrapper(x):
-            out = inductor_compiled_code(fw, [x], name="minimal_fw")
-            return inductor_compiled_code(
-                bw,
-                [out[i] for i in range(num_saved)],
-                name="minimal_bw",
-            )
-
-        gm = make_fx(wrapper)(torch.empty((saved_size,), dtype=dtype))
-        track_memory = True
-
-        try:
-            for _ in range(iterations):
-                cleanup()
-                inp = torch.empty((saved_size,), device=device, dtype=dtype)
-                baseline_memory = torch.cuda.memory_allocated()
-                out = gm(inp)
-                torch.cuda.synchronize()
-                del out, inp
-                cleanup()
-        finally:
-            inductor_code_side_table.reset_table()
-
-        max_live_before_scratch = max(live_before_scratch)
-        max_peak_during_backward = max(peak_during_backward)
-        self.assertLess(max_live_before_scratch, saved_size // 4)
-        self.assertLess(
-            max_peak_during_backward, num_saved * saved_size + saved_size // 2
-        )
-
     @unittest.skipIf(not torch.distributed.is_available(), "requires torch.distributed")
     def test_sac_cached_value_fifo_mismatch(self):
         """
@@ -1459,6 +1468,14 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
                 out.sum().backward()
         finally:
             dist.destroy_process_group()
+
+
+instantiate_device_type_tests(
+    TestWrapInductorCompiledRegionsDevice,
+    globals(),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactor test decoupling in test_dynamo_decompositions.py and test_wrap_inductor_compiled_regions.py:

- move GPU-only cases to class TestWrapInductorCompiledRegionsDevice in test_wrap_inductor_compiled_regions.py
- port device agnostic cases to xpu
- add hardware classification

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98