### PR TITLE
[autograd] Route two-sided clamp.Tensor backward through a private

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -23,6 +23,7 @@
 #else
 #include <ATen/ops/_aminmax_native.h>
 #include <ATen/ops/_assert_async_native.h>
+#include <ATen/ops/_clamp_backward_tensor_native.h>
 #include <ATen/ops/_assert_scalar_native.h>
 #include <ATen/ops/_functional_assert_async_native.h>
 #include <ATen/ops/_functional_assert_scalar_native.h>
@@ -936,6 +937,28 @@ TORCH_IMPL_FUNC(clamp_Tensor_out)
   } else if (max) {
     minimum_stub(device_type(), *this);
   }
+}
+
+static Tensor masked_fill_inplace_if_safe(
+    const Tensor& tensor,
+    const Tensor& mask,
+    const Scalar& value) {
+  return areAnyTensorSubclassLike({tensor, mask})
+      ? tensor.masked_fill(mask, value)
+      : tensor.masked_fill_(mask, value);
+}
+
+Tensor _clamp_backward_tensor_composite(
+    const Tensor& grad_output,
+    const Tensor& self,
+    const Tensor& min,
+    const Tensor& max) {
+  const auto min_lt_max = min < max;
+  const auto tie =
+      ((self == min).logical_or(self == max)).logical_and(min_lt_max);
+  const auto inactive = (self < min).logical_or(self > max);
+  return masked_fill_inplace_if_safe(
+      at::where(tie, grad_output / 2, grad_output), inactive, 0);
 }
 
 TORCH_IMPL_FUNC(clamp_max_out)

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -23,8 +23,8 @@
 #else
 #include <ATen/ops/_aminmax_native.h>
 #include <ATen/ops/_assert_async_native.h>
-#include <ATen/ops/_clamp_backward_tensor_native.h>
 #include <ATen/ops/_assert_scalar_native.h>
+#include <ATen/ops/_clamp_backward_tensor_native.h>
 #include <ATen/ops/_functional_assert_async_native.h>
 #include <ATen/ops/_functional_assert_scalar_native.h>
 #include <ATen/ops/_make_per_tensor_quantized_tensor.h>

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1513,6 +1513,12 @@
   structured_delegate: clamp.Tensor_out
   tags: [core, pointwise]
 
+- func: _clamp_backward_tensor(Tensor grad_output, Tensor self, Tensor min, Tensor max) -> Tensor
+  device_check: NoCheck   # TensorIterator
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: _clamp_backward_tensor_composite
+
 - func: clamp_(Tensor(a!) self, Scalar? min=None, Scalar? max=None) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: function, method

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2836,6 +2836,23 @@ class TestBinaryUfuncsDevice(TestCase):
             ).tangent
         self.assertEqual(tangent, [1.0, float("nan"), float("nan"), 1.0])
 
+    @onlyOn("xpu")
+    def test_tensor_clamp_subgradient_mixed_bounds_xpu(self, device):
+        # Regression test: T5 builds fp32 clamp bounds via torch.where(bool,
+        # py_float, py_float) while hidden_states are fp16. The fused XPU
+        # kernel must handle mixed-dtype bounds without changing comparison
+        # semantics (bounds must not be truncated to fp16).
+        act = torch.tensor([0.5, 0.5, 0.5], device=device, dtype=torch.float16,
+                           requires_grad=True)
+        lo = torch.tensor([-1e4, 1.0, -1e4], device=device, dtype=torch.float32)
+        hi = torch.tensor([1e4, 2.0, 1e4], device=device, dtype=torch.float32)
+        torch.clamp(act, min=lo, max=hi).sum().backward()
+        # v=0.5 with [-1e4, 1e4]: interior -> grad 1.0
+        # v=0.5 with [1.0, 2.0]: below lo=1.0 -> grad 0.0
+        self.assertEqual(act.grad, torch.tensor([1.0, 0.0, 1.0], dtype=torch.float16,
+                                                device=device))
+        self.assertEqual(act.grad.dtype, torch.float16)
+
     @dtypes(torch.float, torch.double)
     def test_min_max_nan_gradients(self, device, dtype):
         for op, a_values in (

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2842,15 +2842,17 @@ class TestBinaryUfuncsDevice(TestCase):
         # py_float, py_float) while hidden_states are fp16. The fused XPU
         # kernel must handle mixed-dtype bounds without changing comparison
         # semantics (bounds must not be truncated to fp16).
-        act = torch.tensor([0.5, 0.5, 0.5], device=device, dtype=torch.float16,
-                           requires_grad=True)
+        act = torch.tensor(
+            [0.5, 0.5, 0.5], device=device, dtype=torch.float16, requires_grad=True
+        )
         lo = torch.tensor([-1e4, 1.0, -1e4], device=device, dtype=torch.float32)
         hi = torch.tensor([1e4, 2.0, 1e4], device=device, dtype=torch.float32)
         torch.clamp(act, min=lo, max=hi).sum().backward()
         # v=0.5 with [-1e4, 1e4]: interior -> grad 1.0
         # v=0.5 with [1.0, 2.0]: below lo=1.0 -> grad 0.0
-        self.assertEqual(act.grad, torch.tensor([1.0, 0.0, 1.0], dtype=torch.float16,
-                                                device=device))
+        self.assertEqual(
+            act.grad, torch.tensor([1.0, 0.0, 1.0], dtype=torch.float16, device=device)
+        )
         self.assertEqual(act.grad.dtype, torch.float16)
 
     @dtypes(torch.float, torch.double)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -422,6 +422,13 @@
   min, max: clamp_backward_min_max(grad, self, min, max, grad_input_mask)
   result: clamp_jvp(self_p, self_t, min_p, min_t, max_p, max_t)
 
+- name: _clamp_backward_tensor(Tensor grad_output, Tensor self, Tensor min, Tensor max) -> Tensor
+  grad_output: _clamp_backward_tensor(grad, self, min, max)
+  self: zeros_like(self)
+  min: zeros_like(min)
+  max: zeros_like(max)
+  result: _clamp_backward_tensor(grad_output_t, self_p, min_p, max_p)
+
 - name: clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
   self: clamp_backward(grad, self, min, max)
   result: auto_element_wise

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -341,6 +341,7 @@ def _core_aten_decompositions_post_autograd() -> dict[
             aten.celu,
             aten.celu_,
             aten.channel_shuffle,
+            aten._clamp_backward_tensor,
             aten.clamp_max,
             aten.clamp_min,
             aten.col2im,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -217,6 +217,15 @@ def hardtanh_backward(
     return torch.where((self <= min_val) | (self >= max_val), 0.0, grad_output)
 
 
+@register_decomposition(aten._clamp_backward_tensor)
+def _clamp_backward_tensor(
+    grad_output: Tensor, self: Tensor, min: Tensor, max: Tensor
+) -> Tensor:
+    tie = ((self == min) | (self == max)) & (min < max)
+    inactive = (self < min) | (self > max)
+    return torch.where(inactive, 0, torch.where(tie, grad_output / 2, grad_output))
+
+
 @register_decomposition(aten.hardswish)
 @out_wrapper()
 @pw_cast_for_opmath

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1460,13 +1460,7 @@ Tensor clamp_backward(
     const Tensor& min,
     const Tensor& max) {
   if (max.defined() && min.defined()) {
-    const auto min_lt_max = min < max;
-    const auto tie =
-        ((self == min).logical_or(self == max)).logical_and(min_lt_max);
-    const auto inactive = (self < min).logical_or(self > max);
-    // The same strict losing-side mask handles ordered, equal, and reversed
-    // finite bounds.
-    return masked_fill_inplace_if_safe(where(tie, grad / 2, grad), inactive, 0);
+    return at::_clamp_backward_tensor(grad, self, min, max);
   } else if (min.defined()) {
     return masked_fill_inplace_if_safe(
         where(self == min, grad / 2, grad), self < min, 0);


### PR DESCRIPTION
dispatched op

- Problem: pytorch/pytorch#191142 rewrote the two-sided clamp.backward(gard, self, Tensor min, Tensor max) self-gradient from 5 to 11 element-wise ops in order to split the 1/2-gradient correctly at ties. The chain is inlined in FunctionsManual.cpp, so no backend can fuse it and every caller pays 11 kernel dispatches. On launch-bound hardware this is expensive: hf_T5_large float16 training issues 120 such calls per training step, and on an Arc B580 the 11-op chain costs roughly 380% more per call than the 5-op version it replaced.
- Root cause: the subgradient formula is hard-coded inside the autograd function. There is no dispatch point at which a backend can provide a fused kernel, and no ATen op that tracers can reason about or decompose.
- Fix: extract the two-sided path into a new private op aten::_clamp_backward_tensor.
  - The CompositeExplicitAutograd kernel (_clamp_backward_tensor_composite in native/TensorCompare.cpp) is the existing 11-op sequence moved verbatim, so behavior is unchanged on every backend.
  - clamp_backward() in FunctionsManual.cpp now calls the op. The min-only and amx-only branches are left untouched.
  - derivatives.yaml entry: the mask depends on self/min/max only through comparisons, so those carry no second-order gradient, and grad_output is re-masked exactly as in the first order.
  - A decomposition is registered in torch/_decomp so tracers don't see an opaque node. This is required: CompositeExplicitAutograd ops are NOT auto-decomposed durning AOTAutograd tracing, so without it the new op becomes an inductor extern-kernel fallback and the 11 element-wise ops stop fusing into neighbouring backward kernels on every backend. Measured on an Arc B580 at hf_T5_large's real shape ([2,128,1024] float16 activations, 0-dim float32 bounds): without the decomposition inductor emits one extern-kernel fakkback and 4 triton kernels; with it, no fallback and 3 triton kernels, and the compiled backward is 14% faster. No XPU dispatch entry is added here. It follows in a separate change once the fused kernel exists in torch-xpu-ops, because the kernel needs this op's generated header to compile while the dispatch entry needs the kernel's symbol to link.
- Validation:
  - pytest test/test_binary_ufuncs.py -k "clamp and xpu": 486 passed
  - pytest test/test_ops.py -k "clamp and xpu": 90 passed
  - pytest test/test_meta.py -k clamp: 282 passed
  - pytest test/test_decomp.py -k clamp: 58 passed
  - PYTORCH_TEST_WITH_SLOW=1 pytest test/test_schema_check.py -k clamp: 29 passed
  - pytest test/test_decomp.py -k "TestDecompOpInfo or table or opset or core": 50 passed
  - pytest test/export/test_export.py -k decomp: 2 passed
  - the decomposition was verified bit-exact against the composite across boundary cases (equal, reversed and reversed-at-min bounds, NaN self), all four float dtypes, mixed and reverse-mixed bound dtypes, broadcast and non-contiguous inputs, and a 4096 randomized elements drawn so that exact ties are hit; gradcheck and gradgradcheck pass.
- Additional tests: added - a mixed-dtype clamp subgradient test.

Related: intel/torch-xpu-ops#5155