### PR TITLE
[test] Add error_inputs for Conv1d/Conv2d/Conv3d

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -1030,6 +1030,66 @@ def module_inputs_torch_nn_ConvNd(module_info, device, dtype, requires_grad, tra
     ]
 
 
+def module_error_inputs_torch_nn_ConvNd(module_info, device, dtype, requires_grad, training, **kwargs):
+    N = kwargs['N']
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    make_module = partial(FunctionInput, device=device, dtype=dtype)
+    kernel_size, C_in, C_out = 3, 4, 5
+    spatial_shape = (kernel_size + 3,) * N
+    return [
+        # Channel count of the input must match in_channels.
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=make_module(C_in, C_out, kernel_size),
+                forward_input=FunctionInput(make_input((2, C_in + 1) + spatial_shape)),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex=f"to have {C_in} channels, but got {C_in + 1} channels instead",
+        ),
+        # Input must be (N + 1)D unbatched or (N + 2)D batched.
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=make_module(C_in, C_out, kernel_size),
+                forward_input=FunctionInput(make_input((2, 2, C_in) + spatial_shape)),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex=f"Expected {N + 1}D [(]unbatched[)] or {N + 2}D [(]batched[)] input to conv{N}d",
+        ),
+        # The kernel must fit inside the padded input.
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=make_module(C_in, C_out, kernel_size),
+                forward_input=FunctionInput(make_input((2, C_in) + (kernel_size - 1,) * N)),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex="Kernel size can't be greater than actual input size",
+        ),
+        # groups must be positive.
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=make_module(C_in, C_out, kernel_size, groups=0),
+                forward_input=FunctionInput(make_input((2, C_in) + spatial_shape)),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=ValueError,
+            error_regex="groups must be a positive integer",
+        ),
+        # in_channels must be divisible by groups.
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=make_module(C_in, C_out, kernel_size, groups=C_in - 1),
+                forward_input=FunctionInput(make_input((2, C_in) + spatial_shape)),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=ValueError,
+            error_regex="in_channels must be divisible by groups",
+        ),
+    ]
+
+
 def module_inputs_torch_nn_CosineEmbeddingLoss(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
     make_target = partial(make_tensor, device=device, dtype=dtype, requires_grad=False)
@@ -4280,6 +4340,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.Conv1d,
                module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=1, lazy=False),
+               module_error_inputs_func=partial(module_error_inputs_torch_nn_ConvNd, N=1),
                gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
                module_memformat_affects_out=True,
                decorators=(
@@ -4287,6 +4348,7 @@ module_db: list[ModuleInfo] = [
                )),
     ModuleInfo(torch.nn.Conv2d,
                module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=2, lazy=False),
+               module_error_inputs_func=partial(module_error_inputs_torch_nn_ConvNd, N=2),
                gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
                module_memformat_affects_out=True,
                skips=(
@@ -4300,6 +4362,7 @@ module_db: list[ModuleInfo] = [
                )),
     ModuleInfo(torch.nn.Conv3d,
                module_inputs_func=partial(module_inputs_torch_nn_ConvNd, N=3, lazy=False),
+               module_error_inputs_func=partial(module_error_inputs_torch_nn_ConvNd, N=3),
                gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
                module_memformat_affects_out=True,
                skips=(


### PR DESCRIPTION
## Issue

Fixes #174183

## Summary

`Conv1d`/`Conv2d`/`Conv3d` have no `module_error_inputs_func`, so their error
messages are not covered by `test_modules.py`. Adds a shared
`module_error_inputs_torch_nn_ConvNd`, parametrized on `N` like the existing
`module_inputs_torch_nn_ConvNd` (per the review comment on the issue asking for
one shared function across ConvNd rather than a Conv2d-only one), and wires it
into the three `ModuleInfo` entries. It covers input channel mismatch, wrong
input dimensionality, a kernel larger than the input, `groups=0`, and
`in_channels` not divisible by `groups`. Transposed and lazy variants are left
for a follow-up.

Test plan:

```
python test/test_modules.py -k test_errors_nn_Conv   # 6 passed
python test/test_modules.py -k test_errors           # 67 passed
```

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. Test-only change; no runtime code is touched.
