### PR TITLE
[BUG] cpu offloding causes rng state reset.

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -8,7 +8,7 @@ import torch.distributed._functional_collectives as funcol
 import torch.distributed.tensor._random as random
 from torch.distributed._local_tensor import LocalTensor, maybe_run_for_local_tensor
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.fsdp import fully_shard
+from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard
 from torch.distributed.tensor import (
     DeviceMesh,
     distribute_tensor,
@@ -1080,6 +1080,55 @@ DistTensorRandomOpTestWithLocalTensor = create_local_tensor_test_class(
 DistTensorRandomOpsTest3DWithLocalTensor = create_local_tensor_test_class(
     DistTensorRandomOpsTest3D,
 )
+
+class DTensorCPUOffloadRandomOpsTest(DTensorTestBase):
+    """random._rng_tracker is a single, lazily-constructed, process-wide
+    singleton, installed for whichever device the first DTensor random op
+    happens to use and never rebuilt for a different device afterward.
+
+    fully_shard(module, mesh=cuda_mesh, offload_policy=CPUOffloadPolicy())
+    keeps the DTensor's mesh CUDA-typed, so the tracker gets installed as
+    CUDA-flavored. But if a parameter is then materialized directly on CPU
+    (module.to_empty(device="cpu")), its local storage is CPU-resident
+    while the mesh stays CUDA. The dispatcher still routes random ops
+    through the (mismatched) tracker, whose _distribute_region() wraps the
+    call in torch.random.fork_rng(devices=[cuda_device]). fork_rng
+    unconditionally restores the CPU default generator's state on exit
+    regardless of which accelerator devices are listed, silently rolling
+    back the CPU op's genuine draw -- so repeated calls kept reproducing
+    the exact same values.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 1
+
+    @with_comms
+    @skip_if_lt_x_gpu(1)
+    def test_repeated_random_ops_differ_on_cpu_offloaded_param(self):
+        dp_mesh = self.build_device_mesh()
+        self.assertEqual(dp_mesh.device_type, self.device_type)
+        self.assertIsNone(random._rng_tracker)
+
+        lin = torch.nn.Linear(4, 4, bias=False)
+        fully_shard(lin, mesh=dp_mesh, offload_policy=CPUOffloadPolicy())
+
+        # Local storage on CPU, mesh still CUDA-typed.
+        lin.to_empty(device="cpu")
+        self.assertEqual(lin.weight.device_mesh.device_type, self.device_type)
+        self.assertEqual(lin.weight.to_local().device.type, "cpu")
+
+        with torch.no_grad():
+            samples = [lin.weight.normal_().to_local().clone() for _ in range(3)]
+
+        # The tracker is now installed and matches the mesh, not the local
+        # tensor's actual device.
+        self.assertIsNotNone(random._rng_tracker)
+        self.assertEqual(random._rng_tracker._device.type, self.device_type)
+
+        for s in samples[1:]:
+            self.assertNotEqual(samples[0], s)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -408,6 +408,8 @@ class OpDispatcher:
                     random._rng_tracker
                     and not first_local_arg.is_meta
                     and random._rng_tracker.distribute_region_enabled
+                    # Tracker only applies to ops on its own device.
+                    and first_local_arg.device.type == random._rng_tracker._device.type
                 ):
                     accelerator = torch.accelerator.current_accelerator()
                     if (
@@ -448,7 +450,10 @@ class OpDispatcher:
                                 **op_info.local_kwargs,
                             )
                 else:
-                    # No rng_tracker, meta tensor, or distribute_region disabled
+                    # No rng_tracker, meta tensor, or distribute_region disabled.
+                    # Nothing else will pass the generator along, so restore it.
+                    if maybe_user_generator is not None:
+                        op_info.local_kwargs["generator"] = maybe_user_generator
                     with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
                         output_sharding.output_spec
                     ):


### PR DESCRIPTION
## Summary


The issue was discovered in torchtitan, where initialization using a truncated normal distribution could get stuck. `trunc_normal_` generates values and resamples any values that fall outside the requested range. Because the underlying `normal_` operation was repeatedly producing the same values, the rejection-sampling loop could never converge.

The root cause is a mismatch between the device tracked by the DTensor RNG tracker and the device where the local tensor actually resides. Under FSDP2's `CPUOffloadPolicy`, a DTensor's mesh remains CUDA-typed even when its local storage has been offloaded to CPU. This causes CPU-side random operations to be incorrectly routed through a CUDA-configured RNG tracker.

**Potential impact:** I have not yet tested the issue broadly across torchtitan, but this could affect tensors initialized after being offloaded to CPU. These tensor may receive identical updates potentially impacting performance heavily!

## Root Cause

`torch.distributed.tensor._random._rng_tracker` is a process-wide singleton.

With FSDP2's `CPUOffloadPolicy`, a module's DTensor *mesh* remains CUDA-typed even though its local storage is CPU-resident. As a result, the RNG tracker can be configured for CUDA while subsequent random operations are performed on CPU tensors.

Those CPU random operations are still routed through the mismatched tracker. Its `_distribute_region()` uses:

```python
torch.random.fork_rng(devices=[cuda_device], ...)
```

`fork_rng` restores the CPU default generator's state when the context exits, regardless of which accelerator devices are specified. Consequently, each CPU-side random operation routed through the mismatched tracker starts from the same RNG state and produces the same values.

This is particularly problematic for operations that rely on resampling, such as `nn.init.trunc_normal_`: if the same out-of-range values are generated on every iteration, the rejection-sampling loop never makes progress and hangs indefinitely.

## Fix

This PR makes two changes in `torch/distributed/tensor/_dispatch.py`, in the tracker-dispatch path:

1. **Only use the tracker-managed path when the local tensor is on the tracker's device.**

   The tracker-managed path now checks that:

   ```python
   first_local_arg.device.type == random._rng_tracker._device.type
   ```

   If the devices do not match, the operation falls through to the normal local-op path instead of being dispatched through an RNG tracker configured for a different device.

2. **Preserve a caller-provided `generator` in the fallback path.**

   The tracker-managed path may pop the `generator` kwarg before determining that it should be skipped. The fallback path now restores the caller-provided `generator` before calling `op_call`, ensuring it is not silently dropped.

## Test

Added `DTensorCPUOffloadRandomOpsTest` to `test/distributed/tensor/test_random_ops.py`.

The test reproduces the torchtitan/FSDP2 CPU-offload mechanism directly and verifies that three consecutive `.normal_()` calls produce different values.

## Minimal Reproduction

The following reproduces the issue on a GH200:

```python
import torch
import torch.distributed as dist
from torch import nn
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard


@torch.no_grad()
def main():
    assert torch.cuda.is_available(), "this repro requires a CUDA device"
    dist.init_process_group(backend="gloo")

    dp_mesh = init_device_mesh("cuda", (1,))

    lin = nn.Linear(4, 4, bias=False)
    fully_shard(lin, mesh=dp_mesh, offload_policy=CPUOffloadPolicy())

    lin.to_empty(device="cpu")

    for i in range(3):
        lin.weight.normal_()
        print(f"iter {i}: {lin.weight.to_local().flatten()}")

    dist.destroy_process_group()


if __name__ == "__main__":
    main()
```

# Version
```
torch: 2.15.0.dev20260902+cu130
```

Associated issue: https://github.com/pytorch/pytorch/issues/196562