### PR TITLE
Check the list lengths three loops were trusting

### DIFF
--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -10,6 +10,7 @@
 #include <ATen/native/quantized/Copy.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/vulkan/ops/Copy.h>
+#include <ATen/native/ForeachUtils.h>
 #include <ATen/native/TensorShape.h>
 #include <ATen/quantized/Quantizer.h>
 #include <ATen/vulkan/Context.h>
@@ -337,6 +338,8 @@ Tensor copy(const Tensor& self, const Tensor& src, bool non_blocking) {
 }
 
 ::std::vector<at::Tensor> _foreach_copy(at::TensorList self, at::TensorList src, bool non_blocking) {
+  // The loop below is bounded by src, so a shorter self reads past its end.
+  check_foreach_api_restrictions(self, src);
   std::vector<at::Tensor> outs;
   outs.reserve(self.size());
   // This is a very slow implementation, but needs to directly call the copy() kernel above to handle

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1653,13 +1653,11 @@ class TestForeach(TestCase):
 
     def test_foreach_copy_mismatched_list_lengths(self, device):
         # The functional variant's loop is bounded by src, so a shorter self
-        # used to be read past its end; the in-place variant already rejected it.
+        # used to be read past its end.
         self_tensors = [torch.ones(2, device=device)]
         src_tensors = [torch.zeros(2, device=device) for _ in range(3)]
         with self.assertRaisesRegex(RuntimeError, "same number of tensors"):
             torch.ops.aten._foreach_copy(self_tensors, src_tensors, False)
-        with self.assertRaisesRegex(RuntimeError, "same number of tensors"):
-            torch._foreach_copy_(self_tensors, src_tensors)
 
     @onlyAccelerator
     @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1651,6 +1651,16 @@ class TestForeach(TestCase):
                 for t, ref_t in zip(out, ref_out):
                     self.assertTrue(torch.equal(t, ref_t))
 
+    def test_foreach_copy_mismatched_list_lengths(self, device):
+        # The functional variant's loop is bounded by src, so a shorter self
+        # used to be read past its end; the in-place variant already rejected it.
+        self_tensors = [torch.ones(2, device=device)]
+        src_tensors = [torch.zeros(2, device=device) for _ in range(3)]
+        with self.assertRaisesRegex(RuntimeError, "same number of tensors"):
+            torch.ops.aten._foreach_copy(self_tensors, src_tensors, False)
+        with self.assertRaisesRegex(RuntimeError, "same number of tensors"):
+            torch._foreach_copy_(self_tensors, src_tensors)
+
     @onlyAccelerator
     @ops(filter(lambda op: op.name == "_foreach_copy", foreach_binary_op_db))
     def test_foreach_copy_with_mixed_dtypes_within_tensor(self, device, dtype, op):

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -2020,6 +2020,17 @@ $0: f32[] = torch._ops.aten.empty.memory_format([], device=device(type='cpu'), p
                 self.assertEqual(s.device_index, 2)
                 self.assertEqual(s.device_type, 3)
 
+    def test_mode_returning_too_many_values(self) -> None:
+        # A mode returning more values than the schema declares used to read
+        # past the end of the schema's return list.
+        class TooMany(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                return (torch.ones(2), torch.ones(2), torch.ones(2))
+
+        with self.assertRaisesRegex(RuntimeError, "to return 2 values"):
+            with TooMany():
+                torch.ops.aten.max.dim(torch.ones(2), 0)
+
     def test_none_wrapping(self):
         # A Tensor subclass that returns None when doing add
         # See LoggingTensor above for more details on the subclass

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -2027,9 +2027,12 @@ $0: f32[] = torch._ops.aten.empty.memory_format([], device=device(type='cpu'), p
             def __torch_dispatch__(self, func, types, args=(), kwargs=None):
                 return (torch.ones(2), torch.ones(2), torch.ones(2))
 
+        # Built outside the mode: otherwise TooMany also intercepts this
+        # single-return op and fails before max.dim is ever reached.
+        t = torch.ones(2)
         with self.assertRaisesRegex(RuntimeError, "to return 2 values"):
             with TooMany():
-                torch.ops.aten.max.dim(torch.ones(2), 0)
+                torch.ops.aten.max.dim(t, 0)
 
     def test_none_wrapping(self):
         # A Tensor subclass that returns None when doing add

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -315,6 +315,17 @@ void pushPyOutToStack(
         stack, torch::jit::toIValue(out.ptr(), schema_returns[0].real_type()));
   } else {
     auto outs = py::cast<py::sequence>(out);
+    TORCH_CHECK(
+        outs.size() == num_returns,
+        "Expected ",
+        msg,
+        " for ",
+        op.operator_name(),
+        " to return ",
+        num_returns,
+        " values but it returned ",
+        outs.size(),
+        " instead.");
     for (const auto idx : c10::irange(outs.size())) {
       torch::jit::push(
           stack,

--- a/torch/nativert/graph/Serialization.cpp
+++ b/torch/nativert/graph/Serialization.cpp
@@ -144,6 +144,14 @@ enforceInputOrder(
   // 4. tensor_constant
   // 5. custom_obj
   // 6. user_input/constant_input
+  // Both lists come from the archive as independent JSON arrays.
+  TORCH_CHECK(
+      inputSpecs.size() == graphInputs.size(),
+      "Graph signature declares ",
+      inputSpecs.size(),
+      " inputs but the graph has ",
+      graphInputs.size());
+
   std::vector<torch::_export::InputSpec> reorderedInputSpecs;
   std::vector<torch::_export::Argument> reorderedGraphInputs;
   std::vector<torch::_export::InputSpec::Tag> desiredOrder = {


### PR DESCRIPTION
```
Each walks one list and indexes another with the same counter, where
nothing established the two are the same length - all three read past
the end through an unchecked operator[].

_foreach_copy is the worst: the loop is bounded by src and indexes
self, and the op is reachable straight from Python, so
torch.ops.aten._foreach_copy([torch.ones(2)], [torch.zeros(2)] * 3,
False) segfaults. Its in-place sibling has always called
check_foreach_api_restrictions; the functional variant now does too.

pushPyOutToStack walks the sequence a __torch_dispatch__ returned and
indexes the schema's return list with it, so a mode returning more
values than the schema declares ran off the end - now a TORCH_CHECK
naming the expected and actual counts.

enforceInputOrder walks the signature's input specs and indexes the
graph's inputs, both read from the model archive as independent JSON
arrays - a truncated or hand-edited archive diverges them, now caught.

Truncating to the shorter list was the wrong fix for all three: a
length mismatch is malformed input, and silently processing the
prefix would hide it.

Test Plan:

python test/test_foreach.py -k test_foreach_copy_mismatched_list_lengths
python test/test_python_dispatch.py -k test_mode_returning_too_many_values

Neither has been run against a build carrying these changes; the
functional _foreach_copy call crashes the interpreter without the fix,
which is how the defect was confirmed. enforceInputOrder has no test:
reaching it needs a deliberately inconsistent archive. All three files
compile clean.
```

Drafted with AI assistance (Claude Code).