### PR TITLE
[dynamo] Run graphs that inlined a TorchFunctionMode with torch function disabled

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -1013,6 +1013,27 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(opt_fn(x), fn(x))
         self.assertEqual(opt_fn(x), fn(x))
 
+    def test_inlined_mode_not_reapplied_at_runtime(self):
+        class AddHundred(BaseTorchFunctionMode):
+            def __torch_function__(self, func, types, args, kwargs=None):
+                kwargs = kwargs or {}
+                out = super().__torch_function__(func, types, args, kwargs)
+                if func is torch.add:
+                    out = out + 100
+                return out
+
+        def fn(x):
+            return torch.add(x, 1) * 2
+
+        x = torch.zeros(2)
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        with AddHundred():
+            expected = fn(x)
+            self.assertEqual(opt_fn(x), expected)
+            self.assertEqual(opt_fn(x), expected)
+        self.assertEqual(cnt.frame_count, 1)
+
 
 class InvokeSubgraphBackendTests(torch._dynamo.test_case.TestCase):
     @torch._dynamo.config.patch(

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -910,8 +910,10 @@ class OutputGraph(OutputGraphCommon):
         self.torch_function_mode_enabled = torch._C._is_torch_function_mode_enabled()
 
         # Used to wrap the compiled graph at runtime with
-        # DisableTorchFunctionSubclass to prevent double dispatch.
+        # DisableTorchFunctionSubclass / DisableTorchFunction to prevent
+        # double dispatch.
         self.torch_function_subclass_inlined = False
+        self.torch_function_mode_inlined = False
 
         # Tracks if the output graph has a user defined allowed function in the
         # graph. This is used later to determine if we should fallback to eager
@@ -3052,19 +3054,28 @@ class OutputGraph(OutputGraphCommon):
             if self.package is not None:
                 self.package.add_backend_id(name, compiled_fn)
 
-            # If __torch_function__ subclass dispatch was inlined during
-            # tracing, wrap the compiled graph to disable __torch_function__
-            # at runtime, preventing double dispatch (the C++ dispatcher
-            # would otherwise re-trigger __torch_function__ on subclass
-            # inputs that the graph already handles).
-            if self.torch_function_subclass_inlined:
+            # If __torch_function__ dispatch was inlined during tracing, wrap
+            # the compiled graph to disable __torch_function__ at runtime,
+            # preventing double dispatch (the C++ dispatcher would otherwise
+            # re-trigger __torch_function__ on subclass inputs that the graph
+            # already handles, and an active TorchFunctionMode would re-run
+            # on every op of the graph).
+            if self.torch_function_mode_inlined:
                 real_compiled_fn = compiled_fn
 
                 def _tf_disabled_wrapper(*args, **kwargs):
-                    with torch._C.DisableTorchFunctionSubclass():
+                    with torch._C.DisableTorchFunction():
                         return real_compiled_fn(*args, **kwargs)
 
                 compiled_fn = _tf_disabled_wrapper
+            elif self.torch_function_subclass_inlined:
+                real_compiled_fn = compiled_fn
+
+                def _tf_subclass_disabled_wrapper(*args, **kwargs):
+                    with torch._C.DisableTorchFunctionSubclass():
+                        return real_compiled_fn(*args, **kwargs)
+
+                compiled_fn = _tf_subclass_disabled_wrapper
 
             compiled_fn = disable(
                 compiled_fn, reason="do not trace Dynamo-compiled graph"

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -322,6 +322,7 @@ class SymbolicTorchFunctionState:
         args: Iterable[Any],
         kwargs: dict[str, Any],
     ) -> Any:
+        tx.output.torch_function_mode_inlined = True
         with self._pop_mode_for_inlining() as cur_mode:
             return cur_mode.call_torch_function(tx, fn, types, args, kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

When a `TorchFunctionMode` is on the stack at compile time, Dynamo inlines its
`__torch_function__` into the graph. The compiled graph then ran with the mode
still active, so with the eager backend every Python-level op in the graph was
dispatched through the mode a second time. A mode that adds 100 to the result
of `torch.add` produced 402 instead of 202 for `torch.add(x, 1) * 2`. With
AOTAutograd backends, the runtime `CompiledFunction.apply` call was likewise
exposed to the mode.

`dispatch_torch_function` already wraps the compiled graph in
`DisableTorchFunctionSubclass` when a subclass override was inlined. This
records the analogous `torch_function_mode_inlined` flag when a mode is
dispatched during tracing and wraps the graph in `DisableTorchFunction`,
which covers both modes and subclasses. Guards on the mode stack already
force a recompile when the set of active modes changes.

Test Plan:

```
python -m pytest test/dynamo/test_modes.py -k test_inlined_mode_not_reapplied_at_runtime
python -m pytest test/dynamo/test_modes.py test/dynamo/test_subclasses.py test/dynamo/test_misc.py
```

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98