### PR TITLE
[Testcase Refactoring][quantization][eager] Add GENERIC hw_classification to test_quantize_eager_ptq.py

### DIFF
--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -63,6 +63,7 @@ from torch.testing._internal.common_quantized import (
     override_quantized_engine,
     supported_qengines,
 )
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 hu.assert_deadline_disabled()
@@ -72,6 +73,8 @@ import numpy as np
 
 
 class TestQuantizeEagerOps(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @override_qengines
     def _test_reference_module_impl(
         self,
@@ -334,6 +337,8 @@ class TestQuantizeEagerOps(QuantizationTestCase):
 
 
 class TestQuantizeEagerPTQStatic(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_single_layer(self):
         r"""Quantize SingleLayerLinearModel which has one Linear module, make sure it is swapped
         to nnq.Linear which is the quantized version of the module
@@ -1233,6 +1238,8 @@ class TestQuantizeEagerPTQStatic(QuantizationTestCase):
 
 @skipIfNoFBGEMM
 class TestQuantizeEagerPTQDynamic(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_single_layer(self):
         r"""Dynamic Quantize SingleLayerLinearDynamicModel which has one Linear module,
         make sure it is swapped to nnqd.Linear which is the quantized version of


### PR DESCRIPTION
## Summary

This PR marks `test/quantization/eager/test_quantize_eager_ptq.py` as
device-agnostic by adding
`hw_classification = HardwareClassification.GENERIC` to
`TestQuantizeEagerOps`, `TestQuantizeEagerPTQStatic`, and
`TestQuantizeEagerPTQDynamic`, aligning with the community device-adaptation
spec and enabling hardware-agnostic test filtering.

### Why no decoupling is needed

`test_quantize_eager_ptq.py` contains only pure-CPU eager-mode post-training
quantization logic with **no accelerator-specific code**. Per the decoupling
standard, a test case only needs decoupling if it has any of the following —
none apply here:

| Check | Result |
|---|---|
| Hardcoded `"cuda"` string / device instance | ❌ None |
| CUDA-only decorators (`@onlyCUDA`, `@skipCUDAIf`, ...) | ❌ None |
| Ops/tensors pinned to CUDA device | ❌ None (all `.to(...)` are dtype-only) |
| CUDA-only device branches | ❌ None |
| `instantiate_device_type_tests` / device dispatch | ❌ None |

All test methods exercise the eager-mode PTQ flow (float vs. quantized
reference modules, static and dynamic quantization) entirely on CPU tensors.
No decoupling is therefore required.

Note: `TestQuantizeEagerPTQDynamic` is decorated with `@skipIfNoFBGEMM`, a
CPU-engine (FBGEMM) availability guard that is unrelated to CUDA and is left
unchanged.

### Changes

- Add `HardwareClassification` to the `common_utils` import
- `TestQuantizeEagerOps.hw_classification = HardwareClassification.GENERIC`
- `TestQuantizeEagerPTQStatic.hw_classification = HardwareClassification.GENERIC`
- `TestQuantizeEagerPTQDynamic.hw_classification = HardwareClassification.GENERIC`

No test methods, test count, or execution semantics are changed.

## Test Plan

CPU: `python -m pytest test/quantization/eager/test_quantize_eager_ptq.py -v` (macOS arm64, Python 3.14)

TestQuantizeEagerOps: 11 passed 
TestQuantizeEagerPTQStatic: 1 failed, 8 passed, 12 skipped 
TestQuantizeEagerPTQDynamic: 13 skipped

- The 25 skips are `@skipIfNoFBGEMM` (class-level on `TestQuantizeEagerPTQDynamic`); FBGEMM is unavailable on arm64 macOS.
- The single failure (`test_quantized_embedding_bag`, quantized-embedding serialization in `torch.jit.load`) is pre-existing: the unmodified file gives identical results.
- CUDA: covered by the Pull Request CI (same command, 45 tests).
- `pytest --collect-only`: 45 tests collected.