### PR TITLE
[dynamo] has_torch_function returns True while a TorchFunctionMode is active

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -975,6 +975,20 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         fn()
         self.assertEqual(_len_torch_function_stack(), 0)
 
+    def test_has_torch_function_with_mode_active(self):
+        from torch.overrides import has_torch_function_unary
+
+        def fn(x):
+            if has_torch_function_unary(x):
+                return x + 1
+            return x - 1
+
+        x = torch.zeros(2)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(opt_fn(x), fn(x))
+        with BaseTorchFunctionMode():
+            self.assertEqual(opt_fn(x), fn(x))
+
 
 class InvokeSubgraphBackendTests(torch._dynamo.test_case.TestCase):
     @torch._dynamo.config.patch(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1679,6 +1679,13 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             if tf_state.skip_next:
                 tf_state.skip_next = False
                 return VariableTracker.build(tx, False)
+            # Mirrors check_has_torch_function in C++: an active torch
+            # function mode makes every argument "have" a torch function.
+            if (
+                tf_state.torch_function_mode_enabled
+                and tf_state.in_torch_function_mode()
+            ):
+                return VariableTracker.build(tx, True)
             elems = (
                 unpack_iterable(tx, args[0])
                 if len(args) == 1 and isinstance(args[0], TupleVariable)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

`torch._C._has_torch_function*` in eager returns True for any argument as soon
as a torch function mode is enabled (see `check_has_torch_function` in
disable_torch_function.cpp). Dynamo's handler only looked at the arguments for
`__torch_function__` subclasses, so code following the standard override
pattern

```
if has_torch_function_unary(x):
    return handle_torch_function(...)
```

took the plain path under a mode and the mode never saw the call.

The handler now consults the symbolic mode stack first, matching eager.

Test Plan:

```
python -m pytest test/dynamo/test_modes.py -k test_has_torch_function_with_mode_active
python -m pytest test/dynamo/test_modes.py test/dynamo/test_subclasses.py
```

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98