### PR TITLE
[Profiler] Introduce CuspyConfig as a way to trigger cuspy without experimental configs

### DIFF
--- a/docs/source/profiler.md
+++ b/docs/source/profiler.md
@@ -32,6 +32,8 @@
 .. autoclass:: torch.profiler.ProfilerActivity
   :members:
 
+.. autoclass:: torch.profiler.CuspyConfig
+
 .. autoclass:: torch.profiler.ProfilerActivityConfig
 
 .. autoclass:: torch.profiler.PerformanceMetricsConfig

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -20,7 +20,7 @@ import types
 import unittest
 import warnings
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 # Suppress libkineto USDT profiler_start/profiler_stop logs in this verbose
@@ -38,6 +38,7 @@ from torch.autograd.profiler import KinetoStepTracker, profile as _profile
 from torch.autograd.profiler_legacy import profile as _profile_legacy
 from torch.profiler import (
     _utils,
+    CuspyConfig,
     DeviceType,
     kineto_available,
     PerformanceMetricsConfig,
@@ -2155,7 +2156,7 @@ class TestProfiler(TestCase):
         self.assertEqual(p.activity_configs, {ProfilerActivity.CUDA: config})
 
         self.assertEqual(
-            _get_profiler_extensions(config),
+            _get_profiler_extensions(config.profiler_configs),
             {
                 "PERFORMANCE_METRICS": "metric_a,metric_b",
                 "PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS": "0.5",
@@ -2164,12 +2165,67 @@ class TestProfiler(TestCase):
         )
         self.assertEqual(
             _get_profiler_extensions(
-                ProfilerActivityConfig(
-                    profiler_configs=[PerformanceMetricsConfig(metric_names=[])]
-                )
+                [PerformanceMetricsConfig(metric_names=[]), CuspyConfig()]
             ),
             {"PERFORMANCE_METRICS": ""},
         )
+
+    def test_cuspy_config_routes_performance_metrics(self):
+        performance_metrics = PerformanceMetricsConfig(
+            metric_names=["metric_a", "metric_b"],
+            sampling_interval_ms=0.5,
+            lookback_window_ms=2000,
+        )
+        cuspy_config = CuspyConfig(
+            enable_cuda_sync_events=True,
+            enable_environment_counters=True,
+            enable_graph_dependencies=False,
+            enable_event_node_ids=False,
+        )
+        p = profile(
+            activities=[
+                ProfilerActivity.CPU,
+                {
+                    ProfilerActivity.CUDA: ProfilerActivityConfig(
+                        profiler_configs=[performance_metrics, cuspy_config]
+                    )
+                },
+            ],
+            experimental_config=_ExperimentalConfig(
+                custom_profiler_config=json.dumps(
+                    {
+                        "enable_cuda_sync_events": False,
+                        "enable_environment_counters": True,
+                        "enable_graph_dependencies": True,
+                        "enable_event_node_ids": True,
+                    }
+                )
+            ),
+        )
+        observer = MagicMock(return_value=object())
+        observer_module = types.ModuleType("torch.profiler._cuspy.observers.profiler")
+        observer_module.ProfilerObserver = observer
+
+        with (
+            patch("torch.profiler.profiler.prof.profile") as kineto_profile,
+            patch.dict(
+                sys.modules,
+                {"torch.profiler._cuspy.observers.profiler": observer_module},
+            ),
+            patch("torch.profiler.profiler.prof._set_active_cuspy_profiler_observer"),
+        ):
+            p.prepare_trace()
+
+        self.assertEqual(kineto_profile.call_args.kwargs["_profiler_extensions"], {})
+        self.assertEqual(
+            observer.call_args.kwargs["pm_metrics"], ["metric_a", "metric_b"]
+        )
+        self.assertTrue(observer.call_args.kwargs["enable_cuda_sync"])
+        self.assertTrue(observer.call_args.kwargs["enable_environment_counters"])
+        self.assertFalse(observer.call_args.kwargs["enable_graph_dependencies"])
+        self.assertFalse(observer.call_args.kwargs["enable_event_node_ids"])
+        self.assertEqual(observer.call_args.kwargs["pm_sampling_interval_ms"], 0.5)
+        self.assertEqual(observer.call_args.kwargs["pm_lookback_window_ms"], 2000)
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_activity_filter_invalid_type_name(self):

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -20,6 +20,7 @@ from torch.optim.optimizer import Optimizer, register_optimizer_step_post_hook
 
 from .profiler import (
     _KinetoProfile,
+    CuspyConfig,
     ExecutionTraceObserver,
     PerformanceMetricsConfig,
     profile,
@@ -38,6 +39,7 @@ __all__ = [
     "tensorboard_trace_handler",
     "ProfilerAction",
     "ProfilerActivity",
+    "CuspyConfig",
     "PerformanceMetricsConfig",
     "ProfilerActivityConfig",
     "kineto_available",

--- a/torch/profiler/_cuspy/core.py
+++ b/torch/profiler/_cuspy/core.py
@@ -938,13 +938,18 @@ class Cuspy:
     # --- PM sampling (opt-in GPU utilization counters) -----------------------
 
     def request_pm_sampling(
-        self, sink: Callable[[dict[str, Any]], None], metrics: Iterable[str]
+        self,
+        sink: Callable[[dict[str, Any]], None],
+        metrics: Iterable[str],
+        *,
+        sampling_interval_ms: float | None = None,
+        lookback_window_ms: float | None = None,
     ) -> None:
         """Register ``sink`` as a PM-sampling consumer wanting ``metrics`` on the current device.
         The shared per-device session samples the union of all consumers' metrics; the first
-        consumer starts it (see PmSampler.configure() for interval/look-back). Frames arrive on the
-        flush thread with ``start_ns`` already converted into the trace clock. No-op if CUDA is
-        unavailable, no metrics are given, or ``sink`` is already registered."""
+        consumer starts it. Frames arrive on the flush thread with ``start_ns`` already converted
+        into the trace clock. No-op if CUDA is unavailable, no metrics are given, or ``sink`` is
+        already registered."""
         from torch.profiler._cuspy.pm_sampling import PmSampler
 
         metrics = list(metrics)
@@ -955,7 +960,11 @@ class Cuspy:
                 return
             sampler = PmSampler()  # per-device singleton for the current device
             try:
-                handle = sampler.add_consumer(metrics)
+                handle = sampler.add_consumer(
+                    metrics,
+                    sampling_interval_ms=sampling_interval_ms,
+                    lookback_window_ms=lookback_window_ms,
+                )
             except Exception as e:
                 logger.warning("PM sampling could not register consumer: %s", e)
                 return

--- a/torch/profiler/_cuspy/observers/profiler.py
+++ b/torch/profiler/_cuspy/observers/profiler.py
@@ -253,6 +253,8 @@ class ProfilerObserver(WindowFinalizerMixin, CuspyObserver):
         defer_export: bool = True,
         enable_pm_sampling: bool = False,
         pm_metrics: Iterable[str] | None = None,
+        pm_sampling_interval_ms: float | None = None,
+        pm_lookback_window_ms: float | None = None,
         enable_graph_dependencies: bool = False,
         enable_event_node_ids: bool = False,
         pftrace_compression_level: int = 1,
@@ -345,7 +347,12 @@ class ProfilerObserver(WindowFinalizerMixin, CuspyObserver):
         # a monotonic guard so each sample is enqueued at most once.
         self._pm_last_ns: dict[int, int] = {}
         if self._pm_enabled and self._cuspy is not None:
-            self._cuspy.request_pm_sampling(self.on_pm_samples, self._pm_metrics)
+            self._cuspy.request_pm_sampling(
+                self.on_pm_samples,
+                self._pm_metrics,
+                sampling_interval_ms=pm_sampling_interval_ms,
+                lookback_window_ms=pm_lookback_window_ms,
+            )
 
     def _boundary_clock_ns(self) -> int:
         # Stamp the boundary in the converted clock the events' start_ns use (convert_time

--- a/torch/profiler/_cuspy/pm_sampling.py
+++ b/torch/profiler/_cuspy/pm_sampling.py
@@ -38,10 +38,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Interval + look-back defaults; override process-wide (first-come-first-serve) via
-# PmSampler.configure() -- there is no env var. Metrics are NOT process-wide -- each consumer
-# brings its own via add_consumer(). The HW sampling interval (GPU_TIME_INTERVAL units = ns),
-# default 1 ms.
+# Interval + look-back defaults; override them process-wide via PmSampler.configure() or for one
+# active session through add_consumer(). Metrics are NOT process-wide -- each consumer brings its
+# own. The HW sampling interval (GPU_TIME_INTERVAL units = ns), default 1 ms.
 _DEFAULT_SAMPLING_INTERVAL_NS = 1_000_000
 # Retained look-back window: the sampler is sized (max_samples + ring) to cover this much wall-clock
 # at the interval. Kept modest because the host counter-data image is ~18 KiB/sample (see
@@ -250,15 +249,37 @@ class PmSampler:
         self._retained_vals = np.empty((0, 0), dtype=np.float64)
         self._lock = threading.RLock()
 
-    def add_consumer(self, metrics: Iterable[str]) -> _Handle:
+    def add_consumer(
+        self,
+        metrics: Iterable[str],
+        *,
+        sampling_interval_ms: float | None = None,
+        lookback_window_ms: float | None = None,
+    ) -> _Handle:
         """Register a consumer for ``metrics`` and return its handle (``handle.poll()`` /
         ``handle.detach()``; dropping the handle also detaches). Raises ValueError if ``metrics`` is
-        empty or the resulting union can't be collected in one PM pass."""
+        empty or the resulting union can't be collected in one PM pass. The first consumer in an
+        active session selects its interval and look-back; later consumers share that timing."""
         metrics = list(metrics)
         if not metrics:
             raise ValueError("PM sampling requires a non-empty metric set")
         consumer = _Consumer(metrics)
         with self._lock:
+            if not self._consumers:
+                cls = type(self)
+                self._sampling_interval_ns = (
+                    cls._sampling_interval_ns
+                    if sampling_interval_ms is None
+                    else int(sampling_interval_ms * 1_000_000)
+                )
+                self._lookback_window_ns = (
+                    cls._lookback_window_ns
+                    if lookback_window_ms is None
+                    else int(lookback_window_ms * 1_000_000)
+                )
+                self._max_samples = max(
+                    1, self._lookback_window_ns // self._sampling_interval_ns
+                )
             self._check_single_pass(self._union_of([*self._consumers, consumer]))
             self._consumers.append(consumer)
             self._reconfigure()

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import partial
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import deprecated, Self
 from warnings import warn
 
@@ -40,6 +40,7 @@ __all__ = [
     "schedule",
     "tensorboard_trace_handler",
     "profile",
+    "CuspyConfig",
     "ExecutionTraceObserver",
     "PerformanceMetricsConfig",
     "ProfilerActivityConfig",
@@ -131,6 +132,36 @@ class _ProfilerExtensionConfig(ABC):
         pass
 
 
+_ProfilerConfigT = TypeVar("_ProfilerConfigT", bound=_ProfilerExtensionConfig)
+
+
+@dataclass(frozen=True)
+class CuspyConfig(_ProfilerExtensionConfig):
+    """Configure Cuspy CUDA activity collection.
+
+    CPU activity is currently required because Cuspy merges its trace with the
+    CPU trace.
+
+    Args:
+        enable_cuda_sync_events (bool, optional): Collect CUDA synchronization
+            activities.
+        enable_environment_counters (bool, optional): Collect GPU environment
+            counters.
+        enable_graph_dependencies (bool, optional): Record CUDA graph
+            dependency edges.
+        enable_event_node_ids (bool, optional): Associate CUDA events with CUDA
+            graph event-record nodes.
+    """
+
+    enable_cuda_sync_events: bool = False
+    enable_environment_counters: bool = False
+    enable_graph_dependencies: bool = False
+    enable_event_node_ids: bool = False
+
+    def _to_config_entries(self) -> dict[str, str]:
+        return {}
+
+
 @dataclass
 class PerformanceMetricsConfig(_ProfilerExtensionConfig):
     """Configure hardware performance-counter metric collection.
@@ -139,12 +170,12 @@ class PerformanceMetricsConfig(_ProfilerExtensionConfig):
 
     Args:
         metric_names (list[str]): Backend-specific hardware metric names to collect.
-        sampling_interval_ms (float, optional): CUDA CUPTI-monitor sampling
-            interval in milliseconds. Defaults to 1 millisecond.
-        lookback_window_ms (float, optional): CUDA CUPTI-monitor look-back
-            window in milliseconds. This bounds the recent sample history
-            retained for decoding; the capacity is the look-back window divided
-            by the sampling interval. Defaults to 10 seconds.
+        sampling_interval_ms (float, optional): CUDA PM-sampling interval in
+            milliseconds. Defaults to 1 millisecond.
+        lookback_window_ms (float, optional): CUDA PM-sampling look-back window
+            in milliseconds. This bounds the recent sample history retained for
+            decoding; the capacity is the look-back window divided by the
+            sampling interval. Defaults to 10 seconds.
 
     CUDA PM sampling uses the current CUDA device.
     """
@@ -175,22 +206,31 @@ class ProfilerActivityConfig:
             collect. ``None`` collects the group's default activity types,
             while an empty list collects none.
         profiler_configs (list): Additional profiler configurations associated
-            with this activity group, such as :class:`PerformanceMetricsConfig`.
+            with this activity group, such as :class:`PerformanceMetricsConfig`
+            and :class:`CuspyConfig`.
     """
 
     activity_types: list[str] | None = None
     profiler_configs: list[_ProfilerExtensionConfig] = field(default_factory=list)
 
+    def _get_profiler_config(
+        self, config_type: type[_ProfilerConfigT]
+    ) -> _ProfilerConfigT | None:
+        return next(
+            (
+                config
+                for config in self.profiler_configs
+                if isinstance(config, config_type)
+            ),
+            None,
+        )
+
 
 def _get_profiler_extensions(
-    config: ProfilerActivityConfig,
+    profiler_configs: Iterable[_ProfilerExtensionConfig],
 ) -> dict[str, str]:
     profiler_extensions = {}
-    for profiler_config in config.profiler_configs:
-        if not isinstance(profiler_config, _ProfilerExtensionConfig):
-            raise TypeError(
-                f"Unsupported profiler config type: {type(profiler_config).__name__}"
-            )
+    for profiler_config in profiler_configs:
         profiler_extensions.update(profiler_config._to_config_entries())
     return profiler_extensions
 
@@ -365,9 +405,19 @@ class _KinetoProfile:
         self._custom_profiler_config = _parse_custom_profiler_config(
             self.experimental_config
         )
-        self._use_cuspy = self._custom_profiler_config.get(
-            "backend"
-        ) == "cuspy" or bool(self._custom_profiler_config.get("cuspy"))
+
+        # Handle combinations of legacy _custom_profiler_config/new ProfilerActivityConfig
+        # implementations for both cuspy and pm sampling until we have migrated off _custom_profiler_config.
+        cuda_config = self.activity_configs.get(ProfilerActivity.CUDA)
+        self._cuspy_config: CuspyConfig | None = (
+            cuda_config._get_profiler_config(CuspyConfig)
+            if cuda_config is not None
+            else None
+        )
+        self._use_cuspy = self._cuspy_config is not None or (
+            self._custom_profiler_config.get("backend") == "cuspy"
+            or bool(self._custom_profiler_config.get("cuspy"))
+        )
         # The ProfilerObserver driving the shared Cuspy singleton this session; window opened
         # at start, closed at stop (_cuspy_window_id), exported by export_chrome_trace.
         self._cuspy_profiler_observer: Any = None
@@ -377,10 +427,23 @@ class _KinetoProfile:
         # wait_for_exports; cuspy-only, rejected elsewhere.
         self._cuspy_async_export = False
         if self._use_cuspy:
-            if ProfilerActivity.CPU not in self.activities:
-                raise ValueError(
-                    "cuspy profiler backend currently requires CPU activity"
+            if self._cuspy_config is None:
+                self._cuspy_config = CuspyConfig(
+                    enable_cuda_sync_events=bool(
+                        self._custom_profiler_config.get("enable_cuda_sync_events")
+                    ),
+                    enable_environment_counters=bool(
+                        self._custom_profiler_config.get("enable_environment_counters")
+                    ),
+                    enable_graph_dependencies=bool(
+                        self._custom_profiler_config.get("enable_graph_dependencies")
+                    ),
+                    enable_event_node_ids=bool(
+                        self._custom_profiler_config.get("enable_event_node_ids")
+                    ),
                 )
+            if ProfilerActivity.CPU not in self.activities:
+                raise ValueError("Cuspy currently requires CPU activity")
             self._cuspy_async_export = bool(
                 self._custom_profiler_config.get("cuspy_async_export", False)
             )
@@ -388,13 +451,13 @@ class _KinetoProfile:
             # training loop captures its CUDA graphs. The recording hook must observe each
             # graph's one-time instantiate(); the per-window ProfilerObserver registers it
             # too late (at prepare_trace, after warm-up capture) to catch replay-only graphs.
-            if self._custom_profiler_config.get("enable_graph_dependencies"):
+            if self._cuspy_config.enable_graph_dependencies:
                 from torch.profiler._cuspy._graph_deps import _GraphDependencyRecorder
 
                 _GraphDependencyRecorder().arm()
             # Same early-arm rationale for the CUDA_EVENT -> graph event-record node bridge:
             # the recorder reads each graph's event nodes at its one-time instantiate().
-            if self._custom_profiler_config.get("enable_event_node_ids"):
+            if self._cuspy_config.enable_event_node_ids:
                 from torch.profiler._cuspy._event_nodes import _EventNodeRecorder
 
                 _EventNodeRecorder().arm()
@@ -424,11 +487,18 @@ class _KinetoProfile:
         if (self.profiler is None) or (not self.acc_events):
             use_device = None if self._use_cuspy else self.use_device
             activity_filters = {}
-            profiler_extensions = {}
+            profiler_configs = []
             for activity, config in self.activity_configs.items():
                 if config.activity_types is not None:
                     activity_filters[activity] = set(config.activity_types)
-                profiler_extensions.update(_get_profiler_extensions(config))
+                profiler_configs.extend(config.profiler_configs)
+            if self._use_cuspy:
+                profiler_configs = [
+                    config
+                    for config in profiler_configs
+                    if not isinstance(config, PerformanceMetricsConfig)
+                ]
+            profiler_extensions = _get_profiler_extensions(profiler_configs)
             self.profiler = prof.profile(
                 use_cpu=(ProfilerActivity.CPU in self.activities),
                 use_device=use_device,
@@ -445,39 +515,43 @@ class _KinetoProfile:
                 activity_filters=activity_filters or None,
                 _profiler_extensions=profiler_extensions,
             )
-        if self._use_cuspy:
+        if self._cuspy_config is not None:
             from torch.profiler._cuspy.observers.profiler import ProfilerObserver
 
+            cuda_config = self.activity_configs.get(ProfilerActivity.CUDA)
+            pm_config = (
+                cuda_config._get_profiler_config(PerformanceMetricsConfig)
+                if cuda_config is not None
+                else None
+            )
+            pm_config = pm_config or PerformanceMetricsConfig(
+                metric_names=self._custom_profiler_config.get("pm_metrics") or []
+            )
             self._cuspy_trace_window = None
             # Constructing the observer registers it with the shared Cuspy singleton and
             # collection. cuda_sync events are opt-in via the config, matching kineto's flag.
             self._cuspy_profiler_observer = ProfilerObserver(
-                enable_cuda_sync=bool(
-                    self._custom_profiler_config.get("enable_cuda_sync_events")
-                ),
+                enable_cuda_sync=self._cuspy_config.enable_cuda_sync_events,
                 # GPU environment counters (power/clock/thermal/cooling) are periodically
                 # sampled; opt-in since the sampling adds overhead.
-                enable_environment_counters=bool(
-                    self._custom_profiler_config.get("enable_environment_counters")
+                enable_environment_counters=(
+                    self._cuspy_config.enable_environment_counters
                 ),
                 # PM sampling (true SM-active % + DRAM-throughput % counters) is a Cuspy
-                # feature, opt-in like the env counters. The metrics are per-profile
-                # (custom_profiler_config["pm_metrics"], a list of CUPTI metric names).
-                enable_pm_sampling=bool(
-                    self._custom_profiler_config.get("enable_pm_sampling")
-                ),
-                pm_metrics=self._custom_profiler_config.get("pm_metrics"),
+                # feature, opt-in like the env counters. PerformanceMetricsConfig supplies
+                # the metrics; custom_profiler_config remains supported during migration.
+                enable_pm_sampling=pm_config is not None
+                or bool(self._custom_profiler_config.get("enable_pm_sampling")),
+                pm_metrics=pm_config.metric_names,
+                pm_sampling_interval_ms=pm_config.sampling_interval_ms,
+                pm_lookback_window_ms=pm_config.lookback_window_ms,
                 # Node->node CUDA-graph dependency arrows are opt-in (extra work at graph
                 # instantiate + arrow rendering); off unless the config requests them.
-                enable_graph_dependencies=bool(
-                    self._custom_profiler_config.get("enable_graph_dependencies")
-                ),
+                enable_graph_dependencies=self._cuspy_config.enable_graph_dependencies,
                 # Join CUDA_EVENT records (graph event-record nodes, e.g. NCCL under
                 # NCCL_GRAPH_MIXING_SUPPORT) back to their graph_node_id. Opt-in: pulls in the
                 # CUDA_EVENT record kind.
-                enable_event_node_ids=bool(
-                    self._custom_profiler_config.get("enable_event_node_ids")
-                ),
+                enable_event_node_ids=self._cuspy_config.enable_event_node_ids,
                 # gzip level for the native .pftrace encoder (0-9; 1 = fast, the default).
                 pftrace_compression_level=int(
                     self._custom_profiler_config.get("pftrace_compression_level", 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196066
* #196065

Usage, turning on both PM sampling and cuspy:

```
pm_config = torch.profiler.PerformanceMetricsConfig(
    metric_names=[
        "sm__cycles_active.avg.pct_of_peak_sustained_elapsed",
        "gpu__dram_throughput.avg.pct_of_peak_sustained_elapsed",
    ],
    sampling_interval_ms=1.0,
    lookback_window_ms=10_000,
)
cuspy_config = torch.profiler.CuspyConfig(
    enable_cuda_sync_events=True,
    enable_environment_counters=True,
    enable_graph_dependencies=True,
    enable_event_node_ids=True,
)
cuda_config = torch.profiler.ProfilerActivityConfig(
    profiler_configs=[pm_config, cuspy_config],
)
with torch.profiler.profile(
    activities=[
        torch.profiler.ProfilerActivity.CPU,
        {torch.profiler.ProfilerActivity.CUDA: cuda_config},
    ],
) as prof:
    workload()
```

cuspy normally sets PM sampling values with a global configure call, this adds support for per-session wiring as well.
