### PR TITLE
Reject non-contiguous noise on CUDA instead of silently dropping its writes

### DIFF
--- a/aten/src/ATen/native/cuda/RreluWithNoise.cu
+++ b/aten/src/ATen/native/cuda/RreluWithNoise.cu
@@ -149,9 +149,8 @@ Tensor& rrelu_with_noise_out_cuda(const Tensor& self,
   checkAllSameGPU("rrelu_with_noise_out_cuda", {self_arg, noise_arg, output_arg});
 
   if (training) {
-    // The kernel writes into noise's raw pointer directly; a non-contiguous
-    // noise used to be silently .contiguous()'d into a temporary that was
-    // never copied back, so the caller's tensor never saw the write.
+    // The kernel writes noise directly; a non-contiguous copy used to go
+    // into a temporary that was never copied back.
     checkContiguous("rrelu_with_noise_out_cuda", noise_arg);
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
         self.scalar_type(), "rrelu_with_noise_out_cuda", [&] {

--- a/aten/src/ATen/native/cuda/RreluWithNoise.cu
+++ b/aten/src/ATen/native/cuda/RreluWithNoise.cu
@@ -74,7 +74,6 @@ inline void _rrelu_with_noise_cuda_train(
     const Scalar& upper_,
     std::optional<Generator> generator) {
   auto input = input_.contiguous();
-  auto noise = noise_.contiguous();
   Tensor tmp_output = output.contiguous();
 
   int64_t numel = input.numel();
@@ -91,7 +90,7 @@ inline void _rrelu_with_noise_cuda_train(
   }
 
   const scalar_t* input_data = input.const_data_ptr<scalar_t>();
-  scalar_t* noise_data = noise.mutable_data_ptr<scalar_t>();
+  scalar_t* noise_data = noise_.mutable_data_ptr<scalar_t>();
   scalar_t* output_data = tmp_output.mutable_data_ptr<scalar_t>();
 
   double lower = lower_.to<double>();
@@ -150,6 +149,10 @@ Tensor& rrelu_with_noise_out_cuda(const Tensor& self,
   checkAllSameGPU("rrelu_with_noise_out_cuda", {self_arg, noise_arg, output_arg});
 
   if (training) {
+    // The kernel writes into noise's raw pointer directly; a non-contiguous
+    // noise used to be silently .contiguous()'d into a temporary that was
+    // never copied back, so the caller's tensor never saw the write.
+    checkContiguous("rrelu_with_noise_out_cuda", noise_arg);
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
         self.scalar_type(), "rrelu_with_noise_out_cuda", [&] {
           _rrelu_with_noise_cuda_train<scalar_t>(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12992,6 +12992,17 @@ if __name__ == '__main__':
         with self.assertRaisesRegex(RuntimeError, "Lower bound should be less than or equal to the upper bound"):
             F.rrelu(x, lower=0.5, upper=0.3)
 
+    @onlyCUDA
+    def test_rrelu_with_noise_cuda_noncontiguous_noise_rejected(self, device):
+        # A non-contiguous noise used to be silently .contiguous()'d into a
+        # temporary the kernel wrote into and never copied back, leaving the
+        # caller's noise tensor unmodified with no error.
+        x = torch.randn(64, device=device)
+        noise = torch.empty(128, device=device)[::2]
+        out = torch.empty(64, device=device)
+        with self.assertRaisesRegex(RuntimeError, "Expected contiguous tensor"):
+            torch._C._nn.rrelu_with_noise(x, noise, 0.1, 0.3, True, None, out=out)
+
     @onlyCPU
     def test_softshrink(self, device):
         x = torch.tensor([[1.21, 0.56, 0.5001, 0.4999, 1.2357, -0.4999, -0.5001, -1.154,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12994,9 +12994,8 @@ if __name__ == '__main__':
 
     @onlyCUDA
     def test_rrelu_with_noise_cuda_noncontiguous_noise_rejected(self, device):
-        # A non-contiguous noise used to be silently .contiguous()'d into a
-        # temporary the kernel wrote into and never copied back, leaving the
-        # caller's noise tensor unmodified with no error.
+        # A non-contiguous noise used to be copied into a temporary that
+        # the kernel wrote into and never copied back.
         x = torch.randn(64, device=device)
         noise = torch.empty(128, device=device)[::2]
         out = torch.empty(64, device=device)


### PR DESCRIPTION
The kernel writes noise through a raw pointer, but got it from noise_.contiguous(), a temporary that was never copied back like output is. Copy-back can't fix an expanded noise either, since distinct per-element values can't land in storage that has only one real element, so this requires noise be contiguous up front instead, matching the CPU implementation's contract (#196087).

Test Plan:

```
python test/test_nn.py -k test_rrelu_with_noise_cuda_noncontiguous_noise_rejected
```

No CUDA device or toolchain on this machine, so unverified beyond reading the kernel; needs a real CUDA run.

This PR was authored with the assistance of an AI coding assistant.