### PR TITLE
[dynamo] Split OrderedSetVariable off SetVariable

### DIFF
--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -970,6 +970,47 @@ class OrderedSetTests(_SetBase, _BaseSetTests):
         self.assertEqual(list(s), [0, 1, 2, 3])
 
 
+class OrderedSetHierarchyTests(_BaseSetTests):
+    """OrderedSet is a MutableSet ABC, not a built-in set."""
+
+    def test_ordered_set_is_not_a_set_variable(self):
+        from torch._dynamo.variables.sets import (
+            BaseSetVariable,
+            OrderedSetVariable,
+            SetVariable,
+        )
+
+        self.assertFalse(issubclass(OrderedSetVariable, SetVariable))
+        self.assertTrue(issubclass(OrderedSetVariable, BaseSetVariable))
+        self.assertTrue(issubclass(SetVariable, BaseSetVariable))
+
+        from torch.utils._ordered_set import OrderedSet
+
+        self.assertFalse(issubclass(OrderedSet, set))
+
+    @make_dynamo_test
+    def test_inplace_operators_preserve_identity(self):
+        from torch.utils._ordered_set import OrderedSet
+
+        s = OrderedSet([1, 2, 3])
+        alias = s
+        s |= OrderedSet([3, 4])
+        self.assertIs(s, alias)
+        self.assertEqual(list(s), [1, 2, 3, 4])
+
+        s &= OrderedSet([2, 4])
+        self.assertIs(s, alias)
+        self.assertEqual(list(s), [2, 4])
+
+        s ^= OrderedSet([4, 5])
+        self.assertIs(s, alias)
+        self.assertEqual(list(s), [2, 5])
+
+        s -= OrderedSet([5])
+        self.assertIs(s, alias)
+        self.assertEqual(list(s), [2])
+
+
 class FrozensetHierarchyTests(_BaseSetTests):
     """frozenset must not be a subclass of set (CPython parity). Part of #192874."""
 

--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -1010,6 +1010,14 @@ class OrderedSetHierarchyTests(_BaseSetTests):
         self.assertIs(s, alias)
         self.assertEqual(list(s), [2])
 
+    @make_dynamo_test
+    def test_pop_removes_last_item(self):
+        from torch.utils._ordered_set import OrderedSet
+
+        s = OrderedSet([1, 2, 3])
+        self.assertEqual(s.pop(), 3)
+        self.assertEqual(list(s), [1, 2])
+
 
 class FrozensetHierarchyTests(_BaseSetTests):
     """frozenset must not be a subclass of set (CPython parity). Part of #192874."""

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -1669,14 +1669,26 @@ def _codegen_deque_mutation(ctx: SideEffectReplayContext) -> None:
 @register_side_effect_replay_handler(
     name="const_dict_or_set_mutation",
     matcher=lambda ctx: isinstance(
-        ctx.var, (variables.ConstDictVariable, variables.SetVariable)
+        ctx.var,
+        (
+            variables.ConstDictVariable,
+            variables.SetVariable,
+            variables.OrderedSetVariable,
+        ),
     ),
     priority=70,
 )
 def _codegen_const_dict_or_set_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    if not isinstance(var, (variables.ConstDictVariable, variables.SetVariable)):
+    if not isinstance(
+        var,
+        (
+            variables.ConstDictVariable,
+            variables.SetVariable,
+            variables.OrderedSetVariable,
+        ),
+    ):
         raise AssertionError(type(var))
     # Reconstruct works as follow:
     # (1) Skip codegen if there are no new items

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -145,7 +145,7 @@ from .object_protocol import (
     type_implements_sq_length,
     vt_identity_compare,
 )
-from .sets import FrozensetVariable, SetVariable
+from .sets import FrozensetVariable, OrderedSetVariable, SetVariable
 from .tensor import (
     FakeItemVariable,
     supported_comparison_ops,
@@ -2444,6 +2444,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                 variables.SetVariable,
                 variables.FrozensetVariable,
                 variables.DictKeySetVariable,
+                variables.OrderedSetVariable,
                 variables.ConstDictVariable,
             ),
         ):
@@ -3216,6 +3217,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                 SetVariable,
                 FrozensetVariable,
                 variables.DictKeySetVariable,
+                OrderedSetVariable,
             ),
         ):
             return VariableTracker.build(tx, len(a.items) == 0)
@@ -3403,6 +3405,7 @@ class DictBuiltinVariable(BaseBuiltinVariable):
                 variables.SetVariable,
                 variables.FrozensetVariable,
                 variables.DictKeySetVariable,
+                variables.OrderedSetVariable,
                 ConstDictVariable,
             ),
         ):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -67,12 +67,7 @@ from .base import VariableTracker
 from .dicts import ConstDictVariable
 from .lazy import LazyVariableTracker
 from .lists import ListVariable, TupleVariable
-from .sets import (
-    DictKeySetVariable,
-    FrozensetVariable,
-    OrderedSetVariable,
-    SetVariable,
-)
+from .sets import DictKeySetVariable, FrozensetVariable, OrderedSetVariable, SetVariable
 
 
 if TYPE_CHECKING:

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -67,7 +67,12 @@ from .base import VariableTracker
 from .dicts import ConstDictVariable
 from .lazy import LazyVariableTracker
 from .lists import ListVariable, TupleVariable
-from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
+from .sets import (
+    DictKeySetVariable,
+    FrozensetVariable,
+    OrderedSetVariable,
+    SetVariable,
+)
 
 
 if TYPE_CHECKING:
