### PR TITLE
flex_gemm: support F.grouped_mm through QuACK varlen-M

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3,6 +3,7 @@
 import contextlib
 import dataclasses
 import importlib
+import itertools
 import math
 import struct
 import sys
@@ -2025,7 +2026,7 @@ class TestFlexGemmAnalysis(TestCase):
 class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     def test_supported_op_names_match_dense_scope(self):
         self.assertEqual(
-            _SUPPORTED_FLEX_GEMM_OP_NAMES, "mm/addmm/bmm/baddbmm/scaled_mm"
+            _SUPPORTED_FLEX_GEMM_OP_NAMES, "mm/addmm/bmm/baddbmm/scaled_mm/grouped_mm"
         )
 
     def test_scaled_mm_requires_functional_api(self):
@@ -2083,6 +2084,155 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
 
         torch.testing.assert_close(actual, expected)
         torch.testing.assert_close(aux, expected_aux)
+
+    @staticmethod
+    def makeGroupedMm(seqlens=(24, 0, 40), k=32, n=16, device="cpu"):
+        """Return bf16 MoE-forward operands (x, w_t, offs) for ``sum(seqlens)`` tokens."""
+        offs = torch.tensor(seqlens, device=device).cumsum(0).to(torch.int32)
+        x = torch.randn(sum(seqlens), k, device=device, dtype=torch.bfloat16)
+        w = torch.randn(len(seqlens), n, k, device=device, dtype=torch.bfloat16)
+        return x, w.transpose(-2, -1), offs
+
+    @parametrize(
+        "case",
+        (
+            ("functional", torch.nn.functional.grouped_mm),
+            ("private", torch._grouped_mm),
+        ),
+        name_fn=lambda case: case[0],
+    )
+    def test_grouped_mm_default_backend_eager_matches_reference(self, case):
+        import torch.nn.functional as F
+
+        _, gemm_op = case
+        x, w_t, offs = self.makeGroupedMm()
+
+        actual = flex_gemm(
+            gemm_op, (x, w_t), lambda acc: acc.relu(), gemm_kwargs={"offs": offs}
+        )
+
+        torch.testing.assert_close(actual, F.grouped_mm(x, w_t, offs=offs).relu())
+
+    def test_grouped_mm_compiled_carries_offs_as_tensor_operand(self):
+        import torch.nn.functional as F
+        from torch._higher_order_ops.flex_gemm import flex_gemm_hop
+
+        graphs = []
+
+        def record_backend(gm, example_inputs):
+            graphs.append(gm)
+            return gm.forward
+
+        def fn(x, w_t, offs):
+            return flex_gemm(
+                F.grouped_mm,
+                (x, w_t),
+                lambda acc: acc.relu(),
+                gemm_kwargs={"offs": offs},
+            )
+
+        x, w_t, offs = self.makeGroupedMm()
+        actual = torch.compile(fn, backend=record_backend, fullgraph=True)(x, w_t, offs)
+
+        torch.testing.assert_close(actual, F.grouped_mm(x, w_t, offs=offs).relu())
+        (graph,) = graphs
+        (hop_node,) = graph.graph.find_nodes(op="call_function", target=flex_gemm_hop)
+        self.assertIs(hop_node.args[0], torch.ops.aten._grouped_mm.default)
+        self.assertEqual(len(hop_node.args[2]), 3)
+        self.assertTrue(all(isinstance(arg, torch.fx.Node) for arg in hop_node.args[2]))
+        self.assertEqual(hop_node.args[3], {})
+        body = getattr(graph, hop_node.args[1].target)
+        (gemm_node,) = body.graph.find_nodes(
+            op="call_function", target=torch.ops.aten._grouped_mm.default
+        )
+        self.assertEqual(len(gemm_node.args), 3)
+
+    def test_grouped_mm_rejects_unsupported_forms(self):
+        import torch.nn.functional as F
+
+        x, w_t, offs = self.makeGroupedMm()
+        cases = (
+            (
+                "bias",
+                F.grouped_mm,
+                (x, w_t),
+                {"offs": offs, "bias": x[:1, :16]},
+                "bias",
+            ),
+            (
+                "out_dtype",
+                F.grouped_mm,
+                (x, w_t),
+                {"offs": offs, "out_dtype": torch.float32},
+                "out_dtype",
+            ),
+            ("no_offs", F.grouped_mm, (x, w_t), {}, "offs=None"),
+            (
+                "3d_a",
+                F.grouped_mm,
+                (x.view(2, 32, 32), w_t.transpose(0, 1)[:2]),
+                {"offs": offs},
+                "3-D A",
+            ),
+            (
+                "2d_b",
+                F.grouped_mm,
+                (x.transpose(0, 1), x),
+                {"offs": offs},
+                "weight-gradient",
+            ),
+            (
+                "scaled",
+                torch._scaled_grouped_mm,
+                (x, w_t),
+                {"offs": offs},
+                "scaled grouped GEMMs",
+            ),
+        )
+        for name, gemm_op, gemm_args, gemm_kwargs, error in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(NotImplementedError, error):
+                    flex_gemm(
+                        gemm_op, gemm_args, lambda acc: acc, gemm_kwargs=gemm_kwargs
+                    )
+        with self.assertRaisesRegex(RuntimeError, "gemm_kwargs={'offs': offs}"):
+            flex_gemm(
+                torch.ops.aten._grouped_mm.default, (x, w_t, offs), lambda acc: acc
+            )
+
+    def test_grouped_mm_quack_pinned_config_rejects_varlen_gaps(self):
+        import torch.nn.functional as F
+
+        x, w_t, offs = self.makeGroupedMm()
+        residual = torch.randn(x.shape[0], w_t.shape[-1], dtype=torch.bfloat16)
+
+        def tile_capture(x, w_t, offs):
+            return flex_gemm(
+                F.grouped_mm,
+                (x, w_t),
+                lambda acc: acc + residual,
+                gemm_kwargs={"offs": offs},
+                kernel_options={"backend": "QUACK", "config": {"swap_ab": False}},
+            )
+
+        def grouped_reduce(x, w_t, offs):
+            return flex_gemm(
+                F.grouped_mm,
+                (x, w_t),
+                lambda acc: (acc, acc.float().view(x.shape[0], -1, 8).sum(-1)),
+                gemm_kwargs={"offs": offs},
+                kernel_options={"backend": "QUACK", "config": {"swap_ab": False}},
+            )
+
+        for fn, error in (
+            (tile_capture, "captured tensors of the full"),
+            (grouped_reduce, "grouped reductions or grouped-main"),
+        ):
+            with self.subTest(fn=fn.__name__):
+                with self.assertRaisesRegex(
+                    Exception, f"grouped_mm \\(varlen\\) .*{error}"
+                ):
+                    torch.compile(fn, backend="inductor", fullgraph=True)(x, w_t, offs)
 
     def test_fake_tensor_mode_tuple_aux_returns_fake_tensors(self):
         from torch._subclasses.fake_tensor import FakeTensorMode
@@ -8695,6 +8845,166 @@ class TestFlexGemmFastMathDevice(FlexGemmTestCase):
 
 
 instantiate_device_type_tests(TestFlexGemmFastMathDevice, globals(), only_for="cuda")
+
+
+@skipIfNoCuteDSL
+@unittest.skipIf(not SM100OrLater, "SM100+ required")
+class TestFlexGemmGroupedMmDevice(FlexGemmTestCase):
+    """MoE-forward ``F.grouped_mm`` through QuACK's varlen-M path."""
+
+    K, N = 256, 384
+
+    def makeGroupedMm(self, seqlens, device, *, total_m=None):
+        """Return (x, w_t, offs) where ``offs`` are int32 end offsets over ``seqlens``."""
+        offs = torch.tensor(seqlens, device=device).cumsum(0).to(torch.int32)
+        x = self.makeTensor(total_m or sum(seqlens), self.K, device=device)
+        w = self.makeTensor(len(seqlens), self.N, self.K, device=device)
+        return x, w.transpose(-2, -1), offs
+
+    def groupedReference(self, x, w_t, offs, epilogue_fn):
+        """Per-group fp64 GEMM plus epilogue over the rows ``offs`` covers."""
+        starts = [0, *offs.tolist()]
+        acc = torch.cat(
+            [
+                x[start:end].double() @ w_t[group].double()
+                for group, (start, end) in enumerate(itertools.pairwise(starts))
+            ]
+        )
+        return epilogue_fn(acc)
+
+    def assertGroupedMmMatches(self, actual, x, w_t, offs, epilogue_fn):
+        import torch.nn.functional as F
+
+        valid = offs[-1].item()
+        expected = self.groupedReference(x, w_t, offs, epilogue_fn)
+        eager = epilogue_fn(F.grouped_mm(x, w_t, offs=offs))[:valid]
+        self.assertEqual(actual.shape, (x.shape[0], self.N))
+        self.assertEqual(actual.dtype, eager.dtype)
+        self.assertTrue(actual[:valid].isfinite().all())
+        self.assertMatchesLowPrecisionEager(actual[:valid], eager, expected, self.K)
+
+    def assertGroupedMmQuackCode(self, code):
+        self.assertIn("flex_gemm_runtime", code)
+        self.assertIn("cu_seqlens_m=", code)
+        self.assertNotIn("extern_kernels._grouped_mm(", code)
+
+    @parametrize(
+        "case",
+        (
+            # An empty group and groups that are not tile multiples.
+            ("ragged", (200, 0, 130, 182), None),
+            # Rows past offs[-1] are ignored by both grouped_mm and QuACK.
+            ("tail_rows", (256, 96, 0, 32), 512),
+        ),
+        name_fn=lambda case: case[0],
+    )
+    def test_grouped_mm_silu_matches_reference(self, device, case):
+        import torch.nn.functional as F
+
+        _, seqlens, total_m = case
+        x, w_t, offs = self.makeGroupedMm(seqlens, device, total_m=total_m)
+
+        def fn(x, w_t, offs):
+            return flex_gemm(
+                F.grouped_mm,
+                (x, w_t),
+                F.silu,
+                gemm_kwargs={"offs": offs},
+                kernel_options={"backend": "QUACK"},
+            )
+
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), x, w_t, offs
+        )
+
+        self.assertGroupedMmQuackCode(code)
+        self.assertGroupedMmMatches(actual, x, w_t, offs, F.silu)
+
+    def test_grouped_mm_captures_and_aux_match_reference(self, device):
+        import torch.nn.functional as F
+
+        x, w_t, offs = self.makeGroupedMm((200, 0, 130, 182), device)
+        bias = torch.randn(self.N, device=device, dtype=torch.float32)
+        scale = torch.rand(x.shape[0], device=device, dtype=torch.float32) + 0.5
+        gain = torch.tensor(1.5, device=device, dtype=torch.float32)
+
+        def epilogue_fn(acc):
+            shifted = acc * scale[:, None] + bias[None, :]
+            return (F.gelu(shifted) * gain).to(acc.dtype), shifted
+
+        def fn(x, w_t, offs):
+            return flex_gemm(
+                F.grouped_mm,
+                (x, w_t),
+                epilogue_fn,
+                gemm_kwargs={"offs": offs},
+                kernel_options={"backend": "QUACK"},
+            )
+
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), x, w_t, offs
+        )
+
+        self.assertGroupedMmQuackCode(code)
+        for kind in ("'row'", "'col'", "'scalar'"):
+            self.assertIn(kind, code)
+        self.assertIn("aux_outs=(", code)
+        self.assertGroupedMmMatches(
+            actual, x, w_t, offs, lambda acc: epilogue_fn(acc)[0]
+        )
+        self.assertGroupedMmMatches(aux, x, w_t, offs, lambda acc: epilogue_fn(acc)[1])
+
+    def test_grouped_mm_tuned_matches_reference(self, device):
+        import torch.nn.functional as F
+
+        x, w_t, offs = self.makeGroupedMm((200, 0, 130, 182), device)
+
+        def fn(x, w_t, offs):
+            return flex_gemm(
+                F.grouped_mm,
+                (x, w_t),
+                lambda acc: acc.relu(),
+                gemm_kwargs={"offs": offs},
+                kernel_options={"backend": "QUACK", "tuned": True},
+            )
+
+        with self.limitEpiModAutotune():
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), x, w_t, offs
+            )
+
+        self.assertGroupedMmQuackCode(code)
+        self.assertIn("config=", code)
+        self.assertGroupedMmMatches(actual, x, w_t, offs, torch.relu)
+
+    def test_grouped_mm_tile_capture_falls_back(self, device):
+        import torch.nn.functional as F
+
+        x, w_t, offs = self.makeGroupedMm((200, 0, 130, 182), device)
+        residual = self.makeTensor(x.shape[0], self.N, device=device)
+
+        def epilogue_fn(acc):
+            return (acc + residual).relu()
+
+        def fn(x, w_t, offs):
+            return flex_gemm(
+                F.grouped_mm,
+                (x, w_t),
+                epilogue_fn,
+                gemm_kwargs={"offs": offs},
+                kernel_options={"backend": "QUACK"},
+            )
+
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), x, w_t, offs
+        )
+
+        self.assertIn("extern_kernels._grouped_mm(", code)
+        self.assertNotIn("flex_gemm_runtime", code)
+        self.assertGroupedMmMatches(actual, x, w_t, offs, epilogue_fn)
+
+
+instantiate_device_type_tests(TestFlexGemmGroupedMmDevice, globals(), only_for="cuda")
 
 
 @skipIfNoCuteDSL

--- a/torch/_higher_order_ops/flex_gemm.py
+++ b/torch/_higher_order_ops/flex_gemm.py
@@ -45,6 +45,9 @@ FLEX_GEMM_OP_SPECS = {
     torch.ops.aten._scaled_mm_v2.default: FlexGemmOpSpec(
         "scaled_mm", 0, 1, input_ndim=2
     ),
+    torch.ops.aten._grouped_mm.default: FlexGemmOpSpec(
+        "grouped_mm", 0, 1, input_ndim=2
+    ),
 }
 FLEX_GEMM_OP_ALIASES = {
     torch.mm: torch.ops.aten.mm.default,
@@ -52,6 +55,8 @@ FLEX_GEMM_OP_ALIASES = {
     torch.bmm: torch.ops.aten.bmm.default,
     torch.baddbmm: torch.ops.aten.baddbmm.default,
     torch.nn.functional.scaled_mm: torch.ops.aten._scaled_mm_v2.default,
+    torch.nn.functional.grouped_mm: torch.ops.aten._grouped_mm.default,
+    torch._grouped_mm: torch.ops.aten._grouped_mm.default,
 }
 _SUPPORTED_BACKENDS = {"NVGEMM", "QUACK", "TRITON"}
 
@@ -365,6 +370,53 @@ def scaled_mm_enum_values(value: Any, name: str) -> tuple[int, ...]:
         raise RuntimeError(f"{name} must contain enum values") from error
 
 
+def flex_gemm_grouped_mm(
+    gemm_op: torch._ops.OpOverload,
+    gemm_args: tuple[Any, ...],
+    epilogue_fn: Callable[[Any], Any],
+    gemm_kwargs: dict[str, Any],
+    kernel_options: dict[str, Any],
+) -> Any:
+    """Normalize the MoE forward grouped GEMM: 2-D A, 3-D B, ``offs`` as a tensor operand.
+
+    ``offs`` moves from ``gemm_kwargs`` into the HOP's tensor operands so Dynamo
+    and the body graph carry it as a tensor rather than a constant.
+    """
+    if len(gemm_args) != 2:
+        raise RuntimeError(
+            "FlexGEMM grouped_mm expects gemm_args=(mat_a, mat_b) and "
+            "gemm_kwargs={'offs': offs}"
+        )
+    mat_a, mat_b = gemm_args
+    options = dict(gemm_kwargs)
+    offs = options.pop("offs", None)
+    if options.pop("bias", None) is not None:
+        raise NotImplementedError("FlexGEMM grouped_mm bias is not supported yet")
+    if options.pop("out_dtype", None) is not None:
+        raise NotImplementedError("FlexGEMM grouped_mm out_dtype is not supported yet")
+    if options:
+        raise RuntimeError(
+            f"unsupported FlexGEMM grouped_mm options: {sorted(options)}"
+        )
+    if (
+        not isinstance(offs, torch.Tensor)
+        or not isinstance(mat_a, torch.Tensor)
+        or not isinstance(mat_b, torch.Tensor)
+        or mat_a.ndim != 2
+        or mat_b.ndim != 3
+    ):
+        raise NotImplementedError(
+            "FlexGEMM grouped_mm supports only the MoE forward form: 2-D A "
+            "[total_m, K], 3-D B [E, K, N] and an int32 offs tensor; 3-D A, the "
+            "2-D/2-D weight-gradient form and offs=None are not supported"
+        )
+
+    def body_fn(*args: Any) -> Any:
+        return epilogue_fn(gemm_op(*args))
+
+    return flex_gemm_hop(gemm_op, body_fn, (mat_a, mat_b, offs), {}, kernel_options)
+
+
 def flex_gemm(
     gemm_op: Callable[..., Any],
     gemm_args: tuple[Any, ...],
@@ -386,7 +438,21 @@ def flex_gemm(
             "FlexGEMM direct aten._scaled_mm_v2 calls are unsupported; "
             "use torch.nn.functional.scaled_mm"
         )
+    if public_gemm_op in (
+        torch._scaled_grouped_mm,
+        torch.ops.aten._scaled_grouped_mm,
+        torch.ops.aten._scaled_grouped_mm.default,
+    ):
+        raise NotImplementedError(
+            "FlexGEMM scaled grouped GEMMs are not supported yet; "
+            "only bf16 torch.nn.functional.grouped_mm with offs is supported"
+        )
     gemm_op = cast(torch._ops.OpOverload, FLEX_GEMM_OP_ALIASES.get(gemm_op, gemm_op))
+
+    if gemm_op is torch.ops.aten._grouped_mm.default:
+        return flex_gemm_grouped_mm(
+            gemm_op, gemm_args, epilogue_fn, gemm_kwargs, kernel_options
+        )
 
     if public_gemm_op is torch.nn.functional.scaled_mm:
         if len(gemm_args) != 4:

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -8,6 +8,7 @@ lowering and routes QUACK requests through shared analysis and one EpiMod choice
 from __future__ import annotations
 
 import dataclasses
+import functools
 import importlib.util
 from typing import Any, TYPE_CHECKING
 
@@ -24,7 +25,13 @@ from torch.utils._ordered_set import OrderedSet
 
 from ... import config, ir
 from ...ir import IRNode, TensorBox
-from ...lowering import empty_strided, process_subgraph_nodes, register_lowering, view
+from ...lowering import (
+    constant_pad_nd,
+    empty_strided,
+    process_subgraph_nodes,
+    register_lowering,
+    view,
+)
 from ...utils import _IntLike, ceildiv
 from ..gemm_epilogue_utils import statically_known_equal, statically_known_shape_equal
 from .configs import flex_gemm_search_space
@@ -83,8 +90,16 @@ def decompose_nvgemm_additive_gemm(graph_module: torch.fx.GraphModule) -> None:
         graph_module.recompile()
 
 
-class QuackScaledMmUnsupported(NotImplementedError):
+class QuackFallbackUnsupported(NotImplementedError):
     """Request ordinary lowering before FlexGEMM mutates the graph or realizes IR."""
+
+
+class QuackScaledMmUnsupported(QuackFallbackUnsupported):
+    """Scaled-mm contract QuACK's block-scaled main loop does not cover."""
+
+
+class QuackGroupedMmUnsupported(QuackFallbackUnsupported):
+    """Grouped-mm contract QuACK's varlen-M path does not cover."""
 
 
 def has_flex_gemm_quack() -> bool:
@@ -93,9 +108,14 @@ def has_flex_gemm_quack() -> bool:
 
 
 # QuACK epilogue captures, aux outputs and local reductions are validated for
-# these 2-D, bias-free GEMMs only.
+# these 2-D, bias-free GEMMs only; grouped_mm additionally rejects the
+# features QuACK's varlen-M path lacks (see quack_grouped_mm_contract).
 QUACK_EPILOGUE_FEATURE_OPS = frozenset(
-    (torch.ops.aten.mm.default, torch.ops.aten._scaled_mm_v2.default)
+    (
+        torch.ops.aten.mm.default,
+        torch.ops.aten._scaled_mm_v2.default,
+        torch.ops.aten._grouped_mm.default,
+    )
 )
 
 _BLOCKWISE_1X16 = torch.nn.functional.ScalingType.BlockWise1x16.value
@@ -202,6 +222,60 @@ def quack_blockscaled_contract(gemm_fx_node: torch.fx.Node) -> QuackBlockScaledC
                 "FlexGEMM NVFP4 TensorWise scales must be scalar Float32 tensors"
             )
     return QuackBlockScaledContract(format_name, gemm_inputs, tensorwise_scales)
+
+
+def quack_grouped_mm_contract(
+    gemm_fx_node: torch.fx.Node,
+) -> tuple[tuple[torch.fx.Node, torch.fx.Node], torch.fx.Node]:
+    """Resolve the varlen-M grouped GEMM operands or request ordinary lowering.
+
+    QuACK's varlen path is the MoE forward form: k-major bf16/fp16 A
+    ``[total_m, K]``, per-group B ``[E, K, N]`` and int32 ``offs[E]`` end offsets,
+    which the runtime turns into ``cu_seqlens_m = [0, *offs]``.
+    """
+    normalized = normalize_function(
+        torch.ops.aten._grouped_mm.default,
+        gemm_fx_node.args,
+        gemm_fx_node.kwargs,
+        normalize_to_only_use_kwargs=True,
+    )
+    if normalized is None:
+        raise AssertionError("aten._grouped_mm arguments must bind to its schema")
+    call = normalized.kwargs
+    mat_a, mat_b, offs = call["input"], call["mat2"], call["offs"]
+    if offs is None or call["bias"] is not None or call["out_dtype"] is not None:
+        raise QuackGroupedMmUnsupported(
+            "FlexGEMM QUACK grouped_mm requires offs and no bias or out_dtype"
+        )
+    a_meta, b_meta, offs_meta = (node.meta["val"] for node in (mat_a, mat_b, offs))
+    if (
+        a_meta.ndim != 2
+        or a_meta.stride(-1) != 1
+        or b_meta.ndim != 3
+        or a_meta.dtype not in (torch.bfloat16, torch.float16)
+        or b_meta.dtype is not a_meta.dtype
+        or offs_meta.dtype is not torch.int32
+    ):
+        raise QuackGroupedMmUnsupported(
+            "FlexGEMM QUACK grouped_mm supports only bf16/fp16 k-major 2-D A "
+            "[total_m, K], 3-D B [E, K, N] and int32 offs"
+        )
+    return (mat_a, mat_b), offs
+
+
+def flex_gemm_cu_seqlens_benchmark_input(
+    node: IRNode, total_m: _IntLike
+) -> torch.Tensor:
+    """Build evenly spaced ``[0, ..., total_m]`` boundaries for autotune benchmarks."""
+    from torch._inductor.virtualized import V
+
+    sizevars = V.graph.sizevars
+    return torch.linspace(
+        0,
+        sizevars.optimization_hint(total_m),
+        sizevars.optimization_hint(node.get_size()[0]),
+        device=node.get_device_or_error(),
+    ).to(torch.int32)
 
 
 def flex_gemm_tensor_placeholders(
@@ -504,32 +578,41 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
     mat1_index = op_spec.mat1_index
     gemm_fx_node = flex_gemm_node(subgraph.graph_module, gemm_op)
     scaled_mm = gemm_op is torch.ops.aten._scaled_mm_v2.default
+    grouped_mm = gemm_op is torch.ops.aten._grouped_mm.default
+    indexed_output_fallback = None
+    if scaled_mm or grouped_mm:
+        fallback_type = (
+            QuackScaledMmUnsupported if scaled_mm else QuackGroupedMmUnsupported
+        )
+        indexed_output_fallback = fallback_type(
+            f"FlexGEMM QUACK {op_spec.name} does not yet support indexed outputs"
+        )
     try:
         indexed_store = flex_gemm_indexed_output_plan(
             *flex_gemm_output_values(subgraph.graph_module)
         )
     except NotImplementedError as exc:
-        if scaled_mm:
-            raise QuackScaledMmUnsupported(
-                "FlexGEMM QUACK scaled-mm does not yet support indexed outputs"
-            ) from exc
+        if indexed_output_fallback is not None:
+            raise indexed_output_fallback from exc
         raise
-    if scaled_mm and indexed_store is not None:
-        raise QuackScaledMmUnsupported(
-            "FlexGEMM QUACK scaled-mm does not yet support indexed outputs"
-        )
+    if indexed_output_fallback is not None and indexed_store is not None:
+        raise indexed_output_fallback
     placeholders = [
         node for node in subgraph.graph_module.graph.nodes if node.op == "placeholder"
     ]
     placeholder_args = dict(zip(placeholders, args, strict=True))
-    if gemm_op is torch.ops.aten._scaled_mm_v2.default:
+    blockscaled = None
+    mainloop_scale_nodes: tuple[torch.fx.Node, ...] = ()
+    offs_node = None
+    if scaled_mm:
         blockscaled = quack_blockscaled_contract(gemm_fx_node)
         gemm_nodes = blockscaled.gemm_inputs
         mainloop_scale_nodes = blockscaled.tensorwise_scales
         alpha, beta = 1.0, 0.0
+    elif grouped_mm:
+        gemm_nodes, offs_node = quack_grouped_mm_contract(gemm_fx_node)
+        alpha, beta = 1.0, 0.0
     else:
-        blockscaled = None
-        mainloop_scale_nodes = ()
         unsupported_gemm_kwargs = OrderedSet(gemm_kwargs) - OrderedSet(
             ["alpha", "beta"]
         )
@@ -610,6 +693,15 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
     ):
         raise NotImplementedError(LOCAL_REDUCE_DENSE_MM_SCOPE_ERROR)
     outputs = epilogue_analysis.outputs
+    if grouped_mm and (
+        epilogue_analysis.required_geometries
+        or outputs.local_reduce is not None
+        or outputs.main_transform is not None
+    ):
+        raise QuackGroupedMmUnsupported(
+            "FlexGEMM QUACK grouped_mm (varlen) does not yet support grouped "
+            "reductions or grouped-main outputs"
+        )
     indexed_output = outputs.indexed_output
     indexed_input = None
     if indexed_output is not None:
@@ -662,6 +754,15 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
             "FlexGEMM generic main outputs support only floating-point and bool dtypes"
         )
     local_reduce_metas = flex_gemm_local_reduce_metas(outputs.local_reduce)
+    cu_seqlens_input_nodes = []
+    if offs_node is not None:
+        # QuACK's varlen path reads [0, *offs]; pad in-graph so Inductor owns
+        # the buffer instead of the runtime allocating during CUDA graph capture.
+        cu_seqlens_input_nodes.append(
+            ir.TemplateBuffer.realize_template_input(
+                constant_pad_nd(placeholder_args[offs_node], [1, 0])
+            )
+        )
     output_stride = ir.convert_shape_to_inductor(output_meta.stride())
     if main_transform is not None:
         # Grouped main outputs use TMA stores, whose outer stride must preserve
@@ -705,6 +806,9 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
     ]
     input_nodes: list[IRNode] = []
     gemm_input_indices = append_flex_gemm_template_inputs(input_nodes, gemm_input_nodes)
+    cu_seqlens_indices = append_flex_gemm_template_inputs(
+        input_nodes, cu_seqlens_input_nodes
+    )
     epilogue_arg_indices = append_flex_gemm_template_inputs(
         input_nodes, epilogue_input_nodes
     )
@@ -733,6 +837,11 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
             output_size,
         ),
     )
+    if grouped_mm and "tile" in epilogue_arg_kinds:
+        raise QuackGroupedMmUnsupported(
+            "FlexGEMM QUACK grouped_mm (varlen) does not yet support captured "
+            "tensors of the full [total_m, N] output shape"
+        )
     epimod_source = materialize_flex_gemm_epimod(
         subgraph.graph_module,
         epilogue_analysis,
@@ -807,6 +916,7 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         ),
         quack_config_constraints=tuple(sorted(quack_config_constraints.items())),
         quack_config=None,
+        cu_seqlens_index=cu_seqlens_indices[0] if cu_seqlens_indices else None,
         epilogue_arg_indices=epilogue_arg_indices,
         epilogue_arg_kinds=epilogue_arg_kinds,
         aux_out_indices=aux_out_indices,
@@ -848,6 +958,10 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         for index, input_node in enumerate(input_nodes)
         if isinstance(input_node, ir.ReinterpretView)
     }
+    for index in cu_seqlens_indices:
+        input_gen_fns[index] = functools.partial(
+            flex_gemm_cu_seqlens_benchmark_input, total_m=output_size[0]
+        )
     result, _ = autotune_select_algorithm(
         "flex_gemm_epilogue",
         choices,
@@ -890,7 +1004,12 @@ def flex_gemm_lowering(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
             return lower_quack_flex_gemm(
                 body_gemm_op, subgraph, args, gemm_kwargs, kernel_options
             )
-        except QuackScaledMmUnsupported as error:
+        except QuackFallbackUnsupported as error:
+            if (
+                isinstance(error, QuackGroupedMmUnsupported)
+                and "config" in kernel_options
+            ):
+                raise
             fallback_reason = str(error)
             log_flex_gemm_artifact(
                 "fallback",

--- a/torch/_inductor/kernel/flex_gemm/runtime.py
+++ b/torch/_inductor/kernel/flex_gemm/runtime.py
@@ -161,6 +161,7 @@ def flex_gemm_candidate_configs(
     operands: dict[str, Any],
     config_constraints: tuple[tuple[str, Any], ...],
     concat_layout: Any,
+    cu_seqlens_m: torch.Tensor | None,
 ) -> list[Any]:
     """Return QuACK's legal configs for this call, its untuned default first.
 
@@ -186,6 +187,7 @@ def flex_gemm_candidate_configs(
         A=a,
         B=b if b_kn else b.mT,
         b_kn=b_kn,
+        cu_seqlens_m=cu_seqlens_m,
         SFA=sfa,
         concat_layout=concat_layout,
     )
@@ -503,14 +505,19 @@ def gemm_epimod(
     indexed_indices: torch.Tensor | None = None,
     local_reduce: FlexGemmEpiModLocalReducePlan | None = None,
     main_transform: FlexGemmGroupedMainOutputTransform | None = None,
+    cu_seqlens_m: torch.Tensor | None = None,
     config: tuple[tuple[str, Any], ...] | None = None,
     config_constraints: tuple[tuple[str, Any], ...] = (),
     stream: int | None = None,
 ) -> torch.Tensor:
-    """Run a dense or block-scaled FlexGEMM call through the vendored QuACK EpiMod.
+    """Run a dense, block-scaled or varlen-M FlexGEMM call through the vendored QuACK EpiMod.
 
     ``config`` pins the exact GemmConfig Inductor selected; ``None`` takes
     QuACK's untuned default for the remaining ``config_constraints``.
+    ``cu_seqlens_m`` (``[0, *offs]``, int32) selects grouped_mm's varlen-M path:
+    ``a`` is ``[total_m, K]``, ``b`` is per-group ``[E, K, N]``, and captured
+    row/col vectors are passed rank-1 (a row is shared by every group, a column
+    is the concatenated ``[total_m]`` vector QuACK offsets per group).
     """
     if blockscaled_format is not None:
         if SFA is None or SFB is None:
@@ -553,9 +560,11 @@ def gemm_epimod(
     for index, (arg, kind) in enumerate(
         zip(quack_epilogue_args, epilogue_arg_kinds, strict=True)
     ):
-        operands[f"operand{index}"] = (
-            arg.squeeze(-1).unsqueeze(0) if kind == "col" else arg
-        )
+        if cu_seqlens_m is not None and kind in ("row", "col"):
+            arg = arg.squeeze(0 if kind == "row" else -1)
+        elif kind == "col":
+            arg = arg.squeeze(-1).unsqueeze(0)
+        operands[f"operand{index}"] = arg
     if indexed_out is not None:
         operands[INDEXED_OUTPUT_INDICES_ARG_NAME] = indexed_indices
         operands[INDEXED_OUTPUT_STORE_ARG_NAME] = indexed_out
@@ -630,6 +639,7 @@ def gemm_epimod(
                 operands,
                 config_constraints,
                 concat_layout,
+                cu_seqlens_m,
             )
         )
         return output_buffers[main_name]
@@ -669,6 +679,7 @@ def gemm_epimod(
             config_constraints=config_constraints,
             tuned=False,
             concat_layout=concat_layout,
+            cu_seqlens_m=cu_seqlens_m,
             compile_dispatch=False,
             **blockscaled_kwargs,
             **operands,

--- a/torch/_inductor/kernel/flex_gemm/template.py
+++ b/torch/_inductor/kernel/flex_gemm/template.py
@@ -99,6 +99,8 @@ class FlexGemmEpilogueConfig:
         quack_config_constraints: Optional native QuACK config field constraints.
         quack_config: Exact QuACK GemmConfig fields pinned for this choice, or
             None to take QuACK's untuned default within the constraints.
+        cu_seqlens_index: Template input index of the varlen-M ``[0, *offs]``
+            boundaries for grouped_mm, or None for dense GEMMs.
         epilogue_arg_indices: Template input indices for read-only epilogue captures.
         epilogue_arg_kinds: Broadcast kind for each captured epilogue tensor.
         aux_out_indices: Template input indices for same-shape aux outputs.
@@ -114,6 +116,7 @@ class FlexGemmEpilogueConfig:
     blockscaled: FlexGemmEpilogueBlockScaledConfig | None
     quack_config_constraints: tuple[tuple[str, Any], ...]
     quack_config: tuple[tuple[str, Any], ...] | None
+    cu_seqlens_index: int | None
     epilogue_arg_indices: tuple[int, ...]
     epilogue_arg_kinds: tuple[str, ...]
     aux_out_indices: tuple[int, ...]
@@ -263,6 +266,8 @@ class FlexGemmEpilogueKernel(CuteDSLTemplateKernel):
                 f"SFB={input_args[config.blockscaled.sfb_index]}, "
                 f"blockscaled_format={config.blockscaled.format!r}"
             )
+        if config.cu_seqlens_index is not None:
+            kwargs.append(f", cu_seqlens_m={input_args[config.cu_seqlens_index]}")
         if epilogue_args:
             kwargs.append(
                 f", epilogue_args=({', '.join(epilogue_args)},), "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193197
* __->__ #196184
* #196183
* #192894
* #192664
* #192663
* #192839
* #196174
* #192662

## Human Note

## Agent note

Add the MoE forward form of `torch.nn.functional.grouped_mm` as a FlexGEMM entry point: 2-D `A [total_m, K]`,
3-D `B [E, K, N]` (`weight.transpose(-2, -1)`), int32 `offs [E]`, output `[total_m, N]`. This is the shape
torchtitan's MoE experts use and the only GEMM in a DeepSeek-V3 layer FlexGEMM could not reach.

The HOP wrapper moves `offs` from `gemm_kwargs` into the tensor operands so the traced body contains
`aten._grouped_mm.default(a, b, offs)` and Dynamo no longer tries to constant-fold a tensor; bias,
`out_dtype`, 3-D A, the 2-D/2-D weight-gradient form, and `_scaled_grouped_mm` are rejected with explicit
messages. The lowering resolves the node once through `normalize_function`, builds
`cu_seqlens_m = constant_pad_nd(offs, [1, 0])` in-graph as a template input (with an autotune input
generator), and passes it to `gemm_epimod`, which hands it to QuACK's existing varlen-M EpiMod path; no
QuACK patch is needed. Under varlen, row captures are passed rank-1 `(N,)` shared across experts and column
captures rank-1 `(total_m,)`. Compositions QuACK's varlen path does not support (indexed outputs, grouped
reductions, grouped-main transforms, full-tile captures) take ordinary Inductor `_grouped_mm` lowering
through the same fallback base class scaled-mm uses, unless a QUACK config is pinned.

At the DeepSeek-V3-16B expert shape (E=8, K=2048, N=1408, total_m=8192, silu epilogue, CUDA graphs) the
untuned default config is 0.62x of stock `torch.compile`; `tuned=True` reaches 1.11x. Selecting a better
varlen default is left for a follow-up.

This change was prepared with assistance from an AI coding tool.

## Test Plan

```bash
python -m pytest test/inductor/test_flex_gemm.py -q -k grouped_mm
python -m pytest test/inductor/test_flex_gemm.py test/python_native/test_quack_vendor.py test/inductor/test_symmetric_mm.py -q
```