### PR TITLE
[aotinductor] Add check_upperbound to gate the upperbound input check

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -10719,6 +10719,52 @@ class TestCheckLowerboundConfig(TestCase):
             ).run(code)
 
 
+class TestCheckUpperboundConfig(TestCase):
+    def test_aoti_check_upperbound_codegen(self):
+        """
+        Test that check_upperbound config controls upperbound check codegen.
+        When check_upperbound=False, no upperbound checks should be generated.
+        """
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        model = Model()
+        batch = Dim("batch", min=2, max=10)
+        example_inputs = (torch.randn(4, 3),)
+
+        # Test with check_upperbound=True (default)
+        with config.patch({"aot_inductor.check_upperbound": True}):
+            result, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile,
+                model,
+                example_inputs,
+                dynamic_shapes={"x": {0: batch}},
+            )
+            # Should have upperbound checks
+            FileCheck().check_count(
+                "dim value is too large",
+                1,
+                exactly=True,
+            ).run(code)
+
+        # Test with check_upperbound=False
+        with config.patch({"aot_inductor.check_upperbound": False}):
+            result, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile,
+                model,
+                example_inputs,
+                dynamic_shapes={"x": {0: batch}},
+            )
+            # Should NOT have upperbound checks
+            FileCheck().check_count(
+                "dim value is too large",
+                0,
+                exactly=True,
+            ).run(code)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -875,7 +875,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                     throw std::runtime_error(std::move(ss).str());
                                 }}
                             """)
-                    if not math.isinf(sym_range.upper):
+                    if config.aot_inductor.check_upperbound and not math.isinf(
+                        sym_range.upper
+                    ):
                         # Limit upper bound to max C long long value (2^63 - 1)
                         max_long_long = ctypes.c_longlong(2**63 - 1).value
                         upper_bound = min(sym_range.upper, max_long_long)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2456,6 +2456,11 @@ class aot_inductor:
     # restriction when backed_size_oblivious is off.
     check_lowerbound: bool = True
 
+    # Whether to check upperbound constraints on dynamic shapes during runtime.
+    # The upperbound is inferred from the lowering inputs and the dynamic shape
+    # spec, so it can be tighter than the traffic the model can actually serve.
+    check_upperbound: bool = True
+
     # dump an aoti minifier if program errors
     dump_aoti_minifier: bool = os.environ.get("DUMP_AOTI_MINIFIER", "0") == "1"
 


### PR DESCRIPTION
Summary:
## Why?
`AOTI_RUNTIME_CHECK_INPUTS=1` codegens input shape checks against the bounds baked in at lowering time. The lowerbound half is already gated by `config.aot_inductor.check_lowerbound` (D88203028). The upperbound half is unconditional.

## How?
Add `config.aot_inductor.check_upperbound`, default `True`, and gate the `dim value is too large` codegen on it. No behavior change until a caller flips it.

Lowering wires it up in the diff on top.

Differential Revision: D118874911




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo