### PR TITLE
[AOTInductor] Avoid mutating package compile configs

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -12,6 +12,7 @@ import unittest
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import patch
 
 from parameterized import parameterized_class
 
@@ -71,6 +72,31 @@ def compile(
     )  # type: ignore[arg-type]
     loaded = load_package(package_path)
     return loaded
+
+
+class TestAOTInductorPackageAPI(TestCase):
+    def test_aoti_compile_and_package_does_not_mutate_configs(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        ep = torch.export.export(Model(), (torch.ones(1),))
+        inductor_configs = {"max_autotune": True}
+
+        with patch(
+            "torch._inductor.debug.aot_inductor_minifier_wrapper",
+            return_value="model.pt2",
+        ) as compile_and_package:
+            result = torch._inductor.aoti_compile_and_package(
+                ep, inductor_configs=inductor_configs
+            )
+
+        self.assertEqual(result, "model.pt2")
+        self.assertEqual(inductor_configs, {"max_autotune": True})
+        self.assertEqual(
+            compile_and_package.call_args.kwargs["inductor_configs"],
+            {"max_autotune": True, "aot_inductor.package": True},
+        )
 
 
 @unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -148,7 +148,7 @@ def aoti_compile_and_package(
             f"Expect package path to be a file ending in .pt2, is None, or is a buffer. Instead got {package_path}"
         )
 
-    inductor_configs = inductor_configs or {}
+    inductor_configs = dict(inductor_configs or {})
     inductor_configs["aot_inductor.package"] = True
 
     if inductor_configs.get("aot_inductor.output_path"):


### PR DESCRIPTION
## Summary

`aoti_compile_and_package` currently inserts `aot_inductor.package` directly into a caller-provided `inductor_configs` dictionary. Copy the dictionary before adding the package-only setting so callers can safely reuse their configuration.

Add a focused test that checks both the unchanged input dictionary and the configuration passed to the compile wrapper.

## Test plan

- focused mocked API test
- `spin lint torch/_inductor/__init__.py test/inductor/test_aot_inductor_package.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo