### PR TITLE
[MPS] Migrate softmax to metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/SoftMax.h
+++ b/aten/src/ATen/native/mps/kernels/SoftMax.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <c10/metal/common.h>
 
-C10_METAL_CONSTEXPR unsigned kLogSoftmaxThreads = 256;
-C10_METAL_CONSTEXPR unsigned kLogSoftmaxMaxThreads = 1024;
+C10_METAL_CONSTEXPR unsigned kSoftmaxThreads = 256;
+C10_METAL_CONSTEXPR unsigned kSoftmaxMaxThreads = 1024;
 
 template <typename index_t = uint64_t>
-struct LogSoftmaxParams {
+struct SoftmaxParams {
   index_t dim_size;
   index_t num_rows;
   index_t inner_size;

--- a/aten/src/ATen/native/mps/kernels/SoftMax.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMax.metal
@@ -1,8 +1,30 @@
-#include <ATen/native/mps/kernels/LogSoftmax.h>
+#include <ATen/native/mps/kernels/SoftMax.h>
 #include <c10/metal/reduction_utils.h>
 #include <metal_stdlib>
 using namespace metal;
 using c10::metal::simdgroup_size;
+
+template <bool log_softmax>
+struct SoftmaxEpilogue {
+  float max_val;
+  float normalizer;
+
+  SoftmaxEpilogue(float max_val, float sum) : max_val(max_val) {
+    if IF_CONSTEXPR (log_softmax) {
+      normalizer = precise::log(sum);
+    } else {
+      normalizer = 1.0f / sum;
+    }
+  }
+
+  float operator()(float value) const {
+    if IF_CONSTEXPR (log_softmax) {
+      return value - max_val - normalizer;
+    } else {
+      return precise::exp(value - max_val) * normalizer;
+    }
+  }
+};
 
 template <typename idx_t>
 inline idx_t out_row_offset(idx_t row, idx_t dim_size, idx_t out_inner) {
@@ -12,7 +34,7 @@ inline idx_t out_row_offset(idx_t row, idx_t dim_size, idx_t out_inner) {
 template <typename idx_t>
 inline idx_t input_row_offset(
     idx_t row,
-    constant LogSoftmaxParams<idx_t>& params) {
+    constant SoftmaxParams<idx_t>& params) {
   idx_t offset = 0;
   for (uint d = params.ndim; d > 0; --d) {
     const uint dim = d - 1;
@@ -29,12 +51,12 @@ inline idx_t input_row_offset(
 // or when reduction dim is between 1025 and 2048 but there are enough rows
 // to fill the GPU with one simdgroup per row (only if there are at least 128
 // rows)
-template <typename T, typename idx_t>
-[[max_total_threads_per_threadgroup(kLogSoftmaxThreads)]] [[kernel]] void
-log_softmax_row(
+template <typename T, typename idx_t, bool log_softmax>
+[[max_total_threads_per_threadgroup(kSoftmaxThreads)]] [[kernel]] void
+softmax_row(
     constant T* input,
     device T* output,
-    constant LogSoftmaxParams<idx_t>& params,
+    constant SoftmaxParams<idx_t>& params,
     uint tptg [[threads_per_threadgroup]],
     uint tgid [[threadgroup_position_in_grid]],
     uint lane [[thread_index_in_simdgroup]],
@@ -54,10 +76,11 @@ log_softmax_row(
   for (idx_t col = lane; col < dim_size; col += simdgroup_size) {
     sum += precise::exp(float(input[in_base + col]) - max_val);
   }
-  const float logsum = precise::log(c10::metal::simd_sum(sum));
+  const SoftmaxEpilogue<log_softmax> epilogue(
+      max_val, c10::metal::simd_sum(sum));
   for (idx_t col = lane; col < dim_size; col += simdgroup_size) {
     output[in_base + col] =
-        static_cast<T>(float(input[in_base + col]) - max_val - logsum);
+        static_cast<T>(epilogue(float(input[in_base + col])));
   }
 }
 
@@ -65,11 +88,11 @@ log_softmax_row(
 // reduction width exceeds 2048 and there are at most 256 logical rows
 // and the input consists of contiguous rows.
 template <typename T, typename idx_t>
-[[max_total_threads_per_threadgroup(kLogSoftmaxThreads)]] [[kernel]] void
-log_softmax_partial(
+[[max_total_threads_per_threadgroup(kSoftmaxThreads)]] [[kernel]] void
+softmax_partial(
     constant T* input,
     device float2* partials,
-    constant LogSoftmaxParams<idx_t>& params,
+    constant SoftmaxParams<idx_t>& params,
     uint2 tgid [[threadgroup_position_in_grid]],
     uint2 tid [[thread_position_in_threadgroup]],
     uint2 tptg [[threads_per_threadgroup]]) {
@@ -99,15 +122,15 @@ log_softmax_partial(
 }
 
 // Second pass of the split path. Combines all chunk partials into row-wide
-// statistics, then each threadgroup writes final log-softmax values for one
+// statistics, then each threadgroup writes final values for one
 // chunk.
-template <typename T, typename idx_t>
-[[max_total_threads_per_threadgroup(kLogSoftmaxThreads)]] [[kernel]] void
-log_softmax_finalize(
+template <typename T, typename idx_t, bool log_softmax>
+[[max_total_threads_per_threadgroup(kSoftmaxThreads)]] [[kernel]] void
+softmax_finalize(
     constant T* input,
     device T* output,
     constant float2* partials,
-    constant LogSoftmaxParams<idx_t>& params,
+    constant SoftmaxParams<idx_t>& params,
     uint2 tgid [[threadgroup_position_in_grid]],
     uint2 tid [[thread_position_in_threadgroup]],
     uint2 tptg [[threads_per_threadgroup]]) {
@@ -129,28 +152,28 @@ log_softmax_finalize(
     sum += row_partials[i].y * precise::exp(row_partials[i].x - max_val);
   }
   sum = c10::metal::threadgroup_sum(shared_sum, sum, ltid, lsize);
-  const float logsum = precise::log(sum);
+  const SoftmaxEpilogue<log_softmax> epilogue(max_val, sum);
   const idx_t row_base = idx_t(tgid.y) * dim_size;
   const idx_t chunk_begin = idx_t(tgid.x) * chunk_size;
   const idx_t chunk_end = min(chunk_begin + chunk_size, dim_size);
   for (idx_t col = chunk_begin + ltid; col < chunk_end; col += lsize) {
     output[row_base + col] =
-        static_cast<T>(float(input[row_base + col]) - max_val - logsum);
+        static_cast<T>(epilogue(float(input[row_base + col])));
   }
 }
 
 // General 2D fallback for strided input and contiguous rows that do not use a
 // specialized kernel.
-template <typename T, typename idx_t>
-[[max_total_threads_per_threadgroup(kLogSoftmaxMaxThreads)]] [[kernel]] void
-log_softmax(
+template <typename T, typename idx_t, bool log_softmax>
+[[max_total_threads_per_threadgroup(kSoftmaxMaxThreads)]] [[kernel]] void
+softmax(
     constant T* input,
     device T* output,
-    constant LogSoftmaxParams<idx_t>& params,
+    constant SoftmaxParams<idx_t>& params,
     uint2 tid [[thread_position_in_threadgroup]],
     uint2 tptg [[threads_per_threadgroup]],
     uint2 tgid [[threadgroup_position_in_grid]]) {
-  threadgroup float shared[kLogSoftmaxMaxThreads];
+  threadgroup float shared[kSoftmaxMaxThreads];
   const auto dim_size = params.dim_size;
   const auto inner_size = params.inner_size;
   const idx_t col = idx_t(tgid.x) * tptg.x + tid.x;
@@ -189,57 +212,60 @@ log_softmax(
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
   }
-  const float logsum = precise::log(shared[tid.x]);
+  const SoftmaxEpilogue<log_softmax> epilogue(max_val, shared[tid.x]);
 
   for (idx_t r = tid.y; active && r < dim_size; r += tptg.y) {
     output[out_base + r * inner_size] =
-        static_cast<T>(float(input[base + r * dim_stride]) - max_val - logsum);
+        static_cast<T>(epilogue(float(input[base + r * dim_stride])));
   }
 }
 
-#define REGISTER_LOG_SOFTMAX_IDX(DTYPE, IDX_T, SUFFIX)                         \
-  template                                                                     \
-      [[host_name("log_softmax_row_" #DTYPE "_" #SUFFIX)]] [[kernel]] void     \
-      log_softmax_row<DTYPE, IDX_T>(                                           \
-          constant DTYPE * input,                                              \
-          device DTYPE * output,                                               \
-          constant LogSoftmaxParams<IDX_T> & params,                           \
-          uint tptg [[threads_per_threadgroup]],                               \
-          uint tgid [[threadgroup_position_in_grid]],                          \
-          uint lane [[thread_index_in_simdgroup]],                             \
-          uint sg [[simdgroup_index_in_threadgroup]]);                         \
-  template                                                                     \
-      [[host_name("log_softmax_partial_" #DTYPE "_" #SUFFIX)]] [[kernel]] void \
-      log_softmax_partial<DTYPE, IDX_T>(                                       \
-          constant DTYPE * input,                                              \
-          device float2 * partials,                                            \
-          constant LogSoftmaxParams<IDX_T> & params,                           \
-          uint2 tgid [[threadgroup_position_in_grid]],                         \
-          uint2 tid [[thread_position_in_threadgroup]],                        \
-          uint2 tptg [[threads_per_threadgroup]]);                             \
-  template [[host_name("log_softmax_finalize_" #DTYPE                          \
-                       "_" #SUFFIX)]] [[kernel]] void                          \
-  log_softmax_finalize<DTYPE, IDX_T>(                                          \
-      constant DTYPE * input,                                                  \
-      device DTYPE * output,                                                   \
-      constant float2 * partials,                                              \
-      constant LogSoftmaxParams<IDX_T> & params,                               \
-      uint2 tgid [[threadgroup_position_in_grid]],                             \
-      uint2 tid [[thread_position_in_threadgroup]],                            \
-      uint2 tptg [[threads_per_threadgroup]]);                                 \
-  template [[host_name("log_softmax_" #DTYPE "_" #SUFFIX)]] [[kernel]] void    \
-  log_softmax<DTYPE, IDX_T>(                                                   \
-      constant DTYPE * input,                                                  \
-      device DTYPE * output,                                                   \
-      constant LogSoftmaxParams<IDX_T> & params,                               \
-      uint2 tid [[thread_position_in_threadgroup]],                            \
-      uint2 tptg [[threads_per_threadgroup]],                                  \
+#define REGISTER_SOFTMAX_OP(DTYPE, IDX_T, SUFFIX, NAME, LOG_SOFTMAX)       \
+  template [[host_name(#NAME "_row_" #DTYPE "_" #SUFFIX)]] [[kernel]] void \
+  softmax_row<DTYPE, IDX_T, LOG_SOFTMAX>(                                  \
+      constant DTYPE * input,                                              \
+      device DTYPE * output,                                               \
+      constant SoftmaxParams<IDX_T> & params,                              \
+      uint tptg [[threads_per_threadgroup]],                               \
+      uint tgid [[threadgroup_position_in_grid]],                          \
+      uint lane [[thread_index_in_simdgroup]],                             \
+      uint sg [[simdgroup_index_in_threadgroup]]);                         \
+  template                                                                 \
+      [[host_name(#NAME "_finalize_" #DTYPE "_" #SUFFIX)]] [[kernel]] void \
+      softmax_finalize<DTYPE, IDX_T, LOG_SOFTMAX>(                         \
+          constant DTYPE * input,                                          \
+          device DTYPE * output,                                           \
+          constant float2 * partials,                                      \
+          constant SoftmaxParams<IDX_T> & params,                          \
+          uint2 tgid [[threadgroup_position_in_grid]],                     \
+          uint2 tid [[thread_position_in_threadgroup]],                    \
+          uint2 tptg [[threads_per_threadgroup]]);                         \
+  template [[host_name(#NAME "_" #DTYPE "_" #SUFFIX)]] [[kernel]] void     \
+  softmax<DTYPE, IDX_T, LOG_SOFTMAX>(                                      \
+      constant DTYPE * input,                                              \
+      device DTYPE * output,                                               \
+      constant SoftmaxParams<IDX_T> & params,                              \
+      uint2 tid [[thread_position_in_threadgroup]],                        \
+      uint2 tptg [[threads_per_threadgroup]],                              \
       uint2 tgid [[threadgroup_position_in_grid]]);
 
-#define REGISTER_LOG_SOFTMAX(DTYPE)          \
-  REGISTER_LOG_SOFTMAX_IDX(DTYPE, uint, u32) \
-  REGISTER_LOG_SOFTMAX_IDX(DTYPE, ulong, u64)
+#define REGISTER_SOFTMAX_IDX(DTYPE, IDX_T, SUFFIX)                         \
+  REGISTER_SOFTMAX_OP(DTYPE, IDX_T, SUFFIX, softmax, false)                \
+  REGISTER_SOFTMAX_OP(DTYPE, IDX_T, SUFFIX, log_softmax, true)             \
+  template                                                                 \
+      [[host_name("softmax_partial_" #DTYPE "_" #SUFFIX)]] [[kernel]] void \
+      softmax_partial<DTYPE, IDX_T>(                                       \
+          constant DTYPE * input,                                          \
+          device float2 * partials,                                        \
+          constant SoftmaxParams<IDX_T> & params,                          \
+          uint2 tgid [[threadgroup_position_in_grid]],                     \
+          uint2 tid [[thread_position_in_threadgroup]],                    \
+          uint2 tptg [[threads_per_threadgroup]]);
 
-REGISTER_LOG_SOFTMAX(float);
-REGISTER_LOG_SOFTMAX(half);
-REGISTER_LOG_SOFTMAX(bfloat);
+#define REGISTER_SOFTMAX(DTYPE)          \
+  REGISTER_SOFTMAX_IDX(DTYPE, uint, u32) \
+  REGISTER_SOFTMAX_IDX(DTYPE, ulong, u64)
+
+REGISTER_SOFTMAX(float);
+REGISTER_SOFTMAX(half);
+REGISTER_SOFTMAX(bfloat);

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -1,20 +1,14 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/ceil_div.h>
 #include <ATen/native/Activation.h>
 #include <ATen/native/Gelu.h>
 #include <ATen/native/mps/OperationUtils.h>
-#include <ATen/native/mps/kernels/LogSoftmax.h>
-#include <c10/util/TypeCast.h>
-#include <c10/util/accumulate.h>
-#include <bit>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_log_softmax_backward_data_native.h>
-#include <ATen/ops/_log_softmax_native.h>
 #include <ATen/ops/_prelu_kernel_backward_native.h>
 #include <ATen/ops/_prelu_kernel_native.h>
 #include <ATen/ops/empty.h>
@@ -32,122 +26,6 @@ using namespace at::mps;
 
 namespace at::native {
 using namespace mps;
-
-#ifndef PYTORCH_JIT_COMPILE_SHADERS
-static auto& lib = MetalShaderLibrary::getBundledLibrary();
-#else
-#include <ATen/native/mps/LogSoftmax_metallib.h>
-#endif
-
-static LogSoftmaxParams<uint32_t> narrow_params(const LogSoftmaxParams<uint64_t>& params) {
-  LogSoftmaxParams<uint32_t> result{.dim_size = c10::checked_convert<uint32_t>(params.dim_size, "uint32_t"),
-                                    .num_rows = c10::checked_convert<uint32_t>(params.num_rows, "uint32_t"),
-                                    .inner_size = c10::checked_convert<uint32_t>(params.inner_size, "uint32_t"),
-                                    .chunk_size = c10::checked_convert<uint32_t>(params.chunk_size, "uint32_t"),
-                                    .n_chunks = c10::checked_convert<uint32_t>(params.n_chunks, "uint32_t"),
-                                    .ndim = params.ndim,
-                                    .dim = params.dim};
-  for (const auto d : c10::irange(params.ndim)) {
-    result.sizes[d] = c10::checked_convert<uint32_t>(params.sizes[d], "uint32_t");
-    result.strides[d] = c10::checked_convert<uint32_t>(params.strides[d], "uint32_t");
-  }
-  return result;
-}
-
-template <typename... Tensors>
-static void run_log_softmax(MPSStream* stream,
-                            const std::string& kernel,
-                            const Tensor& self,
-                            bool use_u32,
-                            MTLSize grid,
-                            MTLSize group,
-                            const LogSoftmaxParams<uint64_t>& params,
-                            const Tensors&... tensors) {
-  auto encoder = stream->commandEncoder();
-  auto pso =
-      lib.getPipelineStateForFunc(fmt::format("{}_{}{}", kernel, scalarToMetalTypeString(self), mtlIdxSuffix(use_u32)));
-  getMPSProfiler().beginProfileKernel(pso, kernel, {self}, stream);
-  [encoder setComputePipelineState:pso];
-  if (use_u32) {
-    mtl_setArgs(encoder, tensors..., narrow_params(params));
-  } else {
-    mtl_setArgs(encoder, tensors..., params);
-  }
-  [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
-  getMPSProfiler().endProfileKernel(pso, stream);
-}
-
-TORCH_IMPL_FUNC(log_softmax_mps_out)
-(const Tensor& self, const int64_t dim, const bool half_to_float, const Tensor& out) {
-  TORCH_CHECK(!half_to_float, "log_softmax with half to float conversion is not supported on MPS");
-  if (self.numel() == 0) {
-    return;
-  }
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      supportedFloatingType(self), "log_softmax not implemented on MPS for ", self.scalar_type());
-
-  const auto self_ = self.dim() == 0 ? self.view(1) : self;
-  const auto wrapped_dim = maybe_wrap_dim(dim, self_.dim());
-  const auto dim_size = static_cast<uint64_t>(self_.size(wrapped_dim));
-  const auto inner_size = static_cast<uint64_t>(c10::multiply_integers(self_.sizes().slice(wrapped_dim + 1)));
-  const auto num_rows = static_cast<uint64_t>(self_.numel()) / dim_size;
-  const bool use_u32 = offsetsFitIn<int32_t>(self_, out);
-  const bool contiguous_rows = self_.is_contiguous() && wrapped_dim == self_.dim() - 1;
-  // one simdgroup per row stops paying off past this width
-  constexpr uint64_t row_kernel_max_dim = 2048;
-  // rows wider than this need many rows to fill the GPU
-  constexpr uint64_t row_kernel_solo_dim = 1024;
-  constexpr uint64_t row_kernel_min_rows = 128;
-  const bool row_dim_fits = dim_size <= row_kernel_solo_dim || num_rows >= row_kernel_min_rows;
-  const bool use_row_kernel = contiguous_rows && dim_size <= row_kernel_max_dim && row_dim_fits;
-  // split long rows into enough chunks to occupy the GPU
-  constexpr uint64_t split_target_groups = 512;
-  // below this width a chunk cannot amortize the second pass
-  constexpr uint64_t split_min_chunk = 2048;
-  const auto n_chunks = std::clamp(split_target_groups / num_rows, uint64_t(1), ceil_div(dim_size, split_min_chunk));
-  const auto chunk_size = ceil_div(dim_size, n_chunks);
-  const bool use_split = contiguous_rows && !use_row_kernel && n_chunks > 1;
-  LogSoftmaxParams<uint64_t> params{.dim_size = dim_size,
-                                    .num_rows = num_rows,
-                                    .inner_size = inner_size,
-                                    .chunk_size = chunk_size,
-                                    .n_chunks = n_chunks,
-                                    .ndim = static_cast<uint32_t>(self_.dim()),
-                                    .dim = static_cast<uint32_t>(wrapped_dim)};
-  for (const auto d : c10::irange(self_.dim())) {
-    params.sizes[d] = self_.size(d);
-    params.strides[d] = self_.size(d) == 1 ? 0 : self_.stride(d);
-  }
-  const auto partials = use_split
-      ? at::empty({static_cast<int64_t>(num_rows), static_cast<int64_t>(n_chunks), 2}, self.options().dtype(kFloat))
-      : Tensor();
-
-  MPSStream* stream = getCurrentMPSStream();
-  dispatch_sync_with_rethrow(stream->queue(), ^() {
-    @autoreleasepool {
-      if (use_row_kernel) {
-        constexpr auto rows_per_group = kLogSoftmaxThreads / c10::metal::simdgroup_size;
-        const auto grid = MTLSizeMake(ceil_div(num_rows, uint64_t(rows_per_group)), 1, 1);
-        const auto group = MTLSizeMake(kLogSoftmaxThreads, 1, 1);
-        run_log_softmax(stream, "log_softmax_row", self, use_u32, grid, group, params, self_, out);
-      } else if (use_split) {
-        const auto grid = MTLSizeMake(n_chunks, num_rows, 1);
-        const auto group = MTLSizeMake(kLogSoftmaxThreads, 1, 1);
-        run_log_softmax(stream, "log_softmax_partial", self, use_u32, grid, group, params, self_, partials);
-        run_log_softmax(stream, "log_softmax_finalize", self, use_u32, grid, group, params, self_, out, partials);
-      } else {
-        // double the width for 2-byte dtypes so a threadgroup row spans a full 128-byte cache line
-        const auto max_tg_x = uint64_t((self.element_size() == 2 ? 2u : 1u) * c10::metal::simdgroup_size);
-        const auto tg_x = std::min(inner_size, max_tg_x);
-        const auto tg_y = std::min(
-            {std::bit_ceil(dim_size), uint64_t(kLogSoftmaxThreads), std::bit_floor(kLogSoftmaxMaxThreads / tg_x)});
-        const auto grid = MTLSizeMake(ceil_div(inner_size, tg_x), num_rows / inner_size, 1);
-        const auto group = MTLSizeMake(tg_x, tg_y, 1);
-        run_log_softmax(stream, "log_softmax", self, use_u32, grid, group, params, self_, out);
-      }
-    }
-  });
-}
 
 TORCH_IMPL_FUNC(log_softmax_backward_mps_out)
 (const Tensor& grad_output, const Tensor& output, int64_t dim, ScalarType input_dtype, const Tensor& out) {

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -1,134 +1,153 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/native/LinearAlgebraUtils.h>
+#include <ATen/ceil_div.h>
 #include <ATen/native/mps/OperationUtils.h>
-
-#ifdef __OBJC__
-#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#endif
+#include <ATen/native/mps/kernels/SoftMax.h>
+#include <c10/util/TypeCast.h>
+#include <c10/util/accumulate.h>
+#include <bit>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_log_softmax_native.h>
 #include <ATen/ops/_softmax_backward_data_native.h>
 #include <ATen/ops/_softmax_native.h>
+#include <ATen/ops/empty.h>
 #endif
 
 namespace at::native {
 
-static void get_shapes(MPSShape* input_shape_readonly,
-                       NSMutableArray<NSNumber*>*& input_shape,
-                       int num_input_dims,
-                       c10::MemoryFormat memory_format) {
-  // Modify the shape
-  if (memory_format == at::MemoryFormat::Contiguous) {
-    for (int i = 0; i < num_input_dims; i++)
-      input_shape[i] = input_shape_readonly[i];
-  } else { // ChannelsLast
-    auto num_channels = input_shape_readonly[1];
-    input_shape[0] = input_shape_readonly[0];
-    for (int i = 1; i < num_input_dims - 1; i++)
-      input_shape[i] = input_shape_readonly[i + 1];
-    input_shape[num_input_dims - 1] = num_channels;
+using namespace mps;
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/SoftMax_metallib.h>
+#endif
+
+static SoftmaxParams<uint32_t> narrow_params(const SoftmaxParams<uint64_t>& params) {
+  SoftmaxParams<uint32_t> result{.dim_size = c10::checked_convert<uint32_t>(params.dim_size, "uint32_t"),
+                                 .num_rows = c10::checked_convert<uint32_t>(params.num_rows, "uint32_t"),
+                                 .inner_size = c10::checked_convert<uint32_t>(params.inner_size, "uint32_t"),
+                                 .chunk_size = c10::checked_convert<uint32_t>(params.chunk_size, "uint32_t"),
+                                 .n_chunks = c10::checked_convert<uint32_t>(params.n_chunks, "uint32_t"),
+                                 .ndim = params.ndim,
+                                 .dim = params.dim};
+  for (const auto d : c10::irange(params.ndim)) {
+    result.sizes[d] = c10::checked_convert<uint32_t>(params.sizes[d], "uint32_t");
+    result.strides[d] = c10::checked_convert<uint32_t>(params.strides[d], "uint32_t");
+  }
+  return result;
+}
+
+template <typename... Tensors>
+static void run_softmax(MPSStream* stream,
+                        const std::string& kernel,
+                        const Tensor& self,
+                        bool use_u32,
+                        MTLSize grid,
+                        MTLSize group,
+                        const SoftmaxParams<uint64_t>& params,
+                        const Tensors&... tensors) {
+  auto encoder = stream->commandEncoder();
+  auto pso =
+      lib.getPipelineStateForFunc(fmt::format("{}_{}{}", kernel, scalarToMetalTypeString(self), mtlIdxSuffix(use_u32)));
+  getMPSProfiler().beginProfileKernel(pso, kernel, {self}, stream);
+  [encoder setComputePipelineState:pso];
+  if (use_u32) {
+    mtl_setArgs(encoder, tensors..., narrow_params(params));
+  } else {
+    mtl_setArgs(encoder, tensors..., params);
+  }
+  [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
+  getMPSProfiler().endProfileKernel(pso, stream);
+}
+
+static void softmax_mps_impl(const Tensor& self, int64_t dim, bool half_to_float, const Tensor& out, bool log_softmax) {
+  const std::string kernel = log_softmax ? "log_softmax" : "softmax";
+  TORCH_CHECK(!half_to_float, kernel, " with half to float conversion is not supported on MPS");
+  if (self.numel() == 0) {
+    return;
+  }
+  TORCH_CHECK_NOT_IMPLEMENTED(supportedFloatingType(self), kernel, " not implemented on MPS for ", self.scalar_type());
+
+  const auto self_ = self.dim() == 0 ? self.view(1) : self;
+  const auto wrapped_dim = maybe_wrap_dim(dim, self_.dim());
+  const auto dim_size = static_cast<uint64_t>(self_.size(wrapped_dim));
+  const auto inner_size = static_cast<uint64_t>(c10::multiply_integers(self_.sizes().slice(wrapped_dim + 1)));
+  const auto num_rows = static_cast<uint64_t>(self_.numel()) / dim_size;
+  const auto output = out.is_contiguous() ? out : at::empty(out.sizes(), out.options());
+  const bool use_u32 = offsetsFitIn<int32_t>(self_, output);
+  const bool contiguous_rows = self_.is_contiguous() && wrapped_dim == self_.dim() - 1;
+  // one simdgroup per row stops paying off past this width
+  constexpr uint64_t row_kernel_max_dim = 2048;
+  // rows wider than this need many rows to fill the GPU
+  constexpr uint64_t row_kernel_solo_dim = 1024;
+  constexpr uint64_t row_kernel_min_rows = 128;
+  const bool row_dim_fits = dim_size <= row_kernel_solo_dim || num_rows >= row_kernel_min_rows;
+  const bool use_row_kernel = contiguous_rows && dim_size <= row_kernel_max_dim && row_dim_fits;
+  // split long rows into enough chunks to occupy the GPU
+  constexpr uint64_t split_target_groups = 512;
+  // below this width a chunk cannot amortize the second pass
+  constexpr uint64_t split_min_chunk = 2048;
+  const auto n_chunks = std::clamp(split_target_groups / num_rows, uint64_t(1), ceil_div(dim_size, split_min_chunk));
+  const auto chunk_size = ceil_div(dim_size, n_chunks);
+  const bool use_split = contiguous_rows && !use_row_kernel && n_chunks > 1;
+  SoftmaxParams<uint64_t> params{.dim_size = dim_size,
+                                 .num_rows = num_rows,
+                                 .inner_size = inner_size,
+                                 .chunk_size = chunk_size,
+                                 .n_chunks = n_chunks,
+                                 .ndim = static_cast<uint32_t>(self_.dim()),
+                                 .dim = static_cast<uint32_t>(wrapped_dim)};
+  for (const auto d : c10::irange(self_.dim())) {
+    params.sizes[d] = self_.size(d);
+    params.strides[d] = self_.size(d) == 1 ? 0 : self_.stride(d);
+  }
+  const auto partials = use_split
+      ? at::empty({static_cast<int64_t>(num_rows), static_cast<int64_t>(n_chunks), 2}, self.options().dtype(kFloat))
+      : Tensor();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      if (use_row_kernel) {
+        constexpr auto rows_per_group = kSoftmaxThreads / c10::metal::simdgroup_size;
+        const auto grid = MTLSizeMake(ceil_div(num_rows, uint64_t(rows_per_group)), 1, 1);
+        const auto group = MTLSizeMake(kSoftmaxThreads, 1, 1);
+        run_softmax(stream, kernel + "_row", self, use_u32, grid, group, params, self_, output);
+      } else if (use_split) {
+        const auto grid = MTLSizeMake(n_chunks, num_rows, 1);
+        const auto group = MTLSizeMake(kSoftmaxThreads, 1, 1);
+        run_softmax(stream, "softmax_partial", self, use_u32, grid, group, params, self_, partials);
+        run_softmax(stream, kernel + "_finalize", self, use_u32, grid, group, params, self_, output, partials);
+      } else {
+        // double the width for 2-byte dtypes so a threadgroup row spans a full 128-byte cache line
+        const auto max_tg_x = uint64_t((self.element_size() == 2 ? 2u : 1u) * c10::metal::simdgroup_size);
+        const auto tg_x = std::min(inner_size, max_tg_x);
+        const auto tg_y =
+            std::min({std::bit_ceil(dim_size), uint64_t(kSoftmaxThreads), std::bit_floor(kSoftmaxMaxThreads / tg_x)});
+        const auto grid = MTLSizeMake(ceil_div(inner_size, tg_x), num_rows / inner_size, 1);
+        const auto group = MTLSizeMake(tg_x, tg_y, 1);
+        run_softmax(stream, kernel, self, use_u32, grid, group, params, self_, output);
+      }
+    }
+  });
+  if (!out.is_contiguous()) {
+    out.copy_(output);
   }
 }
 
-// Note - Currently only supported for 4D image tensors
-
 TORCH_IMPL_FUNC(softmax_mps_out)
-(const Tensor& input_, const int64_t dim, const bool half_to_float, const Tensor& output) {
-  TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
-  TORCH_CHECK(c10::isFloatingType(input_.scalar_type()), "softmax only supported for floating types");
-  static const bool is_macOS_15_0_or_newer = is_macos_at_least(MacOSVersion::MACOS_15_0);
+(const Tensor& self, const int64_t dim, const bool half_to_float, const Tensor& out) {
+  softmax_mps_impl(self, dim, half_to_float, out, false);
+}
 
-  if (input_.numel() == 0) {
-    return;
-  }
-
-  Tensor input;
-  if (input_.dim() == 0) {
-    input = input_.view(1);
-  } else
-    input = input_;
-
-  int64_t dim_ = maybe_wrap_dim(dim, input.dim());
-  TORCH_CHECK(dim_ >= 0 && dim_ < input.dim(), "Softmax:dim must be non-negative and less than input dimensions");
-
-  const auto memory_format = input.suggest_memory_format();
-  // TORCH_CHECK(input.suggest_memory_format() == output.suggest_memory_format(), "Input and output memory format should
-  // match")
-
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string mem_format_key = get_mem_format_string(memory_format);
-    MPSShape* input_shape_readonly = mps::getMPSShape(input);
-    int num_input_dims = [input_shape_readonly count];
-    // Check - Channels last implies 4d
-    TORCH_CHECK(memory_format != at::MemoryFormat::ChannelsLast || num_input_dims == 4,
-                "ChannelsLast implies 4d tensor")
-    // Input shape changes based on memory format
-    NSMutableArray<NSNumber*>* input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-
-    get_shapes(input_shape_readonly, input_shape, num_input_dims, memory_format);
-
-    // Change dim
-    if (memory_format == at::MemoryFormat::ChannelsLast && dim_ > 0 && !is_macOS_15_0_or_newer) {
-      switch (dim_) {
-        case 1:
-          dim_ = 3;
-          break;
-        case 2:
-          dim_ = 1;
-          break;
-        case 3:
-          dim_ = 2;
-          break;
-        default:
-          assert(0 && "Invalid dim\n");
-      }
-    }
-
-    NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
-
-    std::string key = "softmax_mps_out" + getTensorsStringKey(input, true, /*exclude_shape*/ true) + ":" +
-        mem_format_key + ":" + std::to_string(dim_);
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()));
-
-      // passing selector of softMaxWithTensor on the mpsGraph object
-      MPSGraphTensor* outputTensor = [mpsGraph softMaxWithTensor:inputTensor axis:(NSInteger)dim_ name:nil];
-
-      // Output needs to be contiguous format
-      if (memory_format == at::MemoryFormat::ChannelsLast && !is_macOS_15_0_or_newer) {
-        auto N = input_shape[0];
-        auto H = input_shape[1];
-        auto W = input_shape[2];
-        auto C = input_shape[3];
-
-        outputTensor = [mpsGraph reshapeTensor:outputTensor
-                                     withShape:@[ N, ([NSNumber numberWithInt:[H intValue] * [W intValue]]), C ]
-                                          name:nil];
-        outputTensor = [mpsGraph transposeTensor:outputTensor dimension:1 withDimension:2 name:nil];
-        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:@[ N, C, H, W ] name:nil];
-      }
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder inputPlaceholder =
-        Placeholder(cachedGraph->inputTensor_, input, is_macOS_15_0_or_newer ? nil : input_shape);
-    // This must be the Contiguous shape
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
+TORCH_IMPL_FUNC(log_softmax_mps_out)
+(const Tensor& self, const int64_t dim, const bool half_to_float, const Tensor& out) {
+  softmax_mps_impl(self, dim, half_to_float, out, true);
 }
 
 TORCH_IMPL_FUNC(softmax_backward_mps_out)


### PR DESCRIPTION
Migrate softmax to metal kernels reusing log_softmax kernels. Perf (fp32 mainly in benchmarks because Transformers standard sampling path casts logits to fp32 before softmax):

| Shape | Dtype | Dim | Layout | MPSGraph (us) | Metal (us) | Speedup |
|---|---|---:|---|---:|---:|---:|
| `1x128256` | fp32 | -1 | contiguous | 57.37 | 7.14 | 8.035x |
| `1x129280` | fp32 | -1 | contiguous | 50.05 | 7.09 | 7.060x |
| `1x151936` | fp32 | -1 | contiguous | 56.22 | 7.58 | 7.420x |
| `1x154880` | fp32 | -1 | contiguous | 60.75 | 8.02 | 7.576x |
| `1x201088` | fp32 | -1 | contiguous | 74.11 | 9.68 | 7.656x |
| `4x128256` | fp32 | -1 | contiguous | 54.84 | 16.02 | 3.423x |
| `4x129280` | fp32 | -1 | contiguous | 54.42 | 16.30 | 3.339x |
| `4x151936` | fp32 | -1 | contiguous | 61.56 | 19.25 | 3.197x |
| `4x154880` | fp32 | -1 | contiguous | 67.01 | 19.32 | 3.468x |
| `4x201088` | fp32 | -1 | contiguous | 84.67 | 26.62 | 3.181x |
| `8x128256` | fp32 | -1 | contiguous | 63.15 | 33.93 | 1.862x |
| `8x129280` | fp32 | -1 | contiguous | 57.45 | 34.94 | 1.644x |
| `8x151936` | fp32 | -1 | contiguous | 65.42 | 39.73 | 1.646x |
| `8x154880` | fp32 | -1 | contiguous | 67.61 | 41.19 | 1.641x |
| `8x201088` | fp32 | -1 | contiguous | 80.48 | 50.81 | 1.584x |
| `5x51866` | fp32 | -1 | contiguous | 29.44 | 10.54 | 2.793x |
| `1x151936` | fp32 | -1 | offset view | 56.06 | 7.64 | 7.334x |
| `4x499x46` | fp32 | -1 | contiguous | 18.95 | 4.48 | 4.228x |
| `64x1000` | fp32 | -1 | contiguous | 20.37 | 8.40 | 2.424x |
| `4096x30522` | fp32 | -1 | contiguous | 5783.57 | 5515.95 | 1.049x |
| `2x150x512x512` | fp32 | 1 | contiguous | 5223.75 | 2989.85 | 1.747x |
| `4x499x2341` | fp32 | -1 | contiguous | 251.68 | 165.52 | 1.520x |
| `1024x50257` | fp32 | -1 | contiguous | 2602.69 | 3090.39 | 0.842x |
| `2048x128256` | fp32 | -1 | contiguous | 12540.65 | 15957.20 | 0.786x |
| `2048x129280` | fp32 | -1 | contiguous | 12311.65 | 16219.90 | 0.759x |
| `2048x151936` | fp32 | -1 | contiguous | 15902.57 | 18924.41 | 0.840x |
| `8192x151936` | fp32 | -1 | contiguous | 66602.24 | 78375.70 | 0.850x |
| `2048x154880` | fp32 | -1 | contiguous | 14568.02 | 20323.50 | 0.717x |
| `1024x201088` | fp32 | -1 | contiguous | 9858.95 | 12798.42 | 0.770x |
| `4x1023x151936` | bf16 | -1 | contiguous | 18029.44 | 20589.93 | 0.876x |
| `4x151936x128` | fp32 | 1 | contiguous | 5607.67 | 5542.50 | 1.012x |
| `2x150x512x512` | fp32 | 1 | channels_last | 5,509.58 | 3,146.67 | 1.751x |
| `2x150x512x512` | bf16 | 1 | channels_last | 3,667.86 | 1,985.69 | 1.847x |
| `8x21x256x256` | fp32 | 1 | channels_last | 1,054.38 | 1,930.98 | 0.546x |
| `8x21x256x256` | bf16 | 1 | channels_last | 591.70 | 996.26 | 0.594x |
| `1x128256` | bf16 | -1 | contiguous | 45.70 | 7.01 | 6.523x |
| `4x151936` | bf16 | -1 | contiguous | 49.82 | 17.57 | 2.835x |
| `64x1000` | bf16 | -1 | contiguous | 19.35 | 8.40 | 2.305x |
| `4096x30522` | bf16 | -1 | contiguous | 2,966.67 | 2,694.35 | 1.101x |