### PR TITLE
[dynamo] Split OrderedSetVariable off SetVariable to match CPython

### DIFF
--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -1082,6 +1082,518 @@ class FrozensetHierarchyTests(_BaseSetTests):
         self.assertEqual(s, {2, 3, 4, 10})
 
 
+class OrderedSetHierarchyTests(torch._dynamo.test_case.TestCase):
+    """``OrderedSet`` is a ``MutableSet``, not a ``set``. Part of #192874.
+
+    ``torch.utils._ordered_set.OrderedSet`` has ``set``'s whole named-method
+    surface, so unlike the frozenset and dict_keys rows nothing is removed
+    here. What differs is that insertion order is observable and that the
+    in-place operators are ``collections.abc.MutableSet``'s.
+    """
+
+    # Deliberately not in hash order. A result that comes back as [1, 2, 3]
+    # was rebuilt from a set, not from the OrderedSet's own order.
+    BASE = [3, 1, 2]
+    OTHER = [5, 4, 9]
+
+    @staticmethod
+    def _snapshot(value):
+        # OrderedSet.__eq__ ignores order (it compares the backing dicts), so
+        # order has to be checked through list().
+        from torch.utils._ordered_set import OrderedSet
+
+        if isinstance(value, OrderedSet):
+            return ("OrderedSet", list(value))
+        if isinstance(value, tuple):
+            return tuple(OrderedSetHierarchyTests._snapshot(v) for v in value)
+        return value
+
+    def _assert_matches_eager(self, fn, *args, fullgraph=True):
+        expected = self._snapshot(fn(*args))
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, backend="eager", fullgraph=fullgraph)
+        self.assertEqual(self._snapshot(compiled(*args)), expected)
+
+    def test_ordered_set_is_not_a_set_variable(self):
+        """Structural guard against the classes being merged again."""
+        from collections.abc import MutableSet
+
+        from torch._dynamo.variables.sets import (
+            BaseSetVariable,
+            OrderedSetVariable,
+            SetVariable,
+        )
+        from torch.utils._ordered_set import OrderedSet
+
+        self.assertFalse(issubclass(OrderedSetVariable, SetVariable))
+        self.assertTrue(issubclass(OrderedSetVariable, BaseSetVariable))
+        # Matches real CPython.
+        self.assertFalse(issubclass(OrderedSet, set))
+        self.assertTrue(issubclass(OrderedSet, MutableSet))
+
+    def test_named_methods_match_eager(self):
+        """All 17 named set methods trace and agree with eager, order included."""
+        from torch.utils._ordered_set import OrderedSet
+
+        base, other = list(self.BASE), list(self.OTHER)
+        calls = {
+            "isdisjoint": (other,),
+            "intersection": ([2, 1, 9],),
+            "union": (other,),
+            "difference": ([1],),
+            "symmetric_difference": (other,),
+            "issubset": ([3, 1, 2, 9],),
+            "issuperset": ([1],),
+            "copy": (),
+            "add": (9,),
+            "pop": (),
+            "remove": (1,),
+            "discard": (1,),
+            "clear": (),
+            "update": (other,),
+            "intersection_update": ([2, 1, 9],),
+            "difference_update": ([1],),
+            "symmetric_difference_update": (other,),
+        }
+        self.assertEqual(
+            sorted(calls), sorted(n for n in dir(set) if not n.startswith("_"))
+        )
+        for name, args in calls.items():
+            with self.subTest(method=name):
+
+                def fn(_name=name, _args=args):
+                    s = OrderedSet(base)
+                    r = getattr(s, _name)(*_args)
+                    return r, s
+
+                self._assert_matches_eager(fn)
+
+    def test_pop_is_lifo(self):
+        """OrderedSet.pop is dict.popitem: the most recently inserted element."""
+        from torch.utils._ordered_set import OrderedSet
+
+        def fn():
+            s = OrderedSet([3, 1, 2])
+            a = s.pop()
+            b = s.pop()
+            return a, b, list(s)
+
+        self.assertEqual(fn(), (2, 1, [3]))
+        self._assert_matches_eager(fn)
+
+    def test_reconstruction_preserves_insertion_order(self):
+        """An OrderedSet leaving the compiled region keeps its order."""
+        from torch.utils._ordered_set import OrderedSet
+
+        def fn():
+            s = OrderedSet([3, 1, 2])
+            return (
+                s,
+                repr(s),
+                s.copy(),
+                OrderedSet(s),
+                s | [9, 0],
+                OrderedSet([7, 0, 3]),
+            )
+
+        self.assertEqual(
+            self._snapshot(fn())[0:2],
+            (("OrderedSet", [3, 1, 2]), "OrderedSet([3, 1, 2])"),
+        )
+        self._assert_matches_eager(fn)
+
+    def test_inplace_operators_mutate_in_place(self):
+        """MutableSet's in-place operators take any iterable and keep identity.
+
+        set's slots return NotImplemented for a non-set operand, which falls
+        back to the binary operator and rebinds the name to a new object.
+        """
+        from torch.utils._ordered_set import OrderedSet
+
+        base, other = list(self.BASE), list(self.OTHER)
+
+        def ior(ctor):
+            s = OrderedSet(base)
+            alias = s
+            s |= ctor(other)
+            return s is alias, s
+
+        def iand(ctor):
+            s = OrderedSet(base)
+            alias = s
+            s &= ctor([2, 1, 9])
+            return s is alias, s
+
+        def isub(ctor):
+            s = OrderedSet(base)
+            alias = s
+            s -= ctor([1])
+            return s is alias, s
+
+        def ixor(ctor):
+            s = OrderedSet(base)
+            alias = s
+            s ^= ctor(other)
+            return s is alias, s
+
+        for fn in (ior, iand, isub, ixor):
+            for ctor in (OrderedSet, list, tuple):
+                with self.subTest(op=fn.__name__, operand=ctor.__name__):
+                    self.assertTrue(fn(ctor)[0])
+                    self._assert_matches_eager(fn, ctor)
+
+        # set operands as literals: CPython folds a literal of constants into
+        # one frozenset constant, so eager and Dynamo iterate it in the same
+        # order. set([5, 4, 9]) would not: Dynamo keeps the list's order.
+        def with_set_operands():
+            s = OrderedSet(base)
+            alias = s
+            s |= {4, 5, 9}
+            a = s is alias
+            s &= {1, 2, 4}
+            b = s is alias
+            s -= {1}
+            c = s is alias
+            s ^= {2, 7}
+            d = s is alias
+            return (a, b, c, d), s
+
+        self.assertEqual(
+            self._snapshot(with_set_operands()),
+            ((True, True, True, True), ("OrderedSet", [4, 7])),
+        )
+        self._assert_matches_eager(with_set_operands)
+
+    def test_binary_operators_match_eager(self):
+        """Set's operators accept any iterable, on either side, and build an
+        OrderedSet (Set._from_iterable) even when the OrderedSet is the right
+        operand."""
+        from torch.utils._ordered_set import OrderedSet
+
+        base, other = list(self.BASE), list(self.OTHER)
+
+        def forward(ctor):
+            s = OrderedSet(base)
+            o = ctor(other)
+            return s | o, s & o, s - o, s ^ o
+
+        def reflected(ctor):
+            s = OrderedSet(base)
+            o = ctor(other)
+            return o | s, o & s, o - s, o ^ s
+
+        for fn in (forward, reflected):
+            for ctor in (OrderedSet, list, tuple):
+                with self.subTest(op=fn.__name__, operand=ctor.__name__):
+                    for r in fn(ctor):
+                        self.assertIs(type(r), OrderedSet)
+                    self._assert_matches_eager(fn, ctor)
+
+        def reflected_from_set():
+            s = OrderedSet(base)
+            r = {5, 4, 9} - s
+            return type(r), r
+
+        self._assert_matches_eager(reflected_from_set)
+
+    def test_unbound_class_method_calls(self):
+        """OrderedSet.method(obj, ...) is dispatched only for an OrderedSet obj."""
+        from torch.utils._ordered_set import OrderedSet
+
+        base = list(self.BASE)
+
+        def on_ordered_set():
+            s = OrderedSet(base)
+            OrderedSet.add(s, 9)
+            popped = OrderedSet.pop(s)
+            return OrderedSet.union(s, [4]), popped, s
+
+        self._assert_matches_eager(on_ordered_set)
+
+        # With a plain set as the receiver the pure-Python method bodies run
+        # against a set and raise in eager. Before the split Dynamo routed
+        # these to SetVariable and returned a value instead.
+        def add_on_set():
+            s = {3, 1, 2}
+            OrderedSet.add(s, 9)
+            return s
+
+        def union_on_set():
+            return OrderedSet.union({3, 1, 2}, [4])
+
+        for fn, exc in ((add_on_set, AttributeError), (union_on_set, TypeError)):
+            with self.subTest(fn=fn.__name__):
+                with self.assertRaises(exc):
+                    fn()
+                torch._dynamo.reset()
+                with self.assertRaises(exc):
+                    torch.compile(fn, backend="eager", fullgraph=False)()
+                torch._dynamo.reset()
+                with self.assertRaises(Unsupported):
+                    torch.compile(fn, backend="eager", fullgraph=True)()
+
+    def test_unbound_calls_with_unknown_name_or_no_receiver(self):
+        """Names set lacks, or a missing receiver, fall through instead of
+        escaping as IndexError / InternalTorchDynamoError."""
+        from torch.utils._ordered_set import OrderedSet
+
+        def no_receiver():
+            return OrderedSet.union()
+
+        def private_name():
+            return OrderedSet._wrap_iter_in_set(OrderedSet([3, 1, 2]), [1])
+
+        for fn in (no_receiver, private_name):
+            with self.subTest(fn=fn.__name__):
+                # fullgraph=False: graph break, eager semantics (TypeError for
+                # the first two, [2, 1, 3] for the third).
+                torch._dynamo.reset()
+                compiled = torch.compile(fn, backend="eager", fullgraph=False)
+                try:
+                    expected = fn()
+                except TypeError as e:
+                    with self.assertRaises(TypeError) as cm:
+                        compiled()
+                    self.assertEqual(str(cm.exception), str(e))
+                else:
+                    self.assertEqual(compiled(), expected)
+                torch._dynamo.reset()
+                with self.assertRaises(Unsupported):
+                    torch.compile(fn, backend="eager", fullgraph=True)()
+
+    def test_passed_in_ordered_set_reads(self):
+        """Membership and iteration on an OrderedSet argument, and the guards
+        that go with them.
+
+        VariableBuilder guards the argument through ``_dict`` (DICT_KEYS_MATCH
+        with key order). The per-key SET_CONTAINS guard evaluated
+        ``set.__contains__`` on the OrderedSet and failed on the frame that
+        created it, and registering the object's own source for key-order
+        guarding hit ``Expected dict`` in the guard manager.
+        """
+        from torch._dynamo.testing import CompileCounter
+        from torch.utils._ordered_set import OrderedSet
+
+        def fn(x, s):
+            out = []
+            for v in s:  # the iteration protocol itself is under test
+                out.append(v)  # noqa: PERF402
+            return 2 in s, 9 in s, out, list(s), s.union([9]), x + 1
+
+        cnt = CompileCounter()
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.ones(1)
+        # Same content twice, then a different order, different contents and
+        # an empty one: every distinct input must recompile and agree with
+        # eager, including iteration order.
+        inputs = [[3, 1, 2], [3, 1, 2], [2, 1, 3], [3, 1], [3, 1, 2, 9], []]
+        for items in inputs:
+            self.assertEqual(
+                self._snapshot(compiled(x, OrderedSet(items))),
+                self._snapshot(fn(x, OrderedSet(items))),
+            )
+        self.assertEqual(cnt.frame_count, 5)
+
+    def test_passed_in_ordered_set_mutations_reach_caller(self):
+        """Mutating an OrderedSet argument must mutate the caller's object.
+
+        The builder registered a passed-in OrderedSet with
+        ``track_object_existing`` (AttributeMutationExisting), which
+        ``SideEffects.mutation`` never flags, so every mutation was traced
+        and then dropped. A literal ``set`` argument goes through
+        ``wrap_literal`` and ``track_mutable`` instead, which is why sets
+        appeared to work.
+        """
+        from torch.utils._ordered_set import OrderedSet
+
+        base = list(self.BASE)
+
+        def add(s):
+            s.add(9)
+
+        def discard(s):
+            s.discard(1)
+
+        def remove(s):
+            s.remove(1)
+
+        def pop(s):
+            return s.pop()
+
+        def clear(s):
+            s.clear()
+
+        def update(s):
+            s.update([9, 8])
+
+        def intersection_update(s):
+            s.intersection_update([2, 1, 9])
+
+        def difference_update(s):
+            s.difference_update([1])
+
+        def symmetric_difference_update(s):
+            s.symmetric_difference_update([1, 9])
+
+        def ior(s):
+            s |= [9, 8]
+
+        def iand(s):
+            s &= [2, 1, 9]
+
+        def isub(s):
+            s -= [1]
+
+        def ixor(s):
+            s ^= [1, 9]
+
+        def unbound_add(s):
+            OrderedSet.add(s, 9)
+
+        def chain(s):
+            s.add(9)
+            s.discard(3)
+            s |= [7]
+            return s.pop()
+
+        for mutate in (
+            add,
+            discard,
+            remove,
+            pop,
+            clear,
+            update,
+            intersection_update,
+            difference_update,
+            symmetric_difference_update,
+            ior,
+            iand,
+            isub,
+            ixor,
+            unbound_add,
+            chain,
+        ):
+            for fullgraph in (True, False):
+                with self.subTest(op=mutate.__name__, fullgraph=fullgraph):
+
+                    def fn(x, s):
+                        r = mutate(s)
+                        return r, x + 1
+
+                    eager_s = OrderedSet(base)
+                    expected = fn(torch.ones(1), eager_s)
+                    torch._dynamo.reset()
+                    compiled_s = OrderedSet(base)
+                    got = torch.compile(fn, backend="eager", fullgraph=fullgraph)(
+                        torch.ones(1), compiled_s
+                    )
+                    self.assertEqual(self._snapshot(got), self._snapshot(expected))
+                    self.assertEqual(list(compiled_s), list(eager_s))
+
+    def test_passed_in_non_literal_set_mutation_reaches_caller(self):
+        """Same builder branch as OrderedSet: a set whose elements are not all
+        literals was also registered for attribute mutation and lost its
+        mutations. A literal set never hit it."""
+
+        def fn(x, s):
+            s.add(9)
+            s.discard(slice(0, 1))
+            return x + 1
+
+        for make in (lambda: {slice(0, 1), 3}, lambda: {3, 1, 2}):
+            with self.subTest(literal=all(isinstance(v, int) for v in make())):
+                eager_s = make()
+                fn(torch.ones(1), eager_s)
+                torch._dynamo.reset()
+                compiled_s = make()
+                torch.compile(fn, backend="eager", fullgraph=True)(
+                    torch.ones(1), compiled_s
+                )
+                self.assertEqual(compiled_s, eager_s)
+
+    def test_constructor_none_and_iterables(self):
+        """OrderedSet(None) is the documented empty constructor."""
+        from torch.utils._ordered_set import OrderedSet
+
+        def fn():
+            return (
+                OrderedSet(None),
+                OrderedSet(),
+                OrderedSet(iterable=[3, 1]),
+                OrderedSet("cab"),
+                OrderedSet(range(3, 0, -1)),
+                OrderedSet(v * 2 for v in [3, 1, 2]),
+            )
+
+        self._assert_matches_eager(fn)
+
+    def test_dict_attribute_reads(self):
+        """``s._dict`` exposes the backing dict so inlined OrderedSet methods
+        that read it (e.g. ``elem in self._dict``) trace instead of graph
+        breaking on an unmodeled attribute."""
+        from torch.utils._ordered_set import OrderedSet
+
+        def reads(x, s):
+            return 3 in s._dict, 9 in s._dict, list(s._dict), len(s._dict), x + 1
+
+        self._assert_matches_eager(reads, torch.ones(1), OrderedSet([3, 1, 2]))
+
+    def test_reversed_matches_eager(self):
+        """OrderedSet.__reversed__ gives reverse insertion order; set has none."""
+        from torch.utils._ordered_set import OrderedSet
+
+        def in_region():
+            return list(reversed(OrderedSet([3, 1, 2])))
+
+        def unbound():
+            return list(OrderedSet.__reversed__(OrderedSet([3, 1, 2])))
+
+        self.assertEqual(in_region(), [2, 1, 3])
+        self._assert_matches_eager(in_region)
+        self._assert_matches_eager(unbound)
+
+        def passed_in(x, s):
+            return list(reversed(s)), x + 1
+
+        x = torch.ones(1)
+        self.assertEqual(
+            self._snapshot(passed_in(x, OrderedSet([3, 1, 2]))),
+            self._snapshot(
+                torch.compile(passed_in, backend="eager", fullgraph=True)(
+                    x, OrderedSet([3, 1, 2])
+                )
+            ),
+        )
+
+    def test_is_unhashable(self):
+        from torch.utils._ordered_set import OrderedSet
+
+        def fn():
+            return hash(OrderedSet([1]))
+
+        with self.assertRaises(TypeError):
+            fn()
+        torch._dynamo.reset()
+        with self.assertRaises(TypeError):
+            torch.compile(fn, backend="eager", fullgraph=False)()
+
+    def test_regular_set_behaviour_unaffected(self):
+        def fn(s):
+            s.add(4)
+            s |= {10}
+            return (
+                s.union({3}),
+                s.pop() in {1, 2, 4, 10},
+                s == {1, 2},
+                s.isdisjoint({9}),
+            )
+
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled({1, 2}), fn({1, 2}))
+
+
 class DictKeySetHierarchyTests(torch._dynamo.test_case.TestCase):
     """`dict_keys` is not a `set`.
 

--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -1496,21 +1496,116 @@ class OrderedSetHierarchyTests(torch._dynamo.test_case.TestCase):
         literals was also registered for attribute mutation and lost its
         mutations. A literal set never hit it."""
 
-        def fn(x, s):
-            s.add(9)
-            s.discard(slice(0, 1))
-            return x + 1
+        class Key:
+            # Hashable on every supported Python (a slice is not, below 3.12)
+            # and not a dynamo literal, so the set takes the non-literal
+            # builder branch. One shared instance: the eager and compiled
+            # sets below must compare equal.
+            pass
 
-        for make in (lambda: {slice(0, 1), 3}, lambda: {3, 1, 2}):
-            with self.subTest(literal=all(isinstance(v, int) for v in make())):
-                eager_s = make()
-                fn(torch.ones(1), eager_s)
+        key = Key()
+
+        def add_discard(s):
+            s.add(9)
+            s.discard(key)
+
+        def isub(s):
+            # Removal-only: nothing new is added, so this is the case the
+            # mutation replay used to skip entirely.
+            s -= {3}
+
+        def ior(s):
+            s |= {9, 8}
+
+        def iand(s):
+            s &= {key, 9}
+
+        def ixor(s):
+            s ^= {key, 9}
+
+        for mutate in (add_discard, isub, ior, iand, ixor):
+            for make in (lambda: {key, 3}, lambda: {3, 1, 2}):
+                for fullgraph in (True, False):
+                    with self.subTest(
+                        op=mutate.__name__,
+                        literal=all(isinstance(v, int) for v in make()),
+                        fullgraph=fullgraph,
+                    ):
+
+                        def fn(x, s):
+                            mutate(s)
+                            return x + 1
+
+                        eager_s = make()
+                        fn(torch.ones(1), eager_s)
+                        torch._dynamo.reset()
+                        compiled_s = make()
+                        torch.compile(fn, backend="eager", fullgraph=fullgraph)(
+                            torch.ones(1), compiled_s
+                        )
+                        self.assertEqual(compiled_s, eager_s)
+
+    def test_explicit_dunder_init_matches_eager(self):
+        """OrderedSet.__init__(s, ...) re-initializes in place, like set's.
+
+        Only the unbound form is covered: the bound form (``s.__init__(...)``)
+        inlines OrderedSet's Python body and graph-breaks on the ``_dict``
+        store, the same way ``set``'s bound ``__init__`` is not modelled.
+        """
+        from torch.utils._ordered_set import OrderedSet
+
+        def unbound():
+            s = OrderedSet([3, 1, 2])
+            alias = s
+            OrderedSet.__init__(s, [9, 4])
+            return s is alias, s
+
+        def kwarg():
+            s = OrderedSet([3, 1, 2])
+            alias = s
+            OrderedSet.__init__(s, iterable=[9, 4])
+            return s is alias, s
+
+        def none():
+            s = OrderedSet([3, 1, 2])
+            alias = s
+            OrderedSet.__init__(s, None)
+            return s is alias, s
+
+        def no_arg():
+            s = OrderedSet([3, 1, 2])
+            alias = s
+            OrderedSet.__init__(s)
+            return s is alias, s
+
+        for fn in (unbound, kwarg, none, no_arg):
+            with self.subTest(fn=fn.__name__):
+                self._assert_matches_eager(fn)
+
+        # Argument errors match eager, and a failing __init__ leaves the set
+        # unchanged (eager hashes every element before touching _dict).
+        def two_args():
+            return OrderedSet([1], [2])
+
+        def bad_kwarg():
+            return OrderedSet(items=[1])
+
+        def unhashable_reinit():
+            s = OrderedSet([3, 1, 2])
+            try:
+                OrderedSet.__init__(s, [[1], 2])
+            except TypeError:
+                pass
+            return s
+
+        for fn, exc in ((two_args, TypeError), (bad_kwarg, TypeError)):
+            with self.subTest(fn=fn.__name__):
+                with self.assertRaises(exc):
+                    fn()
                 torch._dynamo.reset()
