### PR TITLE
[dynamo] Fix Dynamo Benchmarks: Stabilization iters counted in latency

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2945,11 +2945,13 @@ class BenchmarkRunner:
         tag=None,
         batch_size=None,
     ):
-        niters = 5
+        measure_iters = 5
+        stabilization_iters = 0
         if getattr(self, "hf_llm", False):
             # If we're benchmarking an llm, we want to use the generate function
             self.model_iter_fn = self.generate
-            niters = 1
+            measure_iters = 1
+            stabilization_iters = 4
 
         if self.args.xla:
             with self.pick_grad(name, self.args.training):
@@ -2957,7 +2959,9 @@ class BenchmarkRunner:
                     self.model_iter_fn, *self.maybe_cast(model, example_inputs)
                 )
 
-        def warmup(fn, model, example_inputs, mode, niters=5):
+        def warmup(
+            fn, model, example_inputs, mode, measure_iters=5, stabilization_iters=0
+        ):
             gc.collect()
             peak_mem = 0
             start_stats = get_dynamo_stats()
@@ -2968,10 +2972,12 @@ class BenchmarkRunner:
                 elif current_device == "hpu":
                     torch.hpu.reset_peak_memory_stats()
                 t0 = time.perf_counter()
-                for _ in range(niters):
+                for _ in range(measure_iters):
                     fn(model, example_inputs)
                 t1 = time.perf_counter()
                 latency = t1 - t0
+                for _ in range(stabilization_iters):
+                    fn(model, example_inputs)
                 if current_device == "cuda":
                     peak_mem = get_peak_memory()
                 elif current_device == "hpu":
@@ -3026,7 +3032,7 @@ class BenchmarkRunner:
                         copy.deepcopy(model),
                         example_inputs,
                         "eager",
-                        niters=niters,
+                        measure_iters=measure_iters,
                     )
                     if self.args.use_warm_peak_memory:
                         _, eager_peak_mem, _ = warmup(
@@ -3034,7 +3040,7 @@ class BenchmarkRunner:
                             copy.deepcopy(model),
                             example_inputs,
                             "eager",
-                            niters=1,
+                            measure_iters=1,
                         )
 
             if (
@@ -3057,7 +3063,12 @@ class BenchmarkRunner:
                 self.args.snapshot_memory, f"compiled_{self.args.only}"
             ):
                 dynamo_latency, dynamo_peak_mem, dynamo_stats = warmup(
-                    optimized_model_iter_fn, model, example_inputs, "dynamo"
+                    optimized_model_iter_fn,
+                    model,
+                    example_inputs,
+                    "dynamo",
+                    measure_iters=measure_iters,
+                    stabilization_iters=stabilization_iters,
                 )
                 if self.args.use_warm_peak_memory:
                     _, dynamo_peak_mem, _ = warmup(
@@ -3065,7 +3076,7 @@ class BenchmarkRunner:
                         model,
                         example_inputs,
                         "dynamo",
-                        niters=1,
+                        measure_iters=1,
                     )
                 # If we use warm peak memory, the AOT model loading transient memory
                 # won't be present on the warm measurement.  We only have to account for

--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -1,3 +1,6 @@
+import collections
+import contextlib
+import functools
 import importlib
 import importlib.util
 import io
@@ -8,6 +11,10 @@ import unittest
 from contextlib import redirect_stdout
 from unittest import mock
 
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from . import common
 from .common import parse_args, run
 from .torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
 
@@ -21,7 +28,7 @@ except ImportError:
         return False
 
 
-class TestDynamoBenchmark(unittest.TestCase):
+class TestDynamoBenchmark(TestCase):
     def test_timm_auto_install_uses_no_deps(self) -> None:
         module_name = "benchmarks.dynamo._timm_models_install_test"
         module_path = os.path.join(os.path.dirname(__file__), "timm_models.py")
@@ -157,3 +164,96 @@ class TestDynamoBenchmark(unittest.TestCase):
             run(TorchBenchmarkRunner(), args, original_dir)
         finally:
             os.chdir(original_dir)
