### PR TITLE
Size the output rrelu_with_noise writes into

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -617,17 +617,13 @@ Tensor& rrelu_with_noise_out_cpu(const Tensor& self,
     Tensor& output) {
   TORCH_CHECK(self.sym_sizes() == noise.sym_sizes(), "noise tensor shape must match self tensor shape. Got self.shape = ", self.sym_sizes(), " noise.shape = ", noise.sym_sizes());
   if (training) {
-    // This is not a structured op, so nothing has sized output for us, and the
-    // kernel below writes self.numel() elements into it. noise is written the
-    // same way, and the size check above passes for an expanded noise whose
-    // storage holds one element, so it has to be a real buffer too.
+    // The size check above passes for an expanded noise whose storage holds
+    // one element, but the kernel below writes self.numel() distinct values
+    // into it, so it has to be a real per-element buffer.
+    TORCH_CHECK(noise.is_contiguous(), "rrelu_with_noise: noise tensor must be contiguous, got one with sizes ", noise.sizes(), " and strides ", noise.strides());
+    // Not a structured op, so nothing else has sized output for us, and the
+    // kernel below writes self.numel() elements into it regardless.
     resize_output(output, self.sizes());
-    TORCH_CHECK(
-        noise.is_contiguous(),
-        "rrelu_with_noise: noise tensor must be contiguous, got one with sizes ",
-        noise.sizes(),
-        " and strides ",
-        noise.strides());
     AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, self.scalar_type(), "rrelu_with_noise_out_cpu", [&] {
       _rrelu_with_noise_train<scalar_t>(output, self.contiguous(), noise, lower, upper, generator);
     });

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/xnnpack/Engine.h>
 #endif
 #include <ATen/core/DistributionsHelper.h>
+#include <ATen/native/Resize.h>
 
 #include <c10/util/irange.h>
 #include <c10/core/ScalarType.h>
@@ -616,6 +617,17 @@ Tensor& rrelu_with_noise_out_cpu(const Tensor& self,
     Tensor& output) {
   TORCH_CHECK(self.sym_sizes() == noise.sym_sizes(), "noise tensor shape must match self tensor shape. Got self.shape = ", self.sym_sizes(), " noise.shape = ", noise.sym_sizes());
   if (training) {
+    // This is not a structured op, so nothing has sized output for us, and the
+    // kernel below writes self.numel() elements into it. noise is written the
+    // same way, and the size check above passes for an expanded noise whose
+    // storage holds one element, so it has to be a real buffer too.
+    resize_output(output, self.sizes());
+    TORCH_CHECK(
+        noise.is_contiguous(),
+        "rrelu_with_noise: noise tensor must be contiguous, got one with sizes ",
+        noise.sizes(),
+        " and strides ",
+        noise.strides());
     AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, self.scalar_type(), "rrelu_with_noise_out_cpu", [&] {
       _rrelu_with_noise_train<scalar_t>(output, self.contiguous(), noise, lower, upper, generator);
     });

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -617,12 +617,9 @@ Tensor& rrelu_with_noise_out_cpu(const Tensor& self,
     Tensor& output) {
   TORCH_CHECK(self.sym_sizes() == noise.sym_sizes(), "noise tensor shape must match self tensor shape. Got self.shape = ", self.sym_sizes(), " noise.shape = ", noise.sym_sizes());
   if (training) {
-    // The size check above passes for an expanded noise whose storage holds
-    // one element, but the kernel below writes self.numel() distinct values
-    // into it, so it has to be a real per-element buffer.
+    // The shape check above also passes for an expanded (0-stride) noise.
     TORCH_CHECK(noise.is_contiguous(), "rrelu_with_noise: noise tensor must be contiguous, got one with sizes ", noise.sizes(), " and strides ", noise.strides());
-    // Not a structured op, so nothing else has sized output for us, and the
-    // kernel below writes self.numel() elements into it regardless.
+    // Not a structured op, so nothing else has sized output for us.
     resize_output(output, self.sizes());
     AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, self.scalar_type(), "rrelu_with_noise_out_cpu", [&] {
       _rrelu_with_noise_train<scalar_t>(output, self.contiguous(), noise, lower, upper, generator);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12966,13 +12966,17 @@ if __name__ == '__main__':
         torch._C._nn.rrelu_with_noise(x, noise, 0.1, 0.3, True, None, out=out)
         self.assertEqual(out.shape, x.shape)
 
+    @onlyCPU
+    def test_rrelu_with_noise_expanded_noise_rejected(self, device):
         # The shape check passes for an expanded noise whose storage holds one
-        # element; writing self.numel() of them into it is the same defect.
+        # element; writing self.numel() distinct values into it is the same
+        # out-of-bounds-write defect as an undersized out.
+        x = torch.randn(64, device=device)
         expanded_noise = torch.zeros(1, device=device).expand(64)
-        out2 = torch.empty(64, device=device)
+        out = torch.empty(64, device=device)
         with self.assertRaisesRegex(RuntimeError, "noise tensor must be contiguous"):
             torch._C._nn.rrelu_with_noise(
-                x, expanded_noise, 0.1, 0.3, True, None, out=out2)
+                x, expanded_noise, 0.1, 0.3, True, None, out=out)
 
     @onlyCPU
     def test_rrelu_bounds_validation(self, device):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12956,6 +12956,25 @@ if __name__ == '__main__':
         self.assertEqual(a_bf16.grad, expected_bf16)
 
     @onlyCPU
+    def test_rrelu_with_noise_out_smaller_than_input(self, device):
+        # rrelu_with_noise is not a structured out= op, so nothing sizes out
+        # for the kernel, which writes self.numel() elements into it. A short
+        # out used to be written past its end and corrupt the heap.
+        x = torch.randn(64, device=device)
+        noise = torch.empty_like(x)
+        out = torch.empty(2, device=device)
+        torch._C._nn.rrelu_with_noise(x, noise, 0.1, 0.3, True, None, out=out)
+        self.assertEqual(out.shape, x.shape)
+
+        # The shape check passes for an expanded noise whose storage holds one
+        # element; writing self.numel() of them into it is the same defect.
+        expanded_noise = torch.zeros(1, device=device).expand(64)
+        out2 = torch.empty(64, device=device)
+        with self.assertRaisesRegex(RuntimeError, "noise tensor must be contiguous"):
+            torch._C._nn.rrelu_with_noise(
+                x, expanded_noise, 0.1, 0.3, True, None, out=out2)
+
+    @onlyCPU
     def test_rrelu_bounds_validation(self, device):
         """Test RReLU bounds validation for finite and infinite values."""
         x = torch.randn(5, 5, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12957,9 +12957,7 @@ if __name__ == '__main__':
 
     @onlyCPU
     def test_rrelu_with_noise_out_smaller_than_input(self, device):
-        # rrelu_with_noise is not a structured out= op, so nothing sizes out
-        # for the kernel, which writes self.numel() elements into it. A short
-        # out used to be written past its end and corrupt the heap.
+        # A short out used to be written past its end and corrupt the heap.
         x = torch.randn(64, device=device)
         noise = torch.empty_like(x)
         out = torch.empty(2, device=device)
@@ -12968,9 +12966,8 @@ if __name__ == '__main__':
 
     @onlyCPU
     def test_rrelu_with_noise_expanded_noise_rejected(self, device):
-        # The shape check passes for an expanded noise whose storage holds one
-        # element; writing self.numel() distinct values into it is the same
-        # out-of-bounds-write defect as an undersized out.
+        # An expanded noise's storage holds one element; the same defect as
+        # an undersized out.
         x = torch.randn(64, device=device)
         expanded_noise = torch.zeros(1, device=device).expand(64)
         out = torch.empty(64, device=device)


### PR DESCRIPTION
rrelu_with_noise.out is not structured, so nothing sizes out before the kernel writes self.numel() elements into it; a shorter out corrupts the heap. resize_output fixes that. noise has the same defect through an expanded tensor whose storage holds fewer elements than its size claims, so noise must now be contiguous too.

Test Plan:

```
python test/test_nn.py -k test_rrelu_with_noise_out_smaller_than_input
```

This PR was authored with the assistance of an AI coding assistant.