### PR TITLE
[dynamo] Support super().__init__() resolving to a C exception __init__

### DIFF
--- a/test/dynamo/test_exceptions.py
+++ b/test/dynamo/test_exceptions.py
@@ -1783,6 +1783,22 @@ class ExceptionTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         opt_fn(x)  # diverges: Dynamo does not raise
 
+    def test_exception_subclass_super_init_with_kwargs(self):
+        class MyError(RuntimeError):
+            def __init__(self, msg, *, context=None):
+                super().__init__(msg)
+                self.context = context
+
+        def fn(x):
+            try:
+                raise MyError("bad", context="ctx")
+            except MyError as e:
+                return x + 1, e.args, e.context, str(e)
+
+        x = torch.ones(2)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(opt_fn(x), fn(x))
+
 
 instantiate_parametrized_tests(ExceptionTests)
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -246,6 +246,17 @@ class SuperVariable(VariableTracker):
         # about here (e.g., note the staticmethod, classmethod cases).
         if inner_fn is object.__init__:
             return LambdaVariable(identity)
+        elif (
+            isinstance(inner_fn, types.WrapperDescriptorType)
+            and inner_fn.__name__ == "__init__"
+            and issubclass(inner_fn.__objclass__, BaseException)
+            and isinstance(self.objvar, variables.UserDefinedExceptionObjectVariable)
+            and not kwargs
+        ):
+            # BaseException_init stores the positional args on the instance.
+            # https://github.com/python/cpython/blob/3.13/Objects/exceptions.c#L84
+            self.objvar.exc_vt.args = list(args)
+            return variables.ConstantVariable.create(None)
         elif inner_fn is types.SimpleNamespace.__init__ and isinstance(
             self.objvar, variables.SimpleNamespaceVariable
         ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

A user exception class with its own `__init__` that forwards to
`super().__init__(msg)`, for example to accept extra keyword-only fields,
graph broke with "Attempted to call a super() attribute that is not a
function or method": the resolved attribute is the `BaseException.__init__`
slot wrapper, which none of the branches in `SuperVariable.call_method`
handled.

`BaseException_init` only stores the positional args on the instance, so the
call is modeled by setting `args` on the wrapped `ExceptionVariable`. The
keyword-argument case is left to the existing fallback.

Test Plan:

```
python -m pytest test/dynamo/test_exceptions.py -k test_exception_subclass_super_init_with_kwargs
python -m pytest test/dynamo/test_exceptions.py
```

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98