-                compiled_s = make()
-                torch.compile(fn, backend="eager", fullgraph=True)(
-                    torch.ones(1), compiled_s
-                )
-                self.assertEqual(compiled_s, eager_s)
+                with self.assertRaises(exc):
+                    torch.compile(fn, backend="eager", fullgraph=False)()
+        self._assert_matches_eager(unhashable_reinit)
 
     def test_constructor_none_and_iterables(self):
         """OrderedSet(None) is the documented empty constructor."""

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -1669,14 +1669,26 @@ def _codegen_deque_mutation(ctx: SideEffectReplayContext) -> None:
 @register_side_effect_replay_handler(
     name="const_dict_or_set_mutation",
     matcher=lambda ctx: isinstance(
-        ctx.var, (variables.ConstDictVariable, variables.SetVariable)
+        ctx.var,
+        (
+            variables.ConstDictVariable,
+            variables.SetVariable,
+            variables.OrderedSetVariable,
+        ),
     ),
     priority=70,
 )
 def _codegen_const_dict_or_set_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    if not isinstance(var, (variables.ConstDictVariable, variables.SetVariable)):
+    if not isinstance(
+        var,
+        (
+            variables.ConstDictVariable,
+            variables.SetVariable,
+            variables.OrderedSetVariable,
+        ),
+    ):
         raise AssertionError(type(var))
     # Reconstruct works as follow:
     # (1) Skip codegen if there are no new items

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1339,7 +1339,11 @@ class VariableBuilder:
                 for i, v in enumerate(L)
             ]
             result = set_var_cls(items, source=self.source)
