### PR TITLE
Fix MPS SVD dropping the conjugate bit on Fortran-ordered complex inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -2140,7 +2140,6 @@ static void svd_kernel_mps(const Tensor& A,
     }
   });
 
-
   if (!S_direct) {
     const_cast<Tensor&>(S).copy_(S_k.reshape(S.sizes()));
   }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -2072,7 +2072,15 @@ static void svd_kernel_mps(const Tensor& A,
   // Kernel needs rows >= cols. For m<n run it on A^H: SVD(A^H)=(V,S,U^H), and
   // params.transposed tells the kernel to swap left/right into the right outputs.
   const int64_t wm = transposed ? n : m;
-  Tensor in = (transposed ? A.mH() : A).contiguous().reshape({batch, wm, k});
+  Tensor in = (transposed ? A.mH() : A).contiguous();
+  if (in.is_conj()) {
+    // A physically contiguous conj view (A^H over a Fortran-ordered input,
+    // which is what the lstsq dispatcher feeds in) makes contiguous() a
+    // no-op, so the conjugate bit survives into the kernel's raw pointer
+    // reads and the conjugation silently never happens.
+    in = in.resolve_conj();
+  }
+  in = in.reshape({batch, wm, k});
 
   auto opts = A.options();
   const bool S_direct = S.is_contiguous() && S.scalar_type() == c10::toRealValueType(A.scalar_type());
@@ -2131,6 +2139,7 @@ static void svd_kernel_mps(const Tensor& A,
       getMPSProfiler().endProfileKernel(pso, stream);
     }
   });
+
 
   if (!S_direct) {
     const_cast<Tensor&>(S).copy_(S_k.reshape(S.sizes()));

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12413,6 +12413,32 @@ class TestLinalgMPS(TestCaseMPS):
         # solution is sensitive to conditioning of individual batch members.
         self.assertEqual(A @ xm, A @ xc, atol=1e-4, rtol=1e-4)
 
+    def test_linalg_lstsq_complex_underdetermined_large_batch(self, device="mps"):
+        # Regression test for https://github.com/pytorch/pytorch/issues/196113.
+        # The lstsq dispatcher hands the backend a Fortran-ordered working copy,
+        # and for a complex underdetermined batch `A.mH()` over it is already
+        # physically contiguous, so contiguous() used to no-op and the
+        # conjugate bit rode into the Jacobi kernel's raw reads: the kernel
+        # computed the SVD of conj(A) instead of A.
+        torch.manual_seed(0)
+        A = torch.randn(8, 32, 48, dtype=torch.complex64)  # underdetermined, over the gate
+        B = torch.randn(8, 32, 3, dtype=torch.complex64)
+        sol_m = torch.linalg.lstsq(A.to(device), B.to(device), driver="gelsd", rcond=1e-4).solution.cpu()
+        sol_c = torch.linalg.lstsq(A, B, driver="gelsd", rcond=1e-4).solution
+        # The minimum-norm solution is unique, so compare the raw solutions,
+        # not just fitted values.
+        self.assertEqual(sol_m, sol_c, atol=1e-4, rtol=1e-4)
+
+    def test_linalg_svd_complex_fortran_input(self, device="mps"):
+        # Same root cause as above, one level down: a Fortran-ordered complex
+        # input used to come back as the factorization of conj(A).
+        torch.manual_seed(0)
+        A = torch.randn(8, 32, 48, dtype=torch.complex64)
+        Af = torch.empty(8, 48, 32, dtype=torch.complex64).transpose(-2, -1).copy_(A)
+        U, S, Vh = torch.linalg.svd(Af.to(device), full_matrices=False)
+        recon = (U * S.unsqueeze(-2)) @ Vh
+        self.assertEqual(recon.cpu(), Af, atol=1e-4, rtol=1e-4)
+
     @dtypes(torch.float32, torch.complex64, torch.float16, torch.bfloat16)
     @parametrize("out", ["none", "zeros", "ones"])
     @parametrize("m, n, data, noncontig", [


### PR DESCRIPTION
## Issue

Fixes #196113

## Summary

For a complex underdetermined batch (m < n) arriving Fortran-ordered, which is exactly what the `lstsq` dispatcher always feeds in via `copyBatchedColumnMajor`, the MPS Jacobi SVD returned the factorization of `conj(A)`: `svd_kernel_mps` runs `A.mH().contiguous()` before staging, that view is already physically contiguous for Fortran inputs so `contiguous()` no-ops, the conjugate bit survives onto the view, and the kernel's raw pointer reads never apply the conjugation. Resolve the conj bit explicitly before the raw read, the same idiom `LinearAlgebraUtils.h` uses elsewhere. Bitwise on the reporter's shape, Vh from MPS used to equal `conj(Vh_cpu)`; after the fix the lstsq residual is 2.4e-06 against CPU's 9.1e-07.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

Two regression tests in `test_mps.py`: the reporter's exact complex underdetermined batched `lstsq` shape compared against CPU `gelsd`, and a Fortran-ordered complex SVD reconstruction. Both fail without the fix on an M5 Mac (residual ~1.8) and pass with it, and the 17 existing MPS linalg svd/lstsq tests all still pass. lintrunner (CLANGFORMAT) is clean on the touched files. No CUDA build or run; this was verified on macOS 26.6.2 arm64 with a from-source build.

## BC-breaking?

No. The change only materializes a conjugate flag that was being silently dropped, so previously wrong results become correct; nothing that was computed correctly before is affected (real dtypes and C-ordered inputs never hit the broken path).

---

Prepared with AI assistance (Kimi K3). The mechanism was verified with the runs described above, and the change was reviewed line by line before submission.
