### PR TITLE
Handle tails in Inductor CPU loop splitting

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1119,6 +1119,25 @@ class CPUReproTests(TestCase):
                 (v,),
             )
 
+    def test_negative_pad_loop_split_tail(self):
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(1, 50, (2, 2))
+                self.bn = nn.BatchNorm2d(50)
+                self.fc = nn.Linear(50, 10)
+
+            def forward(self, x):
+                x = self.bn(self.conv(x))
+                x = x.view(x.shape[0], -1)
+                return self.fc(F.pad(x, (0, 50 - x.shape[-1])))
+
+        torch.manual_seed(420)
+        model = M().eval()
+        x = torch.randn(3, 1, 4, 4)
+        with torch.no_grad():
+            self.assertEqual(torch.compile(model)(x), model(x))
+
     def test_masked_fill_with_inf_or_nan_value(self):
         def fn(value, mask):
             y1 = torch.masked_fill(value, mask, float("inf"))

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4924,7 +4924,7 @@ class CppKernelProxy(CppKernel):
             DataTypePropagation.propagate_loopbody(body)
         self.codegen_functions(loop_bodies, var_sizes_list)
 
-    def codegen_nodes(self, nodes: list[SchedulerNode]):
+    def codegen_nodes(self, nodes: list[SchedulerNode], *, mark_run: bool = True):
         # Legalize BF16 node by adding to_dtype explicitly
         self.legalize_lowp_fp_dtype(nodes)
         self.data_type_propagation(nodes)
@@ -4932,8 +4932,9 @@ class CppKernelProxy(CppKernel):
             raise AssertionError("expected len(nodes) >= 1")
 
         def fn(node, *index_vars):
-            node.decide_inplace_update()
-            node.mark_run()
+            if mark_run:
+                node.decide_inplace_update()
+                node.mark_run()
             if isinstance(V.kernel, NullKernelHandler):
                 return node._body(*index_vars)
             else:
@@ -5112,6 +5113,8 @@ class ReasonFusedNodes(Enum):
 
 
 class CppScheduling(BaseScheduling):
+    """Schedule and generate C++ kernels for CPU scheduler nodes."""
+
     # Subclass CppKernelProxy to customize codegen without copying codegen_node().
     # Use kernel_proxy_cls to inject custom proxies in CppScheduling subclasses.
     # Avoid duplicating codegen_node() just to swap in a custom kernel proxy class.
@@ -5489,7 +5492,9 @@ class CppScheduling(BaseScheduling):
             self._can_fuse_horizontal_impl(node1, node2) and not node1.is_reduction()
         ) or self.can_fuse_vertical_outer_loop(node1, node2)
 
