### PR TITLE
Fix clamp scalar overflow handling in Inductor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3571,23 +3571,45 @@ class CommonTemplate:
         with self.assertRaisesRegex(RuntimeError, error):
             torch.compile(fn)(x)
 
+    @parametrize("min, max", ((math.nan, 3.4e39), (-3.4e39, math.nan)))
+    def test_clamp_scalar_overflow_nan(self, min, max):
+        def fn(x):
+            return torch.clamp(x, min=min, max=max)
+
+        x = torch.randn(4, device=self.device)
+        expected = fn(x)
+        self.assertTrue(expected.isnan().all())
+        self.assertEqual(torch.compile(fn, fullgraph=True)(x), expected)
+
+    @parametrize("op", ("clamp", "clamp_min", "clamp_max"))
     @parametrize(
         "dtype, value",
         (
             (torch.float16, 100000.0),
             (torch.bfloat16, 1e40),
             (torch.float16, 100000),
+            (torch.bfloat16, 3.395e38),
         ),
     )
-    def test_clamp_scalar_overflow_lowp(self, dtype, value):
+    def test_clamp_scalar_overflow_lowp(self, op, dtype, value):
+        if self.device not in ("cpu", "cuda"):
+            raise unittest.SkipTest("requires CPU or CUDA scalar conversion semantics")
         if not self.is_dtype_supported(dtype):
             raise unittest.SkipTest(f"{dtype} not supported on {self.device}")
 
         def fn(x):
+            if op == "clamp_min":
+                return torch.clamp_min(x, -value)
+            if op == "clamp_max":
+                return torch.clamp_max(x, value)
             return torch.clamp(x, min=-value, max=value)
 
         x = torch.randn(4, device=self.device, dtype=dtype)
         error = "value cannot be converted to type .* without overflow"
+
+        if self.device == "cuda" and value <= torch.finfo(torch.float32).max:
+            self.assertEqual(torch.compile(fn, fullgraph=True)(x), fn(x))
+            return
 
         with self.assertRaisesRegex(RuntimeError, error):
             fn(x)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3554,6 +3554,46 @@ class CommonTemplate:
 
         self.common(fn, (torch.randint(4, (4,)),))
 
