### PR TITLE
[inductor] Apply xmask before reducing in mix-order-reduction split loop

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1427,6 +1427,59 @@ class MixOrderReductionTest(TestBase):
         self.assertEqual(list(act[1].shape), list(ref[1].shape))
         self.assertTrue(same(ref, act, tol=1e-3))
 
+    def test_unmasked_tail_with_uneven_row_count(self):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/195845
+
+        The mix-order-reduction split loop generates ``xmask`` whenever xnumel
+        isn't a multiple of XBLOCK, but never applied it before reducing: the
+        tail iteration read garbage lanes past xnumel straight into the
+        running accumulator. Checked via absolute error against a float64
+        reference, since ``same()``'s relative tolerance is too loose to
+        catch a small fixed offset against column sums in the thousands.
+        """
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        def f(x):
+            y = x * 2 + 0.25
+            return y.max(dim=-1).values, y.float().sum(dim=0)
+
+        def check(nrows, ncols=129, atol=0.05):
+            torch._dynamo.reset()
+            x = torch.randn(nrows, ncols, dtype=torch.bfloat16, device=GPU_TYPE)
+            ref_y = x.double() * 2 + 0.25
+            ref_rowmax = ref_y.max(dim=-1).values
+            ref_colsum = ref_y.sum(dim=0)
+
+            act_rowmax, act_colsum = torch.compile(f)(x)
+
+            sum_diff = (act_colsum.double() - ref_colsum).abs().max().item()
+            max_diff = (act_rowmax.double() - ref_rowmax).abs().max().item()
+            self.assertLess(
+                sum_diff,
+                atol,
+                f"nrows={nrows}: column-sum abs diff {sum_diff} exceeds the "
+                "bf16 noise floor -- unmasked tail rows corrupting the "
+                "accumulator",
+            )
+            self.assertLess(
+                max_diff, atol, f"nrows={nrows}: row-max abs diff {max_diff}"
+            )
+
+        # 40961 is not a multiple of any typical XBLOCK (32/64/128/...); the
+        # padded/offset rows around it exercise both a mismatched tail and
+        # the evenly-divisible control in one parametrized sweep. metrics
+        # accumulate across compiles, so just confirm mix-order codegen was
+        # actually exercised at least once rather than resetting every lap.
+        for offset in (-1, 0, 1, 2):
+            check(40960 + offset)
+        self.assertGreaterEqual(
+            metrics.codegen_mix_order_reduction,
+            1,
+            "mix-order reduction was never exercised by this test",
+        )
+
 
 class OverFusionTest(TestBase):
     """

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6884,6 +6884,26 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     triton_reduction_function = get_triton_reduction_function(
                         partial_accum.reduction_type,
                     )
+                    if not self._has_constant_xmask():
+                        # xnumel is not necessarily a multiple of XBLOCK, so the
+                        # last iteration of the split loop can read out-of-range
+                        # x rows into var. Those lanes are otherwise summed
+                        # (or maxed/etc.) into the accumulator unmasked, silently
+                        # corrupting the result -- mask them out with the
+                        # reduction's own identity value first, same as the
+                        # established pattern in reduction()/dot() above.
+                        mask_default = ir.Reduction.default_value(
+                            partial_accum.reduction_type, torch.float
+                        )
+                        mask_default = self._map_tuple_or_scalar(
+                            constant_repr, mask_default
+                        )
+                        var = self.cse.generate(
+                            self.body,
+                            f"tl.where(xmask, {var}, {mask_default})",
+                            dtype=var.dtype,
+                            shape=var.shape,
+                        )
                     newval = self.cse.generate(
                         self.body,
                         f"{triton_reduction_function}({var}, 0)",


### PR DESCRIPTION
## Summary

`mix_order_reduction`'s split loop (`torch/_inductor/codegen/triton.py`)
generates `xmask` whenever `xnumel` is not a multiple of `XBLOCK`, but
never applied it before feeding `var` into the reduction call
(`tl.sum(var, 0)` / etc.). The tail iteration of the split loop reads
past `xnumel` for the last partial block, and that out-of-range garbage
was summed (or maxed, etc.) straight into the running accumulator,
silently corrupting the result whenever the reduced dimension isn't an
exact multiple of `XBLOCK`.

This matches the analysis in #195845.

## Root cause

```python
# generate xmask if it's not constant
if not self._has_constant_xmask():
    ...
    self.body.writeline(f"{x}mask = {entry.name} < {x}numel")
...
for idx, partial_accum in enumerate(self.saved_partial_accumulate):
    var = partial_accum.value
    ...
    newval = self.cse.generate(
        self.body,
        f"{triton_reduction_function}({var}, 0)",   # <-- var never masked
        ...
    )
```

Every other reduction path in this file already masks before reducing:
`reduction()`'s `where_cond`/`cond = " & ".join(masks)`, and `dot()`'s
`where_cond(var)` (`tl.where(r0_mask, val, 0)`, documented explicitly as
required "to prevent incorrect results"). The mix-order split loop is the
one place this masking step was missing.

## Fix

Mask `var` with the reduction's own identity value before reducing,
gated the same way `xmask` generation already is:

```python
if not self._has_constant_xmask():
    mask_default = ir.Reduction.default_value(partial_accum.reduction_type, torch.float)
    mask_default = self._map_tuple_or_scalar(constant_repr, mask_default)
    var = self.cse.generate(
        self.body,
        f"tl.where(xmask, {var}, {mask_default})",
        dtype=var.dtype,
        shape=var.shape,
    )
```

## Verification

Reproduced and root-caused on real CUDA hardware (not just read from the
issue) before writing the fix.

```
40961 rows (not a multiple of XBLOCK): max abs diff = 0.751953125  (before)
                                        max abs diff = 0.001953125 (after -- matches noise floor)
40960 rows (control, evenly divisible): max abs diff = 0.001953125 (unchanged by the fix)
```

Also swept row-count offsets around several XBLOCK-adjacent boundaries
(1, 2, 8191, 8193, 40960-40963, 100000-100001) -- all consistent with the
bf16 noise floor after the fix, with the unrelated `max` reduction sharing
the same kernel unaffected throughout.

Added `test_unmasked_tail_with_uneven_row_count` to
`test/inductor/test_mix_order_reduction.py`, matching the file's existing
style. Confirmed red on unpatched code / green after the fix.

I also checked whether the existing `test_xmask` in this file already
covered this: it doesn't -- for its specific shape/config,
`mix_order_reduction` isn't actually triggered at all
(`metrics.codegen_mix_order_reduction == 0`), so it never reaches the
buggy split-loop path. Confirmed this empirically (not just by
inspection) before concluding a new test was needed.

Local validation note: I tested against an installed nightly-adjacent
wheel (2.13.0+cu130) plus this exact source patch applied in-place,
rather than a full from-source build of this branch, since building
would not have been practical in this environment. The changed file
(`torch/_inductor/codegen/triton.py`) is pure Python with no compiled-
extension dependency, so the installed C extensions are unaffected by
this change. I also ran the broader `test_mix_order_reduction.py` suite;
the handful of unrelated failures I saw there (a `FileCheck` string match
and a `mock.create_autospec` attribute mismatch) reproduce identically on
unpatched `main`-adjacent code too and don't touch the file this PR
changes, so they're pre-existing version skew between the installed wheel
and this test file, not caused by this change.

Fixes #195845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo