### PR TITLE
Stop the CTC cuDNN check reading past the input lengths

### DIFF
--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -100,9 +100,6 @@ bool _use_cudnn_ctc_loss(
     // Nothing has compared these sizes yet; without this the loop below
     // reads input_lengths past its end.
     use_cudnn = use_cudnn && (input_lengths.size() == target_lengths.size());
-  }
-
-  if (use_cudnn) {
     int64_t max_input_length = log_probs.size(0);
     for (const auto input_length : input_lengths) {
       use_cudnn = use_cudnn && ((input_length == max_input_length) ? 1 : 0);

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -97,8 +97,12 @@ bool _use_cudnn_ctc_loss(
       (log_probs.device().type() == at::kCUDA) && (log_probs.dim() == 3);
 
   if (use_cudnn) {
-    // we don't know that input_lengths and target_lengths have the same size
-    // (they should, but we didn't check yet)
+    // Nothing has compared these sizes yet; without this the loop below
+    // reads input_lengths past its end.
+    use_cudnn = use_cudnn && (input_lengths.size() == target_lengths.size());
+  }
+
+  if (use_cudnn) {
     int64_t max_input_length = log_probs.size(0);
     for (const auto input_length : input_lengths) {
       use_cudnn = use_cudnn && ((input_length == max_input_length) ? 1 : 0);
@@ -131,16 +135,15 @@ bool _use_cudnn_ctc_loss_tensor(
   if (use_cudnn) {
     if (at::cuda::currentStreamCaptureStatus() ==
         at::cuda::CaptureStatus::None) {
+      // Hoisted out: the inner tlc used to shadow this and redo the copy.
+      Tensor ilc = input_lengths.to(Device(at::kCPU), at::kLong).contiguous();
       Tensor tlc = target_lengths.to(Device(at::kCPU), at::kLong).contiguous();
+      IntArrayRef il(ilc.const_data_ptr<int64_t>(), ilc.numel());
       IntArrayRef tl(tlc.const_data_ptr<int64_t>(), tlc.numel());
+      use_cudnn = use_cudnn && (il.size() == tl.size());
       for (const auto b : c10::irange(tl.size())) {
         // target length < 256 is documented, but we see illegal memory accesses
         // when target lengths > input lengths for CuDNN
-        Tensor ilc = input_lengths.to(Device(at::kCPU), at::kLong).contiguous();
-        Tensor tlc =
-            target_lengths.to(Device(at::kCPU), at::kLong).contiguous();
-        IntArrayRef il(ilc.const_data_ptr<int64_t>(), ilc.numel());
-        IntArrayRef tl(tlc.const_data_ptr<int64_t>(), tlc.numel());
         use_cudnn = use_cudnn && (tl[b] < 256) && (tl[b] <= il[b]);
         if (!use_cudnn) {
           break;

--- a/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
+++ b/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
@@ -97,9 +97,6 @@ bool _use_miopen_ctc_loss(
     // The two length lists should be the same size, but nothing has compared
     // them by the time this runs; see the note in the cuDNN copy.
     use_miopen = use_miopen && (input_lengths.size() == target_lengths.size());
-  }
-
-  if (use_miopen) {
     int64_t max_input_length = log_probs.size(0);
     for (const auto input_length : input_lengths) {
       use_miopen = use_miopen && ((input_length == max_input_length) ? 1 : 0);

--- a/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
+++ b/aten/src/ATen/native/miopen/LossCTC_miopen.cpp
@@ -94,8 +94,12 @@ bool _use_miopen_ctc_loss(
       (log_probs.device().type() == at::kCUDA) && (log_probs.dim() == 3);
 
   if (use_miopen) {
-    // we don't know that input_lengths and target_lengths have the same size
-    // (they should, but we didn't check yet)
+    // The two length lists should be the same size, but nothing has compared
+    // them by the time this runs; see the note in the cuDNN copy.
+    use_miopen = use_miopen && (input_lengths.size() == target_lengths.size());
+  }
+
+  if (use_miopen) {
     int64_t max_input_length = log_probs.size(0);
     for (const auto input_length : input_lengths) {
       use_miopen = use_miopen && ((input_length == max_input_length) ? 1 : 0);
@@ -130,6 +134,7 @@ bool _use_miopen_ctc_loss_tensor(
     Tensor tlc = target_lengths.to(Device(at::kCPU), at::kLong).contiguous();
     IntArrayRef il(ilc.const_data_ptr<int64_t>(), ilc.numel());
     IntArrayRef tl(tlc.const_data_ptr<int64_t>(), tlc.numel());
+    use_miopen = use_miopen && (il.size() == tl.size());
     for (const auto b : c10::irange(tl.size())) {
       // target length < 256 is documented, but we see illegal memory accesses
       // when target lengths > input lengths for MIOpen (same as cuDNN)


### PR DESCRIPTION
```
_use_cudnn_ctc_loss/_use_miopen_ctc_loss walk target_lengths and index
input_lengths with the same counter, bounded by target_lengths.size() -
but nothing compares the two sizes first (the size check that exists in
ctc_loss_cpu/ctc_loss_gpu only runs after this returns, and the op is
also exposed to Python standalone). A longer target_lengths reads past
the end of input_lengths on every remaining iteration via IntArrayRef's
unchecked operator[]. Compare sizes first instead of truncating, so a
mismatch falls through to the CPU/GPU path's real TORCH_CHECK error.

The tensor overloads had the same defect, plus the cuDNN one redid both
.to(CPU) copies on every loop iteration through an inner declaration
that shadowed the outer one - hoisted both out.

Test Plan:

Recompiled both files from their own compile_commands.json commands,
zero errors (CUDA build, so the miopen file only exercises its
!AT_ROCM_ENABLED stub - the ROCm arm is unverified). Confirmed the read
is reachable from Python via
torch._C._VariableFunctions._use_cudnn_ctc_loss with mismatched-length
lists, though no cuDNN build was available to run it under a sanitizer.
```

Drafted with AI assistance (Claude Code).