### PR TITLE
Widen Float2 constructor to accscalar_t in batch norm reduction

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -56,7 +56,10 @@ template <typename scalar_t, typename accscalar_t>
 struct Float2 {
   accscalar_t v1, v2;
   __device__ Float2() = default;
-  __device__ Float2(scalar_t v1, scalar_t v2) : v1(static_cast<accscalar_t>(v1)), v2(static_cast<accscalar_t>(v2)) {}
+  // Parameters are accscalar_t, matching the fields. Both callers (GradOp and
+  // SumReduceOp<Float2>::warp_shfl_down) pass accumulated values; taking
+  // scalar_t here would round-trip them through the lower-precision type.
+  __device__ Float2(accscalar_t v1, accscalar_t v2) : v1(v1), v2(v2) {}
   __device__ Float2(int v) : v1(static_cast<accscalar_t>(v)), v2(static_cast<accscalar_t>(v)) {}
   __device__ Float2& operator+=(const Float2& a) {
     v1 += a.v1;

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -56,9 +56,6 @@ template <typename scalar_t, typename accscalar_t>
 struct Float2 {
   accscalar_t v1, v2;
   __device__ Float2() = default;
-  // Parameters are accscalar_t, matching the fields. Both callers (GradOp and
-  // SumReduceOp<Float2>::warp_shfl_down) pass accumulated values; taking
-  // scalar_t here would round-trip them through the lower-precision type.
   __device__ Float2(accscalar_t v1, accscalar_t v2) : v1(v1), v2(v2) {}
   __device__ Float2(int v) : v1(static_cast<accscalar_t>(v)), v2(static_cast<accscalar_t>(v)) {}
   __device__ Float2& operator+=(const Float2& a) {


### PR DESCRIPTION
Fixes #195701

## Problem

`Float2` stores its two fields as `accscalar_t`, but its two-argument constructor takes `scalar_t`:

```cpp
template <typename scalar_t, typename accscalar_t>
struct Float2 {
  accscalar_t v1, v2;
  __device__ Float2() = default;
  __device__ Float2(scalar_t v1, scalar_t v2) : v1(static_cast<accscalar_t>(v1)), v2(static_cast<accscalar_t>(v2)) {}
  __device__ Float2(int v) : ...
```

`SumReduceOp<Float2<...>>::warp_shfl_down` returns a braced-init-list of two shuffled `accscalar_t` values:

```cpp
return {WARP_SHFL_DOWN(data.v1, offset), WARP_SHFL_DOWN(data.v2, offset)};
```

The only viable two-argument constructor is the `scalar_t` one, so under AMP (`scalar_t = at::Half`, `accscalar_t = float`) every warp-shuffle step converts the accumulated partial sums to `half` and back. This is invisible at compile time because `float -> at::Half` is a user-defined conversion, so the narrowing diagnostic for braced-init-lists does not apply.

Once a per-channel partial sum exceeds the `half` range it saturates:

```
partial sum (fp32)   : 409600.0
after half round-trip: inf
```

`GradOp::operator()` constructs through the same constructor with `accscalar_t` arguments (`g` and `g * c`), so it also narrows. That one does not usually overflow at per-element magnitudes, but it does drop mantissa bits on every element.

`operator+=` adds the `accscalar_t` fields directly and does not narrow, so the reduction arithmetic itself is fine — the loss is confined to construction.

## Fix

Take `accscalar_t` in the constructor, matching the field types:

```cpp
__device__ Float2(accscalar_t v1, accscalar_t v2) : v1(v1), v2(v2) {}
```

This is consistent with the rest of the type and the surrounding code: the fields are already `accscalar_t`, `Float2(int)` already widens to `accscalar_t`, and the generic `SumReduceOp<acc_t>` shuffles `acc_t` with no conversion at all. Only the `Float2` specialization narrowed.

`Float2` is used only in this file, and both construction sites (`GradOp::operator()` and `SumReduceOp<Float2>::warp_shfl_down`) pass `accscalar_t` values — nothing passes `scalar_t` — so widening removes two conversions and changes nothing else. Where `scalar_t == accscalar_t` the signature is unchanged.

## Testing

I could not build or run this locally: I do not have a CUDA device or toolkit available, so this change is unbuilt and untested on my side and I am relying on CI to exercise it. I have not added a regression test for the same reason — it would have to be CUDA-gated and I would be submitting something I had never executed. Happy to add one if you would like, or if a maintainer can confirm the shape they would prefer.

What I did verify is the constructor selection by reading (the two construction sites above are the only ones, and both pass `accscalar_t`), and the arithmetic separately: an fp32 partial sum of 409600 round-tripped through fp16 becomes `inf`, which matches the `inf` the issue reports.
