### PR TITLE
[dynamo] Constant fold __name__/__module__ metadata on torch builtins

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -5349,6 +5349,21 @@ class GraphModule(torch.nn.Module):
 
         self.assertTrue(fn())
 
+    def test_torch_function_metadata_attrs_constant(self):
+        def fn(x):
+            names = [
+                torch.mul.__name__,
+                torch.Tensor.add_.__name__,
+                torch.sin.__module__,
+            ]
+            if torch.Tensor.add_.__name__.endswith("_"):
+                x = x + 1
+            return x, names
+
+        x = torch.ones(2)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(opt_fn(x), fn(x))
+
 
 def udf_mul(x, y):
     return x * y

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -925,6 +925,11 @@ class AllowInGraphKind(enum.Enum):
     LEAF_FUNCTION = "leaf_function"
 
 
+_CONSTANT_FN_METADATA_ATTRS = frozenset(
+    {"__name__", "__qualname__", "__module__", "__doc__"}
+)
+
+
 class TorchInGraphFunctionVariable(BaseTorchVariable):
     """Points to a torch function/method that should be put in FX graph"""
 
@@ -3512,6 +3517,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             member, (torch._ops.OpOverloadPacket, torch._ops.OpOverload)
         ) and torch._dynamo.trace_rules.is_aten_op_or_tensor_method(member):
             return TorchInGraphFunctionVariable(member, source=source)
+        # Function metadata (__name__, __module__, __qualname__, ...) is
+        # immutable on builtins and descriptors, so it can be constant folded.
+        if name in _CONSTANT_FN_METADATA_ATTRS and ConstantVariable.is_literal(member):
+            return ConstantVariable.create(member)
         return variables.GetAttrVariable(self, name, source=source)
 
     def call_function(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196040

`TorchInGraphFunctionVariable.tp_getattro_impl` returned an opaque
`GetAttrVariable` for every attribute other than aten overloads, so code that
inspects a torch function it was handed, e.g. `func.__name__.endswith("_")`
inside a `__torch_function__` implementation, graph broke with "Dynamo does
not know how to trace method `endswith` of class `str`".

`__name__`, `__qualname__`, `__module__` and `__doc__` are immutable on
builtins and method descriptors, so when the value is a literal it is now
returned as a `ConstantVariable`.

Test Plan:

```
python -m pytest test/dynamo/test_functions.py -k test_torch_function_metadata_attrs_constant
python -m pytest test/dynamo/test_functions.py
```

Authored with an AI assistant (Claude).