-    def try_loop_split(self, nodes: list[SchedulerNode]):
+    def try_loop_split(
+        self, nodes: list[SchedulerNode]
+    ) -> tuple[list[SchedulerNode], Callable[[], None] | None]:
         """
         Apply loop split optimization.
         When one of the indexing_exprs contains a division, we eliminate the division by splitting the loop
@@ -5515,7 +5520,7 @@ class CppScheduling(BaseScheduling):
             )
             for node in nodes
         ):
-            return nodes
+            return nodes, None
 
         split_var = None
         split_number = None
@@ -5546,7 +5551,7 @@ class CppScheduling(BaseScheduling):
                         div_expr_ = div_expr
                         num_div += 1
                     if num_div > 1:
-                        return nodes
+                        return nodes, None
                     if (
                         isinstance(div_expr.args[1], sympy.core.numbers.Integer)
                         and div_expr.args[0] in original_body.iter_vars
@@ -5565,7 +5570,7 @@ class CppScheduling(BaseScheduling):
 
         # Only one node contains a division, and the split dimension is contiguous in all other indexing_exprs.
         if not match_div:
-            return nodes
+            return nodes, None
 
         # Check if all nodes have split_var in their iter_vars and have compatible sizes
         # (same number of index dimensions). If not, bail out to avoid incompatible
@@ -5577,9 +5582,19 @@ class CppScheduling(BaseScheduling):
 
         for node, ((index_size, _), original_body, _) in node_bodies:
             if split_var not in original_body.iter_vars:
-                return nodes
+                return nodes, None
             if len(index_size) != matched_num_dims:
-                return nodes
+                return nodes, None
+
+        if split_number is None:
+            raise AssertionError("expected split_number is not None")
+
+        needs_tail = not all(
+            V.graph.sizevars.statically_known_multiple_of(
+                index_size[original_body.iter_vars.index(split_var)], split_number
+            )
+            for _, ((index_size, _), original_body, _) in node_bodies
+        )
 
         def loop_split(sizes, body, vars):
             index_size, reduce_size = sizes
@@ -5594,6 +5609,28 @@ class CppScheduling(BaseScheduling):
             iter_vars = new_index_vars.copy()
             divisor_var = iter_vars.pop(split_idx + 1)
             iter_vars[split_idx] = split_number * iter_vars[split_idx] + divisor_var
+            body = ir.LoopBody(
+                body, [iter_vars, reduce_vars], var_ranges, new_index_vars, reduce_vars
+            )
+            return (
+                (new_index_size, reduce_size),
+                body,
+                (new_index_vars, reduce_vars),
+            )
+
+        def tail_loop(sizes, body, vars):
+            index_size, reduce_size = sizes
+            index_vars, reduce_vars = vars
+            split_idx = index_vars.index(split_var)
+            tail_size = index_size[split_idx] % split_number
+            tail_start = index_size[split_idx] - tail_size
+            new_index_size = index_size.copy()
+            new_index_size[split_idx] = tail_size
+            (new_index_vars, _), var_ranges = dependencies.index_vars_no_squeeze(
+                new_index_size, reduce_size, prefix="y"
+            )
+            iter_vars = new_index_vars.copy()
+            iter_vars[split_idx] += tail_start
             body = ir.LoopBody(
                 body, [iter_vars, reduce_vars], var_ranges, new_index_vars, reduce_vars
             )
@@ -5626,6 +5663,25 @@ class CppScheduling(BaseScheduling):
         )
 
         snapshots = [(node, node.snapshot_loop_state()) for node in nodes]
+        tail_indexing_constraints = None
+        if needs_tail:
+            tail_indexing_ranges = None
+            tail_indexing_exprs = OrderedSet[Any]()
+            for _, sizes_body in node_bodies:
+                _, tail_body, _ = tail_loop(*sizes_body)
+                if tail_indexing_ranges is None:
+                    tail_indexing_ranges = tail_body.var_ranges
+                if tail_indexing_ranges != tail_body.var_ranges:
+                    return nodes, None
+                tail_indexing_exprs.update(tail_body.indexing_exprs.values())
+
+            if tail_indexing_ranges is None:
+                raise AssertionError("tail_indexing_ranges is None")
+            tail_indexing_constraints = ir.ExtraIndexingConstraints(
+                tail_indexing_ranges,
+                list(tail_indexing_exprs),
+            )
+
         for node in nodes:
             node.recompute_size_and_body(
                 extra_indexing_constraints=extra_indexing_constraints,
@@ -5639,8 +5695,22 @@ class CppScheduling(BaseScheduling):
         if any(node.group[1] != group for node in nodes[1:]):
             for node, state in reversed(snapshots):
                 node.restore_loop_state(state)
+            return nodes, None
 
-        return nodes
+        if tail_indexing_constraints is None:
+            return nodes, None
+
+        def setup_tail():
+            for node, state in reversed(snapshots):
+                node.restore_loop_state(state)
+
+            for node in nodes:
+                node.recompute_size_and_body(
+                    extra_indexing_constraints=tail_indexing_constraints,
+                    recompute_sizes_body_func=tail_loop,
+                )
+
+        return nodes, setup_tail
 
     def codegen_outer_loop_node(
         self,
@@ -5904,10 +5974,15 @@ class CppScheduling(BaseScheduling):
             self.codegen_outer_loop_node(node)
         else:
             nodes: list[SchedulerNode] = node.get_nodes()  # type: ignore[assignment]
-            nodes = self.try_loop_split(nodes)
+            nodes, setup_tail = self.try_loop_split(nodes)
             cpp_kernel_proxy = self.kernel_proxy_cls(kernel_group)
             cpp_kernel_proxy.codegen_nodes(nodes)
             kernel_group.finalize_kernel(cpp_kernel_proxy, nodes)
+            if setup_tail is not None:
+                setup_tail()
+                tail_kernel_proxy = self.kernel_proxy_cls(kernel_group)
+                tail_kernel_proxy.codegen_nodes(nodes, mark_run=False)
+                kernel_group.finalize_kernel(tail_kernel_proxy, nodes)
 
         args_num = self._get_scheduled_num_args()
         if args_num > CppScheduling.MAX_FUSED_KERNEL_ARGS_NUM:


### PR DESCRIPTION
Fixes #195582

The CPU loop-split optimization replaced an extent N with (N // factor) * factor, silently dropping N % factor iterations. This left output elements unwritten when the loop extent was not divisible by the split factor.

Keep the division-free split for complete blocks and generate an offset unsplit loop for the remainder.

Test Plan:
```bash
lintrunner -a
python test/inductor/test_cpu_repro.py CPUReproTests.test_negative_pad_loop_split_tail -v

```

Passed.

cc @voznesenskym  @penguinwu  @EikanWang  @jgong5  @Guobing-Chen  @XiaobingSuper  @zhuhaozhe  @blzheng  @wenzhe-nrv  @jiayisunx  @ipiszy  @kadeng  @muchulee8  @amjames  @chauhang  @aakhundov  @coconutruben  @jataylo 