### PR TITLE
[dynamo][inductor] Type diagnostic payloads as object

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -104,10 +104,6 @@ _EXCEPTION_STATE_ATTRS_TO_DROP = frozenset(
 )
 
 
-def _safe_exception_args(args: tuple[object, ...]) -> tuple[object, ...]:
-    return args
-
-
 class _SerializedException(RuntimeError):
     _dynamo_original_exception_type: str
 
@@ -162,7 +158,7 @@ class TorchDynamoException(RuntimeError):
     def __reduce__(self) -> tuple[object, ...]:
         return (
             _reconstruct_torch_dynamo_exception,
-            (type(self), _safe_exception_args(self.args)),
+            (type(self), self.args),
             self.__getstate__(),
         )
 
@@ -292,7 +288,7 @@ class BackendCompilerFailed(ShortenTraceback):
         inner_exception: Exception,
         first_useful_frame: types.FrameType | None,
     ) -> None:
-        self.backend_name: object = getattr(backend_fn, "__name__", "?")
+        self.backend_name: str = getattr(backend_fn, "__name__", "?")
         self.inner_exception = inner_exception
         msg = f"backend={self.backend_name!r} raised:\n{type(inner_exception).__name__}: {inner_exception}"
         super().__init__(msg, first_useful_frame=first_useful_frame)
@@ -448,6 +444,8 @@ class ObservedException(TorchDynamoException):
 
 class ObservedUserStopIteration(ObservedException):
     # An UserStopIteration exception observed during the Dynamo tracing (e.g Dynamo tracing __next__)
+    # Preserve CPython's value attribute for external inspection; Dynamo tracks the
+    # symbolic payload separately through ExceptionVariable.args.
     value: object | None
 
     # Reference `StopIteration_init` in CPython

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -73,6 +73,8 @@ from .utils import counters
 
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from torch._dynamo.variables import VariableTracker
     from torch._guards import CompileId
 
@@ -102,7 +104,7 @@ _EXCEPTION_STATE_ATTRS_TO_DROP = frozenset(
 )
 
 
-def _safe_exception_args(args: tuple[Any, ...]) -> tuple[Any, ...]:
+def _safe_exception_args(args: tuple[object, ...]) -> tuple[object, ...]:
     return args
 
 
@@ -120,8 +122,8 @@ def _safe_inner_exception(exc: BaseException) -> _SerializedException:
     return _SerializedException(exc)
 
 
-def _safe_exception_state(state: dict[str, Any]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
+def _safe_exception_state(state: Mapping[str, object]) -> dict[str, object]:
+    result: dict[str, object] = {}
     for name, value in state.items():
         if name in _EXCEPTION_STATE_ATTRS_TO_DROP or isinstance(value, types.FrameType):
             result[name] = None
@@ -133,7 +135,7 @@ def _safe_exception_state(state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _reconstruct_torch_dynamo_exception(
-    exc_type: type[TorchDynamoException], args: tuple[Any, ...]
+    exc_type: type[TorchDynamoException], args: tuple[object, ...]
 ) -> TorchDynamoException:
     exc = exc_type.__new__(exc_type)
     BaseException.__init__(exc, *args)
@@ -152,22 +154,22 @@ class TorchDynamoException(RuntimeError):
             exception types for control flow.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
         self._torch_dynamo_tracer_output: DynamoTracerOutput | None = None
         self.frame_exec_strategy: FrameExecStrategy | None = None
 
-    def __reduce__(self) -> tuple[Any, ...]:
+    def __reduce__(self) -> tuple[object, ...]:
         return (
             _reconstruct_torch_dynamo_exception,
             (type(self), _safe_exception_args(self.args)),
             self.__getstate__(),
         )
 
-    def __getstate__(self) -> dict[str, Any]:
+    def __getstate__(self) -> dict[str, object]:
         return _safe_exception_state(self.__dict__)
 
-    def __setstate__(self, state: dict[str, Any] | None, /) -> None:
+    def __setstate__(self, state: Mapping[str, object] | None, /) -> None:
         if state is not None:
             self.__dict__.update(state)
 
@@ -183,7 +185,7 @@ class ResumePrologueTracingError(TorchDynamoException):
 class RestartAnalysis(TorchDynamoException):
     restart_reason: str | None
 
-    def __init__(self, *args: Any, restart_reason: str | None = None) -> None:
+    def __init__(self, *args: object, restart_reason: str | None = None) -> None:
         self.restart_reason = restart_reason
         super().__init__(*args)
 
@@ -264,7 +266,10 @@ class ResetRequired(TorchDynamoException):
 
 class ShortenTraceback(TorchDynamoException):
     def __init__(
-        self, *args: Any, first_useful_frame: types.FrameType | None, **kwargs: Any
+        self,
+        *args: object,
+        first_useful_frame: types.FrameType | None,
+        **kwargs: object,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.first_useful_frame = first_useful_frame
@@ -283,11 +288,11 @@ class ShortenTraceback(TorchDynamoException):
 class BackendCompilerFailed(ShortenTraceback):
     def __init__(
         self,
-        backend_fn: Any,
+        backend_fn: object,
         inner_exception: Exception,
         first_useful_frame: types.FrameType | None,
     ) -> None:
-        self.backend_name = getattr(backend_fn, "__name__", "?")
+        self.backend_name: object = getattr(backend_fn, "__name__", "?")
         self.inner_exception = inner_exception
         msg = f"backend={self.backend_name!r} raised:\n{type(inner_exception).__name__}: {inner_exception}"
         super().__init__(msg, first_useful_frame=first_useful_frame)
@@ -431,7 +436,7 @@ class PackageError(TorchDynamoException):
 class ObservedException(TorchDynamoException):
     # An exception observed during the tracing. This exception is used by Dynamo to handle exceptions.
     def __init__(
-        self, *args: Any, real_stack: StackSummary | None = None, **kwargs: Any
+        self, *args: object, real_stack: StackSummary | None = None, **kwargs: object
     ) -> None:
         super().__init__(*args, **kwargs)
         self.real_stack: StackSummary = (
@@ -443,12 +448,12 @@ class ObservedException(TorchDynamoException):
 
 class ObservedUserStopIteration(ObservedException):
     # An UserStopIteration exception observed during the Dynamo tracing (e.g Dynamo tracing __next__)
-    value: Any | None
+    value: object | None
 
     # Reference `StopIteration_init` in CPython
     # https://github.com/python/cpython/blob/3.11/Objects/exceptions.c#L568-L584
     def __init__(
-        self, *args: Any, real_stack: StackSummary | None = None, **kwargs: Any
+        self, *args: object, real_stack: StackSummary | None = None, **kwargs: object
     ) -> None:
         super().__init__("unhandled `raise StopIteration`", real_stack=real_stack)
         if len(args) > 0:
@@ -785,7 +790,7 @@ def unimplemented(
 # KeyError has special handling for its args
 # see https://github.com/python/cpython/blob/3.11/Objects/exceptions.c#L2534 for details
 class KeyErrorMsg:
-    def __init__(self, value: Any) -> None:
+    def __init__(self, value: object) -> None:
         self.value = value
 
     def __str__(self) -> str:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -45,6 +45,7 @@ import uuid
 import warnings
 import weakref
 from collections import Counter, OrderedDict
+from collections.abc import Iterable
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import is_dataclass
 from functools import lru_cache
@@ -102,7 +103,6 @@ if typing.TYPE_CHECKING:
         Container,
         Generator,
         ItemsView,
-        Iterable,
         Iterator,
         KeysView,
         Mapping,
@@ -1744,7 +1744,7 @@ class CompilationMetrics:
         def us_to_ms(metric: int | None) -> int | None:
             return metric // 1000 if metric is not None else None
 
-        def collection_to_str(metric: Any | None) -> str | None:
+        def collection_to_str(metric: object | None) -> str | None:
             def safe_str(item: object) -> str:
                 try:
                     return str(item)
@@ -1759,9 +1759,11 @@ class CompilationMetrics:
 
             return ",".join(safe_str(item) for item in sorted(metric))
 
-        def collection_to_json_str(metric: Any | None) -> str | None:
+        def collection_to_json_str(metric: object | None) -> str | None:
             if metric is None:
                 return None
+            if not isinstance(metric, Iterable):
+                return "<unknown>"
             try:
                 return json.dumps(list(metric))
             except Exception:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -45,7 +45,6 @@ import uuid
 import warnings
 import weakref
 from collections import Counter, OrderedDict
-from collections.abc import Iterable
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import is_dataclass
 from functools import lru_cache
@@ -103,6 +102,7 @@ if typing.TYPE_CHECKING:
         Container,
         Generator,
         ItemsView,
+        Iterable,
         Iterator,
         KeysView,
         Mapping,
@@ -1762,10 +1762,8 @@ class CompilationMetrics:
         def collection_to_json_str(metric: object | None) -> str | None:
             if metric is None:
                 return None
-            if not isinstance(metric, Iterable):
-                return "<unknown>"
             try:
-                return json.dumps(list(metric))
+                return json.dumps(list(cast("Iterable[object]", metric)))
             except Exception:
                 return "<unknown>"
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1745,7 +1745,7 @@ class CompilationMetrics:
             return metric // 1000 if metric is not None else None
 
         def collection_to_str(metric: Any | None) -> str | None:
-            def safe_str(item: Any) -> str:
+            def safe_str(item: object) -> str:
                 try:
                     return str(item)
                 except Exception:
@@ -4459,7 +4459,7 @@ def run_node(
 
     with set_current_node(node):
 
-        def make_error_message(e: Any) -> str:
+        def make_error_message(e: object) -> str:
             return (
                 f"Dynamo failed to run FX node with fake tensors: {op} {node.target}(*{args}, **{kwargs}): got "
                 + repr(e)

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -3644,9 +3644,9 @@ class AOTDispatchAutograd:
     @staticmethod
     def _raise_tangent_metadata_error(
         expected_type: type | None,
-        expected_meta: Any,
+        expected_meta: object,
         runtime_type: type,
-        runtime_meta: Any,
+        runtime_meta: object,
         orig_x: torch.Tensor,
         tangent_idx: int | None,
         tangent_desc: Any | None,

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -3649,7 +3649,7 @@ class AOTDispatchAutograd:
         runtime_meta: object,
         orig_x: torch.Tensor,
         tangent_idx: int | None,
-        tangent_desc: Any | None,
+        tangent_desc: AOTInput | None,
         compile_id_str: str | None,
         tangent_stack_trace: str | None,
     ) -> RuntimeError:
@@ -3721,7 +3721,7 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
         x: Any,
         meta: PlainTensorMeta | SubclassCreationMeta,
         tangent_idx: int | None = None,
-        tangent_desc: Any | None = None,
+        tangent_desc: AOTInput | None = None,
         compile_id_str: str | None = None,
         tangent_stack_trace: str | None = None,
     ) -> tuple[Any, list[Any]]:

--- a/torch/_inductor/exc.py
+++ b/torch/_inductor/exc.py
@@ -4,32 +4,35 @@ import os
 import tempfile
 import textwrap
 from functools import lru_cache
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from torch._dynamo.exc import BackendCompilerFailed, ShortenTraceback
 
 
 if TYPE_CHECKING:
     import types
+    from collections.abc import Mapping, Sequence
 
     from torch.cuda import _CudaDeviceProperties
 
 if os.environ.get("TORCHINDUCTOR_WRITE_MISSING_OPS") == "1":
 
     @lru_cache(None)
-    def _record_missing_op(target: Any) -> None:
+    def _record_missing_op(target: object) -> None:
         with open(f"{tempfile.gettempdir()}/missing_ops.txt", "a") as fd:
             fd.write(str(target) + "\n")
 
 else:
 
-    def _record_missing_op(target: Any) -> None:  # type: ignore[misc]
+    def _record_missing_op(target: object) -> None:  # type: ignore[misc]
         pass
 
 
 class OperatorIssue(RuntimeError):
     @staticmethod
-    def operator_str(target: Any, args: list[Any], kwargs: dict[str, Any]) -> str:
+    def operator_str(
+        target: object, args: Sequence[object], kwargs: Mapping[str, object]
+    ) -> str:
         lines = [f"target: {target}"] + [
             f"args[{i}]: {arg}" for i, arg in enumerate(args)
         ]
@@ -39,13 +42,17 @@ class OperatorIssue(RuntimeError):
 
 
 class MissingOperatorWithoutDecomp(OperatorIssue):
-    def __init__(self, target: Any, args: list[Any], kwargs: dict[str, Any]) -> None:
+    def __init__(
+        self, target: object, args: Sequence[object], kwargs: Mapping[str, object]
+    ) -> None:
         _record_missing_op(target)
         super().__init__(f"missing lowering\n{self.operator_str(target, args, kwargs)}")
 
 
 class MissingOperatorWithDecomp(OperatorIssue):
-    def __init__(self, target: Any, args: list[Any], kwargs: dict[str, Any]) -> None:
+    def __init__(
+        self, target: object, args: Sequence[object], kwargs: Mapping[str, object]
+    ) -> None:
         _record_missing_op(target)
         super().__init__(
             f"missing decomposition\n{self.operator_str(target, args, kwargs)}"
@@ -64,9 +71,9 @@ class LoweringException(OperatorIssue):
     def __init__(
         self,
         exc: Exception,
-        target: Any,
-        args: list[Any],
-        kwargs: dict[str, Any],
+        target: object,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
         stack_trace: str | None = None,
     ) -> None:
         msg = f"{type(exc).__name__}: {exc}\n{self.operator_str(target, args, kwargs)}"


### PR DESCRIPTION
## Summary

- replace `Any` with `object` for opaque Dynamo exception args, serialized state, StopIteration values, and backend identifiers
- accept read-only `Sequence[object]` and `Mapping[str, object]` in Inductor missing/lowering-op diagnostics
- tighten formatting-only Dynamo helpers and AOTAutograd tangent metadata without changing runtime behavior

These payloads are only stored, serialized, or rendered in diagnostics, so callers do not require the unchecked operations provided by `Any`.

## Test plan

```bash
pyrefly check --baseline agent_space/compiler-exception-pyrefly-baseline.json torch/_dynamo/exc.py torch/_inductor/exc.py torch/_dynamo/utils.py torch/_functorch/_aot_autograd/runtime_wrappers.py
```

```bash
UV_NO_CONFIG=1 lintrunner -a --skip PYREFLY torch/_dynamo/exc.py torch/_inductor/exc.py torch/_dynamo/utils.py torch/_functorch/_aot_autograd/runtime_wrappers.py
```

```bash
python test/dynamo/test_exc.py ExcTests.test_backend_compiler_failed_pickles_without_frame ExcTests.test_dynamo_exceptions_pickle_without_rerunning_init
python test/dynamo/test_exceptions.py ExceptionTests.test_stop_iteration ExceptionTests.test_reconstruct_StopIteration
python test/inductor/test_exc_lowering_stack_trace.py
```

Authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98