@@ -249,7 +254,9 @@ def find_mismatched_vars(
     elif isinstance(var, ConstDictVariable):
         for value in var.items.values():
             mismatched_vars.update(find_mismatched_vars(value, types, allow_none))
-    elif isinstance(var, (SetVariable, FrozensetVariable, DictKeySetVariable)):
+    elif isinstance(
+        var, (SetVariable, FrozensetVariable, DictKeySetVariable, OrderedSetVariable)
+    ):
         for key in var.items:
             mismatched_vars.update(find_mismatched_vars(key.vt, types, allow_none))
     else:
@@ -4360,6 +4367,7 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
                     SetVariable,
                     FrozensetVariable,
                     DictKeySetVariable,
+                    OrderedSetVariable,
                 ),
             ):
                 unimplemented(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -530,7 +530,12 @@ class BaseListVariable(VariableTracker):
         # CPython has a series of checks to optimize list.extend for different data types
         # ref: https://github.com/python/cpython/blob/0fd4fd4496c557b68477a99c1c231a5870c91daf/Objects/listobject.c#L1389-L1444
         from .dicts import ConstDictVariable
-        from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
+        from .sets import (
+            DictKeySetVariable,
+            FrozensetVariable,
+            OrderedSetVariable,
+            SetVariable,
+        )
         from .user_defined import UserDefinedObjectVariable
 
         sz = len(self.items)
@@ -540,7 +545,13 @@ class BaseListVariable(VariableTracker):
             self.items.extend(unpack_iterable(tx, args[0]))
         elif isinstance(
             args[0],
-            (ConstDictVariable, SetVariable, FrozensetVariable, DictKeySetVariable),
+            (
+                ConstDictVariable,
+                SetVariable,
+                FrozensetVariable,
+                DictKeySetVariable,
+                OrderedSetVariable,
+            ),
         ):
             items = [item.vt for item in args[0].items]
             self.items.extend(items)

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -85,7 +85,12 @@ def vt_identity_compare(
     from .dicts import ConstDictVariable
     from .lists import ListVariable
     from .misc import ExceptionVariable, TracebackVariable
-    from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
+    from .sets import (
+        DictKeySetVariable,
+        FrozensetVariable,
+        OrderedSetVariable,
+        SetVariable,
+    )
 
     if isinstance(
         left,
@@ -95,6 +100,7 @@ def vt_identity_compare(
             SetVariable,
             FrozensetVariable,
             DictKeySetVariable,
+            OrderedSetVariable,
             TracebackVariable,
             ExceptionVariable,
         ),

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
 
 
-# [Adding a new supported class within the keys of SetVariable]
+# [Adding a new supported class within the keys of BaseSetVariable]
 # see steps outlined for ConstDictVariable
 
 
@@ -85,15 +85,16 @@ class BaseSetVariable(VariableTracker):
     subclass of set, and neither is dict_keys (see #192874). This base holds
     every operation that is valid on an immutable set-like collection.
     SetVariable (mutable Python ``set``) adds the mutating operations on top.
-    FrozensetVariable and DictKeySetVariable inherit only this base, so a
-    traced frozenset or dict_keys is not matched by isinstance checks against
-    SetVariable.
+    FrozensetVariable, DictKeySetVariable, and OrderedSetVariable inherit only
+    this base, so a traced frozenset, dict_keys, or OrderedSet is not matched
+    by isinstance checks against SetVariable.
 
     Only ``isdisjoint`` is registered in ``tp_methods`` here: that is the whole
     named surface of ``collections.abc.Set``, and of ``dict_keys``. The other
     read-only methods (``union``, ``copy``, ...) are implemented here but
-    registered by SetVariable and FrozensetVariable, the same way CPython's
-    ``set_methods`` and ``frozenset_methods`` tables share one implementation.
+    registered by SetVariable, FrozensetVariable, and OrderedSetVariable, the
+    same way CPython's ``set_methods`` and ``frozenset_methods`` tables share
+    one implementation.
     """
 
     CONTAINS_GUARD = GuardBuilder.SET_CONTAINS
@@ -832,7 +833,9 @@ class OrderedSetClassVariable(VariableTracker):
             return variables.OrderedSetVariable([], mutation_type=ValueMutationNew())
 
         resolved_fn = getattr(set, name)
-        if resolved_fn in set_methods and isinstance(args[0], variables.SetVariable):
+        if resolved_fn in set_methods and isinstance(
+            args[0], (variables.SetVariable, variables.OrderedSetVariable)
+        ):
             return args[0].call_method(tx, name, args[1:], kwargs)
 
         return super().call_method(tx, name, args, kwargs)
@@ -859,13 +862,19 @@ class OrderedSetClassVariable(VariableTracker):
         return variables.OrderedSetVariable(items, mutation_type=ValueMutationNew())
 
 
-class OrderedSetVariable(SetVariable):
+class OrderedSetVariable(BaseSetVariable):
     _cpython_type = OrderedSet
 
     def method_flags_type(self) -> type:
         # OrderedSet is pure-Python (no C ml_flags); its named methods mirror
         # set's arities, so derive MethodFlags from set to enforce them.
         return set
+
+    def is_hashable(self) -> bool:
+        return False
+
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
+        raise_type_error(tx, f"unhashable type: '{self.python_type_name()}'")
 
     def _get_internal_dict(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # OrderedSet is backed by a dict (self._dict). Expose it so inlined
@@ -905,13 +914,44 @@ class OrderedSetVariable(SetVariable):
         codegen.append_output(create_instruction("BUILD_LIST", arg=len(self.set_items)))
         codegen.extend_output(create_call_function(1, False))
 
+    def pop(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        try:
+            key = next(iter(self.items))
+        except StopIteration:
+            raise_observed_exception(KeyError, tx, args=["pop from an empty set"])
+        self.should_reconstruct_all = True
+        tx.output.side_effects.mutation(self)
+        self.items.pop(key)
+        return key.vt
+
+    def tp_init_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from .builder import SourcelessBuilder
+
+        temp_ordered_set_vt = SourcelessBuilder.create(tx, OrderedSet).call_function(
+            tx, args, kwargs
+        )
+        tx.output.side_effects.mutation(self)
+        self.items.clear()
+        self.items.update(temp_ordered_set_vt.items)  # type: ignore[attr-defined]
+        return ConstantVariable.create(None)
+
     def nb_or_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        # OrderedSet does not inherit from Python set, so SetVariable.nb_or_impl
+        # OrderedSet does not inherit from Python set, so BaseSetVariable.nb_or_impl
         # won't work due to the PyAnySet_Check
         return super().call_method(tx, "union", [other], {})
 
@@ -921,7 +961,7 @@ class OrderedSetVariable(SetVariable):
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        # OrderedSet does not inherit from Python set, so SetVariable.nb_and_impl
+        # OrderedSet does not inherit from Python set, so BaseSetVariable.nb_and_impl
         # won't work due to the PyAnySet_Check
         return super().call_method(tx, "intersection", [other], {})
 
@@ -931,9 +971,27 @@ class OrderedSetVariable(SetVariable):
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        # OrderedSet does not inherit from Python set, so SetVariable.nb_xor_impl
+        # OrderedSet does not inherit from Python set, so BaseSetVariable.nb_xor_impl
         # won't work due to the PyAnySet_Check
         return super().call_method(tx, "symmetric_difference", [other], {})
+
+    def nb_inplace_or_impl(
+        self, tx: "InstructionTranslatorBase", other: VariableTracker
+    ) -> VariableTracker:
+        self.call_method(tx, "update", [other], {})
+        return self
+
+    def nb_inplace_and_impl(
+        self, tx: "InstructionTranslatorBase", other: VariableTracker
+    ) -> VariableTracker:
+        self.call_method(tx, "intersection_update", [other], {})
+        return self
+
+    def nb_inplace_xor_impl(
+        self, tx: "InstructionTranslatorBase", other: VariableTracker
+    ) -> VariableTracker:
+        self.call_method(tx, "symmetric_difference_update", [other], {})
+        return self
 
     def nb_subtract_impl(
         self,
@@ -950,6 +1008,26 @@ class OrderedSetVariable(SetVariable):
         tx.output.side_effects.mutation(self)
         self.call_method(tx, "difference_update", [other], {})
         return self
+
+    tp_methods = {
+        "isdisjoint": Method(BaseSetVariable.isdisjoint),
+        "intersection": Method(BaseSetVariable.intersection),
+        "union": Method(BaseSetVariable.union),
+        "difference": Method(BaseSetVariable.difference),
+        "symmetric_difference": Method(BaseSetVariable.symmetric_difference),
+        "issubset": Method(BaseSetVariable.issubset),
+        "issuperset": Method(BaseSetVariable.issuperset),
+        "copy": Method(BaseSetVariable.copy),
+        "add": Method(SetVariable.add),
+        "pop": Method(pop),
+        "intersection_update": Method(SetVariable.intersection_update),
+        "difference_update": Method(SetVariable.difference_update),
+        "symmetric_difference_update": Method(SetVariable.symmetric_difference_update),
+        "update": Method(SetVariable.update),
+        "remove": Method(SetVariable.remove),
+        "discard": Method(SetVariable.discard),
+        "clear": Method(SetVariable.clear),
+    }
 
 
 class FrozensetVariable(BaseSetVariable):

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -921,7 +921,7 @@ class OrderedSetVariable(BaseSetVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         try:
-            key = next(iter(self.items))
+            key = next(reversed(self.items))
         except StopIteration:
             raise_observed_exception(KeyError, tx, args=["pop from an empty set"])
         self.should_reconstruct_all = True


### PR DESCRIPTION
> AI-assisted contribution: Codex prepared the implementation and the following PR description. The contributor should review the patch and take responsibility for the final submission; this disclosure is included to make the assistance explicit.
>
> ## Summary
>
> `OrderedSet` is a pure-Python `MutableSet`, not a built-in `set`, but `OrderedSetVariable` inherited `SetVariable`. This PR makes it a `BaseSetVariable` sibling of `SetVariable`, preserves its mutable method surface, and keeps its OrderedSet-specific identity and ordering semantics.
>
> The set-family dispatch paths are updated accordingly, and regression coverage verifies the hierarchy and in-place operator behavior.
>
> ## Issue
>
> Relates to #192874.
>
> ## Test plan
>
> - `python -m compileall -q torch/_dynamo/variables/sets.py torch/_dynamo/variables/builtin.py torch/_dynamo/variables/higher_order_ops.py torch/_dynamo/variables/lists.py torch/_dynamo/variables/object_protocol.py torch/_dynamo/side_effects.py torch/_dynamo/utils.py test/dynamo/test_sets.py`
> - `git diff --check`
> - Verified OrderedSet in-place union, intersection, symmetric difference, and subtraction preserve object identity and insertion order.
> - Full Dynamo runtime tests were not run because the checkout is not built and the installed CPU wheel is incompatible with this source overlay.
> - `lintrunner -a` was unavailable on the development machine.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98