### PR TITLE
[dynamo] Honor a monkey-patched torch.autograd.Function.apply

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -1034,6 +1034,71 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(opt_fn(x), expected)
         self.assertEqual(cnt.frame_count, 1)
 
+    def test_monkey_patched_autograd_function_apply(self):
+        from torch.overrides import handle_torch_function, has_torch_function
+
+        class ApplyDescriptor:
+            def __init__(self, orig):
+                self._orig = orig
+
+            def __get__(self, obj, cls=None):
+                orig_method = self._orig.__get__(obj, cls)
+
+                def wrapper(*args, **kwargs):
+                    tensors = tuple(a for a in args if isinstance(a, torch.Tensor))
+                    if has_torch_function(tensors):
+                        return handle_torch_function(
+                            orig_method, tensors, *args, **kwargs
+                        )
+                    return orig_method(*args, **kwargs)
+
+                return wrapper
+
+        class ApplyMode(BaseTorchFunctionMode):
+            def __torch_function__(self, func, types, args, kwargs=None):
+                kwargs = kwargs or {}
+                out = func(*args, **kwargs)
+                if getattr(func, "__name__", None) == "apply":
+                    out.apply_cls = func.__self__
+                return out
+
+        class Double(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * 2
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad * 2
+
+        def fn(x):
+            y = Double.apply(x)
+            return y, y + 1
+
+        x = torch.ones(2, requires_grad=True)
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        orig_apply = torch.autograd.Function.__dict__["apply"]
+        torch.autograd.Function.apply = ApplyDescriptor(orig_apply)
+        try:
+            with ApplyMode():
+                ref = fn(x)
+                res = opt_fn(x)
+                self.assertEqual(opt_fn(x), ref)
+            self.assertEqual(res, ref)
+            self.assertIs(res[0].apply_cls, Double)
+            res[1].sum().backward()
+            self.assertEqual(x.grad, torch.full((2,), 2.0))
+        finally:
+            torch.autograd.Function.apply = orig_apply
+        self.assertEqual(cnt.frame_count, 1)
+        # Removing the patch changes the class dict entry, so the guard fails
+        # and the recompiled function no longer dispatches apply to the mode.
+        with ApplyMode():
+            res = opt_fn(x)
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertFalse(hasattr(res[0], "apply_cls"))
+
 
 class InvokeSubgraphBackendTests(torch._dynamo.test_case.TestCase):
     @torch._dynamo.config.patch(

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1102,6 +1102,10 @@ def produce_trampoline_autograd_apply(fn_cls: Any) -> Callable[..., Any]:
     return trampoline_autograd_apply
 
 
+# The pristine C classmethod descriptor behind torch.autograd.Function.apply.
+_ORIG_FUNCTION_APPLY = torch._C._FunctionBase.__dict__["apply"]
+
+
 class AutogradFunctionVariable(VariableTracker):
     """represents a torch.autograd.Function subclass"""
 
@@ -1138,6 +1142,31 @@ class AutogradFunctionVariable(VariableTracker):
             )
         )
         return variables.ConstantVariable.create(hasattr(self.fn_cls, name))
+
+    def _resolve_patched_apply(
+        self, tx: "InstructionTranslatorBase", descriptor: object
+    ) -> VariableTracker | None:
+        """Trace ``cls.apply`` when ``Function.apply`` has been monkey patched.
+
+        Libraries replace ``torch.autograd.Function.apply`` with a Python
+        descriptor to intercept every ``apply`` call (e.g. to route it through
+        ``__torch_function__``).  Resolve the attribute the way CPython would:
+        ``descriptor.__get__(None, cls)``.  Guards installed on the raw class
+        ``__dict__`` entry recompile once the patch is removed.
+        """
+        get_fn = inspect.getattr_static(type(descriptor), "__get__", None)
+        if not isinstance(get_fn, types.FunctionType):
+            return None
+        descriptor_source = self._get_raw_attribute_source(tx, "apply")
+        if descriptor_source is None:
+            return None
+        descriptor_var = VariableTracker.build(tx, descriptor, descriptor_source)
+        return variables.UserMethodVariable(
+            get_fn,
+            descriptor_var,
+            source_fn=AttrSource(TypeSource(descriptor_source), "__get__"),
+            source=AttrSource(descriptor_source, "__get__"),
+        ).call_function(tx, [variables.ConstantVariable.create(None), self], {})
 
     def _resolve_kwargs(
         self,
@@ -1444,6 +1473,11 @@ class AutogradFunctionVariable(VariableTracker):
     ) -> VariableTracker:
         source = AttrSource(self.source, name) if self.source is not None else None
         if name == "apply":
+            apply_attr = inspect.getattr_static(self.fn_cls, "apply", None)
+            if apply_attr is not _ORIG_FUNCTION_APPLY:
+                resolved = self._resolve_patched_apply(tx, apply_attr)
+                if resolved is not None:
+                    return resolved
             return GetAttrVariable(self, name, py_type=types.MethodType, source=source)
         if source is None:
             return GetAttrVariable(self, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Libraries that need to observe every custom autograd Function call (the
spmd_types type checker routes `apply` through `__torch_function__` this
way) replace `torch.autograd.Function.apply` with a Python descriptor.
Dynamo ignored the patch: `AutogradFunctionVariable.tp_getattro_impl`
hardwired `cls.apply` to its own `call_apply`, so the compiled program
diverged from eager and, for a TorchFunctionMode, the mode saw the ops
inside `forward` instead of the `apply` call.

When `inspect.getattr_static(cls, "apply")` is not the pristine C descriptor
from `_FunctionBase`, the attribute is now resolved the way CPython would:
the descriptor's `__get__(None, cls)` is inlined, with the descriptor sourced
from the class `__dict__` so a TYPE_MATCH guard recompiles once the patch is
removed. The wrapper the descriptor returns eventually calls the original
bound `apply`, which arrives as a `BoundBuiltinMethodVariable` whose
`call_function` routes back into the regular `call_apply` path, so the
autograd Function is still traced as a HOP with forward and backward.

Alternatives considered: unconditionally dispatching `apply` through active
modes would diverge from eager, where `Function.apply` never reaches
`__torch_function__`; making the patched `apply` a graph break would defeat
the purpose of tracing the mode.

Test Plan:

```
python -m pytest test/dynamo/test_modes.py -k test_monkey_patched_autograd_function_apply
python -m pytest test/dynamo/test_modes.py test/dynamo/test_autograd_function.py
```

End to end, the spmd_types checker (github.com/meta-pytorch/spmd_types) with
its `tests/compile_typecheck_test.py` passes on this stack.

Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98