### PR TITLE
[inductor] Route transcendental codegen through libdevice under strict numerics

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2412,9 +2412,9 @@ class TritonOverrides(OpOverrides):
         # approximate divide the result matches neither eager nor tl.sigmoid, so fall
         # back to the intrinsic unless both knobs are on.
         if (
-            config.numerics == "strict"
-            or config.eager_numerics.use_pytorch_libdevice
-        ) and config.use_eager_division_rounding():
+            config.should_use_pytorch_libdevice()
+            and config.use_eager_division_rounding()
+        ):
             denominator = f"(1.0 + libdevice.exp(-({x})))"
             return f"triton.language.div_rn(1.0, {denominator})"
         return f"tl.sigmoid({x})"
@@ -2491,9 +2491,10 @@ class TritonOverrides(OpOverrides):
     @maybe_upcast_float32()
     # pyrefly: ignore [bad-override]
     def log(x):
-        if config.eager_numerics.use_pytorch_libdevice:
-            # Strict numerics should use the backend math library entry point.
-            # On ROCm this maps to OCML and avoids Triton's generic log lowering.
+        if config.should_use_pytorch_libdevice():
+            # Strict numerics, or an explicit opt-in, uses the backend math library
+            # entry point. On ROCm this maps to OCML and avoids Triton's generic log
+            # lowering.
             return f"libdevice.log({x})"
         return f"tl_math.log({x})"
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1099,6 +1099,17 @@ def should_emulate_precision_casts() -> bool:
     return config.numerics == "strict" or config.emulate_precision_casts
 
 
+def should_use_pytorch_libdevice() -> bool:
+    config = _current_config()
+    # Whether codegen should call into the CUDA toolkit's libdevice (e.g. libdevice.log)
+    # instead of Triton's approximate math, so transcendentals match eager. Strict
+    # numerics needs this; it can also be requested directly via the eager_numerics flag.
+    # (compile_tasks.py selects WHICH libdevice file is linked; this controls WHETHER
+    # codegen calls into it.) Gated on strict only, to leave standalone
+    # emulate_precision_casts=True users unchanged.
+    return config.numerics == "strict" or config.eager_numerics.use_pytorch_libdevice
+
+
 # When we do split reduction, this number control the minimum value for
 # num_split. Too small num_split make the split reduction less efficient.
 # It's a much bigger problem when we compile a dynamic shape kernel with
@@ -3211,8 +3222,9 @@ class eager_numerics:
     # (0.5 * x * (1 + erf(x * sqrt(0.5)))) where a 1 ULP change in erf output
     # can flip the result of a subsequent ceil(log2(...)) and produce a
     # different uint8 encoded value (see gh-178045).
-    # This can be enabled directly; Inductor also enables it while
-    # emulate_precision_casts is active.
+    # This flag can be enabled directly. numerics="strict" does not set it; it takes
+    # the same codegen path via config.should_use_pytorch_libdevice(), which is what
+    # callers should read rather than this flag.
     use_pytorch_libdevice: bool = False
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196039
* #196038
* #196037
* #196036
* __->__ #196035
* #196034
* #196033
* #196032
* #196030
* #196029
* #195640
* #196663

Summary:
config.eager_numerics.use_pytorch_libdevice controls WHETHER Inductor codegen
calls into the CUDA toolkit's libdevice (e.g. libdevice.log) instead of Triton's
approximate math. Under numerics="strict" this flag was left False, so codegen
kept emitting tl_math.* even though strict already links the build-matched
libdevice (compile_tasks.py derives that path from should_emulate_precision_casts).
The config comment already documents the intent ("Inductor also enables it while
emulate_precision_casts is active"); it just was not wired at the codegen sites --
sigmoid had a one-off `numerics=="strict" or flag` special-case while log used the
raw flag.

Add a use_pytorch_libdevice() helper (config.numerics == "strict" or
config.eager_numerics.use_pytorch_libdevice) and route the log and sigmoid emitters
through it. Gated on strict only, so standalone emulate_precision_casts=True users
are unchanged, and the default path is untouched. This is the mechanism the
following i0/i1/erfcx strict fixes rely on to select their eager-matching paths.

No xfail changes: log/libdevice vs log/tl_math both already match eager on the
pointwise sweep, so this clears nothing on its own and introduces no regressions.

Test Plan:
  ./agent_space/run_pointwise.sh    # full suite: no failures
- log now emits libdevice.log under strict; full pointwise suite green, no
  regressions.