### PR TITLE
Use fastAtomicAdd for the max-pool backward scatters

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -6,6 +6,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #include <c10/util/Exception.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -15,7 +16,6 @@
 #include <ATen/ops/adaptive_max_pool2d_backward_native.h>
 #include <ATen/ops/adaptive_max_pool2d_native.h>
 #include <ATen/ops/empty.h>
-#include <ATen/native/cuda/KernelUtils.cuh>
 #endif
 
 #include <algorithm>

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -1,6 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
-#include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/Dispatch.h>
@@ -16,6 +15,7 @@
 #include <ATen/ops/adaptive_max_pool2d_backward_native.h>
 #include <ATen/ops/adaptive_max_pool2d_native.h>
 #include <ATen/ops/empty.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #endif
 
 #include <algorithm>
@@ -193,7 +193,8 @@ __global__ void atomicadaptivemaxgradinput(
       int argmax = (*ptr_ind);
 
       // atomic add since different threads could update same variable
-      gpuAtomicAddNoReturn(&(gradInput[argmax]), z);
+      // numel is the plane the base pointer addresses, not the whole tensor.
+      fastAtomicAdd(gradInput, argmax, isizeH * isizeW, z, true);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -193,7 +193,6 @@ __global__ void atomicadaptivemaxgradinput(
       int argmax = (*ptr_ind);
 
       // atomic add since different threads could update same variable
-      // numel is the plane the base pointer addresses, not the whole tensor.
       fastAtomicAdd(gradInput, argmax, isizeH * isizeW, z, true);
     }
   }

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -6,6 +6,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #include <c10/util/Exception.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -15,7 +16,6 @@
 #include <ATen/ops/adaptive_max_pool3d_backward_native.h>
 #include <ATen/ops/adaptive_max_pool3d_native.h>
 #include <ATen/ops/empty.h>
-#include <ATen/native/cuda/KernelUtils.cuh>
 #endif
 
 #include <algorithm>

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -1,6 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
-#include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/Dispatch.h>
@@ -16,6 +15,7 @@
 #include <ATen/ops/adaptive_max_pool3d_backward_native.h>
 #include <ATen/ops/adaptive_max_pool3d_native.h>
 #include <ATen/ops/empty.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #endif
 
 #include <algorithm>
@@ -256,7 +256,8 @@ __global__ void atomicadaptivemaxgradinput(
   int d = o_plane / osizeT;     // output slice/feature
 
   // gradInput offset by slice/feature
-  T *gradInput_d = gradInput + d*isizeT*isizeH*isizeW;
+  const int64_t isize_dhw = static_cast<int64_t>(isizeT) * isizeH * isizeW;
+  T *gradInput_d = gradInput + d * isize_dhw;
   // gradOutput offset by slice/feature and frame/otme
   const T *gradOutput_dt = gradOutput + o_plane*osizeH*osizeW;
   // indices offset by slice/feature and frame/otme
@@ -270,7 +271,8 @@ __global__ void atomicadaptivemaxgradinput(
       const int64_t *ptr_ind = indices_dt + oh*osizeW + ow;
       T grad_delta = *ptr_gradOutput;
       int64_t argmax = (*ptr_ind);
-      gpuAtomicAddNoReturn(&(gradInput_d[argmax]), grad_delta);
+      // numel is the slice the base pointer addresses, not the whole tensor.
+      fastAtomicAdd(gradInput_d, argmax, isize_dhw, grad_delta, true);
     }
   }
 }

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -271,7 +271,6 @@ __global__ void atomicadaptivemaxgradinput(
       const int64_t *ptr_ind = indices_dt + oh*osizeW + ow;
       T grad_delta = *ptr_gradOutput;
       int64_t argmax = (*ptr_ind);
-      // numel is the slice the base pointer addresses, not the whole tensor.
       fastAtomicAdd(gradInput_d, argmax, isize_dhw, grad_delta, true);
     }
   }

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -5,7 +5,6 @@
 #include <ATen/Dispatch.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/native/Pool.h>
-#include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/cuda/detail/TensorInfo.cuh>
@@ -20,6 +19,7 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/max_pool3d_with_indices_native.h>
 #include <ATen/ops/max_pool3d_with_indices_backward_native.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #endif
 
 namespace at::native {
@@ -190,6 +190,7 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
   int itime, int iheight, int iwidth,
   int obatch, int otime, int oheight, int owidth,
   int offsetZ,
+  const int64_t gradInput_numel,
   bool channels_last)
 {
   int64_t oColumn = blockIdx.x * blockDim.x + threadIdx.x;
@@ -224,11 +225,19 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
     int64_t maxIndex = indicesData[out_index];
     if (maxIndex != -1) {
       if (!channels_last) {
-        gpuAtomicAddNoReturn(&gradInputData[slice * itime  * iheight * iwidth + maxIndex],
-          gradOutputData[out_index]);
+        fastAtomicAdd(
+          gradInputData,
+          slice * itime * iheight * iwidth + maxIndex,
+          gradInput_numel,
+          gradOutputData[out_index],
+          true);
       } else {
-        gpuAtomicAddNoReturn(&gradInputData[((int64_t) batch * itime * iheight * iwidth + maxIndex) * features + channel],
-          gradOutputData[out_index]);
+        fastAtomicAdd(
+          gradInputData,
+          ((int64_t) batch * itime * iheight * iwidth + maxIndex) * features + channel,
+          gradInput_numel,
+          gradOutputData[out_index],
+          true);
       }
     }
   }
@@ -243,6 +252,7 @@ void max_pool3d_with_indices_backward_out_frame(
   int64_t totalZ,
   int itime, int iheight, int iwidth,
   int obatch, int otime, int oheight, int owidth,
+  const int64_t gradInput_numel,
   bool channels_last)
 {
   int offsetZ = 0;
@@ -271,6 +281,7 @@ void max_pool3d_with_indices_backward_out_frame(
         itime, iheight, iwidth,
         obatch, otime, oheight, owidth,
         offsetZ,
+        gradInput_numel,
         channels_last);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
@@ -538,6 +549,7 @@ void max_pool3d_with_indices_backward_out_cuda_template(
         totalZ,
         itime, iheight, iwidth,
         nbatch, otime, oheight, owidth,
+        work_grad_input.numel(),
         channels_last);
     }
   );

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -10,6 +10,7 @@
 #include <ATen/cuda/detail/TensorInfo.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/detail/KernelUtils.h>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #include <c10/macros/Macros.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -19,7 +20,6 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/max_pool3d_with_indices_native.h>
 #include <ATen/ops/max_pool3d_with_indices_backward_native.h>
-#include <ATen/native/cuda/KernelUtils.cuh>
 #endif
 
 namespace at::native {
@@ -190,9 +190,10 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
   int itime, int iheight, int iwidth,
   int obatch, int otime, int oheight, int owidth,
   int offsetZ,
-  const int64_t gradInput_numel,
   bool channels_last)
 {
+  const int64_t gradInput_numel =
+      static_cast<int64_t>(obatch) * features * itime * iheight * iwidth;
   int64_t oColumn = blockIdx.x * blockDim.x + threadIdx.x;
   int64_t oRow = blockIdx.y * blockDim.y + threadIdx.y;
 
@@ -224,21 +225,18 @@ __global__ static void max_pool3d_with_indices_backward_single_out_frame(
     }
     int64_t maxIndex = indicesData[out_index];
     if (maxIndex != -1) {
+      int64_t gradInputIndex;
       if (!channels_last) {
-        fastAtomicAdd(
-          gradInputData,
-          slice * itime * iheight * iwidth + maxIndex,
-          gradInput_numel,
-          gradOutputData[out_index],
-          true);
+        gradInputIndex = slice * itime * iheight * iwidth + maxIndex;
       } else {
-        fastAtomicAdd(
-          gradInputData,
-          ((int64_t) batch * itime * iheight * iwidth + maxIndex) * features + channel,
-          gradInput_numel,
-          gradOutputData[out_index],
-          true);
+        gradInputIndex = ((int64_t) batch * itime * iheight * iwidth + maxIndex) * features + channel;
       }
+      fastAtomicAdd(
+        gradInputData,
+        gradInputIndex,
+        gradInput_numel,
+        gradOutputData[out_index],
+        true);
     }
   }
 }
@@ -252,7 +250,6 @@ void max_pool3d_with_indices_backward_out_frame(
   int64_t totalZ,
   int itime, int iheight, int iwidth,
   int obatch, int otime, int oheight, int owidth,
-  const int64_t gradInput_numel,
   bool channels_last)
 {
   int offsetZ = 0;
@@ -281,7 +278,6 @@ void max_pool3d_with_indices_backward_out_frame(
         itime, iheight, iwidth,
         obatch, otime, oheight, owidth,
         offsetZ,
-        gradInput_numel,
         channels_last);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
@@ -549,7 +545,6 @@ void max_pool3d_with_indices_backward_out_cuda_template(
         totalZ,
         itime, iheight, iwidth,
         nbatch, otime, oheight, owidth,
-        work_grad_input.numel(),
         channels_last);
     }
   );


### PR DESCRIPTION
Three backward kernels scatter half/bfloat16 gradients through gpuAtomicAddNoReturn on a bare pointer, which nvcc lowers to a CAS loop since GPUs have no scalar 16-bit atomic add. fastAtomicAdd reaches the packed instruction instead, pairing the value with a zero on whichever side alignment allows and falling back to the scalar path when the pair would run past the region. Float/double are unaffected.

adaptive_max_pool2d_backward's launcher hardcodes the atomic kernel, so every half/bfloat16 backward on CUDA takes this path.

The bound matters: too large lets the pairing write past the allocation. Both adaptive kernels already pass the same extent they advanced their pointer by; the dilated kernel now takes gradInput's numel as a parameter instead of not bounding the write at all.

The ~20 remaining bare-pointer sites subscript a PackedTensorAccessor and are left for a follow-up (#196155) that derives the bound from the accessor instead of by hand.

Test Plan: no CUDA device available here; offered for CI (test_nn.py / test_modules.py cover all three ops' backward across dtypes).

This PR was authored with the assistance of an AI coding assistant.