### PR TITLE
fix(distributed.rpc): correct rpc_contants -> rpc_constants import alias

### DIFF
--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import torch
 
-from . import _is_tensorpipe_available, constants as rpc_contants
+from . import _is_tensorpipe_available, constants as rpc_constants
 
 
 DeviceType = int | str | torch.device
@@ -84,9 +84,9 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
     def __init__(
         self,
         *,
-        num_worker_threads: int = rpc_contants.DEFAULT_NUM_WORKER_THREADS,
-        rpc_timeout: float = rpc_contants.DEFAULT_RPC_TIMEOUT_SEC,
-        init_method: str = rpc_contants.DEFAULT_INIT_METHOD,
+        num_worker_threads: int = rpc_constants.DEFAULT_NUM_WORKER_THREADS,
+        rpc_timeout: float = rpc_constants.DEFAULT_RPC_TIMEOUT_SEC,
+        init_method: str = rpc_constants.DEFAULT_INIT_METHOD,
         device_maps: dict[str, dict[DeviceType, DeviceType]] | None = None,
         devices: list[DeviceType] | None = None,
         _transports: list | None = None,


### PR DESCRIPTION
## Summary
- In `torch/distributed/rpc/options.py` the local import alias for the RPC constants module is spelled `rpc_contants` in three places.
- The same module is imported as `rpc_constants` in `backend_registry.py`, so this is an inconsistency, not a functional bug.
- Correct the alias to `rpc_constants` so the intended public name is consistent across the module.

## Test plan
- [ ] `python -m py_compile torch/distributed/rpc/options.py`
- [ ] import `torch.distributed.rpc.TensorPipeRpcBackendOptions` and instantiate with defaults
- [ ] relevant rpc tests in `test/distributed/rpc/` if available in CI

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>