### PR TITLE
Move 2.15 and 2.16 release branch cut dates out one week

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -105,8 +105,8 @@ Following is the release cadence. All future dates below are tentative. For late
 | 2.12 | 13 Apr 2026 | 13 May 2026 | Jun 2026 | Not planned |
 | 2.13 | 8 Jun 2026 | 8 Jul 2026 | (Aug 2026) | Not planned |
 | 2.14 | 10 Aug 2026 | 2 Sept 2026 | (Oct 2026) | Not planned |
-| 2.15 | 28 Sept 2026 | 28 Oct 2026 | (Nov 2026) | Not planned |
-| 2.16 | 23 Nov 2026 | 22 Dec 2026 | (Jan 2027) | Not planned |
+| 2.15 | 5 Oct 2026 | 28 Oct 2026 | (Nov 2026) | Not planned |
+| 2.16 | 30 Nov 2026 | 22 Dec 2026 | (Jan 2027) | Not planned |
 
 ## General Overview
 


### PR DESCRIPTION
Pushes the feature freeze / release branch cut for 2.15 and 2.16 back by one week, giving features an extra week to land. **Release dates are unchanged.**

| Minor Version | Release branch cut | Release date |
| --- | --- | --- |
| 2.15 | ~~28 Sept 2026~~ → **5 Oct 2026** | 28 Oct 2026 (unchanged) |
| 2.16 | ~~23 Nov 2026~~ → **30 Nov 2026** | 22 Dec 2026 (unchanged) |

Holiday check — both new dates are Mondays and clear of US holidays:
- **5 Oct 2026** — clear; Indigenous Peoples' Day / Columbus Day is the following Monday, 12 Oct.
- **30 Nov 2026** — clear. This is actually an improvement: 23 Nov was the Monday of Thanksgiving week (Thanksgiving is 26 Nov 2026), and the new date moves the cut past it.

Trade-off: the RC window shrinks to 23 days for 2.15 (was 30) and 22 days for 2.16 (was 29).

Created with Claude
