### PR TITLE
[dynamo] Support hasattr, hashing and issubclass on autograd.Function classes

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -638,18 +638,21 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
         ):
             torch.compile(fn, backend="eager", fullgraph=True)(torch.randn(2))
 
-    def test_missing_attribute_hasattr_graph_breaks(self):
+    def test_missing_attribute_hasattr(self):
         class Function(torch.autograd.Function):
             pass
 
         def fn(x):
-            return x, hasattr(Function, "missing")
+            return x + 1, hasattr(Function, "missing")
 
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "Unsupported hasattr call",
-        ):
-            torch.compile(fn, backend="eager", fullgraph=True)(torch.randn(2))
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.randn(2)
+        self.assertEqual(opt_fn(x), (x + 1, False))
+        self.assertEqual(cnt.frame_count, 1)
+        Function.missing = 1
+        self.assertEqual(opt_fn(x), (x + 1, True))
+        self.assertEqual(cnt.frame_count, 2)
 
     @parametrize("name", ("__name__", "__bases__"))
     def test_dunder_attribute_uses_generic_getattr(self, name):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1121,6 +1121,24 @@ class AutogradFunctionVariable(VariableTracker):
     def python_type(self) -> type:
         return type
 
+    def get_real_python_backed_value(self) -> Any:
+        return self.fn_cls
+
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
+        return hash(self.fn_cls), False
+
+    def call_obj_hasattr(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> "ConstantVariable":
+        if self.fn_cls_source is None:
+            return super().call_obj_hasattr(tx, name)
+        install_guard(
+            self.fn_cls_source.make_guard(
+                functools.partial(GuardBuilder.HASATTR, attr=name)
+            )
+        )
+        return variables.ConstantVariable.create(hasattr(self.fn_cls, name))
+
     def _resolve_kwargs(
         self,
         args: list[VariableTracker],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

`AutogradFunctionVariable` represents a `torch.autograd.Function` subclass but
did not behave like a class value: `issubclass(cls, torch.autograd.Function)`
failed with "Arguments to issubclass() must be backed by python values",
`cls in some_set` could not hash it, and `hasattr(cls, name)` always graph
broke. Registries that key on autograd Function classes, or that look up an
optional hook with `getattr(cls, "hook", None)`, hit all three.

`get_real_python_backed_value` and `hash_impl` expose the class. `hasattr`
constant folds when the class has a source, installing a `HASATTR` guard so
adding the attribute later recompiles; sourceless classes keep the old graph
break. `test_missing_attribute_hasattr_graph_breaks` is updated accordingly
and now also checks the recompile.

Test Plan:

```
python -m pytest test/dynamo/test_autograd_function.py -k test_missing_attribute_hasattr
python -m pytest test/dynamo/test_autograd_function.py
```

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98