### PR TITLE
Return an empty tuple from `torch.meshgrid()` with no tensors

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1414,9 +1414,9 @@ class TestTensorCreation(TestCase):
         self.assertEqual(int(y), 3)
 
     def test_meshgrid_empty(self):
-        with self.assertRaisesRegex(RuntimeError,
-                                    'expects a non-empty TensorList'):
-            torch.meshgrid()
+        self.assertEqual(torch.meshgrid(), ())
+        self.assertEqual(torch.meshgrid(*[]), ())
+        self.assertEqual(torch.meshgrid([]), ())
 
     def test_meshgrid_unsupported_indexing(self):
         with self.assertRaisesRegex(RuntimeError,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5849,19 +5849,21 @@ def meshgrid(
     # This ref simultaneously handles two overloads (see stubs above)
     # The `indexing` argument is currently optional for torch.meshgrid, but we
     # plan to make the argument required: https://github.com/pytorch/pytorch/issues/50276
+    if len(tensors) == 0:
+        return []
     if isinstance(tensors[0], (list, tuple)):
         if len(tensors) != 1:
             raise AssertionError(
                 f"Expected exactly 1 tensor list/tuple, got {len(tensors)}"
             )
         tensors = tuple(tensors[0])
+    if len(tensors) == 0:
+        return []
 
     torch._check(
         builtins.all(isinstance(a, TensorLike) for a in tensors),
         lambda: "meshgrid expects its inputs to be tensors",
     )
-
-    torch._check(len(tensors) > 0, lambda: "meshgrid expects a non-empty TensorList")
 
     for i in range(len(tensors) - 1):
         torch._check(

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -495,6 +495,8 @@ def _meshgrid(*tensors, indexing: str | None):
     if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):
         # the old interface of passing the operands as one list argument
         tensors = tensors[0]  # type: ignore[assignment]
+    if len(tensors) == 0:
+        return ()
 
     # Continue allowing call of old method that takes no indexing
     # kwarg for forward compatibility reasons.


### PR DESCRIPTION
Fixes #181576

`torch.meshgrid()` and `meshgrid(*[])` raised `RuntimeError`. NumPy and the array API return `()`. Return `()` in the Python wrapper after the old list unwrap, and return `[]` on the FakeTensor ref path.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```
python test/test_tensor_creation_ops.py TestTensorCreation.test_meshgrid_empty
```