### PR TITLE
[MPS] Orthonormalize null-space U columns in svd_jacobi

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -3413,6 +3413,69 @@ kernel void svd_jacobi(
   }
   threadgroup_barrier(mem_flags::mem_device);
 
+  // The Jacobi update forms the range factor's columns as (A V)_j / sigma_j,
+  // which collapses to 0 when sigma_j <= eps, leaving U (or V, when transposed)
+  // non-orthonormal for rank-deficient inputs. Replace those null columns with
+  // an orthonormal basis of the complement of the emitted columns (two-pass
+  // Gram-Schmidt of canonical vectors), matching LAPACK gesdd. Columns are
+  // sorted by descending sigma, so the null ones are a contiguous tail. One
+  // simd-group runs it (each lane owns a strided slice of the working column,
+  // so the projections are simd_sum reductions needing no barriers); the rare
+  // degenerate path. Reuses Atg as scratch.
+  if (params.compute_uv && simd_group == 0) {
+    device T* out = (params.transposed == 0u) ? U_b : V_b;
+    const uint32_t ld = (params.transposed == 0u) ? params.u_ld : params.v_ld;
+    // Relative rank cutoff: sigma_j at or below the Jacobi noise floor
+    // (~m*eps*sigma_max) is numerically zero, so its column is arbitrary and
+    // gets completed. An absolute eps would keep noise-amplified columns.
+    const float thresh = eps * sig[ord[0]] * static_cast<float>(m);
+    uint32_t rank = 0;
+    while (rank < n && sig[ord[rank]] > thresh) {
+      ++rank;
+    }
+    // Accept a candidate as a null-space column when its squared residual after
+    // orthogonalization clears this: loose (well above the fp32 roundoff floor),
+    // but enough that the canonicals span the complement. Cf. Rutishauser/DGKS
+    // Gram-Schmidt reorthogonalization.
+    constexpr float kIndepThreshSq = 1e-2f;
+    threadgroup T* col = Atg;
+    uint32_t cand = 0;
+    for (uint32_t j = rank; j < n; ++j) {
+      while (cand < m) {
+        for (uint32_t i = simd_lane; i < m; i += kSimd) {
+          col[i] = (i == cand) ? svd_one(T(0)) : T(0);
+        }
+        ++cand;
+        for (uint32_t pass = 0; pass < 2; ++pass) {
+          for (uint32_t l = 0; l < j; ++l) {
+            device T* cl = out + l * ld;
+            T partial = T(0);
+            for (uint32_t i = simd_lane; i < m; i += kSimd) {
+              partial += svd_conjmul(cl[i], col[i]);
+            }
+            T dot = svd_simd_sum(partial);
+            for (uint32_t i = simd_lane; i < m; i += kSimd) {
+              col[i] -= svd_mul(dot, cl[i]);
+            }
+          }
+        }
+        float partial_n = 0;
+        for (uint32_t i = simd_lane; i < m; i += kSimd) {
+          partial_n += svd_abs2(col[i]);
+        }
+        const float nrm_sq = c10::metal::simd_sum(partial_n);
+        if (nrm_sq > kIndepThreshSq) {
+          const float inv = 1.0f / precise::sqrt(nrm_sq);
+          device T* cj = out + j * ld;
+          for (uint32_t i = simd_lane; i < m; i += kSimd) {
+            cj[i] = col[i] * inv;
+          }
+          break;
+        }
+      }
+    }
+  }
+
   if (tid == 0) {
     // NaN/Inf never triggers a rotation, so flag info to raise like the CPU
     // path.

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -3425,6 +3425,10 @@ kernel void svd_jacobi(
   if (params.compute_uv && simd_group == 0) {
     device T* out = (params.transposed == 0u) ? U_b : V_b;
     const uint32_t ld = (params.transposed == 0u) ? params.u_ld : params.v_ld;
+    // U_b is column-major (elem i of col c at out[c*ld + i]); the transposed
+    // run emits V_b row-major (out[i*ld + c]), so index columns accordingly.
+    const uint32_t col_off = (params.transposed == 0u) ? ld : 1u;
+    const uint32_t elem_step = (params.transposed == 0u) ? 1u : ld;
     // Relative rank cutoff: sigma_j at or below the Jacobi noise floor
     // (~m*eps*sigma_max) is numerically zero, so its column is arbitrary and
     // gets completed. An absolute eps would keep noise-amplified columns.
@@ -3448,14 +3452,14 @@ kernel void svd_jacobi(
         ++cand;
         for (uint32_t pass = 0; pass < 2; ++pass) {
           for (uint32_t l = 0; l < j; ++l) {
-            device T* cl = out + l * ld;
+            device T* cl = out + l * col_off;
             T partial = T(0);
             for (uint32_t i = simd_lane; i < m; i += kSimd) {
-              partial += svd_conjmul(cl[i], col[i]);
+              partial += svd_conjmul(cl[i * elem_step], col[i]);
             }
             T dot = svd_simd_sum(partial);
             for (uint32_t i = simd_lane; i < m; i += kSimd) {
-              col[i] -= svd_mul(dot, cl[i]);
+              col[i] -= svd_mul(dot, cl[i * elem_step]);
             }
           }
         }
@@ -3466,9 +3470,9 @@ kernel void svd_jacobi(
         const float nrm_sq = c10::metal::simd_sum(partial_n);
         if (nrm_sq > kIndepThreshSq) {
           const float inv = 1.0f / precise::sqrt(nrm_sq);
-          device T* cj = out + j * ld;
+          device T* cj = out + j * col_off;
           for (uint32_t i = simd_lane; i < m; i += kSimd) {
-            cj[i] = col[i] * inv;
+            cj[i * elem_step] = col[i] * inv;
           }
           break;
         }

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -3434,9 +3434,9 @@ kernel void svd_jacobi(
       ++rank;
     }
     // Accept a candidate as a null-space column when its squared residual after
-    // orthogonalization clears this: loose (well above the fp32 roundoff floor),
-    // but enough that the canonicals span the complement. Cf. Rutishauser/DGKS
-    // Gram-Schmidt reorthogonalization.
+    // orthogonalization clears this: loose (well above the fp32 roundoff
+    // floor), but enough that the canonicals span the complement. Cf.
+    // Rutishauser/DGKS Gram-Schmidt reorthogonalization.
     constexpr float kIndepThreshSq = 1e-2f;
     threadgroup T* col = Atg;
     uint32_t cand = 0;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12413,20 +12413,27 @@ class TestLinalgMPS(TestCaseMPS):
         # solution is sensitive to conditioning of individual batch members.
         self.assertEqual(A @ xm, A @ xc, atol=1e-4, rtol=1e-4)
 
+    @parametrize("shape", [(16, 48), (48, 16)])
     @dtypes(torch.float32, torch.complex64)
-    def test_linalg_svd_rank_deficient(self, device, dtype):
+    def test_linalg_svd_rank_deficient(self, device, dtype, shape):
         # Regression test for https://github.com/pytorch/pytorch/issues/196112:
-        # the native Jacobi kernel forms U as (A V) / sigma, which collapses to
-        # zero for sigma ~ 0, leaving U non-orthonormal for rank-deficient
-        # inputs. The null-space columns must be an orthonormal completion.
-        q = torch.linalg.qr(torch.randn(16, 32, 32, dtype=dtype)).Q
-        v = torch.linalg.qr(torch.randn(16, 32, 32, dtype=dtype)).Q
-        spectrum = torch.linspace(0.5, 2.0, 32)
-        spectrum[:16] = 0  # exact rank 16, 16384 elements over the gate
+        # the native Jacobi kernel forms the range factor as (A V) / sigma, which
+        # collapses to zero for sigma ~ 0, leaving that factor non-orthonormal for
+        # rank-deficient inputs; the null columns must be an orthonormal
+        # completion. The wide (m<n) case emits V row-major, so the completion has
+        # to honor that layout or it corrupts the emitted singular vectors.
+        m, n = shape
+        k = min(m, n)
+        rank = k // 2
+        q = torch.linalg.qr(torch.randn(16, m, k, dtype=dtype)).Q
+        v = torch.linalg.qr(torch.randn(16, n, k, dtype=dtype)).Q
+        spectrum = torch.linspace(0.5, 2.0, k)
+        spectrum[:rank] = 0  # exact deficiency; 16 batches keep it over the gate
         A = (q * spectrum) @ v.mH
         U, S, Vh = torch.linalg.svd(A.to(device), full_matrices=False)
-        gram = U.mH @ U
-        self.assertEqual(gram, torch.eye(32, dtype=dtype, device=device).expand_as(gram), atol=1e-4, rtol=1e-4)
+        eye = torch.eye(k, dtype=dtype, device=device)
+        self.assertEqual(U.mH @ U, eye.expand(16, k, k), atol=1e-4, rtol=1e-4)
+        self.assertEqual(Vh @ Vh.mH, eye.expand(16, k, k), atol=1e-4, rtol=1e-4)
         self.assertEqual(((U * S.unsqueeze(-2)) @ Vh).cpu(), A, atol=1e-4, rtol=1e-4)
 
     def test_linalg_svd_large_batch_conj(self, device="mps"):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12413,6 +12413,22 @@ class TestLinalgMPS(TestCaseMPS):
         # solution is sensitive to conditioning of individual batch members.
         self.assertEqual(A @ xm, A @ xc, atol=1e-4, rtol=1e-4)
 
+    @dtypes(torch.float32, torch.complex64)
+    def test_linalg_svd_rank_deficient(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/196112:
+        # the native Jacobi kernel forms U as (A V) / sigma, which collapses to
+        # zero for sigma ~ 0, leaving U non-orthonormal for rank-deficient
+        # inputs. The null-space columns must be an orthonormal completion.
+        q = torch.linalg.qr(torch.randn(16, 32, 32, dtype=dtype)).Q
+        v = torch.linalg.qr(torch.randn(16, 32, 32, dtype=dtype)).Q
+        spectrum = torch.linspace(0.5, 2.0, 32)
+        spectrum[:16] = 0  # exact rank 16, 16384 elements over the gate
+        A = (q * spectrum) @ v.mH
+        U, S, Vh = torch.linalg.svd(A.to(device), full_matrices=False)
+        gram = U.mH @ U
+        self.assertEqual(gram, torch.eye(32, dtype=dtype, device=device).expand_as(gram), atol=1e-4, rtol=1e-4)
+        self.assertEqual(((U * S.unsqueeze(-2)) @ Vh).cpu(), A, atol=1e-4, rtol=1e-4)
+
     def test_linalg_svd_large_batch_conj(self, device="mps"):
         # Regression test for https://github.com/pytorch/pytorch/issues/196113:
         # for m<n the native SVD runs the kernel on A.mH(); .contiguous() leaves


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195950
* __->__ #196139

The native Jacobi SVD forms U as (A V)_j / sigma_j, which collapses to zero for sigma_j at the noise floor, so rank-deficient inputs got a non-orthonormal U (U^H U != I) even though A = U S V^H still held. Replace those null columns with an orthonormal completion of the emitted columns (simd-group-parallel Gram-Schmidt of canonical vectors, like gesdd). Full-rank inputs are unaffected since the completion loop has zero trip count.

The ill-conditioned tiny-sigma accuracy reported in the same issue is a separate fp32 limitation of one-sided Jacobi and is not touched here.

Fixes #196112

Authored with assistance from Claude Code.