### PR TITLE
Fix torch.sparse.sum() dtype promotion when reducing over all sparse dims

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1632,7 +1632,11 @@ Tensor sspaddmm(const Tensor& self, const Tensor& mat1, const Tensor& mat2,
 // for ops like sum, max, and min.
 // --------------------------------------------------------------------
 Tensor _sparse_sum(const SparseTensor& input) {
-  return input.coalesce().values().sum();
+  // Pass the input's own dtype explicitly: the no-dtype-arg overload of
+  // Tensor::sum() promotes sub-int64 integral types to int64, but
+  // torch.sparse.sum()'s documented default output dtype is the dtype of
+  // the input (see gh-65392).
+  return input.coalesce().values().sum(input.scalar_type());
 }
 
 Tensor _sparse_sum(const SparseTensor& input, ScalarType dtype) {
@@ -1641,11 +1645,13 @@ Tensor _sparse_sum(const SparseTensor& input, ScalarType dtype) {
   return input.coalesce().values().sum(dtype);
 }
 
-Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, ScalarType dtype) {
-  return at::_sparse_sum(input.to(dtype), dims_to_sum);
-}
-
-Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
+static Tensor _sparse_sum_dim_impl(const SparseTensor& input, IntArrayRef dims_to_sum, std::optional<ScalarType> dtype_opt) {
+  // out_dtype is threaded through every values().sum() call below instead
+  // of relying on their default int64 promotion, so the result dtype is
+  // always exactly the requested (or input's) dtype -- see gh-65392, where
+  // reducing over all sparse dims silently promoted to int64 and an
+  // explicit dtype= was ignored once dims_to_sum was also given.
+  const ScalarType out_dtype = dtype_opt.value_or(input.scalar_type());
   const int64_t input_dim = input.dim();
   auto dims_to_sum_b = dim_list_to_bitset(dims_to_sum, input_dim);
   auto dims_to_sum_v = dims_to_sum.vec();
@@ -1673,15 +1679,15 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
   // new values
   Tensor new_values;
   if (sum_dense_dim) {
-    new_values = values.sum(dense_dims_to_sum_v);
+    new_values = values.sum(dense_dims_to_sum_v, /*keepdim=*/false, out_dtype);
   }
   else {
-    new_values = values.clone(at::MemoryFormat::Contiguous);
+    new_values = values.to(out_dtype).clone(at::MemoryFormat::Contiguous);
   }
 
   if (sum_all_sparse_dim) {
     // return a dense tensor if sum over all sparse dims
-    new_values = new_values.sum(0);
+    new_values = new_values.sum(0, /*keepdim=*/false, out_dtype);
     return new_values;
   }
   else { // !sum_all_sparse_dim
@@ -1709,11 +1715,19 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
 
     // use coalesce() to do sum reduction
     bool is_coalesced = false;  // TODO: can we use input.is_coalesced()?
-    SparseTensor new_sparse = at::_sparse_coo_tensor_with_dims_and_tensors(new_sparse_dim, new_dense_dim, new_sizes, new_indices, new_values, input.options(), is_coalesced);
+    SparseTensor new_sparse = at::_sparse_coo_tensor_with_dims_and_tensors(new_sparse_dim, new_dense_dim, new_sizes, new_indices, new_values, input.options().dtype(out_dtype), is_coalesced);
     new_sparse = new_sparse.coalesce();
     return new_sparse;
   }
 
+}
+
+Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum, ScalarType dtype) {
+  return _sparse_sum_dim_impl(input, dims_to_sum, dtype);
+}
+
+Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
+  return _sparse_sum_dim_impl(input, dims_to_sum, std::nullopt);
 }
 // --------------------------------------------------------------------
 // NOTE [ sparse.sum() backward ]

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2120,6 +2120,32 @@ class TestSparse(TestSparseBase):
             S = self._gen_sparse(sparse_dims, nnz, with_size, dtype, device, coalesced)[0]
             run_tests(S.requires_grad_(True), test_dim)
 
