### PR TITLE
Add doc breadcrumbs pointing at the stateless PRNG API in torch.func._random

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -14320,6 +14320,11 @@ Arguments:
 Returns:
     Generator: An torch.Generator object.
 
+.. seealso::
+    :class:`torch.Generator` is stateful. For a stateless, key-based PRNG API
+    (``key``, ``split``, ``fold_in``, ``uniform``, ``normal``, ``randint``,
+    ``bits``), see the experimental :mod:`torch.func._random` module.
+
 Example::
 
     >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)

--- a/torch/func/__init__.py
+++ b/torch/func/__init__.py
@@ -14,6 +14,10 @@ from torch._functorch.einops import rearrange
 from torch._functorch.functional_call import functional_call, stack_module_state
 
 
+# Experimental stateless (JAX-style, key-based) PRNG API: torch.func._random.
+# Intentionally not re-exported here or listed in __all__ while it is unstable.
+
+
 __all__ = [
     "grad",
     "grad_and_value",

--- a/torch/random.py
+++ b/torch/random.py
@@ -55,6 +55,11 @@ def manual_seed(seed) -> torch._C.Generator:
             `[-0x8000_0000_0000_0000, 0xffff_ffff_ffff_ffff]`. Otherwise, a RuntimeError
             is raised. Negative inputs are remapped to positive values with the formula
             `0xffff_ffff_ffff_ffff + seed`.
+
+    .. seealso::
+        For a stateless, JAX-style PRNG API (explicit ``key``, ``split``,
+        ``fold_in``) that does not touch global generator state, see the
+        experimental :mod:`torch.func._random` module.
     """
     return _manual_seed_impl(seed)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196020

torch.func._random provides a JAX-style stateless PRNG API (key, split,
fold_in, uniform, normal, randint, bits), but nothing in the stateful RNG
surface mentions it. Someone looking for a stateless RNG by inspecting
torch.manual_seed, torch.Generator, or the torch.func package finds no
hint that it exists, since it is a private submodule that is not
re-exported and does not appear in dir(torch.func).

This adds seealso notes to the torch.manual_seed and torch.Generator
docstrings and a comment in torch/func/__init__.py. The module stays
private and out of __all__ since it is still experimental.

Test Plan:

```
python -c "import torch; assert 'torch.func._random' in torch.manual_seed.__doc__"
lintrunner torch/random.py torch/_torch_docs.py torch/func/__init__.py
```

Authored with an AI assistant (Claude).