### PR TITLE
Fix FileStore rendezvous mkstemp file descriptor leak (issue #191394)

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,11 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            try:
+                os.close(fd)
+            except OSError:
+                pass  # best-effort; path is still valid
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
The _create_file_store() function in c10d_rendezvous_backend.py was leaking the file descriptor returned by tempfile.mkstemp(). This change captures the file descriptor and closes it before FileStore construction to prevent resource leak.

Fixes #191394