### PR TITLE
Fix type stub for torch.nn.functional.mse_loss by adding weight argument

### DIFF
--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -603,6 +603,7 @@ def mse_loss(
     size_average: bool | None = ...,
     reduce: bool | None = ...,
     reduction: str = ...,
+    weight: Tensor | None = ...,
 ) -> Tensor: ...
 
 __all__ += ["mse_loss"]


### PR DESCRIPTION
## Summary
Fixes missing `weight: Tensor | None = ...` argument in `torch.nn.functional.mse_loss` type stub (`torch/nn/functional.pyi.in`) to match runtime implementation in `torch/nn/functional.py`.

## Test Plan
- Verified `torch/nn/functional.pyi.in` signature matches `torch/nn/functional.py`.

---
*AI Disclosure: Used Gemini 3.8 Flash for verify code and repository guidelines. All changes were human-reviewed and verified.*