-            return self.tx.output.side_effects.track_object_existing(value, result)
+            # Value mutation, like the literal-set path through wrap_literal:
+            # track_object_existing would give AttributeMutationExisting, which
+            # SideEffects.mutation never flags, so add/discard/|= on a
+            # passed-in set or OrderedSet would silently not reach the caller.
+            return self.tx.output.side_effects.track_mutable(value, result)
         elif istype(value, frozenset) and all(
             (
                 # For DBR quantization, we could get a frozenset of torch funcs.

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -147,7 +147,7 @@ from .object_protocol import (
     type_implements_sq_length,
     vt_identity_compare,
 )
-from .sets import FrozensetVariable, SetVariable
+from .sets import FrozensetVariable, OrderedSetVariable, SetVariable
 from .tensor import (
     FakeItemVariable,
     supported_comparison_ops,
@@ -2459,6 +2459,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                 variables.SetVariable,
                 variables.FrozensetVariable,
                 variables.DictKeySetVariable,
+                variables.OrderedSetVariable,
                 variables.ConstDictVariable,
             ),
         ):
@@ -3231,6 +3232,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                 SetVariable,
                 FrozensetVariable,
                 variables.DictKeySetVariable,
+                OrderedSetVariable,
             ),
         ):
             return VariableTracker.build(tx, len(a.items) == 0)
@@ -3418,6 +3420,7 @@ class DictBuiltinVariable(BaseBuiltinVariable):
                 variables.SetVariable,
                 variables.FrozensetVariable,
                 variables.DictKeySetVariable,
+                variables.OrderedSetVariable,
                 ConstDictVariable,
             ),
         ):
@@ -3884,14 +3887,10 @@ class ListBuiltinVariable(BaseBuiltinVariable):
                 obj,
                 (variables.IteratorVariable, variables.LocalGeneratorObjectVariable),
             ):
