### PR TITLE
Fix mse_loss type stub

### DIFF
--- a/test/typing/pass/nn_functional.py
+++ b/test/typing/pass/nn_functional.py
@@ -1,0 +1,7 @@
+# flake8: noqa
+import torch
+
+
+torch.nn.functional.mse_loss(
+    torch.ones(1), torch.ones(1), weight=torch.ones(1)
+)

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -603,6 +603,7 @@ def mse_loss(
     size_average: bool | None = ...,
     reduce: bool | None = ...,
     reduction: str = ...,
+    weight: Tensor | None = ...,
 ) -> Tensor: ...
 
 __all__ += ["mse_loss"]


### PR DESCRIPTION
fixes #196122 

The mse_loss runtime signature accepts a weight argument, but the corresponding type stub was missing it.

This adds weight: Tensor | None to the mse_loss type stub and adds a typing test