### PR TITLE
Register autograd for wait_tensors to fix zeroed coalesced collective grads

### DIFF
--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
-import unittest
 from functools import partial, wraps
 
 import torch
@@ -1028,6 +1027,38 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
                 self.assertEqual(input_tensor.grad, expected_grad)
 
     @with_comms
+    def test_all_reduce_coalesced_compile(self):
+        """coalesced sum/avg backward flows grad through wait_tensors under compile.
+
+        Companion to the min/max coalesced test: min/max exposed the missing
+        wait_tensors autograd via all-zero grads, but wait_tensors sits on the
+        forward path of every coalesced reduce, so the non-extremum ops must
+        backprop through it too.
+        """
+        shape = (3, 3)
+        group_name = dist.group.WORLD.group_name
+
+        for reduce_op in ["sum", "avg"]:
+            with self.subTest(reduce_op=reduce_op):
+
+                @torch.compile(fullgraph=True)
+                def compiled_fn(a, b):
+                    outs = fcols.all_reduce_coalesced(
+                        [a, b], reduce_op, group=group_name
+                    )
+                    return outs[0].sum() + outs[1].sum()
+
+                a = torch.randn(*shape, device=self.device, requires_grad=True)
+                b = torch.randn(*shape, device=self.device, requires_grad=True)
+
+                compiled_fn(a, b).backward()
+
+                fill = float(self.world_size) if reduce_op == "sum" else 1.0
+                expected_grad = torch.full(shape, fill_value=fill, device=self.device)
+                self.assertEqual(a.grad, expected_grad)
+                self.assertEqual(b.grad, expected_grad)
+
+    @with_comms
     def test_all_reduce_min_max_ties_compile(self):
         """min/max backward splits grad evenly across tied holders under compile.
 
@@ -1062,22 +1093,9 @@ class TestFunctionalDifferentialsWithCompile(DistributedTestBase):
                 self.assertIsNotNone(input_tensor.grad)
                 self.assertEqual(input_tensor.grad, expected_grad)
 
-    # Known-broken: under torch.compile the coalesced min/max backward returns
-    # all-zero grads (eager is correct). The AOT joint graph is right, but
-    # Inductor's lowering of the multi-output wait_tensors op mishandles waiting
-    # the forward's coalesced output again in the backward: unlike the
-    # single-tensor wait_tensor (which gets an alias inserted), the re-wait
-    # yields wrong data, so the `input == output` extremum mask is all-False.
-    # Fixing that lives in torch/_inductor comm lowering, out of scope here.
-    @unittest.expectedFailure
     @with_comms
     def test_all_reduce_coalesced_min_max_ties_compile(self):
-        """coalesced min/max backward splits grad evenly across ties under compile.
-
-        Mirrors the single-tensor compile test for all_reduce_coalesced, whose
-        schema and Inductor lowering this PR touches, so the coalesced min/max
-        backward is traced and lowered.
-        """
+        """coalesced min/max backward splits grad evenly across ties under compile."""
         group_name = dist.group.WORLD.group_name
         ws = self.world_size
         rank = self.rank

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -652,21 +652,32 @@ def wait_tensor_backward(ctx, grad_output: torch.Tensor):
     return grad_output
 
 
-def wait_tensor_setup_context(ctx, inputs, output):
-    """
-    Setup context for wait_tensor backward.
-    Args:
-        ctx: Context object to save state for backward
-        inputs: Tuple of (tensor,)
-        output: Output from forward pass
-    """
-    return
-
-
 torch.library.register_autograd(
     "_c10d_functional::wait_tensor",
     wait_tensor_backward,
-    setup_context=wait_tensor_setup_context,
+)
+
+
+def wait_tensors_backward(ctx, grad_outputs: list[torch.Tensor]):
+    """
+    Backward for wait_tensors: identity (no-op), matching wait_tensor.
+    Wait is just a synchronization primitive, so each gradient flows through
+    unchanged.
+
+    Args:
+        ctx: Context object
+        grad_outputs: List of gradients from downstream operations
+
+    Returns:
+        Gradients unchanged (identity), wrapped in a 1-tuple for the single
+        Tensor[] input
+    """
+    return (grad_outputs,)
+
+
+torch.library.register_autograd(
+    "_c10d_functional::wait_tensors",
+    wait_tensors_backward,
 )
 
 


### PR DESCRIPTION
This PR

1) registers autograd for `wait_tensors` . This fixes the undefined behavior of an op without autograd registered that produce all-zero grads unconditionally. See https://github.com/pytorch/pytorch/blob/dfe5500674d460870c4bd336d10d16cc4180a03d/torch/csrc/autograd/autograd_not_implemented_fallback.cpp#L75-L86
2) adds `test_all_reduce_coalesced_compile` test for `avg` and `sum` op. This test accompanies the existing `test_all_reduce_coalesced_min_max_ties_compile` to provide wider coverage.
3) removes the `setup_context` functions of `all_reduce` and `all_reduce_coalesced`, as they're no-op.

Authored with AI Assistance.