-                if isinstance(
-                    obj,
-                    (
-                        ConstDictVariable,
-                        variables.OrderedSetVariable,
-                        variables.DictKeySetVariable,
-                    ),
-                ):
+                # An OrderedSet's key order is already guarded through the
+                # ``_dict`` source VariableBuilder registers; the object itself
+                # is not a dict and the guard manager would reject it.
+                if isinstance(obj, (ConstDictVariable, variables.DictKeySetVariable)):
                     tx.output.guard_on_key_order.add(obj.source)
                 if isinstance(obj, variables.MappingProxyVariable):
                     install_guard(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -67,7 +67,7 @@ from .base import VariableTracker
 from .dicts import ConstDictVariable
 from .lazy import LazyVariableTracker
 from .lists import ListVariable, TupleVariable
-from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
+from .sets import DictKeySetVariable, FrozensetVariable, OrderedSetVariable, SetVariable
 
 
 if TYPE_CHECKING:
@@ -249,7 +249,9 @@ def find_mismatched_vars(
     elif isinstance(var, ConstDictVariable):
         for value in var.items.values():
             mismatched_vars.update(find_mismatched_vars(value, types, allow_none))
-    elif isinstance(var, (SetVariable, FrozensetVariable, DictKeySetVariable)):
+    elif isinstance(
+        var, (SetVariable, FrozensetVariable, DictKeySetVariable, OrderedSetVariable)
+    ):
         for key in var.items:
             mismatched_vars.update(find_mismatched_vars(key.vt, types, allow_none))
     else:
@@ -4360,6 +4362,7 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
                     SetVariable,
                     FrozensetVariable,
                     DictKeySetVariable,
+                    OrderedSetVariable,
                 ),
             ):
                 unimplemented(

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -530,7 +530,12 @@ class BaseListVariable(VariableTracker):
         # CPython has a series of checks to optimize list.extend for different data types
         # ref: https://github.com/python/cpython/blob/0fd4fd4496c557b68477a99c1c231a5870c91daf/Objects/listobject.c#L1389-L1444
         from .dicts import ConstDictVariable
-        from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
+        from .sets import (
+            DictKeySetVariable,
+            FrozensetVariable,
+            OrderedSetVariable,
+            SetVariable,
+        )
         from .user_defined import UserDefinedObjectVariable
 
         sz = len(self.items)
@@ -540,7 +545,13 @@ class BaseListVariable(VariableTracker):
             self.items.extend(unpack_iterable(tx, args[0]))
         elif isinstance(
             args[0],
-            (ConstDictVariable, SetVariable, FrozensetVariable, DictKeySetVariable),
+            (
+                ConstDictVariable,
+                SetVariable,
+                FrozensetVariable,
+                DictKeySetVariable,
+                OrderedSetVariable,
+            ),
         ):
             items = [item.vt for item in args[0].items]
             self.items.extend(items)

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -85,7 +85,12 @@ def vt_identity_compare(
     from .dicts import ConstDictVariable
     from .lists import ListVariable
     from .misc import ExceptionVariable, TracebackVariable
-    from .sets import DictKeySetVariable, FrozensetVariable, SetVariable
+    from .sets import (
+        DictKeySetVariable,
+        FrozensetVariable,
+        OrderedSetVariable,
+        SetVariable,
+    )
 
     if isinstance(
         left,
@@ -95,6 +100,7 @@ def vt_identity_compare(
             SetVariable,
             FrozensetVariable,
             DictKeySetVariable,
+            OrderedSetVariable,
             TracebackVariable,
             ExceptionVariable,
         ),

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -17,6 +17,7 @@ dictionaries with None values.
 
 import functools
 import operator
+import types
 from collections.abc import Iterable, Iterator
 from typing import Any, TYPE_CHECKING
 
@@ -85,15 +86,16 @@ class BaseSetVariable(VariableTracker):
     subclass of set, and neither is dict_keys (see #192874). This base holds
     every operation that is valid on an immutable set-like collection.
     SetVariable (mutable Python ``set``) adds the mutating operations on top.
-    FrozensetVariable and DictKeySetVariable inherit only this base, so a
-    traced frozenset or dict_keys is not matched by isinstance checks against
-    SetVariable.
+    FrozensetVariable, DictKeySetVariable and OrderedSetVariable inherit only
+    this base, so a traced frozenset, dict_keys or OrderedSet is not matched by
+    isinstance checks against SetVariable.
 
     Only ``isdisjoint`` is registered in ``tp_methods`` here: that is the whole
     named surface of ``collections.abc.Set``, and of ``dict_keys``. The other
     read-only methods (``union``, ``copy``, ...) are implemented here but
-    registered by SetVariable and FrozensetVariable, the same way CPython's
-    ``set_methods`` and ``frozenset_methods`` tables share one implementation.
+    registered by SetVariable, FrozensetVariable and OrderedSetVariable, the
+    same way CPython's ``set_methods`` and ``frozenset_methods`` tables share
+    one implementation.
     """
 
     CONTAINS_GUARD = GuardBuilder.SET_CONTAINS
@@ -303,8 +305,8 @@ class BaseSetVariable(VariableTracker):
         # Constant, exact-builtin fast path: materialize and call the real
         # method. Set/dict operands take the slow VT path below so their keys
         # are not re-hashed (CPython's do-not-rehash-dict-keys fast path);
-        # OrderedSet is excluded because as_python_constant() loses insertion
-        # order (it routes through the unordered set_items).
+        # OrderedSet is excluded because its methods are pure Python, so there
+        # is no C fast path to mirror.
         if (
             not any(isinstance(a, (BaseSetVariable, ConstDictVariable)) for a in args)
             and check_constant_args(args, kwargs)
@@ -831,9 +833,25 @@ class OrderedSetClassVariable(VariableTracker):
 
             return variables.OrderedSetVariable([], mutation_type=ValueMutationNew())
 
-        resolved_fn = getattr(set, name)
-        if resolved_fn in set_methods and isinstance(args[0], variables.SetVariable):
+        # OrderedSet has methods set lacks (_from_dict, __reversed__, ...) and
+        # the receiver may be missing altogether (OrderedSet.union()); neither
+        # is ours to handle, so fall through instead of raising internally.
+        resolved_fn = getattr(set, name, None)
+        if (
+            resolved_fn in set_methods
+            and args
+            and isinstance(args[0], variables.OrderedSetVariable)
+        ):
             return args[0].call_method(tx, name, args[1:], kwargs)
+
+        fn = getattr(OrderedSet, name, None)
+        if isinstance(fn, types.FunctionType):
+            # Any other receiver (a plain set, a frozenset, a subclass instance,
+            # or none at all): run OrderedSet's own Python method, which is what
+            # CPython does, so the result or the exception is the eager one.
+            from .builder import SourcelessBuilder
+
+            return SourcelessBuilder.create(tx, fn).call_function(tx, args, kwargs)
 
         return super().call_method(tx, name, args, kwargs)
 
@@ -843,7 +861,10 @@ class OrderedSetClassVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> "OrderedSetVariable":
-        if len(args) > 1 or kwargs:
+        if not args and set(kwargs) == {"iterable"}:
+            # OrderedSet(iterable=...): the parameter's name in __init__.
+            args = [kwargs["iterable"]]
+        elif len(args) > 1 or kwargs:
             raise_args_mismatch(
                 tx,
                 "OrderedSet",
@@ -851,7 +872,8 @@ class OrderedSetClassVariable(VariableTracker):
                 f"{len(args)} args and {len(kwargs)} kwargs",
             )
 
-        if len(args) == 0:
+        if len(args) == 0 or args[0].is_constant_none():
+            # OrderedSet(iterable=None): the documented empty constructor.
             # pyrefly: ignore [implicit-any]
             items = []
         else:
@@ -859,7 +881,19 @@ class OrderedSetClassVariable(VariableTracker):
         return variables.OrderedSetVariable(items, mutation_type=ValueMutationNew())
 
 
-class OrderedSetVariable(SetVariable):
+class OrderedSetVariable(BaseSetVariable):
+    """``torch.utils._ordered_set.OrderedSet``, an insertion-ordered set.
+
+    OrderedSet is a pure-Python ``collections.abc.MutableSet``, not a subclass
+    of ``set`` (see #192874), so this is a sibling of SetVariable under
+    BaseSetVariable rather than a subclass of it. Its named-method surface is
+    the same as ``set``'s, mutators included, so the ``set`` implementations
+    are registered in ``tp_methods`` below. What OrderedSet does differently
+    is overridden here: insertion order is observable (iteration, ``repr``,
+    ``pop`` and reconstruction all follow it), and the in-place operators are
+    ``MutableSet``'s, which accept any iterable and mutate in place.
+    """
+
     _cpython_type = OrderedSet
 
     def method_flags_type(self) -> type:
@@ -877,6 +911,23 @@ class OrderedSetVariable(SetVariable):
 
     tp_members = {"_dict": Member(_get_internal_dict, readonly_setter)}
 
+    # A passed-in OrderedSet is guarded through its ``_dict`` (DICT_KEYS_MATCH
+    # and key order on ``AttrSource(source, "_dict")``, installed by the
+    # builder), which already pins membership and iteration order. The per-key
+    # SET_CONTAINS guard and the key-order registration BaseSetVariable adds
+    # for the object's own source are both wrong here: SET_CONTAINS evaluates
+    # ``set.__contains__`` on an OrderedSet, and the guard manager expects a
+    # dict at a key-order source.
+    def install_set_contains_guard(
+        self, tx: "InstructionTranslatorBase", args: list[VariableTracker]
+    ) -> None:
+        pass
+
+    def tp_iter_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        from .iter import SetIterator
+
+        return SetIterator(self.items)
+
     def debug_repr(self) -> str:
         if not self.items:
             return "OrderedSet([])"
@@ -888,11 +939,12 @@ class OrderedSetVariable(SetVariable):
             return "OrderedSet([" + ", ".join(items) + "])"
 
     def tp_repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
-        items = ", ".join(tracked_repr(tx, item.vt) for item in self.set_items)
+        # self.items is insertion-ordered; set_items is a set and would not be.
+        items = ", ".join(tracked_repr(tx, item.vt) for item in self.items)
         return VariableTracker.build(tx, f"{self.python_type_name()}([{items}])")
 
     def as_python_constant(self) -> OrderedSet[Any]:
-        return OrderedSet([k.vt.as_python_constant() for k in self.set_items])
+        return OrderedSet([k.vt.as_python_constant() for k in self.items])
 
     def python_type(self) -> type[OrderedSet[Any]]:
         return OrderedSet
@@ -901,17 +953,65 @@ class OrderedSetVariable(SetVariable):
         codegen.add_push_null(
             lambda: codegen.load_import_from("torch.utils._ordered_set", "OrderedSet")
         )
-        codegen.foreach([x.vt for x in self.set_items])
-        codegen.append_output(create_instruction("BUILD_LIST", arg=len(self.set_items)))
+        codegen.foreach([x.vt for x in self.items])
+        codegen.append_output(create_instruction("BUILD_LIST", arg=len(self.items)))
         codegen.extend_output(create_call_function(1, False))
 
+    def is_hashable(self) -> bool:
+        return False
+
+    def hash_impl(self, tx: "InstructionTranslatorBase") -> tuple[int, bool]:
+        raise_type_error(tx, f"unhashable type: '{self.python_type_name()}'")
+
+    def sq_contains_impl(
+        self, tx: "InstructionTranslatorBase", item: VariableTracker
+    ) -> VariableTracker:
+        # OrderedSet.__contains__ is ``elem in self._dict``: an unhashable key
+        # raises TypeError. set_contains's coerce-a-set-key-to-frozenset
+        # special case is set's, not OrderedSet's. remove and discard go
+        # through here first, so they raise the same way.
+        if not is_hashable(item):
+            raise_type_error(tx, f"unhashable type: '{item.python_type_name()}'")
+        return VariableTracker.build(tx, item in self)
+
+    def reversed_(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        # OrderedSet.__reversed__ is reversed(self._dict): reverse insertion
+        # order. Key order of a passed-in OrderedSet is already guarded.
+        keys: list[VariableTracker] = [k.vt for k in reversed(list(self.items))]
+        return variables.ListIteratorVariable(keys, mutation_type=ValueMutationNew())
+
+    def pop(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        # OrderedSet.pop is dict.popitem: the most recently inserted element,
+        # not the arbitrary one set.pop returns.
+        if not self.items:
+            raise_observed_exception(KeyError, tx, args=["pop from an empty set"])
+        self.should_reconstruct_all = True
+        tx.output.side_effects.mutation(self)
+        key, _ = self.items.popitem()
+        return key.vt
+
+    # ``reverse`` is deliberately ignored by the |, & and ^ slots: in
+    # collections.abc.Set ``__ror__``, ``__rand__`` and ``__rxor__`` are the
+    # forward methods, so ``some_set | ordered_set`` runs ``ordered_set.__or__``
+    # and the OrderedSet's elements come first either way. Only ``-`` has a
+    # distinct ``__rsub__``, handled below.
     def nb_or_impl(
         self,
         tx: "InstructionTranslatorBase",
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        # OrderedSet does not inherit from Python set, so SetVariable.nb_or_impl
+        # OrderedSet does not inherit from Python set, so BaseSetVariable.nb_or_impl
         # won't work due to the PyAnySet_Check
         return super().call_method(tx, "union", [other], {})
 
@@ -921,9 +1021,18 @@ class OrderedSetVariable(SetVariable):
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        # OrderedSet does not inherit from Python set, so SetVariable.nb_and_impl
-        # won't work due to the PyAnySet_Check
-        return super().call_method(tx, "intersection", [other], {})
+        # Set.__and__ (and __rand__, the same function) yields in the order of
+        # the *other* operand: ``self._from_iterable(v for v in other if v in
+        # self)``. OrderedSet.__and__ first swaps the operands when the other
+        # is an OrderedSet longer than self, so that case comes out in self's
+        # order. intersection() differs: it copies self and discards, so it
+        # keeps self's order.
+        other_keys = self._operand_keys(tx, other)
+        if isinstance(other, OrderedSetVariable) and len(self.items) < len(other_keys):
+            keys: list[HashableTracker] = [k for k in self.items if k in other.items]
+        else:
+            keys = [k for k in other_keys if k in self.items]
+        return OrderedSetVariable(keys, mutation_type=ValueMutationNew())
 
     def nb_xor_impl(
         self,
@@ -931,7 +1040,7 @@ class OrderedSetVariable(SetVariable):
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        # OrderedSet does not inherit from Python set, so SetVariable.nb_xor_impl
+        # OrderedSet does not inherit from Python set, so BaseSetVariable.nb_xor_impl
         # won't work due to the PyAnySet_Check
         return super().call_method(tx, "symmetric_difference", [other], {})
 
@@ -941,15 +1050,61 @@ class OrderedSetVariable(SetVariable):
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        self_, other_ = (other, self) if reverse else (self, other)
-        return self_.call_method(tx, "difference", [other_], {})
+        if reverse:
+            # Set.__rsub__: ``self._from_iterable(v for v in other if v not in
+            # self)``. The left operand can be any iterable, and the result is
+            # an OrderedSet, not the left operand's type.
+            keys = [k for k in self._operand_keys(tx, other) if k not in self.items]
+            return OrderedSetVariable(keys, mutation_type=ValueMutationNew())
+        return self.call_method(tx, "difference", [other], {})
+
+    # The in-place slots are MutableSet's, not set's: they accept any iterable
+    # and mutate in place. set's slots return NotImplemented for a non-set
+    # operand, which would fall back to the binary operator and rebind the
+    # name to a new object.
+    def nb_inplace_or_impl(
+        self, tx: "InstructionTranslatorBase", other: VariableTracker
+    ) -> VariableTracker:
+        self.call_method(tx, "update", [other], {})
+        return self
+
+    def nb_inplace_and_impl(
+        self, tx: "InstructionTranslatorBase", other: VariableTracker
+    ) -> VariableTracker:
+        self.call_method(tx, "intersection_update", [other], {})
+        return self
+
+    def nb_inplace_xor_impl(
+        self, tx: "InstructionTranslatorBase", other: VariableTracker
+    ) -> VariableTracker:
+        self.call_method(tx, "symmetric_difference_update", [other], {})
+        return self
 
     def nb_inplace_subtract_impl(
         self, tx: "InstructionTranslatorBase", other: VariableTracker
     ) -> VariableTracker:
-        tx.output.side_effects.mutation(self)
         self.call_method(tx, "difference_update", [other], {})
         return self
+
+    tp_methods = {
+        "intersection": Method(BaseSetVariable.intersection),
+        "union": Method(BaseSetVariable.union),
+        "difference": Method(BaseSetVariable.difference),
+        "symmetric_difference": Method(BaseSetVariable.symmetric_difference),
+        "issubset": Method(BaseSetVariable.issubset),
+        "issuperset": Method(BaseSetVariable.issuperset),
+        "copy": Method(BaseSetVariable.copy),
+        "add": Method(SetVariable.add),
+        "pop": Method(pop),
+        "intersection_update": Method(SetVariable.intersection_update),
+        "difference_update": Method(SetVariable.difference_update),
+        "symmetric_difference_update": Method(SetVariable.symmetric_difference_update),
+        "update": Method(SetVariable.update),
+        "remove": Method(SetVariable.remove),
+        "discard": Method(SetVariable.discard),
+        "clear": Method(SetVariable.clear),
+        "__reversed__": Method(reversed_),
+    }
 
 
 class FrozensetVariable(BaseSetVariable):

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -764,6 +764,9 @@ class SetVariable(BaseSetVariable):
             return ConstantVariable.create(NotImplemented)
 
         tx.output.side_effects.mutation(self)
+        # Removal-only, so has_new_items() alone would miss it and the
+        # mutation replay would be skipped (difference_update sets this too).
+        self.should_reconstruct_all = True
         for k in list(other.items.keys()):  # type: ignore[missing-attribute]
             self.items.pop(k, None)
         return self
@@ -827,7 +830,7 @@ class OrderedSetClassVariable(VariableTracker):
                 raise_args_mismatch(
                     tx,
                     name,
-                    "OrderedSet.__new__ only accepts one arg"
+                    "OrderedSet.__new__ only accepts one arg",
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
 
@@ -861,24 +864,11 @@ class OrderedSetClassVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> "OrderedSetVariable":
-        if not args and set(kwargs) == {"iterable"}:
-            # OrderedSet(iterable=...): the parameter's name in __init__.
-            args = [kwargs["iterable"]]
-        elif len(args) > 1 or kwargs:
-            raise_args_mismatch(
-                tx,
-                "OrderedSet",
-                "OrderedSet only accepts one arg"
-                f"{len(args)} args and {len(kwargs)} kwargs",
-            )
-
-        if len(args) == 0 or args[0].is_constant_none():
-            # OrderedSet(iterable=None): the documented empty constructor.
-            # pyrefly: ignore [implicit-any]
-            items = []
-        else:
-            items = unpack_iterable(tx, args[0])
-        return variables.OrderedSetVariable(items, mutation_type=ValueMutationNew())
+        # tp_new + tp_init: the argument handling lives in tp_init_impl so the
+        # constructor and an explicit __init__ call cannot drift apart.
+        var = variables.OrderedSetVariable([], mutation_type=ValueMutationNew())
+        var.tp_init_impl(tx, args, kwargs)
+        return var
 
 
 class OrderedSetVariable(BaseSetVariable):
@@ -1085,6 +1075,44 @@ class OrderedSetVariable(BaseSetVariable):
     ) -> VariableTracker:
         self.call_method(tx, "difference_update", [other], {})
         return self
+
+    def tp_init_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        if not args and set(kwargs) == {"iterable"}:
+            # OrderedSet(iterable=...): the parameter's name in __init__.
+            args = [kwargs["iterable"]]
+        elif len(args) > 1 or kwargs:
+            raise_args_mismatch(
+                tx,
+                "OrderedSet",
+                "OrderedSet only accepts one arg",
+                f"{len(args)} args and {len(kwargs)} kwargs",
+            )
+
+        # OrderedSet(iterable=None): the documented empty constructor.
+        items = (
+            []
+            if len(args) == 0 or args[0].is_constant_none()
+            else unpack_iterable(tx, args[0])
+        )
+        # Build first, mutate second: eager __init__ hashes every element via
+        # dict.fromkeys before touching _dict, so a TypeError leaves the set
+        # unchanged. Clearing first would empty it on the caught-exception path.
+        new_items = {}
+        for item in items:
+            # pyrefly: ignore [bad-argument-type]
+            new_items[HashableTracker(item.realize())] = (
+                BaseSetVariable._default_value()
+            )
+        tx.output.side_effects.mutation(self)
+        self.should_reconstruct_all = True
+        self.items.clear()
+        self.items.update(new_items)
+        return ConstantVariable.create(None)
 
     tp_methods = {
         "intersection": Method(BaseSetVariable.intersection),


### PR DESCRIPTION
## Issue

Part of #192874, the `OrderedSetVariable(SetVariable)` row.

`torch.utils._ordered_set.OrderedSet` is a pure-Python `collections.abc.MutableSet`, not a subclass of `set`: `issubclass(OrderedSet, set)` is `False`. `OrderedSetVariable` inherited `SetVariable`, so wherever the two types differ Dynamo used `set`'s behaviour, and a few paths treated the tracked object as a `set` or a `dict` that it is not.

## Summary

The most visible effect is that an `OrderedSet` loses its insertion order when it crosses the compile boundary, because reconstruction and `repr` iterated an unordered set of the keys instead of the ordered backing dict:

```python
import torch
from torch.utils._ordered_set import OrderedSet

def f(x):
    s = OrderedSet([3, 1, 2])
    return s, repr(s), x + 1

torch.compile(f, backend="eager")(torch.ones(2))
```

Before this change the returned set is `OrderedSet([1, 2, 3])` and `repr(s)` is `'OrderedSet([1, 2, 3])'`. After it, both keep `[3, 1, 2]`, which is what eager produces. Every operation that yields an OrderedSet is affected the same way: returning one, `copy`, `union`, `difference`, `symmetric_difference`, the operators, `add`, `update` and `repr`.

Passing an OrderedSet into a compiled function did not work. Membership, iteration and mutation each failed:

```python
def g(x, s):
    s.add(9)
    return 2 in s, list(s), x + 1

torch.compile(g, backend="eager")(torch.ones(2), OrderedSet([3, 1, 2]))
```

Before, this raises `AssertionError: Expected dict, got OrderedSet` while building guards, `2 in s` on its own fails a `set.__contains__` guard, and the `add` never reaches the caller. After, it returns `(True, [3, 1, 2, 9])` and the caller's set is `OrderedSet([3, 1, 2, 9])`, matching eager.

The remaining differences are smaller and all now match eager:

- `pop()` removed an arbitrary element rather than the most recently inserted one. `OrderedSet([3, 1, 2]).pop()` was `1`, now `2`.
- `|=`, `&=` and `^=` with a non-set operand rebound the name to a new object instead of mutating in place, so `s is alias` was `False` afterwards.
- `some_set - ordered_set` returned a `set`; `Set.__rsub__` builds an OrderedSet.
- `reversed(s)` was unsupported; it now yields reverse insertion order.
- an unhashable key, as in `{1, 2} in s` or `s.discard({1, 2})`, silently returned a result or coerced the key the way `set` does; it now raises `TypeError`, and so does `hash(s)`.

## Fix

`OrderedSetVariable` becomes a sibling of `SetVariable` under `BaseSetVariable`, following the shape of #193580 (frozenset) and #193649 (dict_keys). `OrderedSet`'s public method surface is exactly `set`'s, so `tp_methods` registers the same named entries pointing at the same implementations, with `isdisjoint` coming from the base. What `OrderedSet` does differently is overridden on the class:

- reconstruction, `repr` and `as_python_constant` iterate `self.items`, which is insertion ordered, instead of the unordered `set_items`.
- `pop` removes the most recently inserted key.
- the in-place operators call `update`, `intersection_update`, `symmetric_difference_update` and `difference_update`, so they accept any iterable and mutate in place like `MutableSet`.
- `nb_subtract_impl` and `nb_and_impl` follow CPython's operand order for the reflected and intersection cases, and `__reversed__` yields reverse insertion order.
- `is_hashable`, `hash_impl` and an OrderedSet-specific `sq_contains_impl` are declared here, since they are no longer inherited from `SetVariable`.
- the `_dict` member exposes the backing dict so inlined `OrderedSet` methods trace. A passed-in OrderedSet is guarded through that dict already, so the per-key `SET_CONTAINS` guard and the key-order registration that assume a real `set` or `dict` are skipped for it.

The references to `SetVariable` outside `sets.py` that matched an OrderedSet through inheritance now name `OrderedSetVariable` as well: the set-mutation replay handler in `side_effects.py`, `_unpack_fast_types` in `utils.py`, three checks in `builtin.py`, two in `higher_order_ops.py`, the `list.extend` fast path in `lists.py`, and `vt_identity_compare` in `object_protocol.py`. The builder wraps a passed-in set or OrderedSet with `track_mutable`, so mutations to it replay to the caller as they already do for a set built inside the region.

## Test plan

  New `OrderedSetHierarchyTests` in `test/dynamo/test_sets.py`, 17 tests, covering the hierarchy, ordering, `pop`, the operators, `reversed`, unhashable keys, the unbound `OrderedSet.method(...)` forms, explicit `__init__` calls, and reads and mutations of a passed-in OrderedSet and of a passed-in non-literal set. They pass with this change and fail on `main`. The full file runs 222 passed, 1 skipped on Python 3.10 and 3.12. `lintrunner` and `pyrefly` report no issues on the changed files.

## BC-breaking?

Not for user code: results that previously disagreed with eager now agree with it. For out-of-tree code that touches Dynamo internals, `isinstance(x, SetVariable)` no longer matches an OrderedSet tracker, and `BaseSetVariable` is the check that matches all four set-family trackers.

Related: #196111 was opened for the same row. Happy to consolidate.

Authored with AI assistance.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98