### PR TITLE
[inductor] Type analysis-only OpsHandler payloads as object

### DIFF
--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -49,10 +49,12 @@ class PreservesZeros(SymPyOps, DefaultHandler):
             raise AssertionError("prologue should only have a single store")
         self.store_preserves_zeros = value.is_constant() and value.expr == 0
 
-    def indirect_indexing(self, *args: Any, **kwargs: Any) -> sympy.Expr:
+    def indirect_indexing(self, *args: object, **kwargs: object) -> sympy.Expr:
         return construct_symbol(next(self.count), torch.int32)
 
-    def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    def _default(
+        self, name: str, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> Any:
         from torch._inductor.codegen.common import OpDecompositions
 
         if hasattr(OpDecompositions, name):
@@ -112,10 +114,12 @@ class RecordLowPrecisionOps(DefaultHandler):
 
     @staticmethod
     # pyrefly: ignore [bad-override]
-    def indirect_indexing(*args: Any, **kwargs: Any) -> sympy.Expr:
+    def indirect_indexing(*args: object, **kwargs: object) -> sympy.Expr:
         return sympy.S.Zero
 
-    def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    def _default(
+        self, name: str, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> Any:
         out_dtype = getattr(self.dtype_prop, name)(*args, **kwargs)
         out = DTypeContainer(out_dtype, is_scalar=(name == "constant"))
         if name == "constant":

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -9,6 +9,7 @@ from sympy import Expr
 
 import torch
 from torch.utils._sympy.value_ranges import (
+    AllIn,
     bound_sympy,
     SymPyValueRangeAnalysis,
     ValueRanges,
@@ -209,7 +210,7 @@ class ValueRangeAnalysis(SymPyValueRangeAnalysis, DefaultHandler):
     @staticmethod
     # pyrefly: ignore [bad-override]
     def to_dtype(
-        x: object,
+        x: AllIn | ValueRanges[Any],
         dtype: torch.dtype,
         src_dtype: torch.dtype | None = None,
         use_compute_types: bool = True,

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -168,11 +168,13 @@ class ValueRangeAnalysis(SymPyValueRangeAnalysis, DefaultHandler):
             setattr(self, op, self.bool_handler)
 
     @staticmethod
-    def bool_handler(*args: Any, **kwargs: Any) -> ValueRanges[Any]:
+    def bool_handler(*args: object, **kwargs: object) -> ValueRanges[Any]:
         # just assuming bools can have both values
         return ValueRanges(sympy.false, sympy.true)  # type: ignore[arg-type]
 
-    def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    def _default(
+        self, name: str, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> Any:
         # many ops are unlikely to show up in optimizable indexing compute,
         # so we don't have full coverage
         return ValueRanges.unknown()
@@ -181,7 +183,7 @@ class ValueRangeAnalysis(SymPyValueRangeAnalysis, DefaultHandler):
         return ValueRanges.unknown()
 
     def store(
-        self, name: str, index: sympy.Expr, value: Any, mode: StoreMode = None
+        self, name: str, index: sympy.Expr, value: object, mode: StoreMode = None
     ) -> None:
         return
 
@@ -190,24 +192,24 @@ class ValueRangeAnalysis(SymPyValueRangeAnalysis, DefaultHandler):
         dtype: torch.dtype,
         src_dtype: torch.dtype,
         reduction_type: ReductionType,
-        value: Any,
+        value: object,
     ) -> ValueRanges[Any]:
         return ValueRanges.unknown()
 
     @classmethod
-    def index_expr(cls, index: Any, dtype: torch.dtype) -> ValueRanges[Any]:
+    def index_expr(cls, index: object, dtype: torch.dtype) -> ValueRanges[Any]:
         if not isinstance(index, ValueRanges):
             raise AssertionError(f"expected ValueRanges, got {type(index)}")
         return cls.to_dtype(index, dtype)
 
     @classmethod
-    def value_expr(cls, index: Any, dtype: torch.dtype) -> ValueRanges[Any]:
+    def value_expr(cls, index: object, dtype: torch.dtype) -> ValueRanges[Any]:
         return cls.index_expr(index, dtype)
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def to_dtype(
-        x: Any,
+        x: object,
         dtype: torch.dtype,
         src_dtype: torch.dtype | None = None,
         use_compute_types: bool = True,

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -888,14 +888,16 @@ class FreeSymbolsOpsHandler(DefaultHandler):
         self.symbols = OrderedSet()
         self.get_symbols = free_unbacked_symbols if unbacked_only else free_symbols
 
-    def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    def _default(
+        self, name: str, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> Any:
         for a in itertools.chain(args, kwargs.values()):
             if isinstance(a, (sympy.Expr, sympy.logic.boolalg.Boolean)):
                 self.symbols |= self.get_symbols(a)
 
     def indirect_indexing(
         self,
-        index_var: Any,
+        index_var: object,
         size: int | sympy.Expr,
         check: bool = True,
         wrap_neg: bool = True,
@@ -907,16 +909,20 @@ class FreeSymbolsOpsHandler(DefaultHandler):
         self.symbols |= self.get_symbols(size)
         return sympy_index_symbol(f"({str(index_var)})")
 
-    def frexp(self, x: Any) -> tuple[None, ...]:
+    def frexp(self, x: object) -> tuple[None, ...]:
         return (None,) * 2
 
     def scan(
-        self, dtypes: Any, combine_fn: Any, values: Sequence[Any]
+        self, dtypes: object, combine_fn: object, values: Sequence[object]
     ) -> tuple[None, ...]:
         return (None,) * len(values)
 
     def sort(
-        self, dtypes: Any, values: Sequence[Any], stable: Any, descending: Any
+        self,
+        dtypes: object,
+        values: Sequence[object],
+        stable: object,
+        descending: object,
     ) -> tuple[None, ...]:
         return (None,) * len(values)
 
@@ -930,7 +936,7 @@ class FreeSymbolsOpsHandler(DefaultHandler):
         num_values = reduction_num_outputs(reduction_type)
         return (None,) * num_values if num_values > 1 else None
 
-    def masked(self, mask: Any, body: Callable[..., Any], other: Any) -> None:
+    def masked(self, mask: object, body: Callable[..., object], other: object) -> None:
         if not callable(body):
             raise AssertionError("masked body must always be callable.")
         # The body can make additional calls, for e.g. ops.indirect_indexing
@@ -964,7 +970,9 @@ class SymbolUsageCollectorOpsHandler(DefaultHandler):
         self.symbol = symbol
         self.usages = OrderedSet()
 
-    def _default(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    def _default(
+        self, name: str, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> Any:
         used_here = self.symbol in args or self.symbol in kwargs.values()
         if used_here:
             self.usages.add(name)

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -913,16 +913,19 @@ class FreeSymbolsOpsHandler(DefaultHandler):
         return (None,) * 2
 
     def scan(
-        self, dtypes: object, combine_fn: object, values: Sequence[object]
+        self,
+        dtypes: tuple[torch.dtype, ...],
+        combine_fn: object,
+        values: Sequence[object],
     ) -> tuple[None, ...]:
         return (None,) * len(values)
 
     def sort(
         self,
-        dtypes: object,
+        dtypes: tuple[torch.dtype, ...],
         values: Sequence[object],
-        stable: object,
-        descending: object,
+        stable: bool,
+        descending: bool,
     ) -> tuple[None, ...]:
         return (None,) * len(values)
 
@@ -936,7 +939,7 @@ class FreeSymbolsOpsHandler(DefaultHandler):
         num_values = reduction_num_outputs(reduction_type)
         return (None,) * num_values if num_values > 1 else None
 
-    def masked(self, mask: object, body: Callable[..., object], other: object) -> None:
+    def masked(self, mask: object, body: Callable[[], object], other: object) -> None:
         if not callable(body):
             raise AssertionError("masked body must always be callable.")
         # The body can make additional calls, for e.g. ops.indirect_indexing

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -279,10 +279,10 @@ class _ValueUseRules:
         self,
         dtypes: tuple[torch.dtype, ...],
         combine_fn_or_values: object,
-        values: object | None = None,
+        values: tuple[object, ...] | None = None,
     ) -> _ValueUseRule:
         if values is None:
-            values = combine_fn_or_values
+            values = cast(tuple[object, ...], combine_fn_or_values)
         return _ValueUseRule(value_sinks=(values,))
 
     def bucketize(

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -1,12 +1,12 @@
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import sympy
 
 import torch
-from torch.fx.node import map_arg
+from torch.fx.node import Argument, map_arg
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.value_ranges import ValueRanges
 
@@ -184,25 +184,25 @@ def indexing_dtype_strength_reduction(loop_body: LoopBody) -> None:
 
 @dataclass(frozen=True)
 class _ValueUseRule:
-    # These fields are op arguments, so Any covers FX nodes, SymPy exprs,
+    # These fields are op arguments, so object covers FX nodes, SymPy exprs,
     # scalars, and nested tuples/lists. value_sinks seed the backward walk
     # unconditionally. value_inputs propagate value demand only when the op's
     # result is already value-reachable. indexing_inputs block propagation
     # because they only affect addresses, bounds, masks, or other indexing-only
     # state.
-    value_inputs: tuple[Any, ...] = ()
-    value_sinks: tuple[Any, ...] = ()
-    indexing_inputs: tuple[Any, ...] = ()
+    value_inputs: tuple[object, ...] = ()
+    value_sinks: tuple[object, ...] = ()
+    indexing_inputs: tuple[object, ...] = ()
 
 
-def _collect_fx_nodes(arg: Any) -> OrderedSet[torch.fx.Node]:
+def _collect_fx_nodes(arg: object) -> OrderedSet[torch.fx.Node]:
     nodes: OrderedSet[torch.fx.Node] = OrderedSet()
 
     def add_node(node: torch.fx.Node) -> torch.fx.Node:
         nodes.add(node)
         return node
 
-    map_arg(arg, add_node)
+    map_arg(cast(Argument, arg), add_node)
     return nodes
 
 
@@ -219,7 +219,7 @@ def _collect_input_nodes(node: torch.fx.Node) -> OrderedSet[torch.fx.Node]:
 
 class _ValueUseRules:
     @staticmethod
-    def default_rule(*args: Any, **kwargs: Any) -> _ValueUseRule | None:
+    def default_rule(*args: object, **kwargs: object) -> _ValueUseRule | None:
         return None
 
     def load(self, name: str, index: sympy.Expr) -> _ValueUseRule:
@@ -232,8 +232,8 @@ class _ValueUseRules:
         self,
         name: str,
         index: sympy.Expr,
-        value: Any,
-        mode: Any = None,
+        value: object,
+        mode: object = None,
     ) -> _ValueUseRule:
         return _ValueUseRule(
             value_sinks=(value,),
@@ -241,7 +241,7 @@ class _ValueUseRules:
         )
 
     def store_reduction(
-        self, name: str, index: sympy.Expr, value: Any
+        self, name: str, index: sympy.Expr, value: object
     ) -> _ValueUseRule:
         return _ValueUseRule(
             value_sinks=(value,),
@@ -253,7 +253,7 @@ class _ValueUseRules:
         dtype: torch.dtype,
         src_dtype: torch.dtype,
         reduction_type: str,
-        value: Any,
+        value: object,
     ) -> _ValueUseRule:
         return _ValueUseRule(value_sinks=(value,))
 
@@ -261,15 +261,15 @@ class _ValueUseRules:
         self,
         name: str,
         reduction_type: str,
-        value: Any,
-        extra_meta: dict[str, Any],
+        value: object,
+        extra_meta: dict[str, object],
     ) -> _ValueUseRule:
         return _ValueUseRule(value_sinks=(value,))
 
     def sort(
         self,
         dtypes: tuple[torch.dtype, ...],
-        values: tuple[Any, ...],
+        values: tuple[object, ...],
         stable: bool,
         descending: bool,
     ) -> _ValueUseRule:
@@ -278,8 +278,8 @@ class _ValueUseRules:
     def scan(
         self,
         dtypes: tuple[torch.dtype, ...],
-        combine_fn_or_values: Any,
-        values: tuple[Any, ...] | None = None,
+        combine_fn_or_values: object,
+        values: object | None = None,
     ) -> _ValueUseRule:
         if values is None:
             values = combine_fn_or_values
@@ -287,13 +287,13 @@ class _ValueUseRules:
 
     def bucketize(
         self,
-        values: Any,
+        values: object,
         boundaries: tuple[str, sympy.Expr, sympy.Expr, sympy.Expr],
-        boundary_indices: Any,
+        boundary_indices: object,
         indexing_dtype: torch.dtype,
         right: bool,
         sorter: tuple[str, sympy.Expr] | None = None,
-        sorter_indices: Any | None = None,
+        sorter_indices: object | None = None,
     ) -> _ValueUseRule:
         return _ValueUseRule(
             value_inputs=(values,),
@@ -301,7 +301,7 @@ class _ValueUseRules:
         )
 
     def indirect_indexing(
-        self, x: Any, size: sympy.Expr, check: bool = True, wrap_neg: bool = True
+        self, x: object, size: sympy.Expr, check: bool = True, wrap_neg: bool = True
     ) -> _ValueUseRule:
         return _ValueUseRule(indexing_inputs=(x, size))
 
@@ -310,16 +310,16 @@ class _ValueUseRules:
     ) -> _ValueUseRule:
         return _ValueUseRule(indexing_inputs=(expr, size))
 
-    def masked(self, mask: Any, body: Any, other: Any) -> _ValueUseRule:
+    def masked(self, mask: object, body: object, other: object) -> _ValueUseRule:
         return _ValueUseRule(value_inputs=(other,), indexing_inputs=(mask,))
 
-    def masked_subblock(self, mask: Any, other: Any) -> _ValueUseRule:
+    def masked_subblock(self, mask: object, other: object) -> _ValueUseRule:
         return _ValueUseRule(value_inputs=(other,), indexing_inputs=(mask,))
 
-    def set_indirect(self, new_var: Any) -> _ValueUseRule:
+    def set_indirect(self, new_var: object) -> _ValueUseRule:
         return _ValueUseRule(indexing_inputs=(new_var,))
 
-    def device_assert_async(self, cond: Any, msg: str) -> _ValueUseRule:
+    def device_assert_async(self, cond: object, msg: str) -> _ValueUseRule:
         return _ValueUseRule(indexing_inputs=(cond,))
 
 
@@ -338,7 +338,7 @@ class _ValueUseAnalysis:
 
         self.value_reachable: OrderedSet[torch.fx.Node] = OrderedSet()
         self.worklist: list[tuple[torch.fx.Graph, torch.fx.Node]] = []
-        self.indirect_inputs: dict[sympy.Symbol, tuple[torch.fx.Graph, Any]] = {}
+        self.indirect_inputs: dict[sympy.Symbol, tuple[torch.fx.Graph, Argument]] = {}
 
     def run(self) -> bool:
         if not self.has_index_expr():


### PR DESCRIPTION
## Summary

- type opaque payloads in analysis-only Inductor `OpsHandler` implementations as `object`
- use the FX `Argument` boundary when recursively collecting nodes
- retain `Any` for genuinely dynamic handler returns and arithmetic inputs

These handlers classify, search, ignore, or forward heterogeneous payloads; they do not require the unchecked operations that `Any` permits.

## Test plan

```bash
pyrefly check torch/_inductor/optimize_indexing.py torch/_inductor/dependencies.py torch/_inductor/analyze_preserves_zero_mask.py torch/_inductor/bounds.py
```

0 errors (23 suppressions).

```bash
UV_NO_CONFIG=1 lintrunner -a --skip PYREFLY torch/_inductor/optimize_indexing.py torch/_inductor/dependencies.py torch/_inductor/analyze_preserves_zero_mask.py torch/_inductor/bounds.py
```

```bash
PYTHONPYCACHEPREFIX=/home/bobren/local/b/pytorch/agent_space/inductor-analysis-pycache python -m py_compile torch/_inductor/optimize_indexing.py torch/_inductor/dependencies.py torch/_inductor/analyze_preserves_zero_mask.py torch/_inductor/bounds.py
```

Authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo