### PR TITLE
Update handler clearance logic

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -221,8 +221,13 @@ class LoggingTest(TestCase):
                     for log_qname in log_internal.log_registry.get_log_qnames():
                         logger = logging.getLogger(log_qname)
                         created_handlers.update(logger.handlers)
+                        torch_handlers = [
+                            handler
+                            for handler in logger.handlers
+                            if log_internal._is_torch_handler(handler)
+                        ]
                         self.assertEqual(
-                            len(logger.handlers),
+                            len(torch_handlers),
                             2,
                             f"{log_qname} should only have stream and file handlers",
                         )


### PR DESCRIPTION
The tests, when run in shards, use pytest.
So, `pytest test_logging.py` is used instead of `python test_logging.py`.

The initial code, which was:

```python
for log_qname in log_internal.log_registry.get_log_qnames():
logger = logging.getLogger(log_qname)
created_handlers.update(logger.handlers)
self.assertEqual(
len(logger.handlers),
2,
f"{log_qname} should only have stream and file handlers",
)
```

checks all active handlers. When running the test normally with Python, the active handlers are only the PyTorch handlers. However, when running with pytest, four additional handlers are added by pytest.

This resulted in the following failure:

```python
AssertionError: Scalars are not equal!Expected 2 but got 6.
Absolute difference: 4
Relative difference: 2.0
torch._export.converter should only have stream and file handlers
```

The handlers observed were: [
[<_LiveLoggingNullHandler (NOTSET)>,
<_FileHandler \\.\nul (NOTSET)>,
<LogCaptureHandler (NOTSET)>,
<LogCaptureHandler (NOTSET)>,
<_StderrHandler (DEBUG)>,
<FileHandler C:\Users\SHASHA~1\AppData\Local\Temp\tmpr85qa9dq\torch.log (DEBUG)>]

The `NOTSET` which are pytest-specific handlers are only present when `test_logging.py` is run with pytest. Therefore, the change made was to check that the number of handlers managed by PyTorch is two, instead of asserting that the logger has exactly two handlers in total.

Reviewers: @bobrenjc93 @xuhancn @ezyang

Failure Log :  test_logging_1.1_826110bf06cc9643_.log from https://github.com/NVIDIA/pytorch-windows-ci/actions/runs/33946661418/artifacts/9974562356

Tracked by #195996 NVIDIA Windows nightly failures and upstream fixes


Old PR #195974 closed due to lint failures, fixed here