### PR TITLE
Add grid/block dims to CUDAGraph.get_graph_data

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -1249,9 +1249,7 @@ class TestMarkKernels(TestCase):
             ):
                 with mark_kernels("region"):
                     y = x + 1
-                    stream = cuda_runtime.cudaStream_t(
-                        init_value=torch.cuda.current_stream().cuda_stream
-                    )
+                    stream = torch.cuda.current_stream().cuda_stream
                     _s, _i, cap_graph, deps, _e, num = _check_cuda_bindings(
                         cuda_runtime.cudaStreamGetCaptureInfo(stream)
                     )
@@ -1333,16 +1331,52 @@ class TestGetGraphData(TestCase):
             self.assertIn("graph_id", node)
             self.assertIn("node_id", node)
             self.assertIn("kernel_name", node)
+            self.assertIn("grid_dim", node)
+            self.assertIn("block_dim", node)
             self.assertIn("dependencies", node)
             self.assertIn("dependents", node)
             self.assertEqual(node["graph_id"], exec_graph_id)
             self.assertEqual(node["tools_id"], (exec_graph_id << 32) | node["node_id"])
+            if node["node_type"] == "kernel":
+                for dims in (node["grid_dim"], node["block_dim"]):
+                    self.assertIsInstance(dims, tuple)
+                    self.assertEqual(len(dims), 3)
+                    for d in dims:
+                        self.assertIsInstance(d, int)
+                        self.assertGreater(d, 0)
+            else:
+                self.assertIsNone(node["grid_dim"])
+                self.assertIsNone(node["block_dim"])
 
         kernel_nodes = [n for n in data["nodes"] if n["node_type"] == "kernel"]
         self.assertGreater(len(kernel_nodes), 0)
         for kn in kernel_nodes:
             self.assertIsNotNone(kn["kernel_name"])
             self.assertIsInstance(kn["kernel_name"], str)
+
+        self.assertIn("edges", data)
+        n_nodes = len(data["nodes"])
+        for edge in data["edges"]:
+            for key in ("from", "to", "from_port", "to_port", "type"):
+                self.assertIn(key, edge)
+                self.assertIsInstance(edge[key], int)
+            self.assertGreaterEqual(edge["from"], 0)
+            self.assertLess(edge["from"], n_nodes)
+            self.assertGreaterEqual(edge["to"], 0)
+            self.assertLess(edge["to"], n_nodes)
+            # A plain capture only produces ordinary full-serialization edges.
+            self.assertEqual(edge["from_port"], 0)
+            self.assertEqual(edge["to_port"], 0)
+            self.assertEqual(edge["type"], 0)
+        # The edge list and the per-node lists describe the same relation.
+        self.assertEqual(
+            {(e["from"], e["to"]) for e in data["edges"]},
+            {
+                (dep, node["index"])
+                for node in data["nodes"]
+                for dep in node["dependencies"]
+            },
+        )
 
     def test_export_graph_data_hook(self):
         import os

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -212,9 +212,7 @@ def maybe_stamp_capture_root(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     _capture_root_graph_id = None
     if not _annotations_enabled or _is_tools_id_unavailable():
         return
-    stream_handle = _cuda_runtime.cudaStream_t(  # pyrefly: ignore[missing-attribute]
-        init_value=torch.cuda.current_stream().cuda_stream
-    )
+    stream_handle = torch.cuda.current_stream().cuda_stream
     state = _get_capture_state(stream_handle)
     if state is None:
         return
@@ -559,9 +557,7 @@ class _KernelScope(NamedTuple):
 
 def _begin_kernel_scope() -> _KernelScope | None:
     """Snapshot the current stream's capture frontier; ``None`` if not capturing."""
-    stream = _cuda_runtime.cudaStream_t(  # pyrefly: ignore[missing-attribute]
-        init_value=torch.cuda.current_stream().cuda_stream
-    )
+    stream = torch.cuda.current_stream().cuda_stream
     capture_state = _get_capture_state(stream)
     if capture_state is None:
         return None

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -816,11 +816,23 @@ class CUDAGraph(_CUDAGraph):
                         "graph_id": int,
                         "node_id": int,
                         "kernel_name": str or None,
+                        "grid_dim": tuple(int, int, int) or None,
+                        "block_dim": tuple(int, int, int) or None,
                         "event_ptr": int,
                         "host_fn_addr": int,
                         "host_fn_name": str or None,
                         "dependencies": [int, ...],
                         "dependents": [int, ...],
+                    },
+                    ...,
+                ],
+                "edges": [
+                    {
+                        "from": int,
+                        "to": int,
+                        "from_port": int,
+                        "to_port": int,
+                        "type": int,
                     },
                     ...,
                 ],
@@ -837,10 +849,24 @@ class CUDAGraph(_CUDAGraph):
         demangled symbol name for it (``None`` when it resolves to no exported
         symbol). They are ``0`` / ``None`` for other node types.
 
+        ``grid_dim`` / ``block_dim`` are the kernel launch dimensions
+        ``(x, y, z)`` read from the kernel node's params, populated for kernel
+        nodes (``None`` when the params query fails). They are ``None`` for
+        other node types.
+
         Each node's ``graph_id`` is remapped to the exec graph id so that
         ``tools_id`` values match those reported by CUPTI-based profilers.
         ``dependencies`` and ``dependents`` are lists of node indices within
         the ``nodes`` list.
