### PR TITLE
Replace irange-and-subscript loops with range-based for

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -433,14 +433,14 @@ inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
   // expands a list of Tensors; ignores undefined (null) tensors
   bool first = true;
   SymDimVector sizes;
-  for (const auto i : c10::irange(to_expand.size())) {
-    if (!to_expand[i].defined()) {
+  for (const auto& to_expand_elem : to_expand) {
+    if (!to_expand_elem.defined()) {
       continue;
     } else if (first) {
-      sizes = to_expand[i].sym_sizes();
+      sizes = to_expand_elem.sym_sizes();
       first = false;
     } else {
-      sizes = infer_size_symdimvector(sizes, to_expand[i].sym_sizes());
+      sizes = infer_size_symdimvector(sizes, to_expand_elem.sym_sizes());
     }
   }
 

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -725,8 +725,7 @@ bool isFunctionalTensor(const std::optional<Tensor>& t) {
 bool isFunctionalTensor(const c10::List<::std::optional<Tensor>>& t_list) {
   if (t_list.empty()) { return false; }
   auto functional_count = 0;
-  for (const auto i : c10::irange(t_list.size())) {
-    auto const & e= t_list[i];
+  for (const std::optional<Tensor> e : t_list) {
     if (!e.has_value() || !e->defined()) { continue; }
     if (isFunctionalTensor(e)) {
       ++functional_count;

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -725,7 +725,7 @@ bool isFunctionalTensor(const std::optional<Tensor>& t) {
 bool isFunctionalTensor(const c10::List<::std::optional<Tensor>>& t_list) {
   if (t_list.empty()) { return false; }
   auto functional_count = 0;
-  for (const std::optional<Tensor> e : t_list) {
+  for (const std::optional<Tensor>& e : t_list) {
     if (!e.has_value() || !e->defined()) { continue; }
     if (isFunctionalTensor(e)) {
       ++functional_count;

--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -17,8 +17,8 @@ MemOverlap has_internal_overlap(TensorImpl* t) {
   // When we have unbacked symint strides, is_non_overlapping_and_dense
   // often results in guard on data dependent errors. For now
   // let us bail early if there are unbacked symint strides.
-  for (const auto i : c10::irange(strides.size())) {
-    if (!strides[i].has_hint()) {
+  for (const auto& stride : strides) {
+    if (!stride.has_hint()) {
       return MemOverlap::TooHard;
     }
   }

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -43,8 +43,8 @@ inline void get_base_ptrs(char** ptrs, ArrayRef<OperandInfo> operands) {
 
 inline void get_strides(int64_t* strides, ArrayRef<OperandInfo> operands, int64_t ndim) {
   for (const auto dim : c10::irange(ndim)) {
-    for (const auto arg : c10::irange(operands.size())) {
-      *strides++ = operands[arg].stride_bytes[dim];
+    for (const auto& operand : operands) {
+      *strides++ = operand.stride_bytes[dim];
     }
   }
   // Always at least 2d strides to support 2d for_each loops
@@ -1124,8 +1124,8 @@ TensorIterator TensorIterator::reduce_op(TensorBase& out1, TensorBase& out2, con
 }
 
 void TensorIteratorBase::populate_operands(TensorIteratorConfig& config) {
-  for (const auto idx : c10::irange(config.tensors_.size())) {
-    auto& tensor = config.tensors_[idx];
+  for (auto& tensors_elem : config.tensors_) {
+    auto& tensor = tensors_elem;
     // If *any* of the arguments is a meta tensor, the overall
     // computation is a meta computation (don't do any work,
     // just compute output information).  This aligns with

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -1124,8 +1124,7 @@ TensorIterator TensorIterator::reduce_op(TensorBase& out1, TensorBase& out2, con
 }
 
 void TensorIteratorBase::populate_operands(TensorIteratorConfig& config) {
-  for (auto& tensors_elem : config.tensors_) {
-    auto& tensor = tensors_elem;
+  for (auto& tensor : config.tensors_) {
     // If *any* of the arguments is a meta tensor, the overall
     // computation is a meta computation (don't do any work,
     // just compute output information).  This aligns with

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -148,8 +148,8 @@ inline int64_t legacy_cat_wrap_dim(
 inline void wrap_all_dims(
     std::vector<int64_t>& dims_to_wrap,
     int64_t tensor_total_dims) {
-  for (const auto i : c10::irange(dims_to_wrap.size())) {
-    dims_to_wrap[i] = maybe_wrap_dim(dims_to_wrap[i], tensor_total_dims);
+  for (auto& dims_to_wrap_elem : dims_to_wrap) {
+    dims_to_wrap_elem = maybe_wrap_dim(dims_to_wrap_elem, tensor_total_dims);
   }
 }
 

--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -24,8 +24,8 @@ inline std::bitset<dim_bitset_size> dim_list_to_bitset(
   std::bitset<dim_bitset_size> seen;
   if (opt_dims.has_value()) {
     auto dims = opt_dims.value();
-    for (const auto i : c10::irange(dims.size())) {
-      size_t dim = maybe_wrap_dim(dims[i], static_cast<int64_t>(ndims));
+    for (const auto& dims_elem : dims) {
+      size_t dim = maybe_wrap_dim(dims_elem, static_cast<int64_t>(ndims));
       TORCH_CHECK(
           !seen[dim],
           "dim ",

--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -2,7 +2,6 @@
 
 #include <ATen/WrapDimUtils.h>
 #include <c10/core/TensorImpl.h>
-#include <c10/util/irange.h>
 #include <bitset>
 #include <sstream>
 

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
@@ -45,12 +45,12 @@ void DispatchKeyExtractor::setOperatorHasFallthroughForKey(DispatchKey k, bool h
     // the first time that we see requiresBitsetPerBackend_ = true
     // (which should almost never happen)
     if (has_fallthrough) {
-      for (const auto i : c10::irange(nonFallthroughKeysPerBackend_.size())) {
-        nonFallthroughKeysPerBackend_[i] = nonFallthroughKeysPerBackend_[i].remove(k);
+      for (auto& nonFallthroughKeysPerBackend_elem : nonFallthroughKeysPerBackend_) {
+        nonFallthroughKeysPerBackend_elem = nonFallthroughKeysPerBackend_elem.remove(k);
       }
     } else {
-      for (const auto i : c10::irange(nonFallthroughKeysPerBackend_.size())) {
-        nonFallthroughKeysPerBackend_[i] = nonFallthroughKeysPerBackend_[i].add(k);
+      for (auto& nonFallthroughKeysPerBackend_elem : nonFallthroughKeysPerBackend_) {
+        nonFallthroughKeysPerBackend_elem = nonFallthroughKeysPerBackend_elem.add(k);
       }
     }
   }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
@@ -44,14 +44,8 @@ void DispatchKeyExtractor::setOperatorHasFallthroughForKey(DispatchKey k, bool h
     // TODO: we could probably optimize this by only lazily updating these values
     // the first time that we see requiresBitsetPerBackend_ = true
     // (which should almost never happen)
-    if (has_fallthrough) {
-      for (auto& nonFallthroughKeysPerBackend_elem : nonFallthroughKeysPerBackend_) {
-        nonFallthroughKeysPerBackend_elem = nonFallthroughKeysPerBackend_elem.remove(k);
-      }
-    } else {
-      for (auto& nonFallthroughKeysPerBackend_elem : nonFallthroughKeysPerBackend_) {
-        nonFallthroughKeysPerBackend_elem = nonFallthroughKeysPerBackend_elem.add(k);
-      }
+    for (auto& keys : nonFallthroughKeysPerBackend_) {
+      keys = has_fallthrough ? keys.remove(k) : keys.add(k);
     }
   }
 }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -251,7 +251,8 @@ struct TORCH_API DispatchKeyExtractor final {
   explicit DispatchKeyExtractor(c10::utils::bitset dispatch_arg_indices_reverse)
       : dispatch_arg_indices_reverse_(dispatch_arg_indices_reverse),
         nonFallthroughKeys_(DispatchKeySet::FULL) {
-    for (auto& nonFallthroughKeysPerBackend_elem : nonFallthroughKeysPerBackend_) {
+    for (auto& nonFallthroughKeysPerBackend_elem :
+         nonFallthroughKeysPerBackend_) {
       nonFallthroughKeysPerBackend_elem = DispatchKeySet::FULL;
     }
   }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -251,8 +251,8 @@ struct TORCH_API DispatchKeyExtractor final {
   explicit DispatchKeyExtractor(c10::utils::bitset dispatch_arg_indices_reverse)
       : dispatch_arg_indices_reverse_(dispatch_arg_indices_reverse),
         nonFallthroughKeys_(DispatchKeySet::FULL) {
-    for (const auto i : c10::irange(nonFallthroughKeysPerBackend_.size())) {
-      nonFallthroughKeysPerBackend_[i] = DispatchKeySet::FULL;
+    for (auto& nonFallthroughKeysPerBackend_elem : nonFallthroughKeysPerBackend_) {
+      nonFallthroughKeysPerBackend_elem = DispatchKeySet::FULL;
     }
   }
 

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -251,10 +251,7 @@ struct TORCH_API DispatchKeyExtractor final {
   explicit DispatchKeyExtractor(c10::utils::bitset dispatch_arg_indices_reverse)
       : dispatch_arg_indices_reverse_(dispatch_arg_indices_reverse),
         nonFallthroughKeys_(DispatchKeySet::FULL) {
-    for (auto& nonFallthroughKeysPerBackend_elem :
-         nonFallthroughKeysPerBackend_) {
-      nonFallthroughKeysPerBackend_elem = DispatchKeySet::FULL;
-    }
+    nonFallthroughKeysPerBackend_.fill(DispatchKeySet::FULL);
   }
 
   // this is a bitset that has ones for each argument index which has to be

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -355,14 +355,14 @@ namespace {
   {
     int64_t dims_before = 0, dims_indexed = 0;
     SymIntArrayRef replacement_shape;
-    for (const auto dim : c10::irange(indices_list.size())) {
-      if (!indices_list[dim].defined()) {
+    for (const auto& indices_list_elem : indices_list) {
+      if (!indices_list_elem.defined()) {
         if (dims_indexed == 0) {
           dims_before++;
         }
       } else {
         dims_indexed++;
-        replacement_shape = indices_list[dim].sym_sizes();
+        replacement_shape = indices_list_elem.sym_sizes();
       }
     }
 

--- a/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp
+++ b/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp
@@ -714,8 +714,8 @@ Tensor nested_cat_batching_rule(const ITensorListRef& tensors, int64_t dim) {
   for (auto i : c10::irange(num_components)) {
     std::vector<Tensor> arg_list;
     arg_list.reserve(unbound.size());
-    for (auto j : c10::irange(unbound.size())) {
-      arg_list.push_back(unbound[j][i]);
+    for (const auto& unbound_elem : unbound) {
+      arg_list.push_back(unbound_elem[i]);
     }
     outputs.push_back(at::cat(arg_list, dim));
   }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1072,8 +1072,8 @@ static Tensor convolution_same(
               "stride cannot broadcast to ", dim, " dimensions");
   TORCH_CHECK(dilation.size() == dim || dilation.size() == 1U,
               "dilation cannot broadcast to ", dim, " dimensions");
-  for (auto i: c10::irange(stride.size())) {
-    TORCH_CHECK(stride[i] == 1, "padding='same' is not supported for strided convolutions");
+  for (const auto& stride_elem : stride) {
+    TORCH_CHECK(stride_elem == 1, "padding='same' is not supported for strided convolutions");
   }
 
   // Calculate the correct padding

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -653,9 +653,9 @@ template<typename T>
 std::vector<T> unpair_vec(std::vector<pair_of<T>>&& vals) {
   std::vector<T> result;
   result.reserve(vals.size() * 2);
-  for (const auto i : c10::irange(vals.size())) {
-    result.push_back(std::move(vals[i].first));
-    result.push_back(std::move(vals[i].second));
+  for (auto& val : vals) {
+    result.push_back(std::move(val.first));
+    result.push_back(std::move(val.second));
   }
   return result;
 }

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1110,8 +1110,8 @@ static void pre_check_gradient(const Tensor& self, std::optional<int64_t> spacin
 }
 
 static std::vector<Tensor> gradient_helper(const Tensor& self, TensorList coordinates, IntArrayRef dim, int64_t edge_order) {
-  for (const auto i : c10::irange(coordinates.size())) {
-    TORCH_CHECK(self.device() == coordinates[i].device(), "torch.gradient expected each tensor to be on the same device, but got devices ", self.device(), " and ", coordinates[i].device(), "!");
+  for (const auto& coordinate : coordinates) {
+    TORCH_CHECK(self.device() == coordinate.device(), "torch.gradient expected each tensor to be on the same device, but got devices ", self.device(), " and ", coordinate.device(), "!");
   }
 
   std::vector<Tensor> result;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1896,8 +1896,8 @@ Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {
   const int64_t size_diff = self.dim() - static_cast<int64_t>(reps.size());
   if (size_diff > 0) {
     std::vector<c10::SymInt> new_reps(size_diff, 1);
-    for (const auto i : c10::irange(reps.size())) {
-      new_reps.emplace_back(reps[i]);
+    for (const auto& rep : reps) {
+      new_reps.emplace_back(rep);
     }
     return self.repeat_symint(SymIntArrayRef(new_reps));
   }
@@ -4825,9 +4825,9 @@ void unbind_copy_int_out(
     int64_t dim,
     at::TensorList out) {
   if (at::GradMode::is_enabled()) {
-    for (const auto i : c10::irange(out.size())) {
+    for (const auto& out_elem : out) {
       TORCH_CHECK(
-          !out[i].requires_grad(),
+          !out_elem.requires_grad(),
           "unbind_copy(): functions with out=... arguments don't support automatic differentiation, "
           "but one of the arguments requires grad.");
     }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1896,6 +1896,7 @@ Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {
   const int64_t size_diff = self.dim() - static_cast<int64_t>(reps.size());
   if (size_diff > 0) {
     std::vector<c10::SymInt> new_reps(size_diff, 1);
+    new_reps.reserve(size_diff + static_cast<int64_t>(reps.size()));
     for (const auto& rep : reps) {
       new_reps.emplace_back(rep);
     }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1896,7 +1896,7 @@ Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {
   const int64_t size_diff = self.dim() - static_cast<int64_t>(reps.size());
   if (size_diff > 0) {
     std::vector<c10::SymInt> new_reps(size_diff, 1);
-    new_reps.reserve(size_diff + static_cast<int64_t>(reps.size()));
+    new_reps.reserve(static_cast<size_t>(size_diff) + reps.size());
     for (const auto& rep : reps) {
       new_reps.emplace_back(rep);
     }

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -86,8 +86,8 @@ inline int64_t get_num_splits(
 
 inline bool have_same_ndims(TensorList tensors) {
   auto ndim = tensors[0].dim();
-  for (const auto tensor_idx : c10::irange(tensors.size())) {
-    if (tensors[tensor_idx].dim() != ndim) {
+  for (const auto& tensor : tensors) {
+    if (tensor.dim() != ndim) {
       return false;
     }
   }
@@ -98,8 +98,8 @@ inline void leading_dimension_matches(TensorList tensors, int64_t dim) {
   auto tensor_zero_size = tensors[0].sizes();
   std::vector<c10::SymInt> leading_dim_sizes(
       tensor_zero_size.begin(), tensor_zero_size.begin() + dim);
-  for (const auto i : c10::irange(tensors.size())) {
-    at::Tensor tensor = tensors[i];
+  for (const auto& tensors_elem : tensors) {
+    at::Tensor tensor = tensors_elem;
     for (const auto j : c10::irange(dim)) {
       TORCH_CHECK(
           tensor.size(j) == leading_dim_sizes[j],
@@ -117,13 +117,13 @@ inline int64_t preprocess_chunk_cat_inputs(
       !tensors.empty(), "_chunk_cat expects a non-empty input tensor list");
   auto expected_dtype = tensors[0].dtype();
   auto expected_device = tensors[0].device();
-  for (const auto i : c10::irange(tensors.size())) {
-    TORCH_CHECK(tensors[i].numel() > 0, "_chunk_cat expects non-empty tensor");
+  for (const auto& tensors_elem : tensors) {
+    TORCH_CHECK(tensors_elem.numel() > 0, "_chunk_cat expects non-empty tensor");
     TORCH_CHECK(
-        tensors[i].dtype() == expected_dtype,
+        tensors_elem.dtype() == expected_dtype,
         "_chunk_cat expects all input tensors with the same dtype");
     TORCH_CHECK(
-        tensors[i].device() == expected_device,
+        tensors_elem.device() == expected_device,
         "_chunk_cat expects all inputs tensors on the same device");
   }
   if (have_same_ndims(tensors)) {
@@ -132,9 +132,9 @@ inline int64_t preprocess_chunk_cat_inputs(
     TORCH_CHECK(
         dim >= 0,
         "_chunk_cat expects non-negative dim when input tensors have different ndims")
-    for (const auto i : c10::irange(tensors.size())) {
+    for (const auto& tensor : tensors) {
       TORCH_CHECK(
-          dim < tensors[i].ndimension(),
+          dim < tensor.ndimension(),
           "_chunk_cat expects dim < ndim for all input tensors");
     }
   }

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -118,7 +118,8 @@ inline int64_t preprocess_chunk_cat_inputs(
   auto expected_dtype = tensors[0].dtype();
   auto expected_device = tensors[0].device();
   for (const auto& tensors_elem : tensors) {
-    TORCH_CHECK(tensors_elem.numel() > 0, "_chunk_cat expects non-empty tensor");
+    TORCH_CHECK(
+        tensors_elem.numel() > 0, "_chunk_cat expects non-empty tensor");
     TORCH_CHECK(
         tensors_elem.dtype() == expected_dtype,
         "_chunk_cat expects all input tensors with the same dtype");

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -98,8 +98,7 @@ inline void leading_dimension_matches(TensorList tensors, int64_t dim) {
   auto tensor_zero_size = tensors[0].sizes();
   std::vector<c10::SymInt> leading_dim_sizes(
       tensor_zero_size.begin(), tensor_zero_size.begin() + dim);
-  for (const auto& tensors_elem : tensors) {
-    at::Tensor tensor = tensors_elem;
+  for (const auto& tensor : tensors) {
     for (const auto j : c10::irange(dim)) {
       TORCH_CHECK(
           tensor.size(j) == leading_dim_sizes[j],
@@ -117,14 +116,13 @@ inline int64_t preprocess_chunk_cat_inputs(
       !tensors.empty(), "_chunk_cat expects a non-empty input tensor list");
   auto expected_dtype = tensors[0].dtype();
   auto expected_device = tensors[0].device();
-  for (const auto& tensors_elem : tensors) {
+  for (const auto& tensor : tensors) {
+    TORCH_CHECK(tensor.numel() > 0, "_chunk_cat expects non-empty tensor");
     TORCH_CHECK(
-        tensors_elem.numel() > 0, "_chunk_cat expects non-empty tensor");
-    TORCH_CHECK(
-        tensors_elem.dtype() == expected_dtype,
+        tensor.dtype() == expected_dtype,
         "_chunk_cat expects all input tensors with the same dtype");
     TORCH_CHECK(
-        tensors_elem.device() == expected_device,
+        tensor.device() == expected_device,
         "_chunk_cat expects all inputs tensors on the same device");
   }
   if (have_same_ndims(tensors)) {

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -453,8 +453,8 @@ void vectorized_inner_sum(
 
     alignas(64) std::array<acc_t, vacc_t::size()> partials{};
     vec_acc.store(partials.data());
-    for (const auto k : c10::irange(partials.size())) {
-      final_acc += partials[k];
+    for (const auto& partial : partials) {
+      final_acc += partial;
     }
     store<StorePolicy>(data[0], out_stride, j, final_acc);
   }

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -1025,8 +1025,8 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> miopen_rnn_backward(
     if (output_mask[3]) {
         dw = at::native::miopen_rnn_backward_weight(input, weight, weight_stride0, weight_buf, hx, cx, output, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve, ws);
         if (mode > 1) {
-            for (const auto i : c10::irange(dw.size())) {
-                dw[i] = permute_wei_for_miopen(dw[i], mode);
+            for (auto& dw_elem : dw) {
+                dw_elem = permute_wei_for_miopen(dw_elem, mode);
             }
         }
     }

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -1074,8 +1074,8 @@ static Tensor cat_nested_impl(
     std::vector<at::Tensor> sizes;
     buffers.reserve(tensors.size());
     sizes.reserve(tensors.size());
-    for (const auto i : c10::irange(tensors.size())) {
-      const Tensor& t = tensors[i];
+    for (const auto& tensors_elem : tensors) {
+      const Tensor& t = tensors_elem;
       TORCH_CHECK(
           t.is_nested(), "Expected each tensor in given list to be nested.");
       TORCH_CHECK(

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -1074,8 +1074,7 @@ static Tensor cat_nested_impl(
     std::vector<at::Tensor> sizes;
     buffers.reserve(tensors.size());
     sizes.reserve(tensors.size());
-    for (const auto& tensors_elem : tensors) {
-      const Tensor& t = tensors_elem;
+    for (const Tensor& t : tensors) {
       TORCH_CHECK(
           t.is_nested(), "Expected each tensor in given list to be nested.");
       TORCH_CHECK(

--- a/aten/src/ATen/templates/RegisterFunctionalization.cpp
+++ b/aten/src/ATen/templates/RegisterFunctionalization.cpp
@@ -80,7 +80,9 @@ inline std::vector<Tensor> to_meta(at::ITensorListRef t_list) {
 inline c10::List<Tensor> to_meta(const c10::List<Tensor>& t_list) {
   c10::List<Tensor> outputs;
   outputs.reserve(t_list.size());
-  for (const auto& t_list_elem : t_list) {
+  // Named explicitly: auto would deduce the iterator's proxy type, which
+  // converts to any of to_meta's overloads and makes the call ambiguous.
+  for (const Tensor& t_list_elem : t_list) {
     outputs.push_back(to_meta(t_list_elem));
   }
   return outputs;
@@ -89,7 +91,7 @@ inline c10::List<Tensor> to_meta(const c10::List<Tensor>& t_list) {
 inline c10::List<::std::optional<Tensor>> to_meta(const c10::List<::std::optional<Tensor>>& t_list) {
   c10::List<::std::optional<Tensor>> outputs;
   outputs.reserve(t_list.size());
-  for (const auto& t_list_elem : t_list) {
+  for (const ::std::optional<Tensor>& t_list_elem : t_list) {
     outputs.push_back(to_meta(t_list_elem));
   }
   return outputs;

--- a/aten/src/ATen/templates/RegisterFunctionalization.cpp
+++ b/aten/src/ATen/templates/RegisterFunctionalization.cpp
@@ -80,8 +80,8 @@ inline std::vector<Tensor> to_meta(at::ITensorListRef t_list) {
 inline c10::List<Tensor> to_meta(const c10::List<Tensor>& t_list) {
   c10::List<Tensor> outputs;
   outputs.reserve(t_list.size());
-  for (const auto i : c10::irange(t_list.size())) {
-    outputs.push_back(to_meta(t_list[i]));
+  for (const auto& t_list_elem : t_list) {
+    outputs.push_back(to_meta(t_list_elem));
   }
   return outputs;
 }
@@ -89,8 +89,8 @@ inline c10::List<Tensor> to_meta(const c10::List<Tensor>& t_list) {
 inline c10::List<::std::optional<Tensor>> to_meta(const c10::List<::std::optional<Tensor>>& t_list) {
   c10::List<::std::optional<Tensor>> outputs;
   outputs.reserve(t_list.size());
-  for (const auto i : c10::irange(t_list.size())) {
-    outputs.push_back(to_meta(t_list[i]));
+  for (const auto& t_list_elem : t_list) {
+    outputs.push_back(to_meta(t_list_elem));
   }
   return outputs;
 }

--- a/aten/src/ATen/templates/RegisterFunctionalization.cpp
+++ b/aten/src/ATen/templates/RegisterFunctionalization.cpp
@@ -80,8 +80,8 @@ inline std::vector<Tensor> to_meta(at::ITensorListRef t_list) {
 inline c10::List<Tensor> to_meta(const c10::List<Tensor>& t_list) {
   c10::List<Tensor> outputs;
   outputs.reserve(t_list.size());
-  // Named explicitly: auto would deduce the iterator's proxy type, which
-  // converts to any of to_meta's overloads and makes the call ambiguous.
+  // Named explicitly: the proxy converts to Tensor, tying to_meta(const
+  // Tensor&) against to_meta(ITensorListRef) (constructible from one Tensor).
   for (const Tensor& t_list_elem : t_list) {
     outputs.push_back(to_meta(t_list_elem));
   }

--- a/aten/src/ATen/test/cuda_stream_test.cpp
+++ b/aten/src/ATen/test/cuda_stream_test.cpp
@@ -213,8 +213,8 @@ TEST(TestStream, StreamPoolTest) {
 
   std::unordered_set<cudaStream_t> stream_set{};
   bool hasDuplicates = false;
-  for (const auto i: c10::irange(streams.size())) {
-    cudaStream_t cuda_stream = streams[i];
+  for (const auto& stream : streams) {
+    cudaStream_t cuda_stream = stream;
     auto result_pair = stream_set.insert(cuda_stream);
     if (!result_pair.second)
       hasDuplicates = true;

--- a/c10/util/ApproximateClock.cpp
+++ b/c10/util/ApproximateClock.cpp
@@ -32,8 +32,8 @@ ApproximateClockToUnixTimeConverter::measurePairs() {
   }
 
   time_pairs out;
-  for (const auto i : c10::irange(out.size())) {
-    out[i] = measurePair();
+  for (auto& out_elem : out) {
+    out_elem = measurePair();
   }
   return out;
 }

--- a/c10/xpu/test/impl/XPUStreamTest.cpp
+++ b/c10/xpu/test/impl/XPUStreamTest.cpp
@@ -155,8 +155,8 @@ TEST(XPUStreamTest, StreamPoolRoundRobinTest) {
 
   std::unordered_set<sycl::queue> queue_set{};
   bool hasDuplicates = false;
-  for (const auto i : c10::irange(streams.size())) {
-    auto& queue = streams[i].queue();
+  for (auto& stream : streams) {
+    auto& queue = stream.queue();
     auto result_pair = queue_set.insert(queue);
     if (!result_pair.second) { // already existed
       hasDuplicates = true;

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -302,8 +302,8 @@ void ConcretePyInterpreterVTable::dispatch(
   py::handle torch_api_function_overload = getTorchApiFunction(op);
 
   // Find overloaded tensors
-  for (const auto idx : c10::irange(arguments.size())) {
-    const auto& ivalue = arguments[idx];
+  for (auto& argument : arguments) {
+    const auto& ivalue = argument;
     if (ivalue.isTensor()) {
       const auto& tensor = ivalue.toTensor();
       if (isPythonTensor(tensor)) {

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -302,17 +302,14 @@ void ConcretePyInterpreterVTable::dispatch(
   py::handle torch_api_function_overload = getTorchApiFunction(op);
 
   // Find overloaded tensors
-  for (auto& argument : arguments) {
-    const auto& ivalue = argument;
+  for (const auto& ivalue : arguments) {
     if (ivalue.isTensor()) {
       const auto& tensor = ivalue.toTensor();
       if (isPythonTensor(tensor)) {
         append_overloaded_tensor(&overloaded_args, py::cast(tensor).ptr());
       }
     } else if (ivalue.isList()) {
-      const auto& list = ivalue.toListRef();
-      for (const auto jdx : c10::irange(list.size())) {
-        const auto& nv = list[jdx];
+      for (const auto& nv : ivalue.toListRef()) {
         if (nv.isTensor()) {
           const auto& tensor = nv.toTensor();
           if (isPythonTensor(tensor)) {

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -194,7 +194,7 @@ static void NCCL_CHECK_TIMEOUT(
   ncclResult_t result = to_nccl_result(status);
   auto startTimepoint = std::chrono::steady_clock::now();
   if (result == ncclInProgress) {
-    for (const auto i : c10::irange(comms.size())) {
+    for (const auto& comm : comms) {
       do {
         auto currentTimepoint = std::chrono::steady_clock::now();
         auto timeElapsed = std::chrono::duration_cast<std::chrono::seconds>(
@@ -204,7 +204,7 @@ static void NCCL_CHECK_TIMEOUT(
             timeElapsed <= nccl_nonblocking_timeout(),
             "NCCL timeout when waiting for nonblocking call to become successful.");
         sched_yield(); // yield to other threads
-        ncclCommGetAsyncError(to_nccl_comm(comms[i]), &result);
+        ncclCommGetAsyncError(to_nccl_comm(comm), &result);
       } while (result == ncclInProgress);
       if (result != ncclSuccess) {
         break; /* fall through to failed case */

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -4,6 +4,7 @@
 
 #ifdef USE_C10D_GLOO
 
+#include <ATen/core/functional.h>
 #include <torch/csrc/distributed/c10d/FlightRecorder.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
@@ -1586,14 +1587,14 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter_single_coalesced(
     }
     buffers.push_back(inputTensors[i].clone());
   }
-  std::vector<c10::intrusive_ptr<Work>> works;
-  for (const auto& buffer : buffers) {
-    std::vector<at::Tensor> inp = {buffer};
-    AllreduceOptions arOpts;
-    arOpts.reduceOp = opts.reduceOp;
-    arOpts.timeout = opts.timeout;
-    works.push_back(allreduce(inp, arOpts));
-  }
+  AllreduceOptions arOpts;
+  arOpts.reduceOp = opts.reduceOp;
+  arOpts.timeout = opts.timeout;
+  std::vector<c10::intrusive_ptr<Work>> works =
+      c10::fmap(buffers, [this, &arOpts](const at::Tensor& buffer) {
+        std::vector<at::Tensor> inp = {buffer};
+        return allreduce(inp, arOpts);
+      });
   return c10::make_intrusive<LambdaWork>(
       [rank, worldSize, buffers, outputTensors, works = std::move(works)]() {
         for (const auto i : c10::irange(outputTensors.size())) {
@@ -2269,14 +2270,14 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter(
       buffers.push_back(inputs[0][i].clone());
     }
   }
-  std::vector<c10::intrusive_ptr<Work>> works;
-  for (const auto& buffer : buffers) {
-    std::vector<at::Tensor> inp = {buffer};
-    AllreduceOptions arOpts;
-    arOpts.reduceOp = opts.reduceOp;
-    arOpts.timeout = opts.timeout;
-    works.push_back(allreduce(inp, arOpts));
-  }
+  AllreduceOptions arOpts;
+  arOpts.reduceOp = opts.reduceOp;
+  arOpts.timeout = opts.timeout;
+  std::vector<c10::intrusive_ptr<Work>> works =
+      c10::fmap(buffers, [this, &arOpts](const at::Tensor& buffer) {
+        std::vector<at::Tensor> inp = {buffer};
+        return allreduce(inp, arOpts);
+      });
   return c10::make_intrusive<LambdaWork>(
       [worldSize, works = std::move(works)]() {
         for (const auto i : c10::irange(worldSize)) {

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -1587,8 +1587,8 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter_single_coalesced(
     buffers.push_back(inputTensors[i].clone());
   }
   std::vector<c10::intrusive_ptr<Work>> works;
-  for (const auto i : c10::irange(buffers.size())) {
-    std::vector<at::Tensor> inp = {buffers[i]};
+  for (const auto& buffer : buffers) {
+    std::vector<at::Tensor> inp = {buffer};
     AllreduceOptions arOpts;
     arOpts.reduceOp = opts.reduceOp;
     arOpts.timeout = opts.timeout;
@@ -2270,8 +2270,8 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::reduce_scatter(
     }
   }
   std::vector<c10::intrusive_ptr<Work>> works;
-  for (const auto i : c10::irange(buffers.size())) {
-    std::vector<at::Tensor> inp = {buffers[i]};
+  for (const auto& buffer : buffers) {
+    std::vector<at::Tensor> inp = {buffer};
     AllreduceOptions arOpts;
     arOpts.reduceOp = opts.reduceOp;
     arOpts.timeout = opts.timeout;

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -190,10 +190,10 @@ inline bool getCvarBool(const std::vector<std::string>& env, bool def) {
 inline void assertSameSizes(
     const at::IntArrayRef& sizes,
     const std::vector<at::Tensor>& tensors) {
-  for (const auto i : c10::irange(tensors.size())) {
-    if (!tensors[i].sizes().equals(sizes)) {
+  for (const auto& tensor : tensors) {
+    if (!tensor.sizes().equals(sizes)) {
       const auto expected = toString(sizes);
-      const auto actual = toString(tensors[i].sizes());
+      const auto actual = toString(tensor.sizes());
       throw std::invalid_argument(
           // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
           "mixed sizes (" + expected + " and " + actual + ")");
@@ -414,8 +414,8 @@ inline void assertAllgatherCoalescedOutputTensorLists(
   if (outputTensorLists.size() != static_cast<size_t>(worldSize)) {
     fn("output lists should be equal to world size");
   }
-  for (const auto i : c10::irange(outputTensorLists.size())) {
-    const auto actual = outputTensorLists[i].size();
+  for (const auto& outputTensorList : outputTensorLists) {
+    const auto actual = outputTensorList.size();
     if (actual != inputTensorListSize) {
       fn("invalid output size: (expected length " +
          std::to_string(inputTensorListSize) + ", got " +

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -68,10 +68,10 @@ inline std::string toString(const c10::Layout& layout) {
 inline void assertSameType(
     const at::DeprecatedTypeProperties& type,
     const std::vector<at::Tensor>& tensors) {
-  for (const auto i : c10::irange(tensors.size())) {
-    if (!tensors[i].options().type_equal(type.options())) {
+  for (const auto& tensor : tensors) {
+    if (!tensor.options().type_equal(type.options())) {
       const std::string expected = type.toString();
-      const std::string actual = tensors[i].toString();
+      const std::string actual = tensor.toString();
       throw std::invalid_argument(
           // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
           "mixed types (" + expected + " and " + actual + ")");

--- a/torch/csrc/distributed/c10d/gloo/ProcessGroupGlooDetail.hpp
+++ b/torch/csrc/distributed/c10d/gloo/ProcessGroupGlooDetail.hpp
@@ -535,8 +535,8 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
 
     // This copy is needed when we run a multi-gpu version of reduce (multiple
     // inputs per rank).
-    for (const auto i : c10::irange(inputs.size())) {
-      inputs[i].copy_(output);
+    for (const auto& input : inputs) {
+      input.copy_(output);
     }
   }
 

--- a/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <string_view>
 
+#include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
 #include <ATen/record_function.h>
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
@@ -69,14 +70,9 @@ void TracingGuard::initializeTracingCommon(
     uint64_t sequence_number,
     const std::vector<at::Tensor>& input_tensor_list,
     const std::vector<at::Tensor>& output_tensor_list) {
-  std::vector<int64_t> in_split_sizes;
-  for (const auto& input_tensor_list_elem : input_tensor_list) {
-    in_split_sizes.push_back(input_tensor_list_elem.numel());
-  }
-  std::vector<int64_t> out_split_sizes;
-  for (const auto& output_tensor_list_elem : output_tensor_list) {
-    out_split_sizes.push_back(output_tensor_list_elem.numel());
-  }
+  auto numel = [](const at::Tensor& t) { return t.numel(); };
+  std::vector<int64_t> in_split_sizes = c10::fmap(input_tensor_list, numel);
+  std::vector<int64_t> out_split_sizes = c10::fmap(output_tensor_list, numel);
 
   auto debug_info = getDebugInfo(
       comm_name,

--- a/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
@@ -30,12 +30,12 @@ std::shared_ptr<torch::ParamCommsDebugInfo> TracingGuard::getDebugInfo(
     const std::vector<int64_t>& input_split_sizes,
     const std::vector<int64_t>& output_split_sizes) {
   int64_t input_total_numel = 0;
-  for (const auto r : c10::irange(input_tensor_list.size())) {
-    input_total_numel += input_tensor_list[r].numel();
+  for (const auto& input_tensor_list_elem : input_tensor_list) {
+    input_total_numel += input_tensor_list_elem.numel();
   }
   int64_t output_total_numel = 0;
-  for (const auto r : c10::irange(output_tensor_list.size())) {
-    output_total_numel += output_tensor_list[r].numel();
+  for (const auto& output_tensor_list_elem : output_tensor_list) {
+    output_total_numel += output_tensor_list_elem.numel();
   }
 
   // If both input and output tensor lists are empty, use a default data type.
@@ -70,12 +70,12 @@ void TracingGuard::initializeTracingCommon(
     const std::vector<at::Tensor>& input_tensor_list,
     const std::vector<at::Tensor>& output_tensor_list) {
   std::vector<int64_t> in_split_sizes;
-  for (const auto r : c10::irange(input_tensor_list.size())) {
-    in_split_sizes.push_back(input_tensor_list[r].numel());
+  for (const auto& input_tensor_list_elem : input_tensor_list) {
+    in_split_sizes.push_back(input_tensor_list_elem.numel());
   }
   std::vector<int64_t> out_split_sizes;
-  for (const auto r : c10::irange(output_tensor_list.size())) {
-    out_split_sizes.push_back(output_tensor_list[r].numel());
+  for (const auto& output_tensor_list_elem : output_tensor_list) {
+    out_split_sizes.push_back(output_tensor_list_elem.numel());
   }
 
   auto debug_info = getDebugInfo(

--- a/torch/nativert/python/Bindings.cpp
+++ b/torch/nativert/python/Bindings.cpp
@@ -29,9 +29,9 @@ void initModelRunnerPybind(py::module& m) {
              const py::kwargs& pykwargs) {
             std::vector<c10::IValue> args;
             args.reserve(pyargs.size());
-            for (const auto i : c10::irange(pyargs.size())) {
+            for (const auto& pyarg : pyargs) {
               auto ivalue =
-                  torch::jit::toIValue(pyargs[i], c10::AnyType::get());
+                  torch::jit::toIValue(pyarg, c10::AnyType::get());
               args.push_back(std::move(ivalue));
             }
             std::unordered_map<std::string, c10::IValue> kwargs;
@@ -50,9 +50,9 @@ void initModelRunnerPybind(py::module& m) {
              const py::kwargs& pykwargs) {
             std::vector<c10::IValue> args;
             args.reserve(pyargs.size());
-            for (const auto i : c10::irange(pyargs.size())) {
+            for (const auto& pyarg : pyargs) {
               auto ivalue =
-                  torch::jit::toIValue(pyargs[i], c10::AnyType::get());
+                  torch::jit::toIValue(pyarg, c10::AnyType::get());
               args.push_back(std::move(ivalue));
             }
             std::unordered_map<std::string, c10::IValue> kwargs;
@@ -69,9 +69,9 @@ void initModelRunnerPybind(py::module& m) {
           [](torch::nativert::ModelRunner& self, py::args pyargs) {
             std::vector<c10::IValue> args;
             args.reserve(pyargs.size());
-            for (const auto i : c10::irange(pyargs.size())) {
+            for (const auto& pyarg : pyargs) {
               auto ivalue =
-                  torch::jit::toIValue(pyargs[i], c10::AnyType::get());
+                  torch::jit::toIValue(pyarg, c10::AnyType::get());
               args.push_back(std::move(ivalue));
             }
 

--- a/torch/nativert/python/Bindings.cpp
+++ b/torch/nativert/python/Bindings.cpp
@@ -30,8 +30,7 @@ void initModelRunnerPybind(py::module& m) {
             std::vector<c10::IValue> args;
             args.reserve(pyargs.size());
             for (const auto& pyarg : pyargs) {
-              auto ivalue =
-                  torch::jit::toIValue(pyarg, c10::AnyType::get());
+              auto ivalue = torch::jit::toIValue(pyarg, c10::AnyType::get());
               args.push_back(std::move(ivalue));
             }
             std::unordered_map<std::string, c10::IValue> kwargs;
@@ -51,8 +50,7 @@ void initModelRunnerPybind(py::module& m) {
             std::vector<c10::IValue> args;
             args.reserve(pyargs.size());
             for (const auto& pyarg : pyargs) {
-              auto ivalue =
-                  torch::jit::toIValue(pyarg, c10::AnyType::get());
+              auto ivalue = torch::jit::toIValue(pyarg, c10::AnyType::get());
               args.push_back(std::move(ivalue));
             }
             std::unordered_map<std::string, c10::IValue> kwargs;
@@ -70,8 +68,7 @@ void initModelRunnerPybind(py::module& m) {
             std::vector<c10::IValue> args;
             args.reserve(pyargs.size());
             for (const auto& pyarg : pyargs) {
-              auto ivalue =
-                  torch::jit::toIValue(pyarg, c10::AnyType::get());
+              auto ivalue = torch::jit::toIValue(pyarg, c10::AnyType::get());
               args.push_back(std::move(ivalue));
             }
 


### PR DESCRIPTION
Forty-six loops counted with c10::irange over a container's size and used the counter for nothing but subscripting that same container. A range-based for says it directly, and the unchecked operator[] goes with it.

The reference qualifier follows what each body does: `const auto&` where the element is only read, `auto&` where it is assigned, moved from, or already bound to a non-const reference. WrapDimUtilsMulti.h loses its irange include, which had no other user left.

Three of the matches are over a c10::List, whose iterator hands out a proxy rather than a reference, and they did not convert alike. The read-only one in FunctionalTensorWrapper names the element type, which makes the proxy convert; the two that write an element back -- ZeroTensorFallback and MathBitsFallback -- keep their index, because the proxy's assignment operators are const&&-qualified and its lvalue assignment is deleted, so writing through it needs the `*it = x` form a range-for does not give you. That qualification is deliberate: it is what makes the iterator satisfy std::indirectly_writable while refusing "assign to the proxy, not the element" (see #196002).

Test Plan:

Every changed file and a translation unit including each changed header -- twenty-eight compilations, from their own commands in compile_commands.json, run ten at a time. All clean.

This PR was authored with the assistance of an AI coding assistant.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01