### PR TITLE
[MPS] Remove GPU<->CPU sync in histc

### DIFF
--- a/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
@@ -36,11 +36,9 @@ kernel void histogramdd(
     constant size_t& num_dims [[buffer(4)]],
     constant T* bin_seq [[buffer(5)]],
     constant int64_t* num_bin_edges [[buffer(6)]],
-    constant T* leftmost_edge [[buffer(7)]],
-    constant T* rightmost_edge [[buffer(8)]],
-    constant int64_t* local_out_strides [[buffer(9)]],
-    constant uint8_t& algorithm [[buffer(10)]],
-    constant int64_t& weight_stride [[buffer(11)]],
+    constant int64_t* local_out_strides [[buffer(7)]],
+    constant uint8_t& algorithm [[buffer(8)]],
+    constant int64_t& weight_stride [[buffer(9)]],
     uint tid [[thread_position_in_grid]]) {
   constexpr auto eps = T(4e-6);
   bool skip_element = false;
@@ -49,13 +47,15 @@ kernel void histogramdd(
 
   for (size_t dim = 0; dim < num_dims; dim++) {
     T element = input_[offsets[tid * num_dims + dim]];
+    const T leftmost_edge = bin_seq[bin_seq_offset];
+    const T rightmost_edge = bin_seq[bin_seq_offset + num_bin_edges[dim] - 1];
 
     // Skips elements which fall outside the specified bins and NaN elements
     // Adding an eps to the edges to eliminate precision issues that cause
     // elements accidentally skipped, this is likely due to the minuscule
     // implementation differences between the CPU and MPS's linspace.
-    if (!(element >= (leftmost_edge[dim] - eps) &&
-          element <= (rightmost_edge[dim] + eps))) {
+    if (!(element >= (leftmost_edge - eps) &&
+          element <= (rightmost_edge + eps))) {
       skip_element = true;
       break;
     }
@@ -69,8 +69,8 @@ kernel void histogramdd(
         algorithm ==
             BIN_SELECTION_ALGORITHM::LINEAR_INTERPOLATION_WITH_LOCAL_SEARCH) {
       pos = static_cast<int64_t>(
-          (element - leftmost_edge[dim]) * (num_bin_edges[dim] - 1) /
-          (rightmost_edge[dim] - leftmost_edge[dim]));
+          (element - leftmost_edge) * (num_bin_edges[dim] - 1) /
+          (rightmost_edge - leftmost_edge));
       if (algorithm == LINEAR_INTERPOLATION_WITH_LOCAL_SEARCH) {
         int64_t pos_min = max(static_cast<int64_t>(0), pos - 1);
         int64_t pos_max = min(pos + 2, num_bin_edges[dim]);
@@ -94,21 +94,19 @@ kernel void histogramdd(
   }
 }
 
-#define REGISTER_HISTOGRAMDD_OP(DTYPE)                          \
-  template [[host_name("histogramdd_" #DTYPE)]] kernel void     \
-  histogramdd<DTYPE>(                                           \
-      constant DTYPE * input_ [[buffer(0)]],                    \
-      constant DTYPE * weight [[buffer(1)]],                    \
-      device DTYPE * local_out [[buffer(2)]],                   \
-      constant uint * offsets [[buffer(3)]],                    \
-      constant size_t& num_dims [[buffer(4)]],                  \
-      constant DTYPE* bin_seq [[buffer(5)]],                    \
-      constant int64_t* num_bin_edges [[buffer(6)]],            \
-      constant DTYPE* leftmost_edge [[buffer(7)]],              \
-      constant DTYPE* rightmost_edge [[buffer(8)]],             \
-      constant int64_t* local_out_strides [[buffer(9)]],        \
-      constant uint8_t& bin_selection_algorithm [[buffer(10)]], \
-      constant int64_t& weight_stride [[buffer(11)]],           \
+#define REGISTER_HISTOGRAMDD_OP(DTYPE)                         \
+  template [[host_name("histogramdd_" #DTYPE)]] kernel void    \
+  histogramdd<DTYPE>(                                          \
+      constant DTYPE * input_ [[buffer(0)]],                   \
+      constant DTYPE * weight [[buffer(1)]],                   \
+      device DTYPE * local_out [[buffer(2)]],                  \
+      constant uint * offsets [[buffer(3)]],                   \
+      constant size_t& num_dims [[buffer(4)]],                 \
+      constant DTYPE* bin_seq [[buffer(5)]],                   \
+      constant int64_t* num_bin_edges [[buffer(6)]],           \
+      constant int64_t* local_out_strides [[buffer(7)]],       \
+      constant uint8_t& bin_selection_algorithm [[buffer(8)]], \
+      constant int64_t& weight_stride [[buffer(9)]],           \
       uint tid [[thread_position_in_grid]]);
 
 REGISTER_HISTOGRAMDD_OP(float);

--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -1,5 +1,4 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/Dispatch_v2.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Histogram.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -29,7 +28,7 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/HistogramKernel_metallib.h>
 #endif
 
-template <typename input_t, BIN_SELECTION_ALGORITHM algorithm>
+template <BIN_SELECTION_ALGORITHM algorithm>
 void histogramdd_kernel_impl(Tensor& hist_output,
                              const TensorList& bin_edges,
                              const Tensor& input,
@@ -58,8 +57,6 @@ void histogramdd_kernel_impl(Tensor& hist_output,
   }
 
   std::vector<int64_t> num_bin_edges(D);
-  std::vector<input_t> leftmost_edge(D);
-  std::vector<input_t> rightmost_edge(D);
 
   std::vector<Tensor> bin_edges_dev;
   bin_edges_dev.reserve(D);
@@ -67,8 +64,6 @@ void histogramdd_kernel_impl(Tensor& hist_output,
     const Tensor& dim_edges = bin_edges[dim];
     bin_edges_dev.push_back(dim_edges.to(input.device()));
     num_bin_edges[dim] = dim_edges.numel();
-    leftmost_edge[dim] = dim_edges[0].item().to<input_t>();
-    rightmost_edge[dim] = dim_edges[num_bin_edges[dim] - 1].item().to<input_t>();
   }
   // The kernel indexes the edges linearly, so they must be contiguous. cat already
   // returns a contiguous tensor; the single dimension case can be a view of the
@@ -134,8 +129,6 @@ void histogramdd_kernel_impl(Tensor& hist_output,
                   D,
                   bin_seq_t,
                   num_bin_edges,
-                  leftmost_edge,
-                  rightmost_edge,
                   thread_histograms.strides(),
                   bin_selection_algorithm,
                   weight_stride);
@@ -165,16 +158,11 @@ static void histogramdd_out_mps_template(const Tensor& self,
   const auto reshaped_weight =
       weight.has_value() ? std::optional<Tensor>(weight.value().reshape({M})) : std::optional<Tensor>();
 
-  AT_DISPATCH_V2(self.scalar_type(),
-                 "histogram_mps",
-                 AT_WRAP([&]() {
-                   mps::histogramdd_kernel_impl<scalar_t, bin_algorithm>(
-                       hist, bin_edges, reshaped_input, reshaped_weight);
-                 }),
-                 AT_EXPAND(AT_ALL_TYPES),
-                 kBFloat16,
-                 kHalf,
-                 AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES));
+  TORCH_CHECK_NOT_IMPLEMENTED(supportedFloatingType(self) || isIntegralType(self.scalar_type(), /*includeBool=*/false),
+                              "\"histogram_mps\" not implemented for '",
+                              self.scalar_type(),
+                              "'");
+  mps::histogramdd_kernel_impl<bin_algorithm>(hist, bin_edges, reshaped_input, reshaped_weight);
 
   /* Divides each bin's value by the total count/weight in all bins,
    * and by the bin's volume.


### PR DESCRIPTION
Change is simple, `Histogram.cpp` packed the min/max that is given to us as function arguments in `torch.histc`. In MPS implementation we were reading these back and doing a GPU -> CPU sync, to then again bind them as input arguments to the function. This change just reads them directly from the tensor, removing the need for sync.

This is especially useful for MoE models where histc is used to count tokens routed to each expert.