### PR TITLE
[dynamo] Raise AttributeError for missing members on opaque objects

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -1617,6 +1617,18 @@ def forward(self, arg0_1, arg1_1, arg2_1):
                 NestedCounters(Counter(1, 5)), torch.ones(2, 3)
             )
 
+    def test_compile_missing_attribute(self):
+        counter = Counter(0, 10)
+
+        def foo(counter, x):
+            if hasattr(counter, "missing"):
+                x = x + 1
+            return x, getattr(counter, "missing", None)
+
+        x = torch.ones(2, 3)
+        opt_foo = torch.compile(foo, backend="eager", fullgraph=True)
+        self.assertEqual(opt_foo(counter, x), foo(counter, x))
+
     def test_compile_fixed_stride_order(self):
         hs_name = get_opaque_type_name(HoistedString)
 

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -405,11 +405,12 @@ class CustomClassObjectVariable(UserDefinedObjectVariable):
             elif is_opaque_constant_type(real_obj_type):
                 return super().tp_getattro_impl(tx, name)
 
-            elif name in ("__bool__", "__len__") and not hasattr(real_obj, name):
-                # Special case: __bool__ and __len__ are used for truthiness checks.
-                # If they're not registered and the real object doesn't have them,
-                # raise ObservedAttributeError so the caller can fall back to
-                # treating the object as truthy (Python default behavior)
+            elif not hasattr(real_obj, name):
+                # The real object has no such attribute, so the observable
+                # behavior is an AttributeError.  This lets hasattr() and
+                # getattr(obj, name, default) work on unregistered members,
+                # and lets truthiness checks fall back to the Python default
+                # when __bool__/__len__ are absent.
                 raise_observed_exception(AttributeError, tx)
 
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

`CustomClassObjectVariable.tp_getattro_impl` graph broke with "Attempted to
access unregistered member on an OpaqueObject" for any name that was not
registered via `register_custom_class(members=...)`, even when the real
object does not have that attribute at all. That made `hasattr(obj, name)`
and `getattr(obj, name, default)` on opaque objects such as `ProcessGroup`
untraceable, although both are well defined: the observable eager behavior
is an `AttributeError`.

The existing special case for `__bool__`/`__len__` already raised an observed
`AttributeError` when the real object lacks the attribute. This generalizes
it to every missing attribute. Members that do exist but are unregistered
still graph break as before.

Test Plan:

```
python -m pytest test/test_opaque_obj_v2.py -k test_compile_missing_attribute
python -m pytest test/test_opaque_obj_v2.py
```

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98