### PR TITLE
Make c10::List's iterator model the concepts it claims

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -8,6 +8,8 @@
 #include <c10/util/TypeList.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/ArrayRef.h>
+#include <compare>
+#include <iterator>
 #include <optional>
 #include <vector>
 
@@ -47,10 +49,15 @@ template<class T, class Iterator>
 void swap(ListElementReference<T, Iterator>&& lhs, ListElementReference<T, Iterator>&& rhs) noexcept;
 
 template<class T, class Iterator>
-bool operator==(const ListElementReference<T, Iterator>& lhs, const T& rhs);
+T iter_move(const ListIterator<T, Iterator>& it);
 
 template<class T, class Iterator>
-bool operator==(const T& lhs, const ListElementReference<T, Iterator>& rhs);
+void iter_swap(
+    const ListIterator<T, Iterator>& lhs,
+    const ListIterator<T, Iterator>& rhs) noexcept;
+
+template<class T, class Iterator>
+bool operator==(const ListElementReference<T, Iterator>& lhs, const T& rhs);
 
 template<class T>
 struct ListElementConstReferenceTraits {
@@ -73,12 +80,15 @@ public:
       const T&,
       T>() const;
 
-  ListElementReference& operator=(T&& new_value) &&;
+  // Const-qualified: std::indirectly_writable requires it.
+  // NOLINTBEGIN(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+  const ListElementReference& operator=(T&& new_value) const&&;
 
-  ListElementReference& operator=(const T& new_value) &&;
+  const ListElementReference& operator=(const T& new_value) const&&;
 
   // assigning another ref to this assigns the underlying value
-  ListElementReference& operator=(ListElementReference&& rhs) && noexcept;
+  const ListElementReference& operator=(ListElementReference&& rhs) const&& noexcept;
+  // NOLINTEND(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
 
   const IValue& get() const& {
     return *iterator_;
@@ -87,7 +97,8 @@ public:
   friend void swap<T, Iterator>(ListElementReference&& lhs, ListElementReference&& rhs) noexcept;
 
   ListElementReference(const ListElementReference&) = delete;
-  ListElementReference& operator=(const ListElementReference&) = delete;
+  // Lvalue-only, so it does not compete with the const&& assignments above.
+  ListElementReference& operator=(const ListElementReference&) & = delete;
   ~ListElementReference() = default;
 
 private:
@@ -112,11 +123,14 @@ private:
 template <class T, class Iterator>
 class ListIterator final {
  public:
-   // C++17 friendly std::iterator implementation
-  using iterator_category = std::random_access_iterator_tag;
+  // C++17 forbids a proxy iterator from being forward or better, so the legacy
+  // tag says input and the real category goes in iterator_concept. Spelled out
+  // explicitly rather than left to iterator_traits synthesis: GCC 11 (an actual
+  // CI toolchain) synthesizes something std::reverse's dispatch can't match.
+  using iterator_concept = std::random_access_iterator_tag;
+  using iterator_category = std::input_iterator_tag;
   using value_type = T;
   using difference_type = std::ptrdiff_t;
-  using pointer = T*;
   using reference = ListElementReference<T, Iterator>;
 
   explicit ListIterator() = default;
@@ -149,22 +163,26 @@ class ListIterator final {
       return copy;
   }
 
-  ListIterator& operator+=(typename List<T>::size_type offset) {
+  ListIterator& operator+=(difference_type offset) {
       iterator_ += offset;
       return *this;
   }
 
-  ListIterator& operator-=(typename List<T>::size_type offset) {
+  ListIterator& operator-=(difference_type offset) {
       iterator_ -= offset;
       return *this;
   }
 
-  ListIterator operator+(typename List<T>::size_type offset) const {
+  ListIterator operator+(difference_type offset) const {
     return ListIterator{iterator_ + offset};
   }
 
-  ListIterator operator-(typename List<T>::size_type offset) const {
+  ListIterator operator-(difference_type offset) const {
     return ListIterator{iterator_ - offset};
+  }
+
+  friend ListIterator operator+(difference_type offset, const ListIterator& rhs) {
+    return rhs + offset;
   }
 
   friend difference_type operator-(const ListIterator& lhs, const ListIterator& rhs) {
@@ -175,37 +193,36 @@ class ListIterator final {
     return {iterator_};
   }
 
-  ListElementReference<T, Iterator> operator[](typename List<T>::size_type offset) const {
+  ListElementReference<T, Iterator> operator[](difference_type offset) const {
     return {iterator_ + offset};
   }
+
+  // ranges finds these by ADL; defined in List_inl.h (need a complete IValue).
+  friend T iter_move<T, Iterator>(const ListIterator& it);
+
+  friend void iter_swap<T, Iterator>(
+      const ListIterator& lhs,
+      const ListIterator& rhs) noexcept;
 
 private:
   explicit ListIterator(Iterator iterator): iterator_(std::move(iterator)) {}
 
   Iterator iterator_;
 
-  friend bool operator==(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ == rhs.iterator_;
-  }
+  // Not defaulted: libc++'s __wrap_iter has no <=> of its own, which would
+  // make a defaulted <=> here implicitly deleted.
+  friend bool operator==(const ListIterator&, const ListIterator&) = default;
 
-  friend bool operator!=(const ListIterator& lhs, const ListIterator& rhs) {
-    return !(lhs == rhs);
-  }
-
-  friend bool operator<(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ < rhs.iterator_;
-  }
-
-  friend bool operator<=(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ <= rhs.iterator_;
-  }
-
-  friend bool operator>(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ > rhs.iterator_;
-  }
-
-  friend bool operator>=(const ListIterator& lhs, const ListIterator& rhs) {
-    return lhs.iterator_ >= rhs.iterator_;
+  friend std::strong_ordering operator<=>(
+      const ListIterator& lhs,
+      const ListIterator& rhs) {
+    if (lhs.iterator_ < rhs.iterator_) {
+      return std::strong_ordering::less;
+    }
+    if (rhs.iterator_ < lhs.iterator_) {
+      return std::strong_ordering::greater;
+    }
+    return std::strong_ordering::equal;
   }
 
   friend class ListIterator<T, typename c10::detail::ListImpl::list_type::iterator>;
@@ -442,9 +459,6 @@ public:
   template <class T_>
   friend bool operator==(const List<T_>& lhs, const List<T_>& rhs);
 
-  template <class T_>
-  friend bool operator!=(const List<T_>& lhs, const List<T_>& rhs);
-
   /**
    * Identity comparison. Returns true if and only if `rhs` represents the same
    * List object as `this`.
@@ -457,7 +471,6 @@ public:
    * Returns the number of Lists currently pointing to this same list.
    * If this is the only instance pointing to this list, returns 1.
    */
-  // TODO Test use_count
   size_t use_count() const;
 
   TypePtr elementType() const;

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -96,6 +96,11 @@ namespace detail {
   T list_element_to(IValue&& element) {
     return std::move(element).template to<T>();
   }
+  // to<IValue>() has no rvalue overload and would copy; steal instead.
+  template<>
+  inline IValue list_element_to<IValue>(IValue&& element) {
+    return std::move(element);
+  }
   template<class T>
   struct ListElementFrom {
     static IValue from(const T& element) {
@@ -128,19 +133,20 @@ ListElementReference<T, Iterator>::operator std::conditional_t<
 }
 
 template<class T, class Iterator>
-ListElementReference<T, Iterator>& ListElementReference<T, Iterator>::operator=(T&& new_value) && {
+const ListElementReference<T, Iterator>& ListElementReference<T, Iterator>::operator=(T&& new_value) const&& {
   *iterator_ = c10::detail::ListElementFrom<T>::from(std::move(new_value));
   return *this;
 }
 
 template<class T, class Iterator>
-ListElementReference<T, Iterator>& ListElementReference<T, Iterator>::operator=(const T& new_value) && {
+const ListElementReference<T, Iterator>& ListElementReference<T, Iterator>::operator=(const T& new_value) const&& {
   *iterator_ = c10::detail::ListElementFrom<T>::from(new_value);
   return *this;
 }
 
 template<class T, class Iterator>
-ListElementReference<T, Iterator>& ListElementReference<T, Iterator>::operator=(ListElementReference<T, Iterator>&& rhs) && noexcept {
+const ListElementReference<T, Iterator>& ListElementReference<T, Iterator>::operator=(ListElementReference<T, Iterator>&& rhs) const&& noexcept {
+  // Not a move: the element rhs refers to stays live and keeps its value.
   *iterator_ = *rhs.iterator_;
   return *this;
 }
@@ -151,14 +157,21 @@ void swap(ListElementReference<T, Iterator>&& lhs, ListElementReference<T, Itera
 }
 
 template<class T, class Iterator>
-bool operator==(const ListElementReference<T, Iterator>& lhs, const T& rhs) {
-  const T& lhs_tmp = lhs;
-  return lhs_tmp == rhs;
+T iter_move(const ListIterator<T, Iterator>& it) {
+  return c10::detail::list_element_to<T>(std::move(*it.iterator_));
 }
 
 template<class T, class Iterator>
-inline bool operator==(const T& lhs, const ListElementReference<T, Iterator>& rhs) {
-  return rhs == lhs;
+void iter_swap(
+    const ListIterator<T, Iterator>& lhs,
+    const ListIterator<T, Iterator>& rhs) noexcept {
+  swap(*lhs, *rhs);
+}
+
+template<class T, class Iterator>
+bool operator==(const ListElementReference<T, Iterator>& lhs, const T& rhs) {
+  const T& lhs_tmp = lhs;
+  return lhs_tmp == rhs;
 }
 
 template<class T>
@@ -253,7 +266,7 @@ typename List<T>::iterator List<T>::insert(iterator pos, T&& value) const {
 template<class T>
 template<class... Args>
 typename List<T>::iterator List<T>::emplace(iterator pos, Args&&... value) const {
-  // TODO Use list_element_from?
+  // TODO Use ListElementFrom?
   return iterator { impl_->list.emplace(pos.iterator_, std::forward<Args>(value)...) };
 }
 
@@ -279,7 +292,7 @@ void List<T>::append(List<T> b) const {
 template<class T>
 template<class... Args>
 void List<T>::emplace_back(Args&&... args) const {
-  // TODO Use list_element_from?
+  // TODO Use ListElementFrom?
   impl_->list.push_back(T(std::forward<Args>(args)...));
 }
 
@@ -320,18 +333,16 @@ bool operator==(const List<T>& lhs, const List<T>& rhs) {
 }
 
 template<class T>
-bool operator!=(const List<T>& lhs, const List<T>& rhs) {
-  return !(lhs == rhs);
-}
-
-template<class T>
 bool List<T>::is(const List<T>& rhs) const {
   return this->impl_ == rhs.impl_;
 }
 
 template<class T>
 std::vector<T> List<T>::vec() const {
-  std::vector<T> result(begin(), end());
+  // Not the range constructor: an input iterator would grow the vector.
+  std::vector<T> result;
+  result.reserve(size());
+  result.assign(begin(), end());
   return result;
 }
 
@@ -351,3 +362,4 @@ void List<T>::unsafeSetElementType(TypePtr t) {
 }
 
 }
+

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -266,8 +266,10 @@ typename List<T>::iterator List<T>::insert(iterator pos, T&& value) const {
 template<class T>
 template<class... Args>
 typename List<T>::iterator List<T>::emplace(iterator pos, Args&&... value) const {
-  // TODO Use ListElementFrom?
-  return iterator { impl_->list.emplace(pos.iterator_, std::forward<Args>(value)...) };
+  // Build T first, or the IValue picks the args' own overload, not T's.
+  return iterator{impl_->list.emplace(
+      pos.iterator_,
+      c10::detail::ListElementFrom<T>::from(T(std::forward<Args>(value)...)))};
 }
 
 template<class T>
@@ -292,8 +294,8 @@ void List<T>::append(List<T> b) const {
 template<class T>
 template<class... Args>
 void List<T>::emplace_back(Args&&... args) const {
-  // TODO Use ListElementFrom?
-  impl_->list.push_back(T(std::forward<Args>(args)...));
+  impl_->list.push_back(
+      c10::detail::ListElementFrom<T>::from(T(std::forward<Args>(args)...)));
 }
 
 template<class T>
@@ -362,4 +364,3 @@ void List<T>::unsafeSetElementType(TypePtr t) {
 }
 
 }
-

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -1135,6 +1135,20 @@ TEST(ListTestNonIValueBasedList, useCountCountsSharedStorage) {
   EXPECT_EQ(1, list.use_count());
 }
 
+TEST(ListTestNonIValueBasedList, emplaceConvertsToTheElementType) {
+  // The argument names an IValue overload of its own; emplace has to build the
+  // element type first, or the list holds a value elementType() disagrees with
+  // and reading it back fails.
+  List<double> list({1.5});
+  list.emplace(list.begin(), 1);
+  list.emplace_back(2);
+
+  EXPECT_EQ(3, list.size());
+  EXPECT_DOUBLE_EQ(1.0, list.get(0));
+  EXPECT_DOUBLE_EQ(1.5, list.get(1));
+  EXPECT_DOUBLE_EQ(2.0, list.get(2));
+}
+
 TEST(ListTestNonIValueBasedList, copyHasSeparateStorage) {
   List<int64_t> list1;
   List<int64_t> list2(list1.copy());

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -2,6 +2,27 @@
 #include <gtest/gtest.h>
 
 using namespace c10;
+
+namespace {
+// Ts cover the three shapes ListElementReference's conversion takes.
+template <class T>
+using ListIter =
+    c10::impl::ListIterator<T, c10::detail::ListImpl::list_type::iterator>;
+
+template <class... Ts>
+constexpr bool list_iterators_conform =
+    ((std::random_access_iterator<ListIter<Ts>> &&
+      std::indirectly_writable<ListIter<Ts>, Ts> &&
+      std::permutable<ListIter<Ts>>) &&
+     ...);
+
+static_assert(list_iterators_conform<
+              c10::IValue,
+              int64_t,
+              at::Tensor,
+              std::optional<std::string>>);
+} // namespace
+
 using std::string;
 
 // TODO(NS): Remove me
@@ -527,6 +548,27 @@ TEST(ListTestIValueBasedList, isReferenceType) {
   EXPECT_EQ(1, list1.size());
   EXPECT_EQ(1, list2.size());
   EXPECT_EQ(1, list3.size());
+}
+
+TEST(ListTestIValueBasedList, useCountCountsSharedStorage) {
+  List<string> list;
+  EXPECT_EQ(1, list.use_count());
+  {
+    // A second owner, not a reference: use_count checks two distinct handles.
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    List<string> shared = list;
+    EXPECT_EQ(2, list.use_count());
+    EXPECT_EQ(2, shared.use_count());
+
+    // copy() takes a separate storage, so neither side gains a reference.
+    List<string> copied = list.copy();
+    EXPECT_EQ(2, list.use_count());
+    EXPECT_EQ(1, copied.use_count());
+  }
+  EXPECT_EQ(1, list.use_count());
+
+  list.push_back("three");
+  EXPECT_EQ(1, list.use_count());
 }
 
 TEST(ListTestIValueBasedList, copyHasSeparateStorage) {
@@ -1070,6 +1112,27 @@ TEST(ListTestNonIValueBasedList, isReferenceType) {
   EXPECT_EQ(1, list1.size());
   EXPECT_EQ(1, list2.size());
   EXPECT_EQ(1, list3.size());
+}
+
+TEST(ListTestNonIValueBasedList, useCountCountsSharedStorage) {
+  List<int64_t> list;
+  EXPECT_EQ(1, list.use_count());
+  {
+    // A second owner, not a reference: use_count checks two distinct handles.
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    List<int64_t> shared = list;
+    EXPECT_EQ(2, list.use_count());
+    EXPECT_EQ(2, shared.use_count());
+
+    // copy() takes a separate storage, so neither side gains a reference.
+    List<int64_t> copied = list.copy();
+    EXPECT_EQ(2, list.use_count());
+    EXPECT_EQ(1, copied.use_count());
+  }
+  EXPECT_EQ(1, list.use_count());
+
+  list.push_back(3);
+  EXPECT_EQ(1, list.use_count());
 }
 
 TEST(ListTestNonIValueBasedList, copyHasSeparateStorage) {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -2002,7 +2002,7 @@ class ShapePropagator : public PropertyPropBase {
       auto sizes = tp->sizes().concrete_sizes().value();
       auto dims = node->get<c10::List<int64_t>>(attr::dim).value();
       bool keepdim = node->get<bool>(attr::keepdim).value();
-      std::reverse(dims.begin(), dims.end());
+      std::ranges::reverse(dims);
       for (int64_t dim : dims) {
         SHAPE_ASSERT(dim >= 0 && static_cast<size_t>(dim) < sizes.size());
         if (keepdim) {

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -71,10 +71,8 @@ template <>
 void listSort<at::Tensor>(Stack& stack) {
   bool reverse = pop(stack).toBool();
   c10::List<at::Tensor> list = pop(stack).toTensorList();
-  std::sort(
-      list.begin(),
-      list.end(),
-      [reverse](const at::Tensor& a, const at::Tensor& b) -> bool {
+  std::ranges::sort(
+      list, [reverse](const at::Tensor& a, const at::Tensor& b) -> bool {
         // "strict weak ordering" issue - see other sort
         if (a.getIntrusivePtr() == b.getIntrusivePtr()) {
           return false;
@@ -87,12 +85,9 @@ template <>
 void listCopyAndSort<at::Tensor>(Stack& stack) {
   c10::List<at::Tensor> list = pop(stack).toTensorList();
   auto list_copied = list.copy();
-  std::sort(
-      list_copied.begin(),
-      list_copied.end(),
-      [](const at::Tensor& a, const at::Tensor& b) {
-        return at::native::is_nonzero(a.lt(b));
-      });
+  std::ranges::sort(list_copied, [](const at::Tensor& a, const at::Tensor& b) {
+    return at::native::is_nonzero(a.lt(b));
+  });
   push(stack, list_copied);
 }
 
@@ -192,7 +187,7 @@ void listAppend(Stack& stack) {
 void listReverse(Stack& stack) {
   c10::List<IValue> list = pop(stack).to<c10::List<IValue>>();
 
-  std::reverse(list.begin(), list.end());
+  std::ranges::reverse(list);
 }
 
 void listPopImpl(Stack& stack, const char* empty_message) {

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -352,7 +352,7 @@ template <typename T>
 void listSort(Stack& stack) {
   bool reverse = pop(stack).toBool();
   c10::List<T> list = pop(stack).to<c10::List<T>>();
-  std::sort(list.begin(), list.end(), [reverse](const T& a, const T& b) {
+  std::ranges::sort(list, [reverse](const T& a, const T& b) {
     // FBCode errors without this check - "strict weak ordering"
     // TODO: remove when possible, since it just slows down
     // sorting and doesn't do anything useful
@@ -371,7 +371,7 @@ template <typename T>
 void listCopyAndSort(Stack& stack) {
   c10::List<T> list = pop(stack).to<c10::List<T>>();
   auto list_copied = list.copy();
-  std::sort(list_copied.begin(), list_copied.end(), [](const T& a, const T& b) {
+  std::ranges::sort(list_copied, [](const T& a, const T& b) {
     // "strict weak ordering" issue - see other sort
     if (a == b) {
       return false;

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -171,7 +171,7 @@ void sort_op(Stack& stack) {
     } else {
       comparator = c10::getLessThanComparator(g_list.get(0));
     }
-    std::sort(g_list.begin(), g_list.end(), comparator);
+    std::ranges::sort(g_list, comparator);
   }
 
   if (copy_return_list) {
@@ -2575,7 +2575,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs1{
           } else {
             int64_t index = 0;
             auto iter = size.begin();
-            std::sort(axes.begin(), axes.end());
+            std::ranges::sort(axes);
             for (const auto& axis : axes) {
               // move iter to the next axis
               iter += axis - index;


### PR DESCRIPTION
```
ListIterator claimed random_access_iterator_tag, but operator* returns a
proxy, which C++17 forbids for forward-or-better iterators. Sets
iterator_concept = random_access_iterator_tag (the C++20 point that does
allow proxies); iterator_category stays explicit input_iterator_tag rather
than synthesized, since GCC 11 synthesizes something legacy std::reverse/
std::sort can't dispatch on. Fixed the 8 call sites that called those
directly on List<T> iterators (shape_analysis.cpp, register_ops_utils.{h,cpp},
register_prim_ops.cpp) to use std::ranges::sort/reverse instead.

<=> is hand-written, not defaulted: libc++'s __wrap_iter has no <=> of its
own, so a defaulted <=> is implicitly deleted on macOS, failing every
iterator concept. Derived from < instead.

Const-qualifies the proxy's assignment operators for indirectly_writable,
and adds iter_move/iter_swap so move-based algorithms steal the underlying
IValue instead of copying - e.g. freeze_module.cpp's overrideGradient loop
(extract -> overrideGradient by value -> set) is now copy-free per element.

Second commit: List::emplace forwarded args straight into
std::vector<IValue>::emplace, so they picked whichever IValue overload they
named instead of T's - List<double>().emplace(pos, 1) stored an Int, not a
Double. Construct T first, matching push_back.

Test Plan:

static_assert checking the iterator concepts hold for four element types,
plus regression tests for use_count and emplace. Compiled against GCC 16
and real libc++ since this machine's torch build is stale; the GCC 11 and
macOS CI failures from earlier pushes surfaced the two fixes above.
```

Drafted with AI assistance (Claude Code).