+    @parametrize("op", ("clamp", "clamp_min", "clamp_max"))
+    def test_clamp_scalar_overflow(self, op):
+        def fn(x):
+            if op == "clamp":
+                return torch.clamp(x, min=-3.4e39, max=3.4e39)
+            if op == "clamp_min":
+                return torch.clamp_min(x, -3.4e39)
+            return torch.clamp_max(x, 3.4e39)
+
+        x = torch.randn(4, device=self.device)
+        error = "value cannot be converted to type float without overflow"
+
+        with self.assertRaisesRegex(RuntimeError, error):
+            fn(x)
+        with self.assertRaisesRegex(RuntimeError, error):
+            torch.compile(fn)(x)
+
+    @parametrize(
+        "dtype, value",
+        (
+            (torch.float16, 100000.0),
+            (torch.bfloat16, 1e40),
+            (torch.float16, 100000),
+        ),
+    )
+    def test_clamp_scalar_overflow_lowp(self, dtype, value):
+        if not self.is_dtype_supported(dtype):
+            raise unittest.SkipTest(f"{dtype} not supported on {self.device}")
+
+        def fn(x):
+            return torch.clamp(x, min=-value, max=value)
+
+        x = torch.randn(4, device=self.device, dtype=dtype)
+        error = "value cannot be converted to type .* without overflow"
+
+        with self.assertRaisesRegex(RuntimeError, error):
+            fn(x)
+        with self.assertRaisesRegex(RuntimeError, error):
+            torch.compile(fn)(x)
+
     def test_comparison_scalar_type_promotion_bf16(self):
         if self.device == "mps":
             raise unittest.SkipTest(

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -326,18 +326,18 @@ _CLAMP_SCALAR_TYPE_NAMES = {
 }
 
 
-def _validate_clamp_scalar(value: object, dtype: torch.dtype) -> None:
+def _validate_clamp_scalar(value: object, dtype: torch.dtype, device_type: str) -> None:
     if dtype not in _CLAMP_SCALAR_TYPE_NAMES or type(value) not in (int, float):
         return
+    if device_type == "cuda":
+        dtype = utils.get_computation_dtype(dtype)
     scalar = cast(int | float, value)
     if isinstance(scalar, float) and not math.isfinite(scalar):
         return
     limits = torch.finfo(dtype)
     if scalar < limits.min or scalar > limits.max:
         name = _CLAMP_SCALAR_TYPE_NAMES[dtype]
-        raise RuntimeError(
-            f"value cannot be converted to type {name} without overflow"
-        )
+        raise RuntimeError(f"value cannot be converted to type {name} without overflow")
 
 
 @pw_cast_for_opmath_non_tensor_args
@@ -359,8 +359,12 @@ def clamp(
     min: torch.types.Number | None = None,
     max: torch.types.Number | None = None,
 ) -> torch.Tensor:
-    _validate_clamp_scalar(min, x.dtype)
-    _validate_clamp_scalar(max, x.dtype)
+    if x.dtype in _CLAMP_SCALAR_TYPE_NAMES and any(
+        type(bound) is float and math.isnan(bound) for bound in (min, max)
+    ):
+        return _clamp(x, math.nan, math.nan)
+    _validate_clamp_scalar(min, x.dtype, x.device.type)
+    _validate_clamp_scalar(max, x.dtype, x.device.type)
     return _clamp(x, min, max)
 
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -318,9 +318,30 @@ def sym_constrain_range_for_size(
     return
 
 
-@register_decomposition([aten.clamp])
+_CLAMP_SCALAR_TYPE_NAMES = {
+    torch.float16: "c10::Half",
+    torch.bfloat16: "c10::BFloat16",
+    torch.float32: "float",
+    torch.float64: "double",
+}
+
+
+def _validate_clamp_scalar(value: object, dtype: torch.dtype) -> None:
+    if dtype not in _CLAMP_SCALAR_TYPE_NAMES or type(value) not in (int, float):
+        return
+    scalar = cast(int | float, value)
+    if isinstance(scalar, float) and not math.isfinite(scalar):
+        return
+    limits = torch.finfo(dtype)
+    if scalar < limits.min or scalar > limits.max:
+        name = _CLAMP_SCALAR_TYPE_NAMES[dtype]
+        raise RuntimeError(
+            f"value cannot be converted to type {name} without overflow"
+        )
+
+
 @pw_cast_for_opmath_non_tensor_args
-def clamp(
+def _clamp(
     x: torch.Tensor,
     min: torch.types.Number | None = None,
     max: torch.types.Number | None = None,
@@ -330,6 +351,17 @@ def clamp(
     if max is not None:
         x = x.clamp_max(max)
     return x
+
+
+@register_decomposition([aten.clamp])
+def clamp(
+    x: torch.Tensor,
+    min: torch.types.Number | None = None,
+    max: torch.types.Number | None = None,
+) -> torch.Tensor:
+    _validate_clamp_scalar(min, x.dtype)
+    _validate_clamp_scalar(max, x.dtype)
+    return _clamp(x, min, max)
 
 
 # Inductor-specific SiLU decomposition for exact eager matching.

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -66,7 +66,7 @@ from torch.utils._triton import has_triton_reduction_ordering
 
 from .._dynamo.utils import import_submodule
 from . import config, inductor_prims, ir, test_operators  # NOQA: F401
-from .decomposition import decompositions, get_decompositions
+from .decomposition import _validate_clamp_scalar, decompositions, get_decompositions
 from .ir import (
     BaseView,
     DtypeView,
@@ -8687,8 +8687,20 @@ logical_xor = register_pointwise(
 )
 maximum = register_pointwise(aten.maximum)
 minimum = register_pointwise(aten.minimum)
-register_lowering(aten.clamp_min)(maximum)
-register_lowering(aten.clamp_max)(minimum)
+
+
+@register_lowering(aten.clamp_min)
+def clamp_min(x, min):
+    _validate_clamp_scalar(min, x.get_dtype())
+    return maximum(x, min)
+
+
+@register_lowering(aten.clamp_max)
+def clamp_max(x, max):
+    _validate_clamp_scalar(max, x.get_dtype())
+    return minimum(x, max)
+
+
 register_op_dtype_propagation_rules(
     "fmaximum",
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8691,13 +8691,13 @@ minimum = register_pointwise(aten.minimum)
 
 @register_lowering(aten.clamp_min)
 def clamp_min(x, min):
-    _validate_clamp_scalar(min, x.get_dtype())
+    _validate_clamp_scalar(min, x.get_dtype(), x.get_device().type)
     return maximum(x, min)
 
 
 @register_lowering(aten.clamp_max)
 def clamp_max(x, max):
-    _validate_clamp_scalar(max, x.get_dtype())
+    _validate_clamp_scalar(max, x.get_dtype(), x.get_device().type)
     return minimum(x, max)
 
 


### PR DESCRIPTION
## Summary

Fixes #195675.

`torch.clamp` can raise when a floating-point scalar bound is not representable during eager execution, while the Inductor path could previously lower the same bound as a constant without raising the corresponding overflow error.

This change adds scalar-bound validation to the Inductor clamp paths so compiled behavior matches eager behavior.

The implementation also preserves the existing backend-specific semantics:

- two-sided `clamp` handles a NaN bound before validating the opposite bound;
- CPU half/bfloat16 bounds are validated against the tensor dtype;
- CUDA half/bfloat16 bounds follow float32 opmath conversion.

The same overflow validation is applied to `clamp_min` and `clamp_max`.

## Testing

Added regression coverage for:

- floating-point scalar overflow in `clamp`, `clamp_min`, and `clamp_max`;
- NaN precedence when the opposite bound would overflow;
- CPU half/bfloat16 scalar overflow;
- CUDA half/bfloat16 opmath behavior.

Local validation:

- focused scalar/decomposition checks passed;
- syntax checks passed;
- `git diff --check` passed;
- targeted lintrunner checks passed with no lint issues.

Full checkout-level Inductor tests could not be run locally because the installed PyTorch binary is incompatible with utilities from the current source checkout and the checkout does not contain the required generated/native build artifacts. CUDA runtime coverage is left to CI.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo