### PR TITLE
[MPS] Guard MPP attention include on header availability

### DIFF
--- a/aten/src/ATen/native/mps/kernels/MppAttention.h
+++ b/aten/src/ATen/native/mps/kernels/MppAttention.h
@@ -5,7 +5,8 @@
 
 #include <ATen/native/mps/kernels/PrefillAttention.h>
 
-#if __METAL_VERSION__ >= 400
+#if __METAL_VERSION__ >= 400 && \
+    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
 
 #include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
 
@@ -1057,4 +1058,4 @@ prefill_attention_mpp(
 instantiate_mpp_attn_mask(float16, half);
 instantiate_mpp_attn_mask(bfloat16, bfloat);
 
-#endif // __METAL_VERSION__ >= 400
+#endif // __METAL_VERSION__ >= 400 && __has_include(MetalPerformancePrimitives)


### PR DESCRIPTION
`MppAttention.h` gates its `<MetalPerformancePrimitives/...>` include on `__METAL_VERSION__ >= 400`, which tests the compiler version, not whether the SDK ships the framework. Building with a Metal 4 toolchain against an older SDK (e.g. Xcode 26 with `-isysroot .../MacOSX15.sdk`, as Homebrew does) fails:

```
MppAttention.h:10:10: fatal error: 'MetalPerformancePrimitives/MetalPerformancePrimitives.h' file not found
```

`Convolution.metal` in the same directory already pairs the version check with `__has_include`; this does the same. The whole header body is inside the guard and its only consumer just includes it, so nothing else changes.
