### PR TITLE
[dynamo] Preserve constant-false while_loop cond effects

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: functorch"]
 import contextlib
 import functools
+import random
 import unittest
 
 import torch
@@ -13106,6 +13107,47 @@ class <lambda>(torch.nn.Module):
 
         y = torch.ones(4, requires_grad=False)
         self.check(M, (y,), device, dynamic)
+
+    # https://github.com/pytorch/pytorch/issues/195970
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @parametrize("compile_mode", ["direct", "aot_eager", "inductor"])
+    def test_while_loop_constant_false_cond_mutation(self, device, compile_mode):
+        def f(state):
+            def cond_fn(i):
+                random.random()
+                state.add_(1)
+                return False
+
+            def body_fn(i):
+                return (i + 1,)
+
+            return torch.while_loop(
+                cond_fn,
+                body_fn,
+                (torch.zeros((), dtype=torch.int64, device=state.device),),
+            )
+
+        rng_state = random.getstate()
+        try:
+            random.seed(0)
+            expected_rng = random.Random(0)
+            expected_rng.random()
+            expected_rng.random()
+            expected_next_random = expected_rng.random()
+            fn = (
+                f
+                if compile_mode == "direct"
+                else torch.compile(f, backend=compile_mode, fullgraph=True)
+            )
+            state = torch.zeros((), device=device)
+            with torch.no_grad():
+                for _ in range(2):
+                    result = fn(state)
+            self.assertEqual(result[0], 0)
+            self.assertEqual(state, 2)
+            self.assertEqual(random.random(), expected_next_random)
+        finally:
+            random.setstate(rng_state)
 
     # https://github.com/pytorch/pytorch/issues/195327
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -13154,6 +13154,34 @@ class <lambda>(torch.nn.Module):
             random.setstate(rng_state)
 
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    def test_while_loop_constant_false_explicit_additional_input(self, device):
+        def f(state, x, extra):
+            def cond_fn(x, extra):
+                state.add_(extra.sum())
+                return False
+
+            def body_fn(x, extra):
+                return (x + 1,)
+
+            return torch.ops.higher_order.while_loop(cond_fn, body_fn, (x,), (extra,))
+
+        backend = EagerAndRecordGraphs()
+        state = torch.zeros((), device=device)
+        x = torch.arange(3.0, device=device)
+        extra = torch.tensor([2.0, 3.0], device=device)
+        with torch.no_grad():
+            result = torch.compile(f, backend=backend, fullgraph=True)(state, x, extra)
+        self.assertEqual(result[0], x)
+        self.assertEqual(state, 5)
+        self.assertEqual(len(backend.graphs), 1)
+        graph = backend.graphs[0].graph
+        while_loop_nodes = graph.find_nodes(
+            op="call_function", target=torch.ops.higher_order.while_loop
+        )
+        self.assertEqual(len(while_loop_nodes), 0)
+        self.assertEqual(len(graph.find_nodes(op="call_method", target="add_")), 1)
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
     def test_while_loop_constant_false_replay_input_mutation(self, device):
         def f(x):
             def cond_fn(x):

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -13114,6 +13114,8 @@ class <lambda>(torch.nn.Module):
     @parametrize("compile_mode", ["direct", "aot_eager", "inductor"])
     def test_while_loop_constant_false_cond_mutation(self, device, compile_mode):
         def f(state, x):
+            before = x.new_zeros(()) + random.random()
+
             def cond_fn(x):
                 r = random.randint(1, 10) if x.is_contiguous() else random.random()
                 state.add_(1 if torch.tensor(r).is_floating_point() else 10)
@@ -13122,15 +13124,14 @@ class <lambda>(torch.nn.Module):
             def body_fn(x):
                 return (x + 1,)
 
-            return torch.while_loop(cond_fn, body_fn, (x,))
+            result = torch.while_loop(cond_fn, body_fn, (x,))
+            after = x.new_zeros(()) + random.random()
+            return (*result, before, after)
 
         rng_state = random.getstate()
         try:
             random.seed(0)
             expected_rng = random.Random(0)
-            expected_rng.random()
-            expected_rng.random()
-            expected_next_random = expected_rng.random()
             fn = (
                 f
                 if compile_mode == "direct"
@@ -13140,15 +13141,19 @@ class <lambda>(torch.nn.Module):
             x = torch.arange(8.0, device=device)[::2]
             with torch.no_grad():
                 for _ in range(2):
+                    expected_before = expected_rng.random()
+                    expected_rng.random()
+                    expected_after = expected_rng.random()
                     result = fn(state, x)
+                    self.assertEqual(result[1], expected_before)
+                    self.assertEqual(result[2], expected_after)
             self.assertEqual(result[0], x)
             self.assertEqual(state, 2)
-            self.assertEqual(random.random(), expected_next_random)
+            self.assertEqual(random.random(), expected_rng.random())
         finally:
             random.setstate(rng_state)
 
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
-    @skipCUDAIf(not SM70OrLater, "triton")
     def test_while_loop_constant_false_replay_input_mutation(self, device):
         def f(x):
             def cond_fn(x):

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -13110,22 +13110,19 @@ class <lambda>(torch.nn.Module):
 
     # https://github.com/pytorch/pytorch/issues/195970
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @skipCUDAIf(not SM70OrLater, "triton")
     @parametrize("compile_mode", ["direct", "aot_eager", "inductor"])
     def test_while_loop_constant_false_cond_mutation(self, device, compile_mode):
-        def f(state):
-            def cond_fn(i):
-                random.random()
-                state.add_(1)
+        def f(state, x):
+            def cond_fn(x):
+                r = random.randint(1, 10) if x.is_contiguous() else random.random()
+                state.add_(1 if torch.tensor(r).is_floating_point() else 10)
                 return False
 
-            def body_fn(i):
-                return (i + 1,)
+            def body_fn(x):
+                return (x + 1,)
 
-            return torch.while_loop(
-                cond_fn,
-                body_fn,
-                (torch.zeros((), dtype=torch.int64, device=state.device),),
-            )
+            return torch.while_loop(cond_fn, body_fn, (x,))
 
         rng_state = random.getstate()
         try:
@@ -13140,14 +13137,39 @@ class <lambda>(torch.nn.Module):
                 else torch.compile(f, backend=compile_mode, fullgraph=True)
             )
             state = torch.zeros((), device=device)
+            x = torch.arange(8.0, device=device)[::2]
             with torch.no_grad():
                 for _ in range(2):
-                    result = fn(state)
-            self.assertEqual(result[0], 0)
+                    result = fn(state, x)
+            self.assertEqual(result[0], x)
             self.assertEqual(state, 2)
             self.assertEqual(random.random(), expected_next_random)
         finally:
             random.setstate(rng_state)
+
+    @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")
+    @skipCUDAIf(not SM70OrLater, "triton")
+    def test_while_loop_constant_false_replay_input_mutation(self, device):
+        def f(x):
+            def cond_fn(x):
+                if not x.is_contiguous():
+                    x.add_(1)
+                return False
+
+            def body_fn(x):
+                return (x + 1,)
+
+            return torch.while_loop(cond_fn, body_fn, (x,))
+
+        x = torch.arange(8.0, device=device)[::2]
+        with (
+            torch.enable_grad(),
+            self.assertRaisesRegex(
+                torch._dynamo.exc.UncapturedHigherOrderOpError,
+                "Higher order ops do not support input mutation",
+            ),
+        ):
+            f(x)
 
     # https://github.com/pytorch/pytorch/issues/195327
     @skipIfTorchDynamo("Graph is not captured by backend if test with dynamo")

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -854,6 +854,7 @@ def _call_while_loop(
             for carry in operands_seq
         ]
 
+    random_calls_before_cond = len(tx.output.random_calls)
     # create cond subgrpahs
     (
         (cond_r, _cond_treespec),
@@ -927,6 +928,9 @@ def _call_while_loop(
                 ],
             )
         else:
+            # The speculative trace does not add cond_fn to the parent graph.
+            del tx.output.random_calls[random_calls_before_cond:]
+            cond_fn.call_function(tx, operands_seq + additional_inputs_seq, {})
             return operands
 
     # create body subgraph

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -761,6 +761,8 @@ def _call_while_loop(
 ) -> VariableTracker:
     from torch._higher_order_ops.while_loop import _create_unbacked_symint
 
+    from ..source import RandomValueSource
+
     args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
     cond_fn, body_fn, operands, additional_inputs = args
 
@@ -928,9 +930,55 @@ def _call_while_loop(
                 ],
             )
         else:
-            # The speculative trace does not add cond_fn to the parent graph.
+            # Replay can take a different path on the original operands. Drop
+            # speculative RNG inputs as well as calls so their types cannot be reused.
+            for index in reversed(
+                range(random_calls_before_cond, len(tx.output.random_calls))
+            ):
+                source = RandomValueSource(index)
+                random_var = tx.output.unspec_variable_map.pop(source.name)
+                random_proxy = random_var.as_proxy()
+                for tracer in reversed(tx.output.tracers):
+                    proxy = (
+                        random_proxy
+                        if tracer is tx.output.root_tracer
+                        else tracer.lifted_freevars.pop(random_proxy, None)
+                    )
+                    if proxy is None:
+                        continue
+                    tensor_inputs = [
+                        node
+                        for node in tracer.graph.find_nodes(op="placeholder")
+                        if isinstance(node.meta["example_value"], torch.Tensor)
+                    ]
+                    del tracer._input_versions_at_beginning[
+                        tensor_inputs.index(proxy.node)
+                    ]
+                    tracer.remove_node(proxy.node)
+                tx.output.input_source_to_sizes_strides.pop(source, None)
             del tx.output.random_calls[random_calls_before_cond:]
+
+            input_versions = []
+            if not self.supports_input_mutation:
+                for arg in operands_seq + additional_inputs_seq:
+                    if arg.is_tensor():
+                        example = arg.as_proxy().node.meta["example_value"]
+                        input_versions.append((example, example._version))
             cond_fn.call_function(tx, operands_seq + additional_inputs_seq, {})
+            if any(t._version != version for t, version in input_versions):
+                context = (
+                    f"Input mutation detected while replaying {hop_name}'s cond_fn"
+                )
+                name = hop_name
+                unimplemented(
+                    gb_type="Encountered input mutation during higher order op tracing",
+                    context=context,
+                    explanation=f"Higher order ops do not support input mutation. Found in {name}",
+                    hints=[
+                        "Consider using the debug context to change user code to avoid mutation.",
+                        "Please open an issue.",
+                    ],
+                )
             return operands
 
     # create body subgraph


### PR DESCRIPTION
## Issue

I reviewed the implementation and tests summarized below. This change is relevant because a constant-False condition must still run once and preserve its permitted captured-tensor mutations.

Fixes #195970

> [AI-assisted summary]
>
> ## Summary
>
> Dynamo previously traced a constant-False `cond_fn` only in a discarded speculative subgraph, so captured-tensor mutations never reached the parent graph. This change retraces the condition once in the parent graph and removes Python RNG calls registered by the discarded trace, preserving one condition evaluation without retaining an unreachable `while_loop` body.
>
> ## Testing
>
> - `.venv/bin/python test/functorch/test_control_flow.py -k constant_false_cond_mutation`
> - `.venv/bin/python test/functorch/test_control_flow.py -k test_while_loop_compile`
> - `.venv/bin/python test/functorch/test_control_flow.py -k pre_mutated_tensor_in_cond_zero_iter`
> - `.venv/bin/python test/functorch/test_control_flow.py -k while_loop_auto_functionalize`
> - `.venv/bin/spin lint`
>
> ## Checklist
>
> - [x] Passes lint (`spin lint`)
> - [x] Added/updated tests
> - [x] Updated documentation (not applicable)
> - [x] Included benchmark results (not applicable)
>
> ## BC-breaking?
>
> No.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98