+
+        ``edges`` lists every dependency once, with ``from`` / ``to`` naming
+        node indices into ``nodes`` (the same relation ``dependencies`` /
+        ``dependents`` encode per node) plus the raw ``cudaGraphEdgeData``
+        annotation: ``from_port`` / ``to_port`` / ``type`` as ints. All zero
+        is an ordinary full-serialization edge. A nonzero ``from_port`` or a
+        ``type`` of 1 (``cudaGraphDependencyTypeProgrammatic``) marks a
+        programmatic edge whose semantics reachability alone cannot express,
+        so passes that rewrite the graph must leave such edges alone.
 
         This structure is useful for inspecting a profiler trace and
         establishing whether a particular dependency observed in the profile
@@ -920,14 +946,27 @@ class CUDAGraph(_CUDAGraph):
             node_id = tools_id & 0xFFFFFFFF
 
             kernel_name = None
+            grid_dim = None
+            block_dim = None
             if ntype == node_types.CU_GRAPH_NODE_TYPE_KERNEL:
-                cu_node = _cuda_driver.CUgraphNode(init_value=int(node))
-                err, params = _cuda_driver.cuGraphKernelNodeGetParams(cu_node)
-                if err == _cuda_driver.CUresult.CUDA_SUCCESS and int(params.func):
-                    cu_func = _cuda_driver.CUfunction(init_value=int(params.func))
-                    err, name = _cuda_driver.cuFuncGetName(cu_func)
-                    if err == _cuda_driver.CUresult.CUDA_SUCCESS:
-                        kernel_name = name.decode() if isinstance(name, bytes) else name
+                err, params = _cuda_driver.cuGraphKernelNodeGetParams(node)
+                if err == _cuda_driver.CUresult.CUDA_SUCCESS:
+                    grid_dim = (
+                        int(params.gridDimX),
+                        int(params.gridDimY),
+                        int(params.gridDimZ),
+                    )
+                    block_dim = (
+                        int(params.blockDimX),
+                        int(params.blockDimY),
+                        int(params.blockDimZ),
+                    )
+                    if params.func:
+                        err, name = _cuda_driver.cuFuncGetName(params.func)
+                        if err == _cuda_driver.CUresult.CUDA_SUCCESS:
+                            kernel_name = (
+                                name.decode() if isinstance(name, bytes) else name
+                            )
 
             # Event record/wait nodes carry a cudaEvent_t but emit no timed CUPTI record;
             # capture the handle so a wait node can be matched to the record that signals it.
@@ -968,6 +1007,8 @@ class CUDAGraph(_CUDAGraph):
                     "graph_id": graph_id,
                     "node_id": node_id,
                     "kernel_name": kernel_name,
+                    "grid_dim": grid_dim,
+                    "block_dim": block_dim,
                     "event_ptr": event_ptr,
                     "host_fn_addr": host_fn_addr,
                     "host_fn_name": host_fn_name,
@@ -979,8 +1020,9 @@ class CUDAGraph(_CUDAGraph):
         _, _, _, num_edges = _check_cuda_bindings(
             _cuda_runtime.cudaGraphGetEdges(raw, numEdges=0)
         )
+        edge_infos: list[dict] = []
         if num_edges > 0:
-            from_nodes, to_nodes, _edge_data, num_edges = _check_cuda_bindings(
+            from_nodes, to_nodes, edge_data, num_edges = _check_cuda_bindings(
                 _cuda_runtime.cudaGraphGetEdges(raw, numEdges=num_edges)
             )
             for i in range(num_edges):
@@ -989,12 +1031,19 @@ class CUDAGraph(_CUDAGraph):
                 if src is not None and dst is not None:
                     node_infos[src]["dependents"].append(dst)
                     node_infos[dst]["dependencies"].append(src)
+                    annotation = edge_data[i]
+                    edge_infos.append(
+                        {
+                            "from": src,
+                            "to": dst,
+                            "from_port": int(annotation.from_port),
+                            "to_port": int(annotation.to_port),
+                            "type": int(annotation.type),
+                        }
+                    )
 
-        exec_handle = _cuda_runtime.cudaGraphExec_t(
-            init_value=self.raw_cuda_graph_exec()
-        )
         exec_graph_id = _check_cuda_bindings(
-            _cuda_runtime.cudaGraphExecGetId(exec_handle)
+            _cuda_runtime.cudaGraphExecGetId(self.raw_cuda_graph_exec())
         )
         for info in node_infos:
             info["tools_id"] = (exec_graph_id << 32) | info["node_id"]
@@ -1015,6 +1064,7 @@ class CUDAGraph(_CUDAGraph):
         data = {
             "exec_graph_id": exec_graph_id,
             "nodes": node_infos,
+            "edges": edge_infos,
         }
         if self._caching_graph_data:
             self._instantiate_graph_data = data


### PR DESCRIPTION
Each kernel node now reports grid_dim and block_dim as (x, y, z) tuples read from its kernel node params in the same driver query that resolves the kernel name; other node types report None. 
Also add programmatic edge data
Test Plan:

```
python3 -m py_compile torch/cuda/graphs.py torch/cuda/_graph_annotations.py test/test_cuda_graph_utils.py
lintrunner -a
python test/test_cuda_graph_utils.py TestGetGraphData
```

TestGetGraphData skips on drivers without cudaGraphNodeGetToolsId (requires driver >= 13.1); needs a run on a 13.1+ machine.

Authored with AI assistance.