### PR TITLE
[AOTInductor] Normalize PathLike package paths before compilation

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -331,7 +331,7 @@ model(torch.ones(2))
                     # cubin files are removed when exiting this context
                     package_path = torch._inductor.aoti_compile_and_package(
                         ep,
-                        package_path=f.name,
+                        package_path=Path(f.name),
                     )  # type: ignore[arg-type]
                 loaded = torch._inductor.aoti_load_package(package_path)
                 actual = loaded(*example_inputs)

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -148,6 +148,9 @@ def aoti_compile_and_package(
             f"Expect package path to be a file ending in .pt2, is None, or is a buffer. Instead got {package_path}"
         )
 
+    if isinstance(package_path, os.PathLike):
+        package_path = os.fspath(package_path)
+
     inductor_configs = inductor_configs or {}
     inductor_configs["aot_inductor.package"] = True
 


### PR DESCRIPTION
## Summary

`aoti_compile_and_package` accepts `os.PathLike` package paths, but its internal helper expects a string. Packaging normalizes the path before returning it, so comparing that string with the original `PathLike` raises after the package has already been written.

Normalize `PathLike` inputs at the public API boundary and cover package creation, loading, and execution using `pathlib.Path`.

## Test plan

- `python test/inductor/test_aot_inductor_package.py -k test_remove_intermediate_files`
- `spin quicklint`
- `lintrunner -a`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo