### PR TITLE
Let fastAtomicAdd derive its bound from a packed accessor

### DIFF
--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -2,7 +2,6 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
-#include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
@@ -13,6 +12,7 @@
 #include <ATen/native/FractionalMaxPooling.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/NativeFunctions.h>
 #else
@@ -122,9 +122,10 @@ __global__ void fractional_max_pool2d_backward_out_cuda_frame(
     int inputH = index / gradInput.size(3);
     CUDA_KERNEL_ASSERT(inputH < gradInput.size(2));
 
-    gpuAtomicAddNoReturn(
-      &gradInput[batch][plane][inputH][inputW],
-      gradOutput[batch][plane][outputH][outputW]
+    fastAtomicAdd(
+      gradInput,
+      gradOutput[batch][plane][outputH][outputW],
+      batch, plane, inputH, inputW
     );
   }
 }

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -2,7 +2,6 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
-#include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
@@ -14,6 +13,7 @@
 #include <ATen/native/FractionalMaxPooling.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -145,9 +145,10 @@ __global__ void fractional_max_pool3d_backward_out_frame(
       gradInput.size(4));
     CUDA_KERNEL_ASSERT(inputT < gradInput.size(2));
 
-    gpuAtomicAddNoReturn(
-      &gradInput[batch][plane][inputT][inputH][inputW],
-      gradOutput[batch][plane][outputT][outputH][outputW]
+    fastAtomicAdd(
+      gradInput,
+      gradOutput[batch][plane][outputT][outputH][outputW],
+      batch, plane, inputT, inputH, inputW
       );
     }
   }

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include <ATen/core/TensorAccessor.h>
 #include <torch/headeronly/cuda/Atomic.h>
 #include <torch/headeronly/cuda/KernelUtils.h>
 
@@ -18,6 +19,44 @@ namespace at::native {
 
 using torch::headeronly::fastAtomicAdd;
 using torch::headeronly::fastSpecializedAtomicAdd;
+
+// Scatter into a packed accessor without naming a bound.
+//
+// fastAtomicAdd needs to know how far it may look for a pairing partner -- see
+// Note [Passing pointer and offset to fastAtomicAdd] in GridSampler.cu. A
+// caller holding a raw pointer supplies that by hand, and too large a value
+// lets the pairing write past the allocation. An accessor already carries what
+// it would be derived from:
+//
+//   memory_span = 1 + sum over d of (size[d] - 1) * stride[d]
+//
+// the distance to the last addressable element rather than the element count,
+// which is what at::native::storage_size_for computes on the host. The two
+// differ for a strided view, whose gaps are legal pairing partners: inside the
+// region, though belonging to whatever the view was taken from, and only ever
+// receiving a zero.
+template <
+    typename scalar_t,
+    size_t N,
+    template <typename U> class PtrTraits,
+    typename index_t,
+    typename... Idx>
+__device__ __forceinline__ void fastAtomicAdd(
+    at::GenericPackedTensorAccessor<scalar_t, N, PtrTraits, index_t> accessor,
+    scalar_t value,
+    Idx... indices) {
+  static_assert(
+      sizeof...(Idx) == N, "fastAtomicAdd needs one index per dimension");
+  const index_t index[N] = {static_cast<index_t>(indices)...};
+  index_t offset = 0;
+  index_t memory_span = 1;
+#pragma unroll
+  for (size_t d = 0; d < N; ++d) {
+    offset += index[d] * accessor.stride(d);
+    memory_span += (accessor.size(d) - 1) * accessor.stride(d);
+  }
+  fastAtomicAdd(accessor.data(), offset, memory_span, value, true);
+}
 
 __device__ __forceinline__ size_t
 idx(const size_t nc,

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -2,12 +2,12 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/ceil_div.h>
 #include <ATen/Dispatch.h>
-#include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <c10/util/Exception.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -82,7 +82,7 @@ __global__ void replication_pad_backward_kernel(
   const auto inputPointX = imin(imax(padL, outputPointX), gradInput.size(2) + padL - 1) - oStartX + iStartX;
 
   scalar_t valueToCopy = gradOutput[batch][plane][outputPointX];
-  gpuAtomicAddNoReturn(&gradInput[batch][plane][inputPointX], valueToCopy);
+  fastAtomicAdd(gradInput, valueToCopy, batch, plane, inputPointX);
 }
 
 template <typename scalar_t>
@@ -140,7 +140,7 @@ __global__ void replication_pad_backward_kernel(
   const int inputPointY = imin(imax(padT, outputPointY), gradInput.size(2) + padT - 1) - oStartY + iStartY;
 
   scalar_t valueToCopy = gradOutput[batch][plane][outputPointY][outputPointX];
-  gpuAtomicAddNoReturn(&gradInput[batch][plane][inputPointY][inputPointX], valueToCopy);
+  fastAtomicAdd(gradInput, valueToCopy, batch, plane, inputPointY, inputPointX);
 }
 
 template <typename scalar_t>
@@ -221,8 +221,8 @@ __global__ void replication_pad_backward_kernel(
 
   scalar_t valueToCopy =
     gradOutput[batch][plane][outputPointZ][outputPointY][outputPointX];
-  gpuAtomicAddNoReturn(&gradInput[batch][plane][inputPointZ][inputPointY][inputPointX],
-      valueToCopy);
+  fastAtomicAdd(
+      gradInput, valueToCopy, batch, plane, inputPointZ, inputPointY, inputPointX);
 }
 
 void replication_pad2d_backward_out_cuda_template(

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -7,9 +7,9 @@
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
-#include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/native/cuda/UpSample.cuh>
+#include <ATen/native/cuda/KernelUtils.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -108,9 +108,10 @@ __global__ void upsample_linear1d_out_frame_backward(
     for (int n = 0; n < batchsize; n++) {
       for (int c = 0; c < channels; ++c) {
         const scalar_t d2val = odata[n][c][w2];
-        gpuAtomicAddNoReturn(&idata[n][c][w1], static_cast<scalar_t>(w0lambda * d2val));
-        gpuAtomicAddNoReturn(
-            &idata[n][c][w1 + w1p], static_cast<scalar_t>(w1lambda * d2val));
+        fastAtomicAdd(
+            idata, static_cast<scalar_t>(w0lambda * d2val), n, c, w1);
+        fastAtomicAdd(
+            idata, static_cast<scalar_t>(w1lambda * d2val), n, c, w1 + w1p);
       }
     }
   }

--- a/aten/src/ATen/test/cuda_atomic_ops_test.cu
+++ b/aten/src/ATen/test/cuda_atomic_ops_test.cu
@@ -2,9 +2,15 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <c10/test/util/Macros.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #include <c10/cuda/CUDAException.h>
 
+#include <ATen/ATen.h>
+
 #include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
 
 constexpr int blocksize = 256;
 constexpr int factor = 4;
@@ -287,4 +293,120 @@ TEST(TestAtomicOps, DISABLED_ON_WINDOWS(TestAtomicReturnValue)) {
   test_atomic_return_value<at::Half>();
   test_atomic_return_value<float>();
   test_atomic_return_value<double>();
+}
+
+namespace {
+
+// What the accessor overload has to get right is the bound it derives: the
+// distance to the last addressable element, which stops matching the element
+// count as soon as the accessor is strided.
+//
+// A pairing writes +0 to the neighbour, which no value check can see. The sign
+// bit gives it away, since (-0.0) + (+0.0) == +0.0, so a buffer seeded with
+// -0.0 answers "was this slot touched". Same trick as
+// TestFastAtomicAdd.VectorizedBounds in
+// test/cpp/aoti_abi_check/cuda/test_kernel_utils.cu, for the pointer form.
+constexpr uint16_t kNegZeroBits = 0x8000; // -0.0 as both fp16 and bf16
+
+template <typename scalar_t>
+__global__ void accessor_scatter_kernel(
+    at::PackedTensorAccessor64<scalar_t, 2> acc,
+    int64_t i0,
+    int64_t i1) {
+  at::native::fastAtomicAdd(acc, static_cast<scalar_t>(1), i0, i1);
+}
+
+// A 2x3 view into a 1-D tensor, `offset` elements in with the given strides --
+// the strided accessor is the object under test, so it is built the way one
+// actually reaches a kernel. Scatters +1 at (i0, i1) and returns the whole
+// buffer, so a write outside the view's region shows up.
+template <typename scalar_t>
+std::vector<scalar_t> accessorScatter(
+    std::vector<scalar_t> buf,
+    int64_t offset,
+    int64_t row_stride,
+    int64_t col_stride,
+    int64_t i0,
+    int64_t i1) {
+  const auto opts =
+      at::TensorOptions().dtype(c10::CppTypeToScalarType<scalar_t>::value);
+  const auto base =
+      at::from_blob(buf.data(), {static_cast<int64_t>(buf.size())}, opts)
+          .to(at::kCUDA);
+  const auto view =
+      at::as_strided(base, {2, 3}, {row_stride, col_stride}, offset);
+
+  accessor_scatter_kernel<scalar_t>
+      <<<1, 1>>>(view.packed_accessor64<scalar_t, 2>(), i0, i1);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  const auto out = base.cpu();
+  std::memcpy(buf.data(), out.const_data_ptr(), buf.size() * sizeof(scalar_t));
+  return buf;
+}
+
+template <typename scalar_t>
+bool wasWritten(scalar_t v) {
+  return v.x != kNegZeroBits;
+}
+
+template <typename scalar_t>
+void test_accessor_bounds() {
+  constexpr int64_t buf_numel = 16;
+  constexpr int64_t offset = 1; // odd 16-bit alignment, as a view would give
+
+  // Contiguous 2x3, strides 3/1: memory_span is 6. At this alignment even
+  // offsets pair left and odd ones pair right, so (0,1) at offset 1 pairs and
+  // is the positive control, while (1,2) at offset 5 can only look right, past
+  // the last element, and must fall back to a scalar atomic.
+  {
+    std::vector<scalar_t> buf(buf_numel);
+    for (auto& v : buf) {
+      v.x = kNegZeroBits;
+    }
+    const auto out =
+        accessorScatter<scalar_t>(std::move(buf), offset, 3, 1, 0, 1);
+    EXPECT_EQ(static_cast<float>(out[offset + 1]), 1.0f);
+    EXPECT_TRUE(wasWritten(out[offset + 2])) << "offset 1 should pair right";
+    EXPECT_FALSE(wasWritten(out[0])) << "wrote below the start";
+  }
+  {
+    std::vector<scalar_t> buf(buf_numel);
+    for (auto& v : buf) {
+      v.x = kNegZeroBits;
+    }
+    const auto out =
+        accessorScatter<scalar_t>(std::move(buf), offset, 3, 1, 1, 2);
+    EXPECT_EQ(static_cast<float>(out[offset + 5]), 1.0f);
+    EXPECT_FALSE(wasWritten(out[offset + 6])) << "paired past the last element";
+    EXPECT_FALSE(wasWritten(out[buf_numel - 1])) << "wrote past the end";
+  }
+
+  // Non-contiguous 2x3, strides 6/2: element count is still 6, but the last
+  // addressable offset is 10, so memory_span is 11. Writing (1, 2) lands there
+  // and pairs left into offset 9, a gap the view steps over -- legal, and what
+  // a numel-derived bound of 6 would wrongly have refused.
+  {
+    std::vector<scalar_t> buf(buf_numel);
+    for (auto& v : buf) {
+      v.x = kNegZeroBits;
+    }
+    const auto out =
+        accessorScatter<scalar_t>(std::move(buf), offset, 6, 2, 1, 2);
+    EXPECT_EQ(static_cast<float>(out[offset + 10]), 1.0f);
+    EXPECT_TRUE(wasWritten(out[offset + 9])) << "declined to pair inside the region";
+    EXPECT_FALSE(wasWritten(out[offset + 11])) << "paired past the region";
+    EXPECT_FALSE(wasWritten(out[0])) << "wrote below the start";
+  }
+}
+} // namespace
+
+TEST(TestAtomicOps, DISABLED_ON_WINDOWS(TestFastAtomicAddAccessorBounds)) {
+  if (!at::cuda::is_available()) return;
+  test_accessor_bounds<at::Half>();
+  // fastSpecializedAtomicAdd has no packed bf16 path before sm_80, so the
+  // pairing these cases assert on does not happen there.
+  if (at::cuda::getCurrentDeviceProperties()->major >= 8) {
+    test_accessor_bounds<at::BFloat16>();
+  }
 }


### PR DESCRIPTION
fastAtomicAdd needs a bound on how far it may look for a pairing partner when packing a 16-bit atomic. Callers holding a raw pointer supply that themselves, and getting it wrong is silent (too large lets the pairing write past the allocation) -- which is why ~20 scatter sites that subscript a packed accessor still use the plain atomic rather than hand-deriving a bound.

Adds an accessor overload that derives offset and bound itself:

```
offset = sum over d of index[d] * stride[d]
span   = 1 + sum over d of (size[d] - 1) * stride[d]
```

`span` is the distance to the last addressable element, not the element count -- the two differ for a non-contiguous accessor, whose gaps are legal pairing targets. Converts the 5 sites that subscript a packed accessor (ReplicationPadding, UpSampleLinear1d, FractionalMaxPool2d/3d); they lose their index arithmetic and no longer have a bound to get wrong.

Adds coverage for the accessor overload's derived bound, including the non-contiguous case where element count and last addressable offset differ -- the case a numel-based bound would get wrong.

(An earlier version of this PR also switched the underlying torch::headeronly::fastAtomicAdd from a pointer+numel pair to std::span, to close off transposing numel with the adjacent index argument. Dropped: torch::headeronly is PyTorch's stable ABI surface, and torchvision -- built in CI -- calls the pointer+numel form directly; the span change broke it. The accessor overload here is purely additive and doesn't touch that signature.)

Test Plan: no CUDA device available here; individual commits document the host-side checks (template deduction, span/offset arithmetic). CI exercises replication padding, 1-D linear upsampling, and both fractional max pools across dtypes including half/bfloat16.

This PR was authored with the assistance of an AI coding assistant.