+
+
+# Verify one matched eager/compiled measurement plus four untimed stabilization calls.
+class TestHuggingFaceLLMPerformance(TestCase):
+    def test_compilation_latency_uses_matched_work(self) -> None:
+        calls = collections.Counter()
+        clock = [0.0]
+        result = {}
+
+        class Model(torch.nn.Module):
+            def forward(self, inputs):
+                calls["eager"] += 1
+                clock[0] += 10.0
+
+        class Runner(common.BenchmarkRunner):
+            hf_llm = True
+            suite_name = "test"
+
+            def maybe_cast(self, model, example_inputs):
+                return model, example_inputs
+
+            def deepcopy_and_maybe_parallelize(self, model):
+                return model
+
+            def init_optimizer(self, name, device, params):
+                pass
+
+            def pick_grad(self, name, is_training):
+                return contextlib.nullcontext()
+
+            def generate(self, model, example_inputs):
+                return model(example_inputs)
+
+        def optimize_ctx(fn):
+            def compiled(*args, **kwargs):
+                calls["compiled"] += 1
+                clock[0] += 30.0 if calls["compiled"] == 1 else 10.0
+
+            return compiled
+
+        def experiment(args, model_iter_fn, model, example_inputs, **kwargs):
+            result.update(kwargs)
+            return "done"
+
+        runner = Runner()
+        runner.args = types.SimpleNamespace(
+            aot_precompile=False,
+            export_aot_inductor=False,
+            export_nativert=False,
+            only="model",
+            profile_dynamo_cache_lookup=False,
+            print_compilation_time=False,
+            print_memory=False,
+            snapshot_memory=False,
+            torchscript_jit_trace=False,
+            training=False,
+            use_warm_peak_memory=False,
+            xla=False,
+        )
+        model = Model()
+
+        def get_peak_memory():
+            return calls["compiled"] or calls["eager"]
+
+        def get_dynamo_stats():
+            return collections.Counter(calls_captured=calls["compiled"])
+
+        with (
+            mock.patch.object(common, "current_device", "cuda"),
+            mock.patch.object(common, "empty_gpu_cache"),
+            mock.patch.object(common, "get_dynamo_stats", side_effect=get_dynamo_stats),
+            mock.patch.object(common, "get_peak_memory", side_effect=get_peak_memory),
+            mock.patch.object(common.time, "perf_counter", side_effect=lambda: clock[0]),
+            mock.patch.object(torch.cuda, "reset_peak_memory_stats"),
+            mock.patch.object(common, "speedup_experiment", experiment),
+        ):
+            runner.run_performance_test(
+                "model",
+                model,
+                (),
+                optimize_ctx,
+                functools.partial(experiment, object()),
+            )
+
+        self.assertEqual(calls, {"eager": 1, "compiled": 5})
+        self.assertEqual(result["compilation_latency"], 20.0)
+        self.assertEqual(result["eager_peak_mem"], 1)
+        self.assertEqual(result["dynamo_peak_mem"], 5)
+        self.assertEqual(result["dynamo_stats"], {"calls_captured": 5})
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -236,7 +236,9 @@ class TestHuggingFaceLLMPerformance(TestCase):
             mock.patch.object(common, "empty_gpu_cache"),
             mock.patch.object(common, "get_dynamo_stats", side_effect=get_dynamo_stats),
             mock.patch.object(common, "get_peak_memory", side_effect=get_peak_memory),
-            mock.patch.object(common.time, "perf_counter", side_effect=lambda: clock[0]),
+            mock.patch.object(
+                common.time, "perf_counter", side_effect=lambda: clock[0]
+            ),
             mock.patch.object(torch.cuda, "reset_peak_memory_stats"),
             mock.patch.object(common, "speedup_experiment", experiment),
         ):


### PR DESCRIPTION
## Summary
 
 Fix HF LLM compilation-latency accounting by measuring matched eager and compiled generations, while keeping additional compiled calls as untimed cache stabilization. Peak-memory and Dynamo-stat collection remain unchanged.
 
There was a bug in the Dynamo benchmarks that included stabilization iterations in the compilation latency calculation. `run_performance_test()` sets `niters=1` for HuggingFace LLMs. Eager uses `niters` for warmup explicitly. However, compiled warmup skips `niters` and uses `warmups()`'s default of 5.

`compilation_time = dynamo_latency - eager_latency`, so this compares five compiled geneartions againts one eager generation.

 ## Test Plan
Adds a focused model-free regression test, and I manually ran a Qwen3-0.6B check with 1000 input and 2000 output tokens

| Accounting | Compilation latency |
|---|---:|
| Before: 5 compiled calls - 1 eager call | 44.565 s |
| After: 1 compiled call - 1 eager call | 44.448 s |
| Overcount removed | 0.117 s (0.26%) |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo