### PR TITLE
Break `torch.fx.wrap()` frame cycle from `inspect.currentframe()`

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -732,6 +732,13 @@ class TestFX(JitTestCase):
         self.assertIn("wrapped_decorated_fn", m.code)
         self.assertEqual(m(1), 1)
 
+    def test_wrap_registers_function(self):
+        from torch.fx._symbolic_trace import _wrapped_fns_to_patch
+
+        key = (id(globals()), "a_lifted_leaf")
+        self.assertIn(key, _wrapped_fns_to_patch)
+        self.assertIs(_wrapped_fns_to_patch[key], globals())
+
     def test_graph_edit_with_proxy(self):
         class M(torch.nn.Module):
             def forward(self, a, b):

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -1372,18 +1372,21 @@ def wrap(fn_or_name: str | Callable[..., Any]) -> str | Callable[..., Any]:
         fn_name = fn_or_name
 
     currentframe = inspect.currentframe()
-    if currentframe is None:
-        raise AssertionError("inspect.currentframe() returned None")
-    f = currentframe.f_back
-    if f is None:
-        raise AssertionError("currentframe.f_back is None")
-    if f.f_code.co_name != "<module>":
-        raise NotImplementedError("wrap must be called at the top level of a module")
+    try:
+        if currentframe is None:
+            raise AssertionError("inspect.currentframe() returned None")
+        f = currentframe.f_back
+        if f is None:
+            raise AssertionError("currentframe.f_back is None")
+        if f.f_code.co_name != "<module>":
+            raise NotImplementedError("wrap must be called at the top level of a module")
 
-    # consider implementing Callable version of this via _autowrap_function_ids / _autowrap_search
-    # semantics would be slightly different, but would add support `from x import wrapped_function`
-    _wrapped_fns_to_patch[(id(f.f_globals), fn_name)] = f.f_globals
-    return fn_or_name
+        # consider implementing Callable version of this via _autowrap_function_ids / _autowrap_search
+        # semantics would be slightly different, but would add support `from x import wrapped_function`
+        _wrapped_fns_to_patch[(id(f.f_globals), fn_name)] = f.f_globals
+        return fn_or_name
+    finally:
+        del currentframe
 
 
 @compatibility(is_backward_compatible=True)


### PR DESCRIPTION
Fixes #195586

`torch.fx.wrap()` stored `inspect.currentframe()` in a local, so the wrap frame referenced itself. A first lazy Dynamo import from `checkpoint` could retain the caller stack until cyclic GC. Drop that local in `finally`.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```
python test/test_fx.py TestFX.test_wrap_registers_function
```