### PR TITLE
Allow abbreviated torchrun args and script args

### DIFF
--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -48,6 +48,34 @@ class RunTest(TestCase):
         )
         self.assertEqual(args.signals_to_handle, "SIGTERM,SIGUSR1,SIGUSR2")
 
+    def test_training_script_args_not_shadowed_by_abbreviation(self):
+        """Test that abbreviated args don't get misinterpreted as torchrun flags.
+        Regression test for https://github.com/pytorch/pytorch/issues/120601."""
+        args = run.parse_args(["dummy_script.py", "--r=16"])
+        self.assertEqual(args.training_script, "dummy_script.py")
+        self.assertEqual(args.training_script_args, ["--r=16"])
+
+        args = run.parse_args(
+            ["--nnodes=2", "dummy_script.py", "--r=16", "--standalone"]
+        )
+        self.assertEqual(args.nnodes, "2")
+        self.assertEqual(args.training_script, "dummy_script.py")
+        self.assertEqual(args.training_script_args, ["--r=16", "--standalone"])
+
+    def test_own_flag_abbreviation_still_works(self):
+        """Test abbreviating one of torchrun's flags (before the script)"""
+        args = run.parse_args(["--nnod=2", "dummy_script.py"])
+        self.assertEqual(args.nnodes, "2")
+        self.assertEqual(args.training_script, "dummy_script.py")
+        args = run.parse_args(["--nnod=2", "dummy_script.py", "--r=16"])
+        self.assertEqual(args.nnodes, "2")
+        self.assertEqual(args.training_script, "dummy_script.py")
+        self.assertEqual(args.training_script_args, ["--r=16"])
+        args = run.parse_args(["--nnod=2", "dummy_script.py", "--nnod=16"])
+        self.assertEqual(args.nnodes, "2")
+        self.assertEqual(args.training_script, "dummy_script.py")
+        self.assertEqual(args.training_script_args, ["--nnod=16"])
+
     def test_config_from_args_signals_to_handle(self):
         """Test that the signals_to_handle argument is correctly passed to LaunchConfig."""
         parser = run.get_args_parser()

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -831,9 +831,56 @@ def get_args_parser() -> ArgumentParser:
     return parser
 
 
+def _resolve_flag(parser: ArgumentParser, opt: str):
+    """Resolve ``opt`` to a registered flag, by exact name or unambiguous abbreviation.
+
+    Returns None if ``opt`` is unknown or ambiguous; those cases are left for
+    parser.parse_args() to error on as usual.
+    """
+    option_strings = parser._option_string_actions
+    action = option_strings.get(opt)
+    if action is not None:
+        return action
+    if not (parser.allow_abbrev and opt.startswith("--")):
+        return None
+    matches = {name for name in option_strings if name.startswith(opt)}
+    return option_strings[matches.pop()] if len(matches) == 1 else None
+
+
+def _find_training_script_index(parser: ArgumentParser, args: list[str]) -> int:
+    """Return the index of the training_script positional in ``args``.
+
+    Used to split off the script's own args before argparse sees them, so they
+    can never be misparsed as an abbreviated torchrun flag (gh-120601). Bails
+    out (returns len(args)) on anything ambiguous or unrecognized, deferring to
+    parser.parse_args() on the full list as before.
+    """
+    i, n = 0, len(args)
+    while i < n:
+        token = args[i]
+        if token == "--":
+            return i + 1
+        if not token.startswith("-") or token == "-":
+            return i
+        opt, sep, _ = token.partition("=")
+        action = _resolve_flag(parser, opt if sep else token)
+        if action is None or (sep and action.nargs == 0):
+            return n  # unresolved or malformed option: defer to normal parsing
+        i += 2 if (action.nargs is None and not sep) else 1
+    return n
+
+
+
 def parse_args(args):
     parser = get_args_parser()
-    return parser.parse_args(args)
+    if args is None:
+        args = sys.argv[1:]
+    split = _find_training_script_index(parser, args)
+    namespace = parser.parse_args(args[: split + 1])
+    if split < len(args):
+        namespace.training_script = args[split]
+        namespace.training_script_args = args[split + 1 :]
+    return namespace
 
 
 def parse_min_max_nnodes(nnodes: str):

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -870,7 +870,6 @@ def _find_training_script_index(parser: ArgumentParser, args: list[str]) -> int:
     return n
 
 
-
 def parse_args(args):
     parser = get_args_parser()
     if args is None:


### PR DESCRIPTION
Fixes #120601 

Previously, `torchrun` scripts could crash with `ambiguous option: --r=16 could match ...` when a training script argument happened to be an abbreviated prefix of one of torchrun's own flags (`--rdzv-*`, `--role`, `--redirects`, etc.), because argparse resolves abbreviations for *all* tokens before `training_script_args` (`nargs=REMAINDER`) ever gets a chance to claim them.

## Fix
Instead of disabling abbreviations outright (`allow_abbrev=False`, a breaking change for anyone relying on abbreviating torchrun's own flags — see #126179), locate the `training_script` boundary ourselves before calling into argparse:
- `_find_training_script_index` walks the leading tokens, resolving each one (exact match or unambiguous abbreviation via `_resolve_flag`) the same way argparse would.
- Anything from the script onward is handed to `training_script`/`training_script_args` directly, so it's never re-interpreted as a torchrun option.
- If a leading token is itself ambiguous or unrecognized, we bail and defer to `parser.parse_args()` on the full list, exactly as before (no behavior change for that edge case).

## Testing
Added regression tests in `test/distributed/test_run.py` covering: shadowed script args after the script, combined with an actual torchrun flag before it, and abbreviated torchrun flags before the script (both alone and combined with a shadowed/repeated script arg) to confirm no cross-contamination. `pytest test/distributed/test_run.py` passes.