### PR TITLE
[inductor-perf] Avoid passing a compiler-proven all-zero floating additive bias to aten._scaled_dot_product_efficient_attention.

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -223,6 +223,99 @@ class CudaReproTests(TestCase):
         self.assertEqual(compiled_out["ten0"], eager_out["ten0"])
         self.assertEqual(compiled_out["ten1"], eager_out["ten1"])
 
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        "Does not support mem_eff_attention",
+    )
+    def test_effn_attn_uniform_zero_bias(self):
+        batch_size, num_heads, seq_len, head_dim = 2, 4, 128, 64
+
+        def fn(query, key, value):
+            additive_mask = torch.full(
+                (batch_size, num_heads, seq_len, seq_len),
+                0.0,
+                device=query.device,
+                dtype=query.dtype,
+            )
+            return aten._scaled_dot_product_efficient_attention.default(
+                query, key, value, additive_mask, False
+            )[0]
+
+        query, key, value = (
+            torch.randn(
+                batch_size,
+                num_heads,
+                seq_len,
+                head_dim,
+                device=device_type,
+            )
+            for _ in range(3)
+        )
+
+        def compile_and_capture_bias(fn, *args, strict=False):
+            biases = []
+
+            def capture_bias(graph):
+                nodes = graph.find_nodes(
+                    op="call_function",
+                    target=aten._scaled_dot_product_efficient_attention.default,
+                )
+                biases.extend(node.args[3] for node in nodes)
+
+            torch._dynamo.reset()
+            with (
+                config.patch(
+                    numerics="strict" if strict else "default",
+                    joint_custom_post_pass=capture_bias,
+                ),
+                sdpa_kernel(SDPBackend.EFFICIENT_ATTENTION),
+            ):
+                compiled = torch.compile(fn, fullgraph=True)
+                actual = compiled(*args)
+            self.assertEqual(len(biases), 1)
+            return actual, biases[0], compiled
+
+        expected = fn(query, key, value)
+        actual, bias, _ = compile_and_capture_bias(fn, query, key, value)
+        self.assertEqual(actual, expected)
+        self.assertIsNone(bias)
+
+        strict_actual, strict_bias, _ = compile_and_capture_bias(
+            fn, query, key, value, strict=True
+        )
+        self.assertEqual(strict_actual, expected)
+        self.assertIsInstance(strict_bias, torch.fx.Node)
+
+        # Only compiler-proven zero masks may be removed; a runtime mask must
+        # remain an FX input because its contents can change between calls.
+        def runtime_mask_fn(query, key, value, attention_mask):
+            return F.scaled_dot_product_attention(
+                query, key, value, attn_mask=attention_mask
+            )
+
+        padding_mask = torch.zeros(
+            batch_size,
+            1,
+            seq_len,
+            seq_len,
+            device=device_type,
+        )
+        padding_mask[..., -1] = torch.finfo(padding_mask.dtype).min
+        expected = runtime_mask_fn(query, key, value, padding_mask)
+        actual, runtime_bias, compiled_runtime_mask_fn = compile_and_capture_bias(
+            runtime_mask_fn, query, key, value, padding_mask
+        )
+        self.assertEqual(actual, expected)
+        self.assertIsInstance(runtime_bias, torch.fx.Node)
+
+        # Reuse the same compiled graph with different mask contents.
+        padding_mask.zero_()
+        with sdpa_kernel(SDPBackend.EFFICIENT_ATTENTION):
+            self.assertEqual(
+                compiled_runtime_mask_fn(query, key, value, padding_mask),
+                runtime_mask_fn(query, key, value, padding_mask),
+            )
+
     def test_effn_attn_bias_padding(self):
         batch_size, num_heads, seq_len, head_dim = 2, 32, 512, 128
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -554,8 +554,35 @@ def _has_self_referential_shape(
     return False
 
 
+# TODO: Investigate generalizing this to cuDNN, CPU Flash, and overrideable fused attention.
+def _remove_zero_bias_from_efficient_attention(
+    gm: torch.fx.GraphModule,
+    uniform_values: dict[torch.fx.Node, Any],
+) -> None:
+    if config.numerics == "strict":
+        return
+
+    target = aten._scaled_dot_product_efficient_attention.default
+    for node in gm.graph.find_nodes(op="call_function", target=target):
+        if len(node.args) < 4 or not isinstance(node.args[3], torch.fx.Node):
+            continue
+        bias = node.args[3]
+        # TODO: Also remove zero bias from the backward for training performance.
+        value = uniform_values.get(bias)
+        fake_bias = bias.meta.get("val")
+        if (
+            not isinstance(fake_bias, torch.Tensor)
+            or not fake_bias.dtype.is_floating_point
+            or value != 0.0
+        ):
+            continue
+        args = list(node.args)
+        args[3] = None
+        node.args = tuple(args)
+
+
 def constant_fold_uniform_value(gm: torch.fx.GraphModule):
-    """Runs constant folding and replaces constants which can be constructed with a single `full` call. Calls into remove_no_ops."""
+    """Fold uniform constants and algebraic no-ops, including efficient attention with an all-zero additive bias to no bias."""
     with torch.utils._python_dispatch._disable_current_modes():
         aten = torch.ops.aten
 
@@ -565,6 +592,7 @@ def constant_fold_uniform_value(gm: torch.fx.GraphModule):
         cf.run()
 
         node_replacements = cf.node_replacements
+        _remove_zero_bias_from_efficient_attention(gm, node_replacements)
 
         # note: [constant folding refining of symints]
         # constant folding will partially evaluate a graph such that values which have dependencies which


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196079
* __->__ #196068

as i was working on my ir inductor printer i noticed an odd patter post lowrering
```
# op8
buf8: bf16[1,1,512,512]
    foreach p0 in [0,512), p1 in [0,512):
        t0 = where(False, -3.3895313892515355e+38, 0.0)
        buf8[512*p0 + p1] = t0

# op9, op10, op11, op12, op13
buf10, buf11, buf12, buf13 =
    aten._scaled_dot_product_efficient_attention(
        ...,
        reinterpret_tensor(buf8, [1,12,512,512], [262144,0,512,1], 0),
        False)
```
specifically the all zeros buf8 !! 

## What this PR does 
Avoid passing a compiler-proven all-zero floating additive bias to `aten._scaled_dot_product_efficient_attention`.

BERT-style mask construction can produce a floating attention bias whose value is uniformly zero. Passing that tensor to memory-efficient attention forces the bias-capable path and retains the mask construction even though adding it cannot change the attention scores. This change reuses joint-graph uniform-value analysis and replaces that bias with `None`.

The rewrite is disabled when `torch._inductor.config.numerics == "strict"`, since removing the bias may enable a different efficient-attention kernel with a different floating-point reduction order. Boolean and runtime-provided masks are not rewritten.

## FX graph

Captured from TorchBench `hf_Bert` BF16 inference using `joint_custom_pre_pass` and `joint_custom_post_pass`. All 12 attention layers were rewritten.

Before:

```text
%expand_2 = call_function[target=torch.ops.aten.expand.default](
    args=(%where, [1, 12, 512, 512]), kwargs={})
%_scaled_dot_product_efficient_attention = call_function[
    target=torch.ops.aten._scaled_dot_product_efficient_attention.default
](args=(%permute_1, %permute_3, %permute_5, %expand_2, False), kwargs={})
```

After:

```text
%_scaled_dot_product_efficient_attention = call_function[
    target=torch.ops.aten._scaled_dot_product_efficient_attention.default
](args=(%permute_1, %permute_3, %permute_5, None, False), kwargs={})
```

The same transformation occurred for `%_scaled_dot_product_efficient_attention_1` through `%_scaled_dot_product_efficient_attention_11`.

## Performance (done by agent)

Hardware: NVIDIA H100, BF16 inference, batch size 1, 30 repetitions per run.

### batchsize =1 
The baseline disabled only `_remove_zero_bias_from_efficient_attention`; all other compiler settings and model inputs were unchanged. Each model was measured twice with the rewrite disabled and twice with it enabled.

| TorchBench model | Disabled A1 | Enabled B1 | Pair 1 | Disabled A2 | Enabled B2 | Pair 2 | Mean improvement | A/A drift |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `hf_Bert` | 1.406820 ms | 1.306389 ms | **7.14%** | 1.413025 ms | 1.316248 ms | **6.85%** | **6.99%** | 0.44% |
| `hf_Albert` | 1.132008 ms | 1.036268 ms | **8.46%** | 1.141441 ms | 1.027636 ms | **9.97%** | **9.22%** | 0.83% |
| `hf_DistilBert` | 0.839292 ms | 0.775011 ms | **7.66%** | 0.843523 ms | 0.819957 ms | **2.79%** | **5.22%** | 0.50% |

All six A/B pairs agree in direction. Every model's mean improvement is substantially larger than its observed A/A drift.

#### batch size = 100
```
Run | No optimization | Optimized | Improvement
-- | -- | -- | --
Pair 1 | 37.153 ms | 33.653 ms | 9.42%
Pair 2 | 37.162 ms | 33.688 ms | 9.35%

</div>
```
## Correctness and safety

The rewrite requires:

- an FX-node bias whose metadata is a floating-point tensor;
- uniform-value analysis proving its scalar value equals zero;
- non-strict numerics mode.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo