### PR TITLE
Expose torch.assert_async as the public name for torch._assert_async

### DIFF
--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -989,6 +989,7 @@ during migration, we recommend using the public APIs.
     set_warn_always
     is_warn_always_enabled
     vmap
+    assert_async
     _assert
     typename
 ```

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2491,24 +2491,24 @@ if __name__ == '__main__':
         with self.assertRaisesRegex(
             RuntimeError, "Boolean value of Tensor with no values is ambiguous"
         ):
-            torch._assert_async(torch.tensor([], device="cuda"))
+            torch.assert_async(torch.tensor([], device="cuda"))
         with self.assertRaisesRegex(
             RuntimeError,
             "Boolean value of Tensor with more than one value is ambiguous",
         ):
-            torch._assert_async(torch.tensor([0, 0], device="cuda"))
+            torch.assert_async(torch.tensor([0, 0], device="cuda"))
 
-        torch._assert_async(torch.tensor(1, device="cuda"))
-        torch._assert_async(torch.tensor(0.1, device="cuda"))
-        torch._assert_async(torch.tensor(-0.1, device="cuda"))
-        torch._assert_async(torch.tensor(True, device="cuda"))
-        torch._assert_async(torch.tensor(0 + 0.1j, device="cuda"))
+        torch.assert_async(torch.tensor(1, device="cuda"))
+        torch.assert_async(torch.tensor(0.1, device="cuda"))
+        torch.assert_async(torch.tensor(-0.1, device="cuda"))
+        torch.assert_async(torch.tensor(True, device="cuda"))
+        torch.assert_async(torch.tensor(0 + 0.1j, device="cuda"))
 
         fail_stmts = [
-            "torch._assert_async(torch.tensor(0, device='cuda'))",
-            "torch._assert_async(torch.tensor(0.0, device='cuda'))",
-            "torch._assert_async(torch.tensor(False, device='cuda'))",
-            "torch._assert_async(torch.tensor(0 + 0j, device='cuda'))",
+            "torch.assert_async(torch.tensor(0, device='cuda'))",
+            "torch.assert_async(torch.tensor(0.0, device='cuda'))",
+            "torch.assert_async(torch.tensor(False, device='cuda'))",
+            "torch.assert_async(torch.tensor(0 + 0j, device='cuda'))",
         ]
 
         import subprocess

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8885,23 +8885,26 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertTrue(torch.tensor(0 + 0.1j).is_nonzero())
 
     def test_assert_async(self):
+        self.assertIs(torch.assert_async, torch._assert_async)
         with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with no values is ambiguous"):
-            torch._assert_async(torch.tensor([]))
+            torch.assert_async(torch.tensor([]))
         with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with more than one value is ambiguous"):
-            torch._assert_async(torch.tensor([0, 0]))
+            torch.assert_async(torch.tensor([0, 0]))
         with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-            torch._assert_async(torch.tensor(0))
-        torch._assert_async(torch.tensor(1))
-        torch._assert_async(torch.tensor(0.1))
-        torch._assert_async(torch.tensor(-0.1))
+            torch.assert_async(torch.tensor(0))
+        torch.assert_async(torch.tensor(1))
+        torch.assert_async(torch.tensor(0.1))
+        torch.assert_async(torch.tensor(-0.1))
         with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-            torch._assert_async(torch.tensor(0.0))
-        torch._assert_async(torch.tensor(True))
+            torch.assert_async(torch.tensor(0.0))
+        torch.assert_async(torch.tensor(True))
         with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-            torch._assert_async(torch.tensor(False))
-        torch._assert_async(torch.tensor(0 + 0.1j))
+            torch.assert_async(torch.tensor(False))
+        torch.assert_async(torch.tensor(0 + 0.1j))
         with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-            torch._assert_async(torch.tensor(0 + 0j))
+            torch.assert_async(torch.tensor(0 + 0j))
+        with self.assertRaisesRegex(RuntimeError, "value must be nonzero"):
+            torch.assert_async(torch.tensor(0), "value must be nonzero")
 
     # NB: we must not be built with CUDA; if we are built with CUDA but no CUDA
     # is available, we get a different error.

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2598,6 +2598,7 @@ if TYPE_CHECKING:
     # Fixup segment_reduce visibility
     _segment_reduce = segment_reduce
     del segment_reduce  # noqa: F821
+    from torch._C._VariableFunctions import _assert_async as assert_async
 
 # Ops not to be exposed in `torch` namespace,
 # mostly helper ops.
@@ -2614,6 +2615,10 @@ for __name in dir(_C._VariableFunctions):
         # TODO: Once the undocumented FC window is passed, remove the line below
         globals()[__name] = __obj
         __name = "_" + __name
+    # Public alias; the underscored name is kept for backward compatibility
+    if __name == "_assert_async":
+        globals()[__name] = __obj
+        __name = "assert_async"
     globals()[__name] = __obj
     if not __name.startswith("_"):
         __all__.append(__name)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -14566,9 +14566,9 @@ Example::
 )
 
 add_docstr(
-    torch._assert_async,
+    torch.assert_async,
     r"""
-_assert_async(tensor) -> void
+assert_async(tensor, assert_msg=None) -> None
 
 Asynchronously assert that the contents of tensor are nonzero.  For CPU tensors,
 this is equivalent to ``assert tensor`` or ``assert tensor.is_nonzero()``; for
@@ -14578,10 +14578,20 @@ testing invariants in CUDA tensors without giving up performance.  This function
 is NOT intended to be used for regular error checking, as it will trash your CUDA
 context if the assert fails (forcing you to restart your PyTorch process.)
 
+``torch._assert_async`` is an alias of this function kept for backward
+compatibility.
+
 Args:
     tensor (Tensor): a one element tensor to test to see if it is nonzero.  Zero
         elements (including False for boolean tensors) cause an assertion failure
         to be raised.
+    assert_msg (str, optional): message to include in the error raised when the
+        assertion fails.
+
+Example::
+
+    >>> torch.assert_async(torch.tensor(1))
+    >>> torch.assert_async(torch.tensor(1), "value must be nonzero")
 """,
 )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196069

Fixes #53284

torch._assert_async was underscored when it was added because we had not
decided where it should live. It has since become genuinely useful outside
of PyTorch internals (asserting on device values without forcing a sync),
and there is no public equivalent. This makes torch.assert_async the public
name, alongside torch._assert in the torch namespace, and keeps
torch._assert_async as an alias for backward compatibility.

The alias is added at the Python level in torch/__init__.py, where
_C._VariableFunctions is exported into the torch namespace (the same spot
that already fixes up segment_reduce visibility). The aten schema is
unchanged, so serialized TorchScript and export artifacts, the
forward/backward compatibility check, and the many passes that key on
aten._assert_async are all unaffected. Renaming the aten op instead would
have required either a schema BC break or carrying two op identities through
every pass that recognizes the assert; that can be done as a follow-up if
the graph-level name turns out to matter.

The docstring is retitled to the public name and now documents the
assert_msg overload. The function is listed in docs/source/torch.md.

Test Plan:

```
python test/test_torch.py -k test_assert_async
python test/test_public_bindings.py
```

test_public_bindings has one pre-existing failure in this environment
(test_modules_can_be_imported, missing optional deps such as tensorboard);
the other three tests pass. TestCuda.test_fixed_cuda_assert_async was run
via a unittest loader with psutil stubbed out since psutil is not installed
here, and passed. lintrunner is not available in this environment and was
not run.

Authored with an AI assistant (Claude Code).