### PR TITLE
[inductor] Make _split_iteration_ranges leftover check size-oblivious

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -2461,6 +2461,83 @@ class TestSplitIterationRanges(MockSchedulerTest):
                 [[sympy.Integer(2)], []],
             )
 
+    @staticmethod
+    def _unbacked_size_like():
+        """An unbacked symint constrained size-like, as a sympy symbol."""
+        from torch.fx.experimental.symbolic_shapes import _constrain_range_for_size
+
+        symint = V.graph.sizevars.shape_env.create_unbacked_symint()
+        _constrain_range_for_size(symint)
+        return symint.node.expr
+
+    def test_unbacked_leftover_extent_raises_cant_split(self):
+        """Leftover extent is an unbacked size-like symbol.
+
+        Same shape as test_leftover_extent_raises_cant_split, but the
+        unconsumed group extent is unbacked rather than a constant. The
+        leftover check must not try to resolve it to a concrete hint:
+        guarding_hint_or_throw raises GuardOnDataDependentSymNode, which is not
+        a CantSplit, so it escapes the `except CantSplit` in every caller and
+        aborts the whole compile instead of just skipping the fusion.
+        """
+        from torch._inductor.codegen.simd import CantSplit, SIMDKernel
+
+        u0 = self._unbacked_size_like()
+
+        # groups=[2, u0], lengths=[[2], []]: size 2 maps onto group 0, leaving
+        # group 1 (extent u0) unconsumed -> remaining=[1, u0].
+        with self.assertRaises(CantSplit):
+            SIMDKernel._split_iteration_ranges(
+                [sympy.Integer(2), u0],
+                [[sympy.Integer(2)], []],
+            )
+
+    def test_is_compatible_false_for_unbacked_leftover(self):
+        """is_compatible answers False rather than propagating.
+
+        This is the contract _try_reindex_pointwise_for_reduction relies on: it
+        asks is_compatible whether a pointwise can be reindexed onto a
+        reduction's groups and expects a bool back, so anything that escapes
+        turns a skipped fusion into a lowering failure.
+        """
+        from torch._inductor.codegen.simd import SIMDKernel
+
+        u0 = self._unbacked_size_like()
+
+        self.assertFalse(
+            SIMDKernel.is_compatible(
+                [sympy.Integer(2), u0],
+                [[sympy.Integer(2)], []],
+            )
+        )
+
+    def test_backed_leftover_extent_still_splits(self):
+        """A backed leftover extent that resolves to 1 still splits.
+
+        Guards against over-tightening the leftover check to
+        statically_known_equals, which cannot prove s0 == 1 for a backed symbol
+        and would silently stop fusing on every dynamic-shape model. Resolving
+        a backed symbol here is fine, it just installs a guard.
+        """
+        from torch._dynamo.source import ConstantSource
+        from torch._inductor.codegen.simd import SIMDKernel
+        from torch.fx.experimental.symbolic_shapes import DimDynamic
+
+        s0 = V.graph.sizevars.shape_env.create_symbol(
+            1,
+            ConstantSource("s0"),
+            dynamic_dim=DimDynamic.DYNAMIC,
+            do_not_specialize_zero_one=True,
+        )
+        # Guard the guard: a specialized-away s0 would make this test vacuous.
+        self.assertNotEqual(s0, sympy.Integer(1))
+
+        new_ranges, _ = SIMDKernel._split_iteration_ranges(
+            [sympy.Integer(2), s0],
+            [[sympy.Integer(2)], []],
+        )
+        self.assertEqual(new_ranges[0], [sympy.Integer(2)])
+
 
 class TestIndexInversion(TestCase):
     @classmethod

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -967,7 +967,13 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
                     )
             return_getters_groups.append(return_getters)
 
-        if not all(V.graph.sizevars.guarding_hint_or_throw(s) == 1 for s in remaining):
+        # is_size_one_or_false rather than guarding_hint_or_throw: a leftover
+        # extent can be an unbacked size-like symbol, and guarding_hint_or_throw
+        # raises GuardOnDataDependentSymNode on those. That escapes the
+        # `except CantSplit` in is_compatible and Scheduler.speedup_by_fusion and
+        # hard-fails the whole compile. Treating "cannot prove it is 1" as
+        # not-splittable keeps every exit from this function a CantSplit.
+        if not all(sv.is_size_one_or_false(s) for s in remaining):
             # Non-unit leftover extents mean the node's iteration space does not
             # tile onto the kernel groups -- e.g. fusing an epilogue whose row
             # count is a strict sub-multiple of a template's tiling ([s, N] into


### PR DESCRIPTION
Summary:
`SIMDKernel._split_iteration_ranges` ends by checking that no non-unit extent is
left over once a node's iteration lengths have been mapped onto the kernel's
tiling groups. That check called `guarding_hint_or_throw`, which returns an
`int` and so has no way to express "unknown": when a leftover extent is an
unbacked size-like symbol it raises `GuardOnDataDependentSymNode` instead.

Every caller wraps this function in `try/except CantSplit` precisely so that an
incompatible fusion is skipped rather than fatal, so the data-dependent error
escapes those handlers and aborts the whole AOTInductor compile:

```
GuardOnDataDependentSymNode: Could not extract specialized integer from
data-dependent expression u4 (unhinted: u4).  (Size-like symbols: u4)
```

reached through `Scheduler._try_reindex_pointwise_for_reduction` ->
`SIMDKernel.is_compatible` -> `_split_iteration_ranges`.

This is the data-dependent twin of D108339950, which converted the same line's
`AssertionError` into a `CantSplit` in June. That fix covered the static case
only, because `guarding_hint_or_throw` throws before the `CantSplit` is reached.

The fix uses `sizevars.is_size_one_or_false`, an existing helper whose contract
is exactly what is wanted here: prove the extent is 1 where possible, return
False for an unbacked symbol without introducing a guard. Every exit from the
function is now a `CantSplit`, so an unsplittable fusion is skipped and codegen
falls back to a separate kernel rather than failing the compile.

The tempting alternative, `statically_known_equals(s, 1)`, is wrong. That family
never guards at all, so it also returns False for a backed symbol whose hint is
1, silently dropping fusions that work today on every dynamic-shape model.
`is_size_one_or_false` still resolves backed symbols, so backed behavior is
unchanged, and `test_backed_leftover_extent_still_splits` pins that distinction.

Authored with Claude.

Differential Revision: D118899133




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo