### PR TITLE
[flop counter] Fix _efficient_attention_forward/backward layout mismatch

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -880,6 +880,103 @@ class TestFlopCounter(TestCase):
         )
         self.assertEqual(bwd_flops, expected)
 
+    def test_efficient_attention_forward_flop_layout(self):
+        # _efficient_attention_forward takes BMHK; sdpa_flop_count expects BHSD.
+        # S != H so a swap is visible.
+        B, S, H, D = 2, 128, 8, 64
+        q = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        k = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        v = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+
+        with FlopCounterMode() as mode:
+            torch.ops.aten._efficient_attention_forward(
+                q,
+                k,
+                v,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0.0,
+                0,
+                False,
+            )
+
+        flops = int(get_total_flops(mode))
+        expected = sdpa_flop_count((B, H, S, D), (B, H, S, D), (B, H, S, D))
+        self.assertEqual(flops, expected)
+
+    def test_efficient_attention_backward_flop_layout(self):
+        B, S, H, D = 2, 128, 8, 64
+        q = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        k = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        v = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        out = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        grad_out = torch.randn(B, S, H, D, device="meta", dtype=torch.float16)
+        logsumexp = torch.randn(B, H, S, device="meta", dtype=torch.float32)
+
+        with FlopCounterMode() as mode:
+            torch.ops.aten._efficient_attention_backward(
+                grad_out,
+                q,
+                k,
+                v,
+                None,
+                out,
+                None,
+                None,
+                S,
+                S,
+                logsumexp,
+                0.0,
+                torch.tensor(0),
+                torch.tensor(0),
+                0,
+                False,
+            )
+
+        flops = int(get_total_flops(mode))
+        expected = sdpa_backward_flop_count(
+            (B, H, S, D),
+            (B, H, S, D),
+            (B, H, S, D),
+            (B, H, S, D),
+        )
+        self.assertEqual(flops, expected)
+
+    def test_efficient_attention_varlen_flop_unchanged(self):
+        # the cu_seqlens path builds its shapes separately and must not be
+        # transposed; cu_seqlens has to carry real values, so it is not meta
+        H, D = 8, 64
+        lengths = [4, 6]
+        total = sum(lengths)
+        cu_seqlens = torch.tensor([0, 4, 10], dtype=torch.int32)
+        q = torch.randn(1, total, H, D, device="meta", dtype=torch.float16)
+        k = torch.randn(1, total, H, D, device="meta", dtype=torch.float16)
+        v = torch.randn(1, total, H, D, device="meta", dtype=torch.float16)
+
+        with FlopCounterMode() as mode:
+            torch.ops.aten._efficient_attention_forward(
+                q,
+                k,
+                v,
+                None,
+                cu_seqlens,
+                cu_seqlens,
+                max(lengths),
+                max(lengths),
+                0.0,
+                0,
+                False,
+            )
+
+        flops = int(get_total_flops(mode))
+        expected = sum(
+            sdpa_flop_count((1, H, n, D), (1, H, n, D), (1, H, n, D)) for n in lengths
+        )
+        self.assertEqual(flops, expected)
+
     def test_addmm_out(self):
         def f(x):
             y = torch.zeros(10, 10)

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -573,6 +573,15 @@ def _efficient_attention_forward_flop(
 ) -> int:
     """Count flops for self-attention."""
     # NB: We aren't accounting for causal attention here
+    # _efficient_attention_forward takes its tensors in BMHK layout, but
+    # sdpa_flop_count unpacks BHSD. Transpose the dense case first, otherwise
+    # heads and sequence length are swapped and the count is off by a factor of
+    # seq_len / n_heads. The varlen path builds its own shapes from cu_seqlens
+    # and is already correct, so it is left alone.
+    if cu_seqlens_q is None and query.ndim == 4:
+        query = query.transpose(-2, -3)
+        key = key.transpose(-2, -3)
+        value = value.transpose(-2, -3)
     # in case this is a nested tensor, we unpack the individual batch elements
     # and then sum the flops per batch element
     sizes = _unpack_efficient_attention_nested_shapes(
@@ -687,6 +696,12 @@ def _efficient_attention_backward_flop(
     *args,
     **kwargs,
 ) -> int:
+    # BMHK in, BHSD expected: see _efficient_attention_forward_flop above.
+    if cu_seqlens_q is None and query.ndim == 4:
+        grad_out = grad_out.transpose(-2, -3)
+        query = query.transpose(-2, -3)
+        key = key.transpose(-2, -3)
+        value = value.transpose(-2, -3)
     # in case this is a nested tensor, we unpack the individual batch elements
     # and then sum the flops per batch element
     shapes = _unpack_efficient_attention_nested_shapes(


### PR DESCRIPTION
`aten::_efficient_attention_forward` takes BMHK. The meta kernel says so directly (`torch/_meta_registrations.py`):

```python
B = query.size(0)
M = query.size(1)
N = key.size(1)
num_heads = query.size(-2)
Kv = value.size(-1)
```

`_efficient_attention_forward_flop` passes the raw shapes straight into `sdpa_flop_count`, which unpacks BHSD:

```python
b, h_q, s_q, d_q = query_shape
```

so `h_q` gets the sequence length and `s_q` gets the head count. `FlopCounterMode` then reports `4*B*M*H*H*K` instead of `4*B*H*M*N*K` — off by `seq_len / n_heads` — with no warning.

`_flash_attention_forward_flop`, a few functions earlier in the same file, already guards against this:

```python
if cum_seq_q is None and query.ndim == 4:
    query = query.transpose(-2, -3)
    ...
```

The mem-efficient pair does not. This adds the same guard to the forward and the backward, and leaves the varlen path alone since it builds its shapes from `cu_seqlens` and is already correct.

### Numbers

On meta tensors, B=2 H=16 M=N=1024 K=64:

| | before | after | hand |
|---|---|---|---|
| forward | 134,217,728 | 8,589,934,592 | `4*B*H*M*N*K` = 8,589,934,592 |
| backward | 335,544,320 | 21,474,836,480 | `10*B*H*M*N*K` = 21,474,836,480 |

64x, and the ratio is exactly `seq_len / n_heads`. Attention is two `B*H*M*N*K` matmuls forward and five backward, which is where the 4 and the 10 come from.

For self-attention this is a silent wrong number. For cross-attention and decode the swapped dims instead trip `sdpa_flop_count`'s own shape assertion, so the same change also removes a confusing `AssertionError` on those shapes.

A caller that hits it: `torch/nn/attention/bias.py` calls `torch.ops.aten._efficient_attention_forward` with 4-D BMHK tensors and `cu_seqlens_q=None`.

### Tests

Three, mirroring the existing flash layout tests: forward, backward, and a varlen case asserting the `cu_seqlens` path is unchanged (212,992, matching the hand-summed per-sequence count for lengths [4, 6]). All meta tensors, so no CUDA or ROCm dependency.

### What I have not done

I did not build PyTorch from source and did not run the test suite. Verification was by direct reproduction against the released CPU wheel, whose copy of `_efficient_attention_forward_flop` and `_efficient_attention_backward_flop` is byte-identical to main — I diffed both. The numbers above come from that run. Happy to have someone run the new tests in a proper build.

Written with AI assistance; I have read and can explain every changed line.

cc @drisspg @liangel-02