### PR TITLE
[dynamo] Trace torch.overrides.handle_torch_function

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -989,6 +989,30 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         with BaseTorchFunctionMode():
             self.assertEqual(opt_fn(x), fn(x))
 
+    def test_handle_torch_function_explicit_dispatch(self):
+        from torch.overrides import handle_torch_function, has_torch_function_unary
+
+        def my_op(x):
+            if has_torch_function_unary(x):
+                return handle_torch_function(my_op, (x,), x)
+            return x + 1
+
+        class MyOpMode(BaseTorchFunctionMode):
+            def __torch_function__(self, func, types, args, kwargs=None):
+                kwargs = kwargs or {}
+                if func is my_op:
+                    return args[0] * 10
+                return super().__torch_function__(func, types, args, kwargs)
+
+        def fn(x):
+            return my_op(x) + my_op(x)
+
+        x = torch.ones(2)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        with MyOpMode():
+            self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(opt_fn(x), fn(x))
+
 
 class InvokeSubgraphBackendTests(torch._dynamo.test_case.TestCase):
     @torch._dynamo.config.patch(

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -167,6 +167,7 @@ manual_torch_name_rule_map: dict[
     "torch.onnx.is_in_onnx_export": TorchInGraphFunctionVariable,
     "torch.onnx.operators.shape_as_tensor": TorchInGraphFunctionVariable,
     "torch.overrides.is_tensor_like": TorchInGraphFunctionVariable,
+    "torch.overrides.handle_torch_function": TorchInGraphFunctionVariable,
     "torch._C._skip_one_hop_torch_function": TorchInGraphFunctionVariable,
     "torch.jit.is_scripting": TorchInGraphFunctionVariable,
     "torch.jit.is_tracing": TorchInGraphFunctionVariable,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1693,6 +1693,25 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
             return VariableTracker.build(tx, any(has_torch_function(x) for x in elems))
 
+        @register(torch.overrides.handle_torch_function)
+        def handle_handle_torch_function(
+            self,
+            tx: "InstructionTranslatorBase",
+            public_api: VariableTracker,
+            relevant_args: VariableTracker,
+            *args: VariableTracker,
+            **kwargs: VariableTracker,
+        ) -> VariableTracker:
+            from .torch_function import dispatch_torch_function
+
+            return dispatch_torch_function(
+                tx,
+                public_api,
+                list(args),
+                kwargs,
+                relevant_args=unpack_iterable(tx, relevant_args),
+            )
+
         @register(torch._C._skip_one_hop_torch_function)
         def handle_skip_one_hop_torch_function(
             self,

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -545,10 +545,19 @@ def dispatch_torch_function(
     fn: VariableTracker,
     args: Iterable[Any],
     kwargs: dict[str, Any],
+    relevant_args: Iterable[VariableTracker] | None = None,
 ) -> Any:
-    """Gathers all args that are TensorWithTFOverrideVariable and dispatches based on the ordering in _get_overloaded_args"""
+    """Gathers all args that are TensorWithTFOverrideVariable and dispatches based on the ordering in _get_overloaded_args
 
-    all_args = _get_all_args(args, kwargs)
+    ``relevant_args`` restricts the overload search to an explicit set of
+    values, matching ``torch.overrides.handle_torch_function``.
+    """
+
+    all_args = (
+        _get_all_args(args, kwargs)
+        if relevant_args is None
+        else _flatten_vts(relevant_args)
+    )
     overloaded_args = _get_overloaded_args(
         [arg for arg in all_args if has_torch_function(arg)],
         _get_subclass_type,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

`torch.overrides.handle_torch_function` is how Python-level functions
participate in `__torch_function__` dispatch. Dynamo tried to inline its body,
which touches the C mode stack directly and fails. It is now a
`TorchInGraphFunctionVariable` whose handler forwards to
`dispatch_torch_function`, which gained a `relevant_args` parameter so that
overload resolution only considers the objects the caller passed, as the
eager implementation does. Modes on the symbolic stack are dispatched first,
then subclass overrides, exactly like eager.

Test Plan:

```
python -m pytest test/dynamo/test_modes.py -k test_handle_torch_function_explicit_dispatch
python -m pytest test/dynamo/test_modes.py test/dynamo/test_subclasses.py
```

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98