+    @dtypes(*integral_types())
+    def test_sparse_sum_dtype_preserved(self, device, dtype):
+        # gh-65392: torch.sparse.sum's documented default output dtype is
+        # the input's dtype, but reducing over all sparse dims (with or
+        # without an explicit dim=) silently promoted integral dtypes to
+        # int64, and an explicit dtype= was ignored once dim= was also
+        # given and covered all sparse dims.
+        i = torch.tensor([[0, 1], [1, 0]], device=device)
+        v = torch.tensor([1, 2], dtype=dtype, device=device)
+        t = torch.sparse_coo_tensor(i, v, size=(2, 2))
+
+        self.assertEqual(torch.sparse.sum(t).dtype, dtype)
+        self.assertEqual(torch.sparse.sum(t).item(), 3)
+
+        self.assertEqual(torch.sparse.sum(t, dim=(0, 1)).dtype, dtype)
+        self.assertEqual(torch.sparse.sum(t, dim=(0, 1)).item(), 3)
+
+        self.assertEqual(torch.sparse.sum(t, dtype=torch.float64).dtype, torch.float64)
+        self.assertEqual(torch.sparse.sum(t, dim=(0, 1), dtype=torch.float64).dtype, torch.float64)
+
+        # Partial reduction (not all sparse dims summed) must also honor
+        # an explicit dtype=.
+        partial = torch.sparse.sum(t, dim=0, dtype=torch.float64)
+        self.assertEqual(partial.dtype, torch.float64)
+        self.assertEqual(partial.to_dense(), torch.tensor([2., 1.], dtype=torch.float64, device=device))
+
     def _test_basic_ops_shape(self, nnz_x1, nnz_x2, shape_i, shape_v, dtype, device, coalesced):
         shape = shape_i + (shape_v)
         x1, _, _ = self._gen_sparse(len(shape_i), nnz_x1, shape, dtype, device, coalesced)


### PR DESCRIPTION
Fixes #65392.

## Root cause

`torch.sparse.sum()`'s documented default output dtype is the dtype of the input, but reducing over all sparse dimensions silently promoted integral dtypes to `int64` instead, and an explicit `dtype=` was ignored once `dim=` also covered every sparse dimension.

The "sum over all sparse dims" path in `_sparse_sum` falls back to a dense `values().sum()` call to collapse the sparse indices, and the dtype-less overload of `Tensor::sum()` auto-promotes sub-`int64` integral types to `int64`. The `dims_to_sum` + `dtype` overload compounded this: it first cast the whole input sparse tensor via `input.to(dtype)`, then delegated to the no-dtype overload, so the cast was silently discarded by that same promotion once all sparse dims were being reduced.

```python
>>> t = torch.sparse_coo_tensor([[0, 1], [1, 0]], [1, 2], dtype=torch.int16)
>>> torch.sparse.sum(t).dtype
torch.int64  # expected torch.int16 per the docs
>>> torch.sparse.sum(t, dim=(0, 1), dtype=torch.int16).dtype
torch.int64  # explicit dtype= silently ignored
```

## Fix

Thread the target dtype explicitly through every `values().sum()` call in the reduction instead of relying on their default promotion, so the result dtype is always exactly the requested (or input's) dtype. The two `dims_to_sum` overloads (with/without `dtype`) are merged onto one `_sparse_sum_dim_impl` helper parameterized by `std::optional<ScalarType>`, which also drops the old whole-tensor `input.to(dtype)` copy in favor of casting only the `values` tensor.

This only changes behavior for integral dtypes: for floating-point tensors (the differentiable/training-relevant case), `out_dtype` always equals the tensor's own already-correct dtype, so `Tensor::sum()` would have picked the same dtype anyway -- the change is a no-op on that path, and no autograd formula needed updating.

A prior attempt at this fix ([#66153](https://github.com/pytorch/pytorch/pull/66153)) got most of the way through design review (converging on passing an optional dtype through rather than casting eagerly) before stalling on the original author's availability. This PR follows that same converged direction.

## Test plan

Added `test_sparse_sum_dtype_preserved` covering all 5 integral dtypes (`uint8`/`int8`/`int16`/`int32`/`int64`), checking `sum()` and `sum(dim=...)` preserve input dtype by default, and that an explicit `dtype=` is honored both for a full reduction and a partial (not-all-sparse-dims) reduction:

```
python test/test_sparse.py -k test_sparse_sum_dtype_preserved -v
```

Ran the existing sum-related sparse tests to check for regressions (113 tests, all pass):

```
python test/test_sparse.py -k "sum" -v
```

Ran the full `test_sparse.py` suite (3107 tests): 10 errors, all pre-existing `test_sparse_spdiags_*` failures (a numpy 0-dim slicing issue in the test's own `reference()` helper, unrelated to this change -- confirmed by reproducing the same failures via `git stash` against unmodified `main`):

```
python test/test_sparse.py -v
```

## Disclosure

This PR was authored with the assistance of [Claude Code](https://claude.com/claude-code) (Anthropic), based on the fix direction reviewers had already converged on in the prior, stalled PR #66153. Opened as a draft pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)