### PR TITLE
[dde] Defer shape equality in canDispatchToMaskedFill for unbacked symints

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -358,14 +358,19 @@ inline std::tuple<bool, Tensor> canDispatchToMaskedFill(
         mask = index;
         for (const auto j : c10::irange(index.dim())) {
           int64_t srcIdx = num_ind + j;
+          // Compare the extents symbolically: an unbacked extent has no hint,
+          // so resolving the equality as int64_t would specialize a
+          // data-dependent size. expect_true defers it instead.
           TORCH_CHECK_INDEX(
-              index.size(j) == self.size(srcIdx),
+              index.sym_size(j)
+                  .sym_eq(self.sym_size(srcIdx))
+                  .expect_true(__FILE__, __LINE__),
               "The shape of the mask ",
-              index.sizes(),
+              index.sym_sizes(),
               " at index ",
               j,
               " does not match the shape of the indexed tensor ",
-              self.sizes(),
+              self.sym_sizes(),
               " at index ",
               srcIdx);
         }

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -8,6 +8,7 @@ import sympy
 import torch
 from torch._dynamo import config as dynamo_config
 from torch._dynamo.exc import InternalTorchDynamoError
+from torch._dynamo.testing import CompileCounterWithBackend
 from torch._inductor import config as inductor_config, ir
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.sizevars import SizeVarAllocator
@@ -1413,6 +1414,30 @@ class TestUnbackedSymints(InductorTestCase):
         actual = torch.compile(fn, fullgraph=True)(*example_inputs)
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
+
+    def test_masked_fill_scalar_assignment(self, device):
+        # canDispatchToMaskedFill compares the mask extents against self's; doing
+        # that with int64_t sizes used to specialize the unbacked extents.
+        def fn(x, mask, value):
+            x[mask] = value
+            return x
+
+        def make_inputs(n):
+            x = torch.zeros(n, 3, device=device)
+            mask = torch.zeros(n, 3, dtype=torch.bool, device=device)
+            mask[:, 0] = True
+            torch._dynamo.decorators.mark_unbacked(x, 0)
+            torch._dynamo.decorators.mark_unbacked(mask, 0)
+            return x, mask
+
+        cnt = CompileCounterWithBackend("inductor")
+        compiled_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        for n in (2, 5):
+            x, mask = make_inputs(n)
+            expected = fn(*make_inputs(n), 7.0)
+            torch.testing.assert_close(compiled_fn(x, mask, 7.0), expected)
+        # A specializing guard would force a second graph for n=5.
+        self.assertEqual(cnt.frame_count, 1)
 
 
 instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)


### PR DESCRIPTION
Summary:
Fix DDE with `masked_fill` scalar assignment on data-dependent shaped tensor. 

Replace concrete size comparison (`index.size(...) == self.size(...)`) in `canDispatchToMaskedFill` with symbolic comparison (`sym_eq(...).expect_true(...)`) to defer guard emission rather than specializing data-dependent dimensions.

This preserves the `masked_fill_` optimization path while supported unbacked symints.

Stack trace:
```
File ".../torch/_dynamo/utils.py", line 4470, in run_node
  return node.target(*args, **kwargs)  # type: ignore[operator]
...
File "_operator.c", line 0, in _operator_setitem(_object*, _object* const*, long)
File "<invalid>", line 0, in torch::autograd::THPVariable_setitem(_object*, _object*, _object*)
File "<invalid>", line 0, in at::indexing::try_dispatch_masked_fill_(at::Tensor&, std::vector<at::Tensor, std::allocator<at::Tensor>>, c10::Scalar const&)
File "<invalid>", line 0, in at::indexing::impl::canDispatchToMaskedFill(at::Tensor const&, c10::List<std::optional<at::Tensor>> const&)
File "<invalid>", line 0, in c10::TensorImpl::size_custom(long) const
File "<invalid>", line 0, in c10::TensorImpl::sizes_custom() const
File "<invalid>", line 0, in c10::SymbolicShapeMeta::set_materialized_sizes() const
File "<invalid>", line 0, in torch::impl::PythonSymNodeImpl::guard_int(char const*, long)
...
File ".../torch/fx/experimental/symbolic_shapes.py", line 8743, in _inner_evaluate_expr
  return self._evaluate_expr(
File ".../torch/fx/experimental/symbolic_shapes.py", line 8976, in _evaluate_expr
  raise self._make_data_dependent_error(
```

Differential Revision: D118686677




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo