### PR TITLE
Skip regional codegen cpp wrapper subprocess test on XPU

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -86,7 +86,7 @@ test_failures = {
         ("cpu", "cuda"), is_skip=True
     ),
     "test_regional_codegen_only_config_cpp_wrapper": TestFailure(
-        ("cpu", "cuda"), is_skip=True
+        ("cpu", "cuda", "xpu"), is_skip=True
     ),
     # This manually constructs an FX graph with an OpOverloadPacket target to
     # cover a legacy lowering table entry, which is outside the subprocess


### PR DESCRIPTION
To solve https://github.com/pytorch/pytorch/issues/195875

This PR is to skip `test_regional_codegen_only_config_cpp_wrapper_xpu`, which tests the regional codegen-only configuration with the C++ wrapper in Inductor subprocess compilation. On XPU, serializing `NestedCompileRegionOptions` with `dill` fails with `TypeError: cannot pickle '_thread._local' object`. The CPU and CUDA variants are already skipped, so this PR adds XPU to the existing `TestFailure` entry.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo