### PR TITLE
Build Windows MAGMA for CUDA 13.4, drop CUDA 12.x builds

### DIFF
--- a/.ci/pytorch/windows/internal/cuda_install.bat
+++ b/.ci/pytorch/windows/internal/cuda_install.bat
@@ -28,6 +28,7 @@ if %CUDA_VER% EQU 128 goto cuda128
 if %CUDA_VER% EQU 129 goto cuda129
 if %CUDA_VER% EQU 130 goto cuda130
 if %CUDA_VER% EQU 132 goto cuda132
+if %CUDA_VER% EQU 134 goto cuda134
 
 echo CUDA %CUDA_VERSION_STR% is not supported
 exit /b 1
@@ -60,6 +61,12 @@ goto cuda_download
 
 :cuda132
 set CUDA_INSTALL_EXE=cuda_13.2.1_windows.exe
+set "ARGS="
+set CUDNN_FOLDER=cudnn-windows-x86_64-9.25.1.1_cuda13-archive
+goto cuda_download
+
+:cuda134
+set CUDA_INSTALL_EXE=cuda_13.4.0_windows_x86_64.exe
 set "ARGS="
 set CUDNN_FOLDER=cudnn-windows-x86_64-9.25.1.1_cuda13-archive
 goto cuda_download
@@ -180,6 +187,10 @@ if %CUDA_VER% EQU 130 (
     set EXPECTED_CUDNN_VERSION=9.25.1
 )
 if %CUDA_VER% EQU 132 (
+    set CUDNN_FOLDER=cudnn-windows-x86_64-9.25.1.1_cuda13-archive
+    set EXPECTED_CUDNN_VERSION=9.25.1
+)
+if %CUDA_VER% EQU 134 (
     set CUDNN_FOLDER=cudnn-windows-x86_64-9.25.1.1_cuda13-archive
     set EXPECTED_CUDNN_VERSION=9.25.1
 )

--- a/.github/scripts/windows/build_magma.bat
+++ b/.github/scripts/windows/build_magma.bat
@@ -35,20 +35,14 @@ cd magma
 mkdir build && cd build
 
 set GPU_TARGET=All
+if "%CUVER_NODOT%" == "134" (
+  set CUDA_ARCH_LIST=-gencode=arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
+)
 if "%CUVER_NODOT%" == "132" (
   set CUDA_ARCH_LIST=-gencode=arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
 )
 if "%CUVER_NODOT%" == "130" (
   set CUDA_ARCH_LIST=-gencode=arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
-)
-if "%CUVER_NODOT%" == "129" (
-  set CUDA_ARCH_LIST=-gencode=arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
-)
-if "%CUVER_NODOT%" == "128" (
-  set CUDA_ARCH_LIST=-gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
-)
-if "%CUVER_NODOT%" == "126" (
-  set CUDA_ARCH_LIST=-gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90
 )
 
 set CC=cl.exe

--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        cuda_version: ["132", "130", "129", "128", "126"]
+        cuda_version: ["134", "132", "130"]
         config: ["Release", "Debug"]
     env:
       CUDA_VERSION: ${{ matrix.cuda_version }}


### PR DESCRIPTION
Windows `cu134` wheel builds die in `build_env_setup.py`'s `install_magma()` because `magma_2.5.4_cuda134_release.7z` was never published to the `ossci-windows` bucket:

```
magma_2.5.4_cuda132_release.7z -> 200
magma_2.5.4_cuda134_release.7z -> 404
```

This PR:
- adds `134` to the `build-magma-windows.yml` matrix, with the matching `CUDA_ARCH_LIST` in `build_magma.bat` (same list as 13.2);
- adds the `cuda134` branch to `.ci/pytorch/windows/internal/cuda_install.bat`, which the MAGMA job runs to provision the toolkit (`cuda_13.4.0_windows_x86_64.exe` is already on the bucket);
- drops `126`/`128`/`129` from the matrix. `CUDA_ARCHES` is now `["12.6", "13.0", "13.2", "13.4"]` and `MAGMA_VERSION` is pinned at 2.5.4, so the already-published CUDA 12.x archives stay on S3 and keep serving the cu126 Windows builds -- there is nothing left to rebuild for them.

Once this lands on `main`, the `push-windows-magma` job uploads `magma_2.5.4_cuda134_{release,debug}.7z` and unblocks the cu134 Windows wheels.
