### PR TITLE
Reject `DataLoader(prefetch_factor=0)` at construction

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1639,6 +1639,17 @@ except RuntimeError as e:
         ):
             self._get_data_loader(dataset, batch_sampler=3)
 
+        with self.assertRaisesRegex(
+            ValueError, "prefetch_factor option should be greater than 0"
+        ):
+            self._get_data_loader(self.dataset, num_workers=1, prefetch_factor=0)
+        with self.assertRaisesRegex(
+            ValueError, "prefetch_factor option should be greater than 0"
+        ):
+            self._get_data_loader(self.dataset, num_workers=1, prefetch_factor=-1)
+        loader = self._get_data_loader(self.dataset, num_workers=1, prefetch_factor=2)
+        self.assertEqual(loader.prefetch_factor, 2)
+
     def test_builtin_collection_conversion(self):
         for coll_ty in (list, tuple):
             for num_workers in (0, 1):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -198,7 +198,8 @@ class DataLoader(Generic[_T_co]):
             ``base_seed`` for workers. (default: ``None``)
         prefetch_factor (int, optional, keyword-only arg): Number of batches loaded
             in advance by each worker. ``2`` means there will be a total of
-            2 * num_workers batches prefetched across all workers. (default value depends
+            2 * num_workers batches prefetched across all workers. Must be greater
+            than ``0`` if specified. (default value depends
             on the set value for num_workers. If value of num_workers=0 default is ``None``.
             Otherwise, if value of ``num_workers > 0`` default is ``2``).
         persistent_workers (bool, optional): If ``True``, the data loader will not shut down
@@ -291,8 +292,8 @@ class DataLoader(Generic[_T_co]):
             )
         elif num_workers > 0 and prefetch_factor is None:
             prefetch_factor = 2
-        elif prefetch_factor is not None and prefetch_factor < 0:
-            raise ValueError("prefetch_factor option should be non-negative")
+        elif prefetch_factor is not None and prefetch_factor <= 0:
+            raise ValueError("prefetch_factor option should be greater than 0")
 
         if persistent_workers and num_workers == 0:
             raise ValueError("persistent_workers option needs num_workers > 0")


### PR DESCRIPTION
Fixes #196089

The constructor allowed `prefetch_factor=0` while the multiprocessing iterator requires a positive factor, so the first iteration raised `AssertionError`. Reject `<= 0` with `ValueError` at construction.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```
python test/test_dataloader.py TestDataLoader
```