### PR TITLE
[inductor] Match eager for sigmoid under strict pointwise numerics

### DIFF
--- a/test/inductor/test_strict_numerics.py
+++ b/test/inductor/test_strict_numerics.py
@@ -801,8 +801,6 @@ POINTWISE_XFAIL = frozenset(
         ("short", "bfloat16"),
         ("short", "float16"),
         ("short", "float32"),
-        ("sigmoid", "float16"),
-        ("sigmoid", "float32"),
         ("special_bessel_j0", "float32"),
         ("special_bessel_j1", "float32"),
         ("special_bessel_y0", "float32"),

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2308,6 +2308,18 @@ class TritonOverrides(OpOverrides):
     @staticmethod
     @maybe_upcast_float32()
     def sigmoid(x):
+        # Eager CUDA computes sigmoid as 1 / (1 + exp(-x)); Triton's tl.sigmoid uses an
+        # intrinsic exp and approximate divide that differ by 1-9 ULP on fp32. Under
+        # strict numerics, reproduce eager's formula with libdevice.exp and round-to-
+        # nearest division. Both halves are required: with libdevice.exp but an
+        # approximate divide the result matches neither eager nor tl.sigmoid, so fall
+        # back to the intrinsic unless both knobs are on.
+        if (
+            config.numerics == "strict"
+            or config.eager_numerics.use_pytorch_libdevice
+        ) and config.use_eager_division_rounding():
+            denominator = f"(1.0 + libdevice.exp(-({x})))"
+            return f"triton.language.div_rn(1.0, {denominator})"
         return f"tl.sigmoid({x})"
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196039
* #196038
* #196037
* #196036
* #196035
* #196034
* #196033
* __->__ #196032
* #196030
* #196029
* #195640
* #196663

Summary:
Under numerics="strict", Inductor aims to be bitwise-identical to eager. ATen CUDA
computes sigmoid as 1 / (1 + exp(-x)), while Inductor emits tl.sigmoid, whose
intrinsic exponential and approximate division differ from eager by 1-9 ULP on
finite float32/float16 inputs.

This reproduces eager's formula in the strict-only path: route the exponential
through libdevice.exp and, when eager division rounding is in effect, use
round-to-nearest division (triton.language.div_rn):

    1 / (1 + libdevice.exp(-x))            # div_rn when use_eager_division_rounding()

The gate follows this repo's helper pattern -- libdevice is used when
`config.numerics == "strict" or config.eager_numerics.use_pytorch_libdevice`, and
the divide uses `config.use_eager_division_rounding()`. The default (non-strict)
path still emits tl.sigmoid, so there is no impact outside strict numerics.

Removes ("sigmoid", "float16"/"float32") from POINTWISE_XFAIL. The sigmoid
backward pass is unaffected by this change and remains tracked in BACKWARD_XFAIL.

Test Plan:
  ./agent_space/run_pointwise.sh -k sigmoid
- sigmoid forward now matches eager bitwise for float16/float32 (bfloat16 already
  matched); no regressions.