### PR TITLE
[dynamo] Type runtime predicate inputs as object

### DIFF
--- a/torch/_dynamo/polyfills/pytree.py
+++ b/torch/_dynamo/polyfills/pytree.py
@@ -263,7 +263,7 @@ class PyTreeSpec:
     def __len__(self, /) -> int:
         return self.num_leaves
 
-    def __eq__(self, other: Any, /) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         if not isinstance(other, PyTreeSpec):
             return NotImplemented
         if (
@@ -493,7 +493,9 @@ class PyTreeSpec:
         return self._unflatten_func(self._metadata, subtrees)
 
 
-def _is_pytreespec_instance(obj: Any, /) -> TypeIs[PyTreeSpec | python_pytree.TreeSpec]:
+def _is_pytreespec_instance(
+    obj: object, /
+) -> TypeIs[PyTreeSpec | python_pytree.TreeSpec]:
     return isinstance(obj, (PyTreeSpec, python_pytree.TreeSpec))
 
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1443,7 +1443,7 @@ _FuncTypes: TypeAlias = (
 
 
 def is_function_or_wrapper(
-    value: Any,
+    value: object,
 ) -> TypeIs[_FuncTypes | torch._ops.OpOverloadPacket | torch._ops.OpOverload]:
     return is_function(value) or isinstance(
         value, (torch._ops.OpOverloadPacket, torch._ops.OpOverload)
@@ -1451,7 +1451,7 @@ def is_function_or_wrapper(
 
 
 def is_function(
-    value: Any,
+    value: object,
 ) -> TypeIs[_FuncTypes]:
     return isinstance(
         value,
@@ -1485,7 +1485,7 @@ cmp_name_to_op_str_mapping = {
 
 
 def is_wrapper_or_member_descriptor(
-    value: Any,
+    value: object,
 ) -> TypeIs[
     types.GetSetDescriptorType
     | types.MethodDescriptorType
@@ -1537,14 +1537,14 @@ def unwrap_with_attr_name_if_wrapper(fn: Any) -> tuple[Any, str | None]:
     return fn, attr_name
 
 
-def is_numpy_ndarray(value: Any) -> TypeGuard[np.ndarray]:  # type: ignore[type-arg]
+def is_numpy_ndarray(value: object) -> TypeGuard[np.ndarray]:  # type: ignore[type-arg]
     if not np:
         return False
 
     return istype(value, np.ndarray)
 
 
-def istensor(obj: Any) -> bool:
+def istensor(obj: object) -> bool:
     """Check of obj is a tensor"""
     tensor_list: tuple[type, ...] = (
         torch.Tensor,
@@ -1555,7 +1555,7 @@ def istensor(obj: Any) -> bool:
     return istype(obj, tensor_list)
 
 
-def is_lazy_module(mod: Any) -> bool:
+def is_lazy_module(mod: object) -> bool:
     return isinstance(mod, LazyModuleMixin)
 
 
@@ -2781,7 +2781,7 @@ def preserve_rng_state() -> Generator[None, None, None]:
 
 
 def is_jit_model(
-    model0: Any,
+    model0: object,
 ) -> TypeIs[
     torch.jit._trace.TopLevelTracedModule
     | torch.jit._script.RecursiveScriptModule
@@ -3485,7 +3485,7 @@ def iter_contains(
 
 
 def key_is_id(
-    k: Any,
+    k: object,
 ) -> TypeIs[torch.Tensor | torch.nn.Module | MethodWrapperType]:
     """Returns whether it indexes dictionaries using its id"""
     return isinstance(k, (torch.Tensor, torch.nn.Module, MethodWrapperType))
@@ -3540,7 +3540,7 @@ GLOBAL_KEY_PREFIX = "__dict_key"
 from torch._subclasses import UnsupportedFakeTensorException
 
 
-def get_safe_global_name(tx: InstructionTranslatorBase, root: str, obj: Any) -> str:
+def get_safe_global_name(tx: InstructionTranslatorBase, root: str, obj: object) -> str:
     # The global_mangled_class_name should be different for different
     # invocations of torch.compile. Otherwise, we can run into a situation
     # where multiple torch.compile invocations reuse the same global name,

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -129,7 +129,7 @@ class BaseListVariable(VariableTracker):
     _index_not_found_msg = "tuple.index(x): x not in tuple"
 
     @staticmethod
-    def cls_for_instance(obj: Any) -> type["BaseListVariable"]:
+    def cls_for_instance(obj: object) -> type["BaseListVariable"]:
         return BaseListVariable.cls_for(type(obj))
 
     @staticmethod

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1409,7 +1409,7 @@ class AutogradFunctionVariable(VariableTracker):
 
     def _resolve_staticmethod(
         self,
-        obj: Any,
+        obj: object,
         source: Source | None,
         descriptor_source: Source | None,
         name: str,

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1409,7 +1409,7 @@ class AutogradFunctionVariable(VariableTracker):
 
     def _resolve_staticmethod(
         self,
-        obj: object,
+        obj: Any,
         source: Source | None,
         descriptor_source: Source | None,
         name: str,
@@ -2539,7 +2539,7 @@ class DebuggingVariable(VariableTracker):
 
     @staticmethod
     def is_reorderable_logging_function(
-        obj: Any,
+        obj: object,
     ) -> TypeGuard[types.FunctionType | types.BuiltinFunctionType]:
         return (
             callable(obj)

--- a/torch/_dynamo/variables/sdpa.py
+++ b/torch/_dynamo/variables/sdpa.py
@@ -99,5 +99,5 @@ class SDPAParamsVariable(VariableTracker):
             return wrap_fx_proxy(tx=tx, proxy=proxy)
 
     @staticmethod
-    def is_sdpa_params(value: Any) -> TypeGuard["SDPAParams"]:
+    def is_sdpa_params(value: object) -> TypeGuard["SDPAParams"]:
         return value is SDPAParams

--- a/torch/_dynamo/variables/sdpa.py
+++ b/torch/_dynamo/variables/sdpa.py
@@ -1,5 +1,6 @@
 from inspect import getattr_static
-from typing import Any, TYPE_CHECKING, TypeGuard
+from typing import Any, TYPE_CHECKING
+from typing_extensions import TypeIs
 
 from torch._guards import Source
 from torch.backends.cuda import SDPAParams
@@ -99,5 +100,5 @@ class SDPAParamsVariable(VariableTracker):
             return wrap_fx_proxy(tx=tx, proxy=proxy)
 
     @staticmethod
-    def is_sdpa_params(value: object) -> TypeGuard["SDPAParams"]:
+    def is_sdpa_params(value: object) -> TypeIs[type[SDPAParams]]:
         return value is SDPAParams


### PR DESCRIPTION
## Summary

- replace `Any` with `object` for private Dynamo runtime predicates and identity-only helpers
- cover the scoped utility, SDPA, list, logging, and pytree sites
- correct the SDPA class-identity predicate to narrow to `type[SDPAParams]`
- leave wrapper unwrapping and callable invocation helpers unchanged

## Test plan

- `python -m py_compile torch/_dynamo/utils.py torch/_dynamo/variables/sdpa.py torch/_dynamo/variables/lists.py torch/_dynamo/variables/misc.py torch/_dynamo/polyfills/pytree.py`
- focused Pyrefly comparison: the same 20 pre-existing diagnostics before and after the change, with no new diagnostics
- focused `pyrefly check` for `torch/_dynamo/variables/sdpa.py`: 0 errors
- full CI: 374 passed, 4 skipped; TorchTitan models integration is a Dr. CI-classified broken-trunk failure (`qwen3_5_moe_fsdp+tp+ep: No module named fla`) reproduced on three attempts

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98