### PR TITLE
Reject `DistributedSampler(num_replicas<=0)` before the rank check

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -2191,6 +2191,16 @@ except RuntimeError as e:
         with self.assertRaisesRegex(ValueError, "Invalid rank"):
             sampler = DistributedSampler(dataset, 3, -1)
 
+    def test_distributed_sampler_invalid_num_replicas(self):
+        from torch.utils.data.distributed import DistributedSampler
+
+        dataset = torch.IntTensor(range(10))
+        with self.assertRaisesRegex(ValueError, "Invalid num_replicas"):
+            DistributedSampler(dataset, num_replicas=0, rank=0)
+
+        with self.assertRaisesRegex(ValueError, "Invalid num_replicas"):
+            DistributedSampler(dataset, num_replicas=-1, rank=0)
+
     def test_duplicating_data_with_drop_last(self):
         from torch.utils.data.distributed import DistributedSampler
 

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -80,6 +80,10 @@ class DistributedSampler(Sampler[_T_co]):
             if not dist.is_available():
                 raise RuntimeError("Requires distributed package to be available")
             rank = dist.get_rank()
+        if num_replicas <= 0:
+            raise ValueError(
+                f"Invalid num_replicas {num_replicas}, num_replicas should be a positive integer"
+            )
         if rank >= num_replicas or rank < 0:
             raise ValueError(
                 f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas - 1}]"


### PR DESCRIPTION
Fixes #196090

`DistributedSampler(..., num_replicas=0, rank=0)` raised `ValueError` about an invalid rank in `[0, -1]`. Check that `num_replicas` is a positive integer first.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```
python test/test_dataloader.py TestDataLoader.test_distributed_sampler_invalid_num_replicas
```