### PR TITLE
[Inductor-perf] Eliminate zero bias from efficient-attention backward

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -316,6 +316,109 @@ class CudaReproTests(TestCase):
                 runtime_mask_fn(query, key, value, padding_mask),
             )
 
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        "Does not support mem_eff_attention",
+    )
+    def test_effn_attn_uniform_zero_bias_backward(self):
+        batch_size, num_heads, seq_len, head_dim = 2, 4, 128, 64
+
+        def fn(query, key, value):
+            additive_mask = torch.full(
+                (batch_size, num_heads, seq_len, seq_len),
+                0.0,
+                device=query.device,
+                dtype=query.dtype,
+            )
+            return aten._scaled_dot_product_efficient_attention.default(
+                query, key, value, additive_mask, True
+            )[0]
+
+        inputs = tuple(
+            torch.randn(
+                batch_size,
+                num_heads,
+                seq_len,
+                head_dim,
+                device=device_type,
+                requires_grad=True,
+            )
+            for _ in range(3)
+        )
+        eager_inputs = tuple(
+            tensor.detach().clone().requires_grad_() for tensor in inputs
+        )
+        compiled_inputs = tuple(
+            tensor.detach().clone().requires_grad_() for tensor in inputs
+        )
+        expected = fn(*eager_inputs)
+        expected.sum().backward()
+
+        biases = {}
+
+        def capture_biases(graph):
+            for target, bias_index in (
+                (aten._scaled_dot_product_efficient_attention.default, 3),
+                (aten._scaled_dot_product_efficient_attention_backward.default, 4),
+            ):
+                nodes = graph.find_nodes(op="call_function", target=target)
+                self.assertEqual(len(nodes), 1)
+                biases[target] = nodes[0].args[bias_index]
+
+        torch._dynamo.reset()
+        with (
+            config.patch(joint_custom_post_pass=capture_biases),
+            sdpa_kernel(SDPBackend.EFFICIENT_ATTENTION),
+        ):
+            compiled = torch.compile(fn, fullgraph=True)
+            actual = compiled(*compiled_inputs)
+            actual.sum().backward()
+
+        self.assertEqual(actual, expected)
+        for actual_input, expected_input in zip(compiled_inputs, eager_inputs):
+            self.assertEqual(actual_input.grad, expected_input.grad)
+        # check zero bias is removed.
+        self.assertIsNone(biases[aten._scaled_dot_product_efficient_attention.default])
+        self.assertIsNone(
+            biases[aten._scaled_dot_product_efficient_attention_backward.default]
+        )
+
+        def bias_grad_fn(query, key, value, bias_seed):
+            additive_mask = bias_seed * 0.0
+            return aten._scaled_dot_product_efficient_attention.default(
+                query, key, value, additive_mask, True
+            )[0]
+
+        bias_seed = torch.randn(
+            batch_size,
+            num_heads,
+            seq_len,
+            seq_len,
+            device=device_type,
+            requires_grad=True,
+        )
+        bias_grad_bias = []
+
+        def capture_bias_grad_bias(graph):
+            nodes = graph.find_nodes(
+                op="call_function",
+                target=aten._scaled_dot_product_efficient_attention_backward.default,
+            )
+            self.assertEqual(len(nodes), 1)
+            bias_grad_bias.append(nodes[0].args[4])
+
+        torch._dynamo.reset()
+        with (
+            config.patch(joint_custom_post_pass=capture_bias_grad_bias),
+            sdpa_kernel(SDPBackend.EFFICIENT_ATTENTION),
+        ):
+            compiled = torch.compile(bias_grad_fn, fullgraph=True)
+            compiled(*compiled_inputs, bias_seed).sum().backward()
+        # check zero bias is NOT removed due to rqurie bias grad.
+        self.assertEqual(len(bias_grad_bias), 1)
+        self.assertIsInstance(bias_grad_bias[0], torch.fx.Node)
+        self.assertIsNotNone(bias_seed.grad)
+
     def test_effn_attn_bias_padding(self):
         batch_size, num_heads, seq_len, head_dim = 2, 32, 512, 128
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -562,27 +562,43 @@ def _remove_zero_bias_from_efficient_attention(
     if config.numerics == "strict":
         return
 
-    target = aten._scaled_dot_product_efficient_attention.default
-    for node in gm.graph.find_nodes(op="call_function", target=target):
-        if len(node.args) < 4 or not isinstance(node.args[3], torch.fx.Node):
-            continue
-        bias = node.args[3]
-        # TODO: Also remove zero bias from the backward for training performance.
-        value = uniform_values.get(bias)
-        fake_bias = bias.meta.get("val")
-        if (
-            not isinstance(fake_bias, torch.Tensor)
-            or not fake_bias.dtype.is_floating_point
-            or value != 0.0
-        ):
-            continue
-        args = list(node.args)
-        args[3] = None
-        node.args = tuple(args)
+    targets = (
+        (aten._scaled_dot_product_efficient_attention.default, 3),
+        (aten._scaled_dot_product_efficient_attention_backward.default, 4),
+    )
+    for target, bias_index in targets:
+        for node in gm.graph.find_nodes(op="call_function", target=target):
+            bias = node.args[bias_index]
+            if not isinstance(bias, torch.fx.Node):
+                continue
+            if target is aten._scaled_dot_product_efficient_attention_backward.default:
+                # Backward positional argument 10 is a four-element bool sequence:
+                # [..., compute_grad_bias]. Thus grad_input_mask[3] says whether backward
+                # must produce grad_bias, which requires retaining the bias. This is
+                # rare for a proven-zero bias, but can occur for a differentiable
+                # expression such as parameter * 0.
+                grad_input_mask = node.args[10]
+                compute_bias_gradient = grad_input_mask[3]
+                if compute_bias_gradient:
+                    continue
+            value = uniform_values.get(bias)
+            fake_bias = bias.meta.get("val")
+            if (
+                not isinstance(fake_bias, torch.Tensor)
+                or not fake_bias.dtype.is_floating_point
+                or value != 0.0
+            ):
+                continue
+            args = list(node.args)
+            args[bias_index] = None
+            node.args = tuple(args)
 
 
 def constant_fold_uniform_value(gm: torch.fx.GraphModule):
-    """Fold uniform constants and algebraic no-ops, including efficient attention with an all-zero additive bias to no bias."""
+    """Fold uniform constants and algebraic no-ops.
+
+    This includes replacing an all-zero additive efficient-attention bias with no bias.
+    """
     with torch.utils._python_dispatch._disable_current_modes():
         aten = torch.ops.aten
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196079
* #196068

This PR extends the compiler-proven zero-bias elimination from efficient-attention forward to:
```text
aten._scaled_dot_product_efficient_attention_backward
```
When joint-graph uniform-value analysis proves that the floating-point attention bias is uniformly zero, backward now receives None instead of the redundant bias tensor.

### Bias-gradient safety
Backward argument 10 is grad_input_mask, a four-element Boolean sequence:

[compute_grad_query, compute_grad_key, compute_grad_value, compute_grad_bias]
The optimization is skipped when grad_input_mask[3] is true. Backward must retain the real bias tensor in that case to compute grad_bias.

This case is uncommon for a compiler-proven zero bias, but it can occur for differentiable expressions such as:

bias = parameter * 0.0
Compiler-generated zero attention masks normally do not request a bias gradient and can be safely removed from both forward and backward.

The existing strict-numerics behavior is preserved: neither rewrite runs when torch._inductor.config.numerics == "strict".

### Correctness
For a zero additive bias:

scores = query @ key.T + zero_bias
is equivalent to:

scores = query @ key.T

### performance (done by Agent)
Note this is benchmarking training with the base of both PRs on stack, results on previous PR only benchmark inference only. 
```
hf_Albert | 12.119 ms -> 11.609 ms  : 4.57%
```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo