### PR TITLE
[AOTInductor] Reuse package loader metadata during load

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -12,6 +12,7 @@ import unittest
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import patch
 
 from parameterized import parameterized_class
 
@@ -24,6 +25,7 @@ from torch._inductor.utils import fresh_cache
 from torch.export import Dim
 from torch.export.experimental import _ExportPackage
 from torch.export.pt2_archive._package import (
+    _load_aoti,
     AOTICompiledModel,
     load_pt2,
     load_weights_to_pt2_contents,
@@ -71,6 +73,25 @@ def compile(
     )  # type: ignore[arg-type]
     loaded = load_package(package_path)
     return loaded
+
+
+class TestAOTInductorPackageAPI(TestCase):
+    def test_load_aoti_reuses_loader_metadata(self):
+        with (
+            patch(
+                "torch.export.pt2_archive._package.torch._C._aoti.AOTIModelPackageLoader"
+            ) as package_loader,
+            patch("torch._inductor.codecache.get_device_information", return_value={}),
+        ):
+            loader = package_loader.return_value
+            loader.get_metadata.return_value = {"AOTI_DEVICE_KEY": "cpu"}
+
+            loaded = _load_aoti("model.pt2", "model", False, 1, -1)
+
+        self.assertIs(loaded.loader, loader)
+        package_loader.assert_called_once_with("model.pt2", "model", False, 1, -1)
+        loader.get_metadata.assert_called_once_with()
+        package_loader.load_metadata_from_package.assert_not_called()
 
 
 @unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1046,19 +1046,15 @@ def _load_aoti(
     num_runners: int,
     device_idx: int,
 ) -> AOTICompiledModel:
-    loaded_metadata = torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(  # type: ignore[attr-defined]
-        file, model_name
+    loader = torch._C._aoti.AOTIModelPackageLoader(
+        file,
+        model_name,
+        run_single_threaded,
+        num_runners,
+        device_idx,
     )
-
-    aoti_compiled_model = AOTICompiledModel(
-        torch._C._aoti.AOTIModelPackageLoader(
-            file,
-            model_name,
-            run_single_threaded,
-            num_runners,
-            device_idx,
-        )
-    )
+    loaded_metadata = loader.get_metadata()
+    aoti_compiled_model = AOTICompiledModel(loader)
 
     device = loaded_metadata["AOTI_DEVICE_KEY"]
     from torch._inductor.codecache import get_device_information


### PR DESCRIPTION
## Summary

`_load_aoti` reads package metadata with `load_metadata_from_package` and then constructs `AOTIModelPackageLoader`, which reads the same metadata again. Construct the loader first and use its cached metadata for device validation.

This removes one archive scan and metadata extraction from each model load without changing validation behavior.

## Test plan

- focused mocked loader test verifies one loader construction and one metadata lookup
- `spin lint torch/export/pt2_archive/_package.py test/inductor/test_aot_inductor_package.py`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo