### PR TITLE
Preserve nn.Module parameter order in prune.remove

### DIFF
--- a/test/nn/test_pruning.py
+++ b/test/nn/test_pruning.py
@@ -620,6 +620,54 @@ class TestPruningNN(NNTestCase):
 
                     self.assertEqual(pruned_t, final_t)
 
+    def test_remove_pruning_preserves_parameter_order(self):
+        r"""``prune.remove`` must restore the original OrderedDict parameter order.
+
+        See https://github.com/pytorch/pytorch/issues/85397
+        """
+        module = nn.Conv2d(1, 6, 3)
+        original = list(module.state_dict().keys())
+        self.assertEqual(original, ["weight", "bias"])
+        prune.random_unstructured(module, name="weight", amount=0.3)
+        self.assertEqual(list(module._parameters.keys()), ["weight_orig", "bias"])
+        prune.remove(module, name="weight")
+        self.assertEqual(list(module.state_dict().keys()), original)
+
+        module = nn.Linear(4, 3)
+        original = list(module.state_dict().keys())
+        prune.random_unstructured(module, name="bias", amount=0.3)
+        prune.remove(module, name="bias")
+        self.assertEqual(list(module.state_dict().keys()), original)
+
+        module = nn.Linear(4, 3)
+        original = list(module.state_dict().keys())
+        prune.random_unstructured(module, name="weight", amount=0.3)
+        prune.random_unstructured(module, name="bias", amount=0.3)
+        prune.remove(module, name="weight")
+        prune.remove(module, name="bias")
+        self.assertEqual(list(module.state_dict().keys()), original)
+
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc = nn.Linear(4, 3)
+                self.bn = nn.BatchNorm1d(3)
+
+        m = M()
+        original = list(dict(m.named_parameters()).keys())
+        prune.random_unstructured(m.fc, name="weight", amount=0.3)
+        prune.remove(m.fc, name="weight")
+        self.assertEqual(list(dict(m.named_parameters()).keys()), original)
+
+        lstm = nn.LSTM(8, 8)
+        original = list(dict(lstm.named_parameters()).keys())
+        prune.l1_unstructured(lstm, "weight_ih_l0", 0.5)
+        prune.remove(lstm, "weight_ih_l0")
+        self.assertEqual(list(dict(lstm.named_parameters()).keys()), original)
+        self.assertEqual(
+            sum(isinstance(p, nn.Parameter) for p in lstm._flat_weights), 4
+        )
+
     def test_remove_pruning_exception(self):
         r"""Removing from an unpruned tensor throws an assertion error"""
         modules = [nn.Linear(5, 7), nn.Conv3d(2, 2, 2)]

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -8,6 +8,20 @@ from collections.abc import Iterable
 import torch
 
 
+def _move_parameter(module, name, index):
+    """Place parameter ``name`` at ``index`` in ``module._parameters``.
+
+    ``register_parameter`` / ``setattr`` append to the OrderedDict, which
+    reorders ``state_dict()`` keys after pruning. Keep using those APIs
+    (RNN modules listen to ``setattr``) and then restore the slot.
+    """
+    params = module._parameters
+    value = params[name]
+    items = [(k, v) for k, v in params.items() if k != name]
+    items.insert(index, (name, value))
+    module._parameters = params.__class__(items)
+
+
 class BasePruningMethod(ABC):
     r"""Abstract base class for creation of new pruning techniques.
 
@@ -168,10 +182,12 @@ class BasePruningMethod(ABC):
         # the original tensor to a new parameter called name + '_orig'
         # and deleting the original parameter
         if not isinstance(method, PruningContainer):
+            param_index = list(module._parameters).index(name)
             # copy `module[name]` to `module[name + '_orig']`
             module.register_parameter(name + "_orig", orig)
             # temporarily delete `module[name]`
             del module._parameters[name]
+            _move_parameter(module, name + "_orig", param_index)
             default_mask = torch.ones_like(orig)  # temp
         # If this is not the first time pruning is applied, all of the above
         # has been done before in a previous pruning iteration, so we're good
@@ -199,8 +215,10 @@ class BasePruningMethod(ABC):
         except Exception as e:
             if not isinstance(method, PruningContainer):
                 orig = getattr(module, name + "_orig")
+                orig_index = list(module._parameters).index(name + "_orig")
                 module.register_parameter(name, orig)
                 del module._parameters[name + "_orig"]
+                _move_parameter(module, name, orig_index)
             raise e
 
         return method
@@ -257,13 +275,16 @@ class BasePruningMethod(ABC):
         weight = self.apply_mask(module)  # masked weights
 
         # delete and reset
+        orig_key = self._tensor_name + "_orig"
+        param_index = list(module._parameters).index(orig_key)
         if hasattr(module, self._tensor_name):
             delattr(module, self._tensor_name)
-        orig = module._parameters[self._tensor_name + "_orig"]
+        orig = module._parameters[orig_key]
         orig.data = weight.data
-        del module._parameters[self._tensor_name + "_orig"]
+        del module._parameters[orig_key]
         del module._buffers[self._tensor_name + "_mask"]
         setattr(module, self._tensor_name, orig)
+        _move_parameter(module, self._tensor_name, param_index)
 
 
 class PruningContainer(BasePruningMethod):


### PR DESCRIPTION
Fixes #85397

`prune.remove` was putting the restored parameter at the end of `_parameters`, so `Conv2d.state_dict()` keys went from `['weight', 'bias']` to `['bias', 'weight']`. Same for Linear / nested modules / LSTM.

The fix still uses `register_parameter` and `setattr` (LSTM `_flat_weights` is updated in `__setattr__`), then moves the key back to the slot occupied by `name + '_orig'`. First-time `apply` does the same so `_orig` sits where `name` was.

Local checks on 2.11.0 CPU (import of the patched `prune.py`, no source build): Conv2d / Linear / nested `named_parameters` / LSTM order, plus existing remove semantics and `_flat_weights` Parameter count.

Cursor helped write the patch and this description:

> Restore OrderedDict slots with `_move_parameter` after the existing register/setattr calls. Add `test_remove_pruning_preserves_parameter_order`.

I read both diffs before opening this draft.

## Test plan
- [x] `test_remove_pruning_preserves_parameter_order` cases on CPU
- [x] LSTM `prune.remove` still restores Parameters in `_flat_weights`
- [ ] CI `test/nn/test_pruning.py`

Made with [Cursor](https://cursor.com)