### PR TITLE
[inductor][ci] Add the inductor_aoti_fallback config, marked unstable (#196076)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -786,6 +786,35 @@ test_inductor_aoti_cpp() {
   /usr/bin/env "${TEST_ENVS[@]}" python test/run_test.py --cpp --verbose -i cpp/test_aoti_abi_check cpp/test_shim cpp/test_aoti_inference cpp/test_vec_half_AVX2 -dist=loadfile
 }
 
+test_inductor_aoti_fallback_shard() {
+  if [[ -z "$NUM_TEST_SHARDS" ]]; then
+    echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
+    exit 1
+  fi
+
+  # Re-run the AOTInductor suites under Inductor lite / all-fallback mode: every
+  # op goes to ATen unless it sits inside a regional-inductor annotation.
+  # TORCHINDUCTOR_LITE_MODE is read once when torch._inductor.config is imported,
+  # so it also reaches the model-generation subprocess behind the C++ tests --
+  # which is why those can be reused as-is rather than reimplemented.
+  export TORCHINDUCTOR_LITE_MODE=1
+
+  # --upload-artifacts-while-running is load bearing here, not cosmetic: this mode
+  # can abort the interpreter mid-file (a proxy-executor CHECK failure), and an
+  # aborted process writes no junit XML at exit. Streaming the reports out keeps
+  # the failure visible on HUD instead of leaving a shard that is red with no
+  # per-test record of why.
+  python test/run_test.py \
+    --include inductor/test_inductor_lite_mode \
+              inductor/test_aot_inductor \
+              inductor/test_aot_inductor_arrayref \
+              inductor/test_aot_inductor_custom_ops \
+              inductor/test_aot_inductor_package \
+    --shard "$1" "$NUM_TEST_SHARDS" \
+    --verbose \
+    --upload-artifacts-while-running
+}
+
 test_inductor_aoti_cross_compile_for_windows() {
 
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
@@ -2595,6 +2624,18 @@ elif [[ "${TEST_CONFIG}" == *inductor_cpp_wrapper* ]]; then
     test_inductor_aoti_cpp
   fi
   collect_tlparse_output
+elif [[ "${TEST_CONFIG}" == *inductor_aoti_fallback* ]]; then
+  setup_torch_trace
+  # This config is expected to be red while the all-fallback bugs are triaged, and
+  # test.sh runs under `set -e`. Guard each leg so a red Python shard still lets the
+  # C++ leg run and still uploads tlparse, then report the first failure at the end.
+  aoti_fallback_status=0
+  test_inductor_aoti_fallback_shard "$SHARD_NUMBER" || aoti_fallback_status=$?
+  if [[ "$SHARD_NUMBER" -eq "1" ]]; then
+    TORCHINDUCTOR_LITE_MODE=1 test_inductor_aoti_cpp || aoti_fallback_status=$?
+  fi
+  collect_tlparse_output
+  exit "$aoti_fallback_status"
 elif [[ "${TEST_CONFIG}" == *inductor_core* ]]; then
   setup_torch_trace
   test_inductor_core

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -189,6 +189,13 @@ jobs:
           { config: "inductor_amx", shard: 5, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
           { config: "inductor_amx", shard: 6, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
           { config: "inductor_amx", shard: 7, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          # Staging: re-runs the AOTInductor suites under all-fallback mode. Known red
+          # (torch.cond subgraph constants, proxy-executor constant folding) -- the
+          # `unstable` key keeps the name out of trymerge's blocking set while the
+          # failures are triaged. Drop the key to promote; delete the entries if nobody
+          # is driving the failures down.
+          { config: "inductor_aoti_fallback", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx", unstable: "unstable" },
+          { config: "inductor_aoti_fallback", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx", unstable: "unstable" },
         ]}
       python-version: "3.10"
       compiler: gcc11


### PR DESCRIPTION
Summary:

Turns on CI for the all-fallback switch added in the previous diff: a new
`inductor_aoti_fallback` config that re-runs the AOTInductor suites -- including the C++
ones -- with `TORCHINDUCTOR_LITE_MODE=1`.

It lands **marked `unstable`**, on purpose. This config is known red today, and the point
of landing it is to make those failures visible so they get fixed, not to block anyone.

## Reusing test_inductor_aoti_cpp rather than reimplementing it

The whole reason the previous diff used an environment variable is this branch:

```bash
if [[ "$SHARD_NUMBER" -eq "1" ]]; then
  TORCHINDUCTOR_LITE_MODE=1 test_inductor_aoti_cpp
fi
```

`test_inductor_aoti_cpp` runs gtest binaries whose fixtures are AOTI artifacts built by a
separate Python process (`test/cpp/aoti_inference/test.py` calls
`torch._export.aot_compile`). An exported variable is the only thing that reaches into
that subprocess, so the existing function is reused verbatim. The shard-1 guard mirrors
how the `inductor_cpp_wrapper` config already invokes it.

The Python leg runs four AOTI modules plus the lite-mode unit test, sharded. The dispatch
branch sits above the `*inductor*` catch-all, and the config is spelled `aoti` rather
than `aot_inductor` so it does not also match the
`DYNAMO_BENCHMARK_FLAGS+=(--export-aot-inductor)` branch at `test.sh:840`.

## Where it runs, and why it does not block

Two entries on `inductor-unittest.yml`'s **existing** `inductor-cpu-build`
(`linux-jammy-py3.10-gcc11-build`, already built for the seven `inductor_amx` shards), so
no new build job:

```yaml
{ config: "inductor_aoti_fallback", shard: 1, num_shards: 2, runner: "...linux.2xlarge.amx", unstable: "unstable" },
{ config: "inductor_aoti_fallback", shard: 2, num_shards: 2, runner: "...linux.2xlarge.amx", unstable: "unstable" },
```

`unstable: "unstable"` is the same key `filter_test_configs.py:284-295` injects when a job
is marked via an `UNSTABLE <job name>` issue. GitHub renders matrix values into the check
name, and `trymerge.py:2408` treats a check whose name contains "unstable" as
non-blocking (`:2872-2892` routes it to `failed_checks_categorization`, not
`failed_checks`).

Writing the key statically rather than opening an issue keeps the intent visible in the
diff, avoids the landing-order race (an issue-based mark that has not propagated yet
leaves the config blocking, and `labeler.yml:11-19` auto-applies `ciflow/inductor` to any
PR touching `torch/_inductor/**`, i.e. exactly the audience), and drops the dependency on
an out-of-repo S3 blob.

Honest limits, both verified locally:

- **The marker is conditional on Dr.CI.** `trymerge.py:2400-2401`
  (`if not check or not drci_classifications: return False`) runs *before* the name test
  at `:2408`. With an empty classification dict the shard is classified as an ordinary
  failure and does block.
- **The static key is a one-way lever.** `_filter_jobs` only ever adds the key, so closing
  an `UNSTABLE` issue cannot clear a hard-coded one. Promotion means deleting the key.
- No in-repo workflow hand-writes an `unstable:` key today; every instance is
  machine-injected or a unit-test fixture. The precedent for arbitrary extra matrix keys
is `periodic.yml:148` (`owners:
["oncall:debug-build"]
`, read by nothing). Happy to
  switch to the issue route if reviewers prefer it -- runtime behaviour is identical.

CPU rather than CUDA because that is where the measured evidence is,and the C++ leg works
there: `.ci/docker/build.sh` sets `INDUCTOR_BENCHMARKS=yes` for that image,
`ubuntu/Dockerfile:94` maps it to `BUILD_AOT_INDUCTOR_TEST`,and
`caffe2/CMakeLists.txt:1455` then builds `test_aoti_inference`.

Rejected alternatives: a build+test pair in `unstable.yml` (duplicates the CUDA build --
artifacts are keyed `{run_id}/{build_environment}` -- has no `pull_request` trigger, and
the XLA jobs parked there ran red from Aug 7 until someone deleted them in
`b454fd4c469d`); and `inductor-periodic.yml` (its `aot_inductor_*` entries are dynamo
benchmark configs, and `nightly.yml:229-242` auto-labels the triton-pin PR with
`ciflow/inductor-periodic` then auto-comments `pytorchbot merge`, which a permanently-red
job would wedge).

## Two details in the shard function

- **`--upload-artifacts-while-running`** is load bearing,not cosmetic. This mode can
abort the interpreter mid-file (a proxy-executor CHECK failure),and an aborted process
writes no junit XML at exit. Without streaming,the config's defining failure mode is
  red on HUD with no per-test record of why.
- **Per-leg status guarding.** `test.sh:7` is `set -ex -o pipefail`. Written the obvious
  way, a red Python shard means `test_inductor_aoti_cpp` and `collect_tlparse_output`
  never run on shard 1 -- and this config is *expected* to be red, so the C++ leg would
  effectively never execute. Each leg now records its status and the branch exits with the
  first failure. (The explicit `exit` is safe: the dispatch chain is the last statement in
  the file.)

## What it will find

A 51-test slice of the CPU AOTI template under the switch gave 18 ok / 5 error /
5 skipped and then a hard process abort, from three real bugs:

- `torch.cond` (5 tests): `AssertionError: Can not find the original value for
  false_graph_0_constant0`, at `graph.py:1213` via
  `cpp_wrapper_cpu.py:1281 codegen_model_constructor` -- subgraph constants are not in the
  parent's original-constant map, so the model constructor cannot classify them CPU vs
  CUDA.
- constant folding (2 tests): `aoti_torch_proxy_executor_call_function(...) API call
  failed` at runtime.
- `test_constant_folding_with_update`: `FbProxyExecutor.cpp:828 Check failed: tensor_id ==
  num_tensors - num_output_tensors`, a glog CHECK that kills the interpreter.

The third rules out xfail as the universal remedy: a dead process takes the rest of the
shard with it, so it will need a hard skip.

## 2026-09-07 production-model context

A production merge-net run of the all-fallback configuration and a fresh nine-trace reproduction are documented at https://www.internalfb.com/intern/paste/P2494174947/. The run validates that the configuration reaches an ATen-heavy fallback graph while retaining user Triton attention launches, and it identifies RMSNorm decomposition plus proxy/runtime plumbing as concrete follow-up targets. The report also documents why allowed_percent_mismatch=0 with 10x tolerance multipliers is not bitwise proof.

Test Plan:
## The CI wiring, verified locally with the real CI tooling

Nothing was pushed to check any of this.

```
bash -n .ci/pytorch/test.sh                                          -> OK
tools/linter/adapters/actionlint_linter.py ... inductor-unittest.yml -> clean
arc lint .ci/pytorch/test.sh .github/workflows/inductor-unittest.yml -> No lint issues.
```

Ran the actual `.github/scripts/filter_test_configs.py` against the edited workflow. Note
the matrix is parsed with `yaml.safe_load` (`filter_test_configs.py:593`), not
`json.loads`, which is why the YAML comment inside the block scalar is legal:

```
inductor_amx             1/7 .. 7/7   unstable=-
inductor_aoti_fallback   1/2          unstable=unstable
inductor_aoti_fallback   2/2          unstable=unstable

is-unstable (whole build): False
```

Both new shards are marked; the seven `inductor_amx` shards and the build itself keep
blocking normally (`filter_test_configs.py:570-578` only marks a build unstable when
*every* entry is).

Exercised `trymerge.is_unstable` directly on the check name GitHub will render:

```
--- Dr.CI responded ---
  inductor_aoti_fallback -> non-blocking? True
  inductor_amx           -> non-blocking? False
--- Dr.CI empty/down ---
  inductor_aoti_fallback -> non-blocking? False     <- the caveat above
  inductor_amx           -> non-blocking? False
```

Drove PyTorch's own `calculate_shards()` over the include list to confirm the work splits
sensibly, and to show the automatic within-file sub-sharding (timings illustrative; CI
reads `test-times.json`):

```
shard 1/2  est 20.0 min   test_aot_inductor 1/4, 3/4, 4/4 + _arrayref
shard 2/2  est 10.0 min   test_aot_inductor 2/4 + _package + _custom_ops + lite_mode
```

## OSS

Not executable from this devserver; the command for the PR:

```bash
TEST_CONFIG=inductor_aoti_fallback NUM_TEST_SHARDS=2 SHARD_NUMBER=1 .ci/pytorch/test.sh
```

## Not covered

- The config has never executed in CI. The evidence for what it will do is the local CPU
  slice above, on one box.
- The GPU arm of the AOTI template was not sampled under the switch.
- `FbProxyExecutor.cpp` is fbcode-internal, so the exact fatal CHECK may not reproduce in
  OSS -- but the same malformed proxy-executor call reaches the OSS executor.
- Dr.CI's and HUD's own "unstable" rendering lives in pytorch/test-infra, which is not in
  this tree; only the pytorch-side consumers were verified.

## Follow-ups

1. Fix the three bug clusters above.
2. Promote by deleting the `unstable` key once reliability clears the documented bar
   (Failures % < 10% over 7 days, `viable_strict.md:15`).
3. Name an owner. The XLA precedent is what happens to an unstable job without one.

Differential Revision: D118885775




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo