### PR TITLE
[dynamo] Fix Dynamo Benchmark: Eager Deepcopy Inflating Memory Compression

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3000,14 +3000,6 @@ class BenchmarkRunner:
         # Cast the model to float16/float32 as necessary
         model, example_inputs = self.maybe_cast(model, example_inputs)
 
-        # Use distributed wrapping as necessary
-        model = self.deepcopy_and_maybe_parallelize(model)
-
-        if not hasattr(model, name):
-            model.name = name
-
-        self.init_optimizer(name, current_device, model.parameters())
-
         # The self.autocast context is needed for the model we export with aot_compile,
         # similar to what we do in the check_accuracy function
         ctx = (
@@ -3027,21 +3019,40 @@ class BenchmarkRunner:
                 self.args.snapshot_memory, f"eager_{self.args.only}"
             ):
                 with torch.compiler.set_stance("force_eager"):
-                    eager_latency, eager_peak_mem, _ = warmup(
-                        self.model_iter_fn,
-                        copy.deepcopy(model),
-                        example_inputs,
-                        "eager",
-                        measure_iters=measure_iters,
+                    eager_model = self.deepcopy_and_maybe_parallelize(model)
+                    if not hasattr(eager_model, name):
+                        eager_model.name = name
+                    self.init_optimizer(
+                        name, current_device, eager_model.parameters()
                     )
-                    if self.args.use_warm_peak_memory:
-                        _, eager_peak_mem, _ = warmup(
+                    try:
+                        eager_latency, eager_peak_mem, _ = warmup(
                             self.model_iter_fn,
-                            copy.deepcopy(model),
+                            eager_model,
                             example_inputs,
                             "eager",
-                            measure_iters=1,
+                            measure_iters=measure_iters,
                         )
+                        if self.args.use_warm_peak_memory:
+                            _, eager_peak_mem, _ = warmup(
+                                self.model_iter_fn,
+                                eager_model,
+                                example_inputs,
+                                "eager",
+                                measure_iters=1,
+                            )
+                    finally:
+                        self.optimizer = None
+                        del eager_model
+                        if current_device in ("cuda", "xpu", "mps"):
+                            empty_gpu_cache(current_device)
+
+            # Use a fresh model for the compiled pass. In particular, generate()
+            # can mutate model and cache state during the eager warmup.
+            model = self.deepcopy_and_maybe_parallelize(model)
+            if not hasattr(model, name):
+                model.name = name
+            self.init_optimizer(name, current_device, model.parameters())
 
             if (
                 self.args.export_aot_inductor

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3022,9 +3022,7 @@ class BenchmarkRunner:
                     eager_model = self.deepcopy_and_maybe_parallelize(model)
                     if not hasattr(eager_model, name):
                         eager_model.name = name
-                    self.init_optimizer(
-                        name, current_device, eager_model.parameters()
-                    )
+                    self.init_optimizer(name, current_device, eager_model.parameters())
                     try:
                         eager_latency, eager_peak_mem, _ = warmup(
                             self.model_iter_fn,

--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -8,7 +8,8 @@ import os
 import sys
 import types
 import unittest
-from contextlib import redirect_stdout
+import weakref
+from contextlib import nullcontext, redirect_stdout
 from unittest import mock
 
 import torch
@@ -29,6 +30,57 @@ except ImportError:
 
 
 class TestDynamoBenchmark(TestCase):
+    def test_eager_warmup_does_not_retain_compiled_model(self) -> None:
+        live_copies = weakref.WeakSet()
+
+        class TrackingModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2)
+
+            def __deepcopy__(self, memo):
+                model_copy = type(self)()
+                model_copy.load_state_dict(self.state_dict())
+                memo[id(self)] = model_copy
+                live_copies.add(model_copy)
+                return model_copy
+
+            def forward(self, inputs):
+                return self.linear(inputs)
+
+        class TrackingRunner(common.BenchmarkRunner):
+            def __init__(self):
+                super().__init__()
+                self.copy_counts = []
+
+            def pick_grad(self, name, is_training):
+                return nullcontext()
+
+        runner = TrackingRunner()
+        runner.args = parse_args(
+            ["-dcpu", "--backend=eager", "--performance", "--inference", "-n1"]
+        )
+
+        def model_iter_fn(model, inputs, collect_outputs=True):
+            runner.copy_counts.append(len(live_copies))
+            return model(inputs)
+
+        runner.model_iter_fn = model_iter_fn
+        experiment = mock.Mock(return_value="done")
+        experiment.func = common.speedup_experiment
+
+        with mock.patch("benchmarks.dynamo.common.current_device", "cpu"):
+            runner.run_performance_test(
+                "model",
+                TrackingModel(),
+                torch.ones(1, 2),
+                lambda fn: fn,
+                experiment,
+            )
+
+        self.assertTrue(runner.copy_counts)
+        self.assertEqual(max(runner.copy_counts), 1)
+
     def test_timm_auto_install_uses_no_deps(self) -> None:
         module_name = "benchmarks.dynamo._timm_models_install_test"
         module_path = os.path.join(os.path.dirname(__file__), "timm_models.py")


### PR DESCRIPTION
## Summary

Correct Dynamo benchmark eager-memory accounting by ensuring the eager and
compiled measurements have the same number of resident model copies.

## Bug

The performance runner created the compiled model copy before eager warmup.
Eager warmup then ran on another deepcopy(model) to prevent stateful
operations such as generate() from mutating the model used for compilation.

Consequently, memory measurement included:

- Eager: loaded model + compiled copy + eager copy
- Compiled: loaded model + compiled copy

This extra weight copy inflated eager_peak_mem and therefore
compression_ratio.

## Fix

Run eager warmup using an isolated model before creating the compiled model:

1. Create the eager model and its optimizer.
2. Perform the existing eager warmups and memory measurement.
3. Release the eager optimizer/model and clear the device cache.
4. Create a fresh compiled model from the unmodified loaded model.

This preserves model-state isolation for generate() and other stateful
workloads. It also preserves the existing measured/stabilization iteration
accounting and adds no forward passes.

The change applies to models using the shared Dynamo performance runner,
including TorchBench, timm, and HuggingFace models.

## Memory impact

Qwen3-0.6B, BF16, 1,000 input tokens and 2,000 generated tokens:

| Metric | Before | After | Change |
|---|---|---|---|
| Eager peak memory | 3.959 GB | 2.765 GB | -1.194 GB |
| Compiled peak memory | 2.385 GB | 2.385 GB | unchanged |
| Compression ratio | 1.659x | 1.159x | -0.500x |

The 1.194 GB reduction closely matches the model’s 1.192 GB of BF16
parameters, confirming that the extra weight copy was removed.

## Test plan

python -m unittest \

  benchmarks.dynamo.test.TestDynamoBenchmark.test_eager_warmup_does_not_retain_c
  ompiled_model \

  benchmarks.dynamo.test.TestHuggingFaceLLMPerformance.test_compilation_latency_
  uses_matched_work

python -m py_compile benchmarks/dynamo/common.py benchmarks/dynamo/test.py

Also measured Qwen3-0.6B before and after using dashboard-style warm peak-
memory collection.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo