### PR TITLE
[Feature Refactoring] Replace hardcoded device type gate with torch.accelerator API in RNG tracker

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -797,7 +797,8 @@ class _LocalOffsetBasedRNGTracker:
                 any_rank_state = lm._any_local_rng_state()
                 any_rank_cpu, any_rank_cuda = any_rank_state
 
-                if self._device.type in {"cuda", "xpu"}:
+                current_acc = torch.accelerator.current_accelerator()
+                if current_acc is not None and current_acc.type == self._device.type:
                     if self._device.index not in any_rank_cuda:
                         raise AssertionError
                     any_rank_device_state = any_rank_cuda[self._device.index]


### PR DESCRIPTION
## Summary
This PR replaces a hardcoded `{"cuda", "xpu"}` device type check in `_LocalOffsetBasedRNGTracker._distribute_region` with a `torch.accelerator.current_accelerator()` query, allowing any registered accelerator backend to correctly use its collected RNG state.

## Changes
- **`torch/distributed/_local_tensor/__init__.py`** (L800): Replaced hardcoded device type gate with `torch.accelerator` API query.
  - **Before:** `if self._device.type in {"cuda", "xpu"}:` — only CUDA and XPU could use their accelerator RNG state.
  - **After:** `current_acc = torch.accelerator.current_accelerator()` + `if current_acc is not None and current_acc.type == self._device.type:` — any registered accelerator backend that `torch.accelerator` recognizes will use its own RNG state.
  - The variable `any_rank_cuda` is populated by `_collect_accelerator_rng_states()` (L231–247), which already uses `torch.accelerator.is_available()` and `torch.accelerator.current_device_index()` to collect states from all accelerators — not just CUDA/XPU. The hardcoded gate at L800 was inconsistent with this collection logic.

## Motivation
`_collect_accelerator_rng_states()` (L231) already uses the `torch.accelerator` API to collect RNG states from any registered accelerator. However, the hardcoded `{"cuda", "xpu"}` gate at L800 was inconsistent: it prevented non-CUDA/XPU accelerators from using their collected states, forcing them to fall back to CPU RNG state. This is a latent bug — the accelerator's RNG state is collected into `any_rank_cuda` but never used because the gate sends the execution to the `else` branch (CPU state).

For CPU tensors, behavior is unchanged: `torch.accelerator.current_accelerator()` returns `None` on CPU-only environments, so the condition evaluates to `False`, and the `else` branch (CPU state) is taken — identical to the previous behavior where `"cpu" not in {"cuda", "xpu"}`.

## Test Plan
- Verified on CPU (no accelerator available):
  `python /workspace/pytorch/test/distributed/test_local_tensor.py`
  ```
  Ran 43 tests in 2.001s
  OK
  ```
- Verified on CPU (distributed RNG tests):
  `python /workspace/pytorch/test/distributed/tensor/test_random_ops.py`
  ```
  Ran 41 tests in 173.257s
  OK (skipped=35)
  ```
- Verified on an accelerator backend:
  `python /workspace/pytorch/test/distributed/tensor/test_random_ops.py`
  ```
  Ran 41 tests in 372.538s
  FAILED (errors=3, skipped=35)
  ```
  The 3 errors are in `DistTensorRandomInitTest` (`test_init_ops`, `test_multinomial_sharded`) — pre-existing failures caused by `RuntimeError: No backend type associated with device type` in `__torch_dispatch__` (L1380), unrelated to this change. The `test_run_dtensor_rng_op_rejects_non_accelerator` test passes on both CPU and accelerator.

## Notes
- No new API or capability bit is introduced — `torch.accelerator.current_accelerator()` is an existing stable API.