### PR TITLE
[BE] Fix B023 loop variable capture in torchgen utilities

### DIFF
--- a/torchgen/utils.py
+++ b/torchgen/utils.py
@@ -300,7 +300,7 @@ class FileManager:
             self.write_with_template(
                 file.with_stem(f"{file.stem}{shard_id}"),
                 template_fn,
-                lambda: shard,
+                lambda shard=shard: shard,
             )
 
         # filenames is used to track compiled files, but FooEverything.cpp isn't meant to be compiled


### PR DESCRIPTION
Fixes part of #106571

### Description

In `torchgen/utils.py` within `FileManager.write_sharded_with_template`, an anonymous function captures loop variable `shard` without default argument binding:

```python
self.write_with_template(
    file.with_stem(f"{file.stem}{shard_id}"),
    template_fn,
    lambda: shard,
)
```

`write_with_template` passes the callable to `substitute_with_template`, which executes it synchronously during the iteration. The closure does not outlive or escape the loop, so there is no runtime defect today.

Explicitly binding the loop variable via default argument (`lambda shard=shard: shard`) makes the binding semantics explicit, cleans up flake8-bugbear `B023` in `torchgen/utils.py`, and preserves exact behaviour.

### Test plan

- **Ruff B023 check:**
  ```powershell
  python -m ruff check torchgen/utils.py --select B023 --config pyproject.toml --config "lint.ignore=[]"
  ```
  *(Passes with 0 errors)*

- **Formatting, compile, and git diff checks:**
  ```powershell
  python -m ruff format --check torchgen/utils.py
  python -m py_compile torchgen/utils.py
  git diff --check
  ```
  *(All clean)*

- **Unit tests:**
  ```powershell
  python -m unittest tools/test/test_utils.py tools/test/test_codegen.py
  ```
  *(32 tests passed)*

- **Bitwise generated code validation:**
  Ran `python -m torchgen.gen -s aten/src/ATen -d ...` on both unpatched and patched sources across all 96 generated C++ targets (`RegisterCPU_*.cpp`, etc.). Verified 0 file additions/deletions and 0 byte differences.

Authored with AI assistance.
