### PR TITLE
[dynamo] Wrap classmethod_descriptor values; expose __name__/__self__ on bound builtin methods

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -5349,6 +5349,22 @@ class GraphModule(torch.nn.Module):
 
         self.assertTrue(fn())
 
+    def test_classmethod_descriptor_instance_attribute(self):
+        class Holder:
+            def __init__(self):
+                self._orig = dict.__dict__["fromkeys"]
+
+        holder = Holder()
+
+        def fn(x):
+            bound = holder._orig.__get__(None, dict)
+            d = bound(["a", "b"], 1)
+            return x + d["a"], bound.__name__, bound.__self__ is dict
+
+        x = torch.ones(2)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(opt_fn(x), fn(x))
+
     def test_torch_function_metadata_attrs_constant(self):
         def fn(x):
             names = [

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -228,6 +228,7 @@ from .dicts import ConstDictVariable, MappingProxyVariable, OrderedDictVariable
 from .distributed import WorldMetaClassVariable
 from .functions import (
     BoundBuiltinMethodVariable,
+    ClassMethodDescriptorVariable,
     CollectionsNamedTupleFunction,
     CollectiveFunctionRewriteVariable,
     CreateTMADescriptorExperimentalVariable,
@@ -1959,6 +1960,8 @@ class VariableBuilder:
             return GetSetDescriptorVariable(value)
         elif isinstance(value, types.MemberDescriptorType):
             return MemberDescriptorVariable(value)
+        elif isinstance(value, types.ClassMethodDescriptorType):
+            return ClassMethodDescriptorVariable(value, source=self.source)
         elif isinstance(value, types.MethodWrapperType):
             # Method-wrappers are written in C, and they are not guaranteed to
             # return the same object on attribute lookup. Therefore, we cannot

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -4554,6 +4554,14 @@ class BoundBuiltinMethodVariable(VariableTracker):
             return self.descriptor.__get__(obj)  # type: ignore[union-attr]
         return getattr(obj, self.descriptor.__name__)
 
+    # meth_getset / meth_members on builtin_function_or_method.
+    # https://github.com/python/cpython/blob/3.13/Objects/methodobject.c#L266-L296
+    tp_members = {
+        "__name__": Member(getset_build(lambda s: s.descriptor.__name__)),
+        "__qualname__": Member(getset_build(lambda s: s.descriptor.__qualname__)),
+        "__self__": Member(getset_read(lambda s: s.obj)),
+    }
+
     def call_function(
         self,
         tx: "InstructionTranslatorBase",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

A `classmethod_descriptor` (e.g. `dict.__dict__["fromkeys"]` or
`torch._C._FunctionBase.__dict__["apply"]`) reached through anything other
than a class attribute lookup, such as an instance attribute, was wrapped by
the builder as a generic `UserDefinedObjectVariable`. Calling `__get__` on it
then crashed with "type object 'UserDefinedObjectVariable' has no attribute
'tp_descr_get_impl'". The builder now produces the existing
`ClassMethodDescriptorVariable`, whose `tp_descr_get_impl` binds to the owner
and yields a `BoundBuiltinMethodVariable`.

`BoundBuiltinMethodVariable` also gains `__name__`, `__qualname__` and
`__self__` members, mirroring `meth_getset`/`meth_members` on
`builtin_function_or_method`, so introspecting the bound method works.

Test Plan:

```
python -m pytest test/dynamo/test_functions.py -k test_classmethod_descriptor_instance_attribute
python -m pytest test/dynamo/test_functions.py
```

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98