### PR TITLE
Fix histc(out=) dtype validation mismatch between CPU and CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -421,6 +421,8 @@ Tensor _histc_cuda(
 }
 
 Tensor& _histc_out_cuda(const Tensor& self, int64_t bins, const Scalar& min, const Scalar& max, Tensor& result) {
+  TORCH_CHECK(self.dtype() == result.dtype(), "torch.histogram: input tensor and hist tensor should",
+      " have the same dtype, but got input ", self.dtype(), " and hist ", result.dtype());
   auto ret = _histc_cuda(self, bins, min, max);
   resize_output(result, ret.sizes());
   result.copy_(ret);

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -421,6 +421,7 @@ Tensor _histc_cuda(
 }
 
 Tensor& _histc_out_cuda(const Tensor& self, int64_t bins, const Scalar& min, const Scalar& max, Tensor& result) {
+  // Keep message in sync with histogramdd_prepare_out (Histogram.cpp:132).
   TORCH_CHECK(self.dtype() == result.dtype(), "torch.histogram: input tensor and hist tensor should",
       " have the same dtype, but got input ", self.dtype(), " and hist ", result.dtype());
   auto ret = _histc_cuda(self, bins, min, max);

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -143,7 +143,6 @@ meta_consistency_out_dtype_mismatch_xfails = {
     xfail("diag"),
     xfail("geqrf"),
     xfail("heaviside"),
-    xfail("histc"),
     xfail("isin"),
     xfail("kthvalue"),
     xfail("lerp"),

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -3348,6 +3348,17 @@ class TestReductions(TestCase):
         linear = torch.linspace(0, 0.99 - 5.0e-7, 101).to(device)
         test_against_np(linear, bins=20, min=0, max=0.99)
 
+    @skipIfMPS
+    def test_histc_out_dtype(self, device):
+        x = torch.randn(8, dtype=torch.float64, device=device)
+        out = torch.empty(4, dtype=torch.int64, device=device)
+        msg = "torch.histogram: input tensor and hist tensor should have the same dtype"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.histc(x, bins=4, min=-2.0, max=2.0, out=out)
+        out = torch.empty(4, dtype=torch.float64, device=device)
+        h = torch.histc(x, bins=4, min=-2.0, max=2.0, out=out)
+        self.assertEqual(h.dtype, torch.float64)
+
     @dtypes(torch.uint8, torch.int8, torch.int, torch.long, torch.float, torch.double)
     @skipIfMPS
     def test_histc_min_max_errors(self, device, dtype):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -26,7 +26,7 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     IS_WINDOWS)
 from torch.testing._internal.common_device_type import (
-    OpDTypes, onlyCPU, onlyNativeDeviceTypes, expectedFailureMeta, instantiate_device_type_tests, dtypes, dtypesIfCUDA,
+    OpDTypes, onlyCPU, onlyNativeDeviceTypes, expectedFailureMeta, expectedFailureXPU, instantiate_device_type_tests, dtypes, dtypesIfCUDA,
     dtypesIfCPU, dtypesIfMPS, dtypesIfXPU, onlyAccelerator, largeMPSBufferTest, largeTensorTest, ops,
     precisionOverride)
 from torch.testing._internal.common_methods_invocations import (
@@ -3348,16 +3348,27 @@ class TestReductions(TestCase):
         linear = torch.linspace(0, 0.99 - 5.0e-7, 101).to(device)
         test_against_np(linear, bins=20, min=0, max=0.99)
 
-    @skipIfMPS
-    def test_histc_out_dtype(self, device):
-        x = torch.randn(8, dtype=torch.float64, device=device)
-        out = torch.empty(4, dtype=torch.int64, device=device)
+    @dtypes(torch.float32, torch.float64)
+    @expectedFailureXPU  # XPU _histc_out_xpu (out-of-tree) does not enforce dtype check yet
+    def test_histc_out_dtype(self, device, dtype):
+        x = torch.randn(8, dtype=dtype, device=device)
+        # Mismatched out dtype should raise
+        out_wrong = torch.empty(4, dtype=torch.int64, device=device)
         msg = "torch.histogram: input tensor and hist tensor should have the same dtype"
         with self.assertRaisesRegex(RuntimeError, msg):
-            torch.histc(x, bins=4, min=-2.0, max=2.0, out=out)
-        out = torch.empty(4, dtype=torch.float64, device=device)
-        h = torch.histc(x, bins=4, min=-2.0, max=2.0, out=out)
-        self.assertEqual(h.dtype, torch.float64)
+            torch.histc(x, bins=4, min=-2.0, max=2.0, out=out_wrong)
+        # Safe widening (float32 in, float64 out) should also raise — histc
+        # enforces exact dtype equality, matching CPU/MPS behaviour.
+        if dtype == torch.float32:
+            out_wide = torch.empty(4, dtype=torch.float64, device=device)
+            with self.assertRaisesRegex(RuntimeError, msg):
+                torch.histc(x, bins=4, min=-2.0, max=2.0, out=out_wide)
+        # Matching dtype should succeed and write in-place
+        out_ok = torch.empty(4, dtype=dtype, device=device)
+        h = torch.histc(x, bins=4, min=-2.0, max=2.0, out=out_ok)
+        self.assertIs(h.data_ptr(), out_ok.data_ptr())
+        expected = torch.histc(x, bins=4, min=-2.0, max=2.0)
+        self.assertEqual(out_ok, expected)
 
     @dtypes(torch.uint8, torch.int8, torch.int, torch.long, torch.float, torch.double)
     @skipIfMPS

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -3366,7 +3366,7 @@ class TestReductions(TestCase):
         # Matching dtype should succeed and write in-place
         out_ok = torch.empty(4, dtype=dtype, device=device)
         h = torch.histc(x, bins=4, min=-2.0, max=2.0, out=out_ok)
-        self.assertIs(h.data_ptr(), out_ok.data_ptr())
+        self.assertEqual(h.data_ptr(), out_ok.data_ptr())
         expected = torch.histc(x, bins=4, min=-2.0, max=2.0)
         self.assertEqual(out_ok, expected)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8171,7 +8171,7 @@ def meta_bucketize_scalar(
 
 
 @register_meta([aten.histc])
-@out_wrapper()
+@out_wrapper(exact_dtype=True)
 def meta_histc(input, bins=100, min=0, max=0):
     fn_name = "histc()"
     if device_hint(input) == "cpu":

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20608,12 +20608,7 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
            sample_inputs_func=sample_inputs_histc,
            supports_out=True,
            supports_autograd=False,
-           skips=(
-               # CUDA histc returns a float tensor but does not correctly warn when passed an integral out tensor
-               # "AssertionError: RuntimeError not raised : Expected RuntimeError when doing an unsafe cast
-               # from a result of dtype torch.float32 into an out= with dtype torch.long"
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type=('cuda', 'xpu')),
-           )),
+    ),
     OpInfo('bincount',
            dtypes=integral_types_and(),
            sample_inputs_func=sample_inputs_bincount,


### PR DESCRIPTION
Fixes #196008

### Summary

`torch.histc(..., out=)` applied different dtype checks on CPU vs CUDA (and XPU):

- **CPU / MPS** dispatch `histc.out` to `histogram_histc_out`, which routes through
  `histogramdd_prepare_out` and its strict check
  (`aten/src/ATen/native/Histogram.cpp:132`): the output must match the input dtype
  or it raises:
  ```
  RuntimeError: torch.histogram: input tensor and hist tensor should have the same
  dtype, but got input double and hist long int
  ```
- **CUDA** dispatches to `_histc_out_cuda` (`aten/src/ATen/native/cuda/SummaryOps.cu`),
  which computes into a fresh tensor of the input dtype and then `result.copy_(ret)`.
  `copy_` silently casts, so any `out` dtype was accepted and the float64 histogram was
  truncated into the int64 tensor without any validation.

This adds the missing `TORCH_CHECK` to `_histc_out_cuda` with the same message text as
the CPU path, so both backends raise identically on a mismatched `out` dtype.

### Test

Adds `test_histc_out_dtype` to `test/test_reductions.py`, which verifies that a
mismatched `out` dtype raises on every device (CPU and CUDA) and that a matching dtype
still succeeds.

### Note

The XPU entry in `native_functions.yaml` points at `_histc_out_xpu`, a same-shaped
wrapper that lives out of tree in the xpu fork; it likely shares this gap and should get
the same fix there.

cc @he-yufeng for the mechanism analysis.