### PR TITLE
Fold BoxedSize instead of recursing

### DIFF
--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -103,14 +103,9 @@ inline constexpr size_t boxed_size_one<c10::TensorOptions>() {
   return 4;
 }
 
-// NOTE: this could probably be simplified with C++17 fold expressions.
-template <typename...>
-struct BoxedSize : std::integral_constant<size_t, 0> {};
-template <class T, class... Args>
-struct BoxedSize<T, Args...>
-    : std::integral_constant<
-          size_t,
-          boxed_size_one<T>() + BoxedSize<Args...>::value> {};
+template <class... Args>
+struct BoxedSize
+    : std::integral_constant<size_t, (boxed_size_one<Args>() + ... + 0)> {};
 
 template <class... Args>
 static inline constexpr size_t boxed_size() {


### PR DESCRIPTION
```
BoxedSize summed boxed_size_one over a parameter pack via a base case
and a recursive partial specialization, with a note that a fold
expression would do it in one - it does: the pack is only ever summed,
and boxed_size_one's TensorOptions specialization still applies since
the fold expands the call per element rather than counting them.

Test Plan:

static_assert(BoxedSize<>::value == 0);
static_assert(BoxedSize<int, TensorOptions, char>::value == 6);

Verified standalone against GCC 16 (both compile-time and runtime),
matching the recursive version's values. KernelFunction.cpp, which
instantiates boxed_size through the boxing layer, recompiled clean
from its own compile_commands.json command.
```

Drafted with AI assistance (Claude Code).