### PR TITLE
Fix const-correctness and pass-by-value issues in serialization headers

### DIFF
--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -94,200 +94,200 @@ typedef struct mz_zip_archive mz_zip_archive;
 namespace caffe2::serialize {
 
 static constexpr const char* kSerializationIdRecordName =
-    ".data/serialization_id";
+   ".data/serialization_id";
 
 struct MzZipReaderIterWrapper;
 
 class TORCH_API ChunkRecordIterator {
- public:
-  ~ChunkRecordIterator();
+public:
+ ~ChunkRecordIterator();
 
-  // Read at most `chunkSize` into `buf`. Return the number of actual bytes
-  // read.
-  size_t next(void* buf);
-  size_t recordSize() const {
-    return recordSize_;
-  }
+ // Read at most `chunkSize` into `buf`. Return the number of actual bytes
+ // read.
+ size_t next(void* buf);
+ size_t recordSize() const {
+   return recordSize_;
+ }
 
- private:
-  ChunkRecordIterator(
-      size_t recordSize,
-      size_t chunkSize,
-      std::unique_ptr<MzZipReaderIterWrapper> iter);
+private:
+ ChunkRecordIterator(
+     size_t recordSize,
+     size_t chunkSize,
+     std::unique_ptr<MzZipReaderIterWrapper> iter);
 
-  const size_t recordSize_;
-  const size_t chunkSize_;
-  size_t offset_;
-  std::unique_ptr<MzZipReaderIterWrapper> iter_;
+ const size_t recordSize_;
+ const size_t chunkSize_;
+ size_t offset_;
+ std::unique_ptr<MzZipReaderIterWrapper> iter_;
 
-  friend class PyTorchStreamReader;
+ friend class PyTorchStreamReader;
 };
 
 class TORCH_API PyTorchStreamReader final {
- public:
-  explicit PyTorchStreamReader(const std::string& file_name);
-  explicit PyTorchStreamReader(std::istream* in);
-  explicit PyTorchStreamReader(std::shared_ptr<ReadAdapterInterface> in);
+public:
+ explicit PyTorchStreamReader(const std::string& file_name);
+ explicit PyTorchStreamReader(std::istream* in);
+ explicit PyTorchStreamReader(std::shared_ptr<ReadAdapterInterface> in);
 
-  // return dataptr, size
-  // set allocator to override default cpu allocator
-  std::tuple<at::DataPtr, size_t> getRecord(
-      const std::string& name,
-      std::optional<at::Allocator*> allocator = std::nullopt);
-  // multi-thread getRecord
-  std::tuple<at::DataPtr, size_t> getRecord(
-      const std::string& name,
-      std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
-      std::optional<at::Allocator*> allocator = std::nullopt);
-  // inplace memory writing
-  size_t getRecord(const std::string& name, void* dst, size_t n);
-  // inplace memory writing, multi-threads.
-  // When additionalReaders is empty, the default behavior is call
-  // getRecord(name, dst, n) with default reader This approach can be used for
-  // reading large tensors.
-  size_t getRecord(
-      const std::string& name,
-      void* dst,
-      size_t n,
-      std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders);
-  size_t getRecord(
-      const std::string& name,
-      void* dst,
-      size_t n,
-      size_t chunk_size,
-      void* buf,
-      const std::function<void(void*, const void*, size_t)>& memcpy_func =
-          nullptr);
+ // return dataptr, size
+ // set allocator to override default cpu allocator
+ std::tuple<at::DataPtr, size_t> getRecord(
+     const std::string& name,
+     std::optional<at::Allocator*> allocator = std::nullopt);
+ // multi-thread getRecord
+ std::tuple<at::DataPtr, size_t> getRecord(
+     const std::string& name,
+     std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
+     std::optional<at::Allocator*> allocator = std::nullopt);
+ // inplace memory writing
+ size_t getRecord(const std::string& name, void* dst, size_t n);
+ // inplace memory writing, multi-threads.
+ // When additionalReaders is empty, the default behavior is call
+ // getRecord(name, dst, n) with default reader This approach can be used for
+ // reading large tensors.
+ size_t getRecord(
+     const std::string& name,
+     void* dst,
+     size_t n,
+     std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders);
+ size_t getRecord(
+     const std::string& name,
+     void* dst,
+     size_t n,
+     size_t chunk_size,
+     void* buf,
+     const std::function<void(void*, const void*, size_t)>& memcpy_func =
+         nullptr);
 
-  // Concurrent reading records with multiple readers.
-  // additionalReaders are additional clients to access the underlying record at
-  // different offsets and write to different trunks of buffers. If the overall
-  // size of the tensor is 10, and size of additionalReader is 2. The default
-  // thread will read [0,4), the additional reader will read [4,8). The default
-  // reader will read [8,10). The default reader will write to buffer[0,4), the
-  // additional reader will write to buffer[4,8), the additional reader will
-  // write to buffer[8,10). When additionalReaders is empty, the default
-  // behavior is call getRecord(name) with default reader This approach can be
-  // used for reading large tensors.
-  size_t getRecordMultiReaders(
-      const std::string& name,
-      std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
-      void* dst,
-      size_t n);
+ // Concurrent reading records with multiple readers.
+ // additionalReaders are additional clients to access the underlying record at
+ // different offsets and write to different trunks of buffers. If the overall
+ // size of the tensor is 10, and size of additionalReader is 2. The default
+ // thread will read [0,4), the additional reader will read [4,8). The default
+ // reader will read [8,10). The default reader will write to buffer[0,4), the
+ // additional reader will write to buffer[4,8), the additional reader will
+ // write to buffer[8,10). When additionalReaders is empty, the default
+ // behavior is call getRecord(name) with default reader This approach can be
+ // used for reading large tensors.
+ size_t getRecordMultiReaders(
+     const std::string& name,
+     std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
+     void* dst,
+     size_t n);
 
-  size_t getRecordSize(const std::string& name);
-  size_t getRecordHeaderOffset(const std::string& name);
-  size_t getRecordOffset(const std::string& name);
-  size_t getRecordOffsetNoRead(
-      size_t cursor,
-      std::string filename,
-      size_t size,
-      uint64_t alignment);
-  bool hasRecord(const std::string& name);
-  std::vector<std::string> getAllRecords();
+ size_t getRecordSize(const std::string& name);
+ size_t getRecordHeaderOffset(const std::string& name);
+ size_t getRecordOffset(const std::string& name);
+ size_t getRecordOffsetNoRead(
+     size_t cursor,
+     const std::string& filename,
+     size_t size,
+     uint64_t alignment);
+ bool hasRecord(const std::string& name);
+ std::vector<std::string> getAllRecords();
 
-  ChunkRecordIterator createChunkReaderIter(
-      const std::string& name,
-      const size_t recordSize,
-      const size_t chunkSize);
+ ChunkRecordIterator createChunkReaderIter(
+     const std::string& name,
+     const size_t recordSize,
+     const size_t chunkSize);
 
-  ~PyTorchStreamReader();
-  uint64_t version() const {
-    return version_;
-  }
-  const std::string& serializationId() {
-    return serialization_id_;
-  }
+ ~PyTorchStreamReader();
+ uint64_t version() const {
+   return version_;
+ }
+ const std::string& serializationId() const {
+   return serialization_id_;
+ }
 
-  void setShouldLoadDebugSymbol(bool should_load_debug_symbol) {
-    load_debug_symbol_ = should_load_debug_symbol;
-  }
-  void setAdditionalReaderSizeThreshold(const size_t& size) {
-    additional_reader_size_threshold_ = size;
-  }
+ void setShouldLoadDebugSymbol(bool should_load_debug_symbol) {
+   load_debug_symbol_ = should_load_debug_symbol;
+ }
+ void setAdditionalReaderSizeThreshold(size_t size) {
+   additional_reader_size_threshold_ = size;
+ }
 
- private:
-  void init();
-  size_t read(uint64_t pos, char* buf, size_t n);
-  void valid(const char* what, const char* info = "");
-  size_t getRecordID(const std::string& name);
+private:
+ void init();
+ size_t read(uint64_t pos, char* buf, size_t n);
+ void valid(const char* what, const char* info = "");
+ size_t getRecordID(const std::string& name);
 
-  friend size_t
-  istream_read_func(void* pOpaque, uint64_t file_ofs, void* pBuf, size_t n);
-  std::unique_ptr<mz_zip_archive> ar_;
-  std::string archive_name_;
-  std::string archive_name_plus_slash_;
-  std::shared_ptr<ReadAdapterInterface> in_;
-  int64_t version_;
-  std::mutex reader_lock_;
-  bool load_debug_symbol_ = true;
-  std::string serialization_id_;
-  size_t additional_reader_size_threshold_;
+ friend size_t
+ istream_read_func(void* pOpaque, uint64_t file_ofs, void* pBuf, size_t n);
+ std::unique_ptr<mz_zip_archive> ar_;
+ std::string archive_name_;
+ std::string archive_name_plus_slash_;
+ std::shared_ptr<ReadAdapterInterface> in_;
+ int64_t version_;
+ std::mutex reader_lock_;
+ bool load_debug_symbol_ = true;
+ std::string serialization_id_;
+ size_t additional_reader_size_threshold_;
 };
 
 class TORCH_API PyTorchStreamWriter final {
- public:
-  explicit PyTorchStreamWriter(
-      const std::string& archive_name,
-      bool compute_crc32 = true,
-      uint64_t alignment = 64);
-  explicit PyTorchStreamWriter(
-      const std::function<size_t(const void*, size_t)> writer_func,
-      bool compute_crc32 = true,
-      uint64_t alignment = 64);
+public:
+ explicit PyTorchStreamWriter(
+     const std::string& archive_name,
+     bool compute_crc32 = true,
+     uint64_t alignment = 64);
+ explicit PyTorchStreamWriter(
+     const std::function<size_t(const void*, size_t)>& writer_func,
+     bool compute_crc32 = true,
+     uint64_t alignment = 64);
 
-  void setMinVersion(const uint64_t version);
+ void setMinVersion(uint64_t version);
 
-  void writeRecord(
-      const std::string& name,
-      const void* data,
-      size_t size,
-      bool compress = false);
-  void writeEndOfFile();
+ void writeRecord(
+     const std::string& name,
+     const void* data,
+     size_t size,
+     bool compress = false);
+ void writeEndOfFile();
 
-  const std::unordered_set<std::string>& getAllWrittenRecords();
+ const std::unordered_set<std::string>& getAllWrittenRecords();
 
-  bool finalized() const {
-    return finalized_;
-  }
+ bool finalized() const {
+   return finalized_;
+ }
 
-  const std::string& archiveName() {
-    return archive_name_;
-  }
+ const std::string& archiveName() const {
+   return archive_name_;
+ }
 
-  const std::string& serializationId() {
-    return serialization_id_;
-  }
+ const std::string& serializationId() const {
+   return serialization_id_;
+ }
 
-  ~PyTorchStreamWriter();
+ ~PyTorchStreamWriter();
 
- private:
-  void setup(const std::string& file_name);
-  void valid(const char* what, const char* info = "");
-  void writeSerializationId();
-  size_t current_pos_ = 0;
-  std::unordered_set<std::string> files_written_;
-  std::unique_ptr<mz_zip_archive> ar_;
-  std::string archive_name_;
-  std::string archive_name_plus_slash_;
-  std::string padding_;
-  std::ofstream file_stream_;
-  std::function<size_t(const void*, size_t)> writer_func_;
-  uint64_t combined_uncomp_crc32_ = 0;
-  std::string serialization_id_;
-  bool compute_crc32_;
-  uint64_t alignment_;
+private:
+ void setup(const std::string& file_name);
+ void valid(const char* what, const char* info = "");
+ void writeSerializationId();
+ size_t current_pos_ = 0;
+ std::unordered_set<std::string> files_written_;
+ std::unique_ptr<mz_zip_archive> ar_;
+ std::string archive_name_;
+ std::string archive_name_plus_slash_;
+ std::string padding_;
+ std::ofstream file_stream_;
+ std::function<size_t(const void*, size_t)> writer_func_;
+ uint64_t combined_uncomp_crc32_ = 0;
+ std::string serialization_id_;
+ bool compute_crc32_;
+ uint64_t alignment_;
 
-  // This number will be updated when the model has operators
-  // that have valid upgraders.
-  uint64_t version_ = kMinProducedFileFormatVersion;
-  bool finalized_ = false;
-  bool err_seen_ = false;
-  friend size_t ostream_write_func(
-      void* pOpaque,
-      uint64_t file_ofs,
-      const void* pBuf,
-      size_t n);
+ // This number will be updated when the model has operators
+ // that have valid upgraders.
+ uint64_t version_ = kMinProducedFileFormatVersion;
+ bool finalized_ = false;
+ bool err_seen_ = false;
+ friend size_t ostream_write_func(
+     void* pOpaque,
+     uint64_t file_ofs,
+     const void* pBuf,
+     size_t n);
 };
 
 namespace detail {
@@ -295,11 +295,11 @@ namespace detail {
 // Returns a record to be appended to the local user extra data entry in order
 // to make data beginning aligned at kFieldAlignment bytes boundary.
 size_t getPadding(
-    size_t cursor,
-    size_t filename_size,
-    size_t size,
-    std::string& padding_buf,
-    uint64_t alignment);
+   size_t cursor,
+   size_t filename_size,
+   size_t size,
+   std::string& padding_buf,
+   uint64_t alignment);
 
 std::tuple<size_t, size_t>
 getOffset(size_t cursor, size_t filename_size, size_t size, uint64_t alignment);

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -94,200 +94,200 @@ typedef struct mz_zip_archive mz_zip_archive;
 namespace caffe2::serialize {
 
 static constexpr const char* kSerializationIdRecordName =
-   ".data/serialization_id";
+    ".data/serialization_id";
 
 struct MzZipReaderIterWrapper;
 
 class TORCH_API ChunkRecordIterator {
-public:
- ~ChunkRecordIterator();
+ public:
+  ~ChunkRecordIterator();
 
- // Read at most `chunkSize` into `buf`. Return the number of actual bytes
- // read.
- size_t next(void* buf);
- size_t recordSize() const {
-   return recordSize_;
- }
+  // Read at most `chunkSize` into `buf`. Return the number of actual bytes
+  // read.
+  size_t next(void* buf);
+  size_t recordSize() const {
+    return recordSize_;
+  }
 
-private:
- ChunkRecordIterator(
-     size_t recordSize,
-     size_t chunkSize,
-     std::unique_ptr<MzZipReaderIterWrapper> iter);
+ private:
+  ChunkRecordIterator(
+      size_t recordSize,
+      size_t chunkSize,
+      std::unique_ptr<MzZipReaderIterWrapper> iter);
 
- const size_t recordSize_;
- const size_t chunkSize_;
- size_t offset_;
- std::unique_ptr<MzZipReaderIterWrapper> iter_;
+  const size_t recordSize_;
+  const size_t chunkSize_;
+  size_t offset_;
+  std::unique_ptr<MzZipReaderIterWrapper> iter_;
 
- friend class PyTorchStreamReader;
+  friend class PyTorchStreamReader;
 };
 
 class TORCH_API PyTorchStreamReader final {
-public:
- explicit PyTorchStreamReader(const std::string& file_name);
- explicit PyTorchStreamReader(std::istream* in);
- explicit PyTorchStreamReader(std::shared_ptr<ReadAdapterInterface> in);
+ public:
+  explicit PyTorchStreamReader(const std::string& file_name);
+  explicit PyTorchStreamReader(std::istream* in);
+  explicit PyTorchStreamReader(std::shared_ptr<ReadAdapterInterface> in);
 
- // return dataptr, size
- // set allocator to override default cpu allocator
- std::tuple<at::DataPtr, size_t> getRecord(
-     const std::string& name,
-     std::optional<at::Allocator*> allocator = std::nullopt);
- // multi-thread getRecord
- std::tuple<at::DataPtr, size_t> getRecord(
-     const std::string& name,
-     std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
-     std::optional<at::Allocator*> allocator = std::nullopt);
- // inplace memory writing
- size_t getRecord(const std::string& name, void* dst, size_t n);
- // inplace memory writing, multi-threads.
- // When additionalReaders is empty, the default behavior is call
- // getRecord(name, dst, n) with default reader This approach can be used for
- // reading large tensors.
- size_t getRecord(
-     const std::string& name,
-     void* dst,
-     size_t n,
-     std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders);
- size_t getRecord(
-     const std::string& name,
-     void* dst,
-     size_t n,
-     size_t chunk_size,
-     void* buf,
-     const std::function<void(void*, const void*, size_t)>& memcpy_func =
-         nullptr);
+  // return dataptr, size
+  // set allocator to override default cpu allocator
+  std::tuple<at::DataPtr, size_t> getRecord(
+      const std::string& name,
+      std::optional<at::Allocator*> allocator = std::nullopt);
+  // multi-thread getRecord
+  std::tuple<at::DataPtr, size_t> getRecord(
+      const std::string& name,
+      std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
+      std::optional<at::Allocator*> allocator = std::nullopt);
+  // inplace memory writing
+  size_t getRecord(const std::string& name, void* dst, size_t n);
+  // inplace memory writing, multi-threads.
+  // When additionalReaders is empty, the default behavior is call
+  // getRecord(name, dst, n) with default reader This approach can be used for
+  // reading large tensors.
+  size_t getRecord(
+      const std::string& name,
+      void* dst,
+      size_t n,
+      std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders);
+  size_t getRecord(
+      const std::string& name,
+      void* dst,
+      size_t n,
+      size_t chunk_size,
+      void* buf,
+      const std::function<void(void*, const void*, size_t)>& memcpy_func =
+          nullptr);
 
- // Concurrent reading records with multiple readers.
- // additionalReaders are additional clients to access the underlying record at
- // different offsets and write to different trunks of buffers. If the overall
- // size of the tensor is 10, and size of additionalReader is 2. The default
- // thread will read [0,4), the additional reader will read [4,8). The default
- // reader will read [8,10). The default reader will write to buffer[0,4), the
- // additional reader will write to buffer[4,8), the additional reader will
- // write to buffer[8,10). When additionalReaders is empty, the default
- // behavior is call getRecord(name) with default reader This approach can be
- // used for reading large tensors.
- size_t getRecordMultiReaders(
-     const std::string& name,
-     std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
-     void* dst,
-     size_t n);
+  // Concurrent reading records with multiple readers.
+  // additionalReaders are additional clients to access the underlying record at
+  // different offsets and write to different trunks of buffers. If the overall
+  // size of the tensor is 10, and size of additionalReader is 2. The default
+  // thread will read [0,4), the additional reader will read [4,8). The default
+  // reader will read [8,10). The default reader will write to buffer[0,4), the
+  // additional reader will write to buffer[4,8), the additional reader will
+  // write to buffer[8,10). When additionalReaders is empty, the default
+  // behavior is call getRecord(name) with default reader This approach can be
+  // used for reading large tensors.
+  size_t getRecordMultiReaders(
+      const std::string& name,
+      std::vector<std::shared_ptr<ReadAdapterInterface>>& additionalReaders,
+      void* dst,
+      size_t n);
 
- size_t getRecordSize(const std::string& name);
- size_t getRecordHeaderOffset(const std::string& name);
- size_t getRecordOffset(const std::string& name);
- size_t getRecordOffsetNoRead(
-     size_t cursor,
-     const std::string& filename,
-     size_t size,
-     uint64_t alignment);
- bool hasRecord(const std::string& name);
- std::vector<std::string> getAllRecords();
+  size_t getRecordSize(const std::string& name);
+  size_t getRecordHeaderOffset(const std::string& name);
+  size_t getRecordOffset(const std::string& name);
+  size_t getRecordOffsetNoRead(
+      size_t cursor,
+      const std::string& filename,
+      size_t size,
+      uint64_t alignment);
+  bool hasRecord(const std::string& name);
+  std::vector<std::string> getAllRecords();
 
- ChunkRecordIterator createChunkReaderIter(
-     const std::string& name,
-     const size_t recordSize,
-     const size_t chunkSize);
+  ChunkRecordIterator createChunkReaderIter(
+      const std::string& name,
+      const size_t recordSize,
+      const size_t chunkSize);
 
- ~PyTorchStreamReader();
- uint64_t version() const {
-   return version_;
- }
- const std::string& serializationId() const {
-   return serialization_id_;
- }
+  ~PyTorchStreamReader();
+  uint64_t version() const {
+    return version_;
+  }
+  const std::string& serializationId() const {
+    return serialization_id_;
+  }
 
- void setShouldLoadDebugSymbol(bool should_load_debug_symbol) {
-   load_debug_symbol_ = should_load_debug_symbol;
- }
- void setAdditionalReaderSizeThreshold(size_t size) {
-   additional_reader_size_threshold_ = size;
- }
+  void setShouldLoadDebugSymbol(bool should_load_debug_symbol) {
+    load_debug_symbol_ = should_load_debug_symbol;
+  }
+  void setAdditionalReaderSizeThreshold(size_t size) {
+    additional_reader_size_threshold_ = size;
+  }
 
-private:
- void init();
- size_t read(uint64_t pos, char* buf, size_t n);
- void valid(const char* what, const char* info = "");
- size_t getRecordID(const std::string& name);
+ private:
+  void init();
+  size_t read(uint64_t pos, char* buf, size_t n);
+  void valid(const char* what, const char* info = "");
+  size_t getRecordID(const std::string& name);
 
- friend size_t
- istream_read_func(void* pOpaque, uint64_t file_ofs, void* pBuf, size_t n);
- std::unique_ptr<mz_zip_archive> ar_;
- std::string archive_name_;
- std::string archive_name_plus_slash_;
- std::shared_ptr<ReadAdapterInterface> in_;
- int64_t version_;
- std::mutex reader_lock_;
- bool load_debug_symbol_ = true;
- std::string serialization_id_;
- size_t additional_reader_size_threshold_;
+  friend size_t
+  istream_read_func(void* pOpaque, uint64_t file_ofs, void* pBuf, size_t n);
+  std::unique_ptr<mz_zip_archive> ar_;
+  std::string archive_name_;
+  std::string archive_name_plus_slash_;
+  std::shared_ptr<ReadAdapterInterface> in_;
+  int64_t version_;
+  std::mutex reader_lock_;
+  bool load_debug_symbol_ = true;
+  std::string serialization_id_;
+  size_t additional_reader_size_threshold_;
 };
 
 class TORCH_API PyTorchStreamWriter final {
-public:
- explicit PyTorchStreamWriter(
-     const std::string& archive_name,
-     bool compute_crc32 = true,
-     uint64_t alignment = 64);
- explicit PyTorchStreamWriter(
-     const std::function<size_t(const void*, size_t)>& writer_func,
-     bool compute_crc32 = true,
-     uint64_t alignment = 64);
+ public:
+  explicit PyTorchStreamWriter(
+      const std::string& archive_name,
+      bool compute_crc32 = true,
+      uint64_t alignment = 64);
+  explicit PyTorchStreamWriter(
+      const std::function<size_t(const void*, size_t)>& writer_func,
+      bool compute_crc32 = true,
+      uint64_t alignment = 64);
 
- void setMinVersion(uint64_t version);
+  void setMinVersion(uint64_t version);
 
- void writeRecord(
-     const std::string& name,
-     const void* data,
-     size_t size,
-     bool compress = false);
- void writeEndOfFile();
+  void writeRecord(
+      const std::string& name,
+      const void* data,
+      size_t size,
+      bool compress = false);
+  void writeEndOfFile();
 
- const std::unordered_set<std::string>& getAllWrittenRecords();
+  const std::unordered_set<std::string>& getAllWrittenRecords();
 
- bool finalized() const {
-   return finalized_;
- }
+  bool finalized() const {
+    return finalized_;
+  }
 
- const std::string& archiveName() const {
-   return archive_name_;
- }
+  const std::string& archiveName() const {
+    return archive_name_;
+  }
 
- const std::string& serializationId() const {
-   return serialization_id_;
- }
+  const std::string& serializationId() const {
+    return serialization_id_;
+  }
 
- ~PyTorchStreamWriter();
+  ~PyTorchStreamWriter();
 
-private:
- void setup(const std::string& file_name);
- void valid(const char* what, const char* info = "");
- void writeSerializationId();
- size_t current_pos_ = 0;
- std::unordered_set<std::string> files_written_;
- std::unique_ptr<mz_zip_archive> ar_;
- std::string archive_name_;
- std::string archive_name_plus_slash_;
- std::string padding_;
- std::ofstream file_stream_;
- std::function<size_t(const void*, size_t)> writer_func_;
- uint64_t combined_uncomp_crc32_ = 0;
- std::string serialization_id_;
- bool compute_crc32_;
- uint64_t alignment_;
+ private:
+  void setup(const std::string& file_name);
+  void valid(const char* what, const char* info = "");
+  void writeSerializationId();
+  size_t current_pos_ = 0;
+  std::unordered_set<std::string> files_written_;
+  std::unique_ptr<mz_zip_archive> ar_;
+  std::string archive_name_;
+  std::string archive_name_plus_slash_;
+  std::string padding_;
+  std::ofstream file_stream_;
+  std::function<size_t(const void*, size_t)> writer_func_;
+  uint64_t combined_uncomp_crc32_ = 0;
+  std::string serialization_id_;
+  bool compute_crc32_;
+  uint64_t alignment_;
 
- // This number will be updated when the model has operators
- // that have valid upgraders.
- uint64_t version_ = kMinProducedFileFormatVersion;
- bool finalized_ = false;
- bool err_seen_ = false;
- friend size_t ostream_write_func(
-     void* pOpaque,
-     uint64_t file_ofs,
-     const void* pBuf,
-     size_t n);
+  // This number will be updated when the model has operators
+  // that have valid upgraders.
+  uint64_t version_ = kMinProducedFileFormatVersion;
+  bool finalized_ = false;
+  bool err_seen_ = false;
+  friend size_t ostream_write_func(
+      void* pOpaque,
+      uint64_t file_ofs,
+      const void* pBuf,
+      size_t n);
 };
 
 namespace detail {
@@ -295,11 +295,11 @@ namespace detail {
 // Returns a record to be appended to the local user extra data entry in order
 // to make data beginning aligned at kFieldAlignment bytes boundary.
 size_t getPadding(
-   size_t cursor,
-   size_t filename_size,
-   size_t size,
-   std::string& padding_buf,
-   uint64_t alignment);
+    size_t cursor,
+    size_t filename_size,
+    size_t size,
+    std::string& padding_buf,
+    uint64_t alignment);
 
 std::tuple<size_t, size_t>
 getOffset(size_t cursor, size_t filename_size, size_t size, uint64_t alignment);


### PR DESCRIPTION
Summary:
- Mark serializationId() and archiveName() as const so they can be called
  on const instances.
- Change getRecordOffsetNoRead to take filename by const reference instead
  of by value to avoid unnecessary string copy.
- Change PyTorchStreamWriter constructor to take writer_func by const
  reference to avoid std::function copy.
- Change setAdditionalReaderSizeThreshold to take size_t by value.
- Remove redundant const from setMinVersion value parameter.
close:https://github.com/pytorch/pytorch/issues/196110

cc @jbschlosser @mruberry @mikaylagawarecki
