### PR TITLE
[Inductor] Treat a concurrently cleared local aot_autograd cache as a miss, not an error.

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -532,6 +532,77 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
         self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
 
     @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch(
+        {"enable_autograd_cache": True, "strict_autograd_cache": True}
+    )
+    def test_lookup_races_with_concurrent_clear(self):
+        """
+        The local cache root is shared by every process of this user, so another
+        process can clear it while we are looking a key up. That must degrade to
+        a miss rather than raising out of the compile.
+        """
+
+        def fn(x, y):
+            return (x * 2, y @ y)
+
+        a = torch.rand(25)
+        b = torch.rand(5, 5)
+
+        compiled_fn = torch.compile(fn, backend="inductor")
+        self.assertEqual(fn(a, b), compiled_fn(a, b))
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+        self._clear_dynamo_and_codecache()
+
+        real_listdir = os.listdir
+        aotautograd_dir = AOTAutogradCache._get_tmp_dir()
+
+        def clear_then_listdir(path, *args, **kwargs):
+            # Stands in for another process rmtree'ing the cache root after we
+            # resolved the subdir for this key but before we list it. Only the
+            # AOTAutograd cache root is raced; everything else lists normally.
+            if os.fspath(path).startswith(aotautograd_dir):
+                AOTAutogradCache.clear()
+            return real_listdir(path, *args, **kwargs)
+
+        with patch("torch._inductor.codecache.os.listdir", clear_then_listdir):
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch(
+        {"enable_autograd_cache": True, "strict_autograd_cache": True}
+    )
+    def test_save_races_with_concurrent_clear(self):
+        """
+        A local cache write can lose the same race, with the key's subdir going
+        away between write_atomic()'s temp write and its rename. Skipping the
+        save is not a bypass and must not fail the compile, even in strict mode.
+        """
+
+        def fn(x, y):
+            return (x * 2, y @ y)
+
+        a = torch.rand(25)
+        b = torch.rand(5, 5)
+
+        def raise_missing_dir(path, content, make_dirs=False, encode_utf_8=False):
+            raise FileNotFoundError(f"No such file or directory: {path}")
+
+        compiled_fn = torch.compile(fn, backend="inductor")
+        with patch.object(autograd_cache, "write_atomic", raise_missing_dir):
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch({"fx_graph_cache": True, "compile_threads": 1})
     @functorch_config.patch({"enable_autograd_cache": True})
     @unittest.skipIf(not torch.distributed.is_available(), "requires distributed")

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -57,7 +57,6 @@ from functorch.experimental import control_flow
 from torch._decomp import decomposition_table
 from torch._dynamo.testing import normalize_gm
 from torch._dynamo.utils import counters
-from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 from torch._functorch.aot_autograd import (
     _aot_export_function,
     aot_export_joint_simple,
@@ -73,6 +72,7 @@ from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.codecache import compiled_fx_graph_hash
 from torch._inductor.custom_graph_pass import CustomPartitionerFn
 from torch._inductor.output_code import MockFXGraphCacheOutput
+from torch._inductor.utils import fresh_cache
 from torch._subclasses.fake_tensor import DynamicOutputShapeException, FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     _FAKE_TENSOR_ID_TO_PROXY_MAP_FOR_EXPORT,
@@ -13058,11 +13058,14 @@ class TestAOTAutogradWithCache(TestAOTAutogradWithDynamo):
         make_inputs_subclasses: bool = False,
     ):
         self.inductor_cache = MockFXGraphCache()
-        AOTAutogradCache.clear()
-        with patch(
+        mock_fx_graph_cache = patch(
             "torch._inductor.codecache.FxGraphCache.load_with_key",
             new=self.inductor_cache.load_with_key,
-        ):
+        )
+        # fresh_cache() rather than AOTAutogradCache.clear(): clear() rmtree's the
+        # cache root shared by every process of this user, so under a parallel
+        # runner it deletes entries other workers are mid-read/mid-write on.
+        with fresh_cache(), mock_fx_graph_cache:
             return super().verify_aot_autograd(
                 f,
                 inp_,

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -1544,19 +1544,20 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 artifact = BundledAOTAutogradCacheArtifact(precompile_key, entry)
                 entry.sanitized_aot_config.precompile_backend_id = None
                 PrecompileContext.record_artifact(artifact)
-            AOTAutogradCache._write_to_local_cache(key, content)
+            try:
+                AOTAutogradCache._write_to_local_cache(key, content)
+            except OSError as e:
+                # The local cache root is shared across processes, so a concurrent
+                # AOTAutogradCache.clear() can remove the key's subdir between the
+                # temp write and the rename inside write_atomic(). Losing that race
+                # means we don't save the entry; it is not a bypass, and it is not a
+                # reason to fail the compile, so don't re-raise even in strict mode.
+                log.warning("AOTAutograd cache unable to write compiled graph: %s", e)
+                return None
             counters["aot_autograd"]["autograd_cache_saved"] += 1
             cache_stats.put("LocalAOTAutogradCache")
         except BypassAOTAutogradCache as e:
             AOTAutogradCache._handle_save_error(e, remote, is_bypass=True)
-            return None
-        except OSError as e:
-            # The local cache root is shared across processes, so a concurrent
-            # AOTAutogradCache.clear() can remove the key's subdir between the
-            # temp write and the rename inside write_atomic(). Losing that race
-            # means we don't save the entry; it is not a bypass, and it is not a
-            # reason to fail the compile, so don't re-raise even in strict mode.
-            log.warning("AOTAutograd cache unable to write compiled graph: %s", e)
             return None
         except Exception as e:
             AOTAutogradCache._handle_save_error(e, remote, is_bypass=False)

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -1456,15 +1456,13 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
     def _write_to_local_cache(key: str, content: bytes) -> None:
         """Write an entry to the local cache."""
         subdir = AOTAutogradCache._get_tmp_dir_for_key(key)
-        if not os.path.exists(subdir):
-            os.makedirs(subdir, exist_ok=True)
 
         # Use a hash of the serialized entry to get a unique file
         # name. The specific name doesn't matter since a lookup involves
         # iterating over all entries in the parent subdir.
         path = os.path.join(subdir, sha256_hash(content))
         log.info("Writing AOTAutograd cache entry to %s", path)
-        write_atomic(path, content)
+        write_atomic(path, content, make_dirs=True)
 
     @staticmethod
     def _find_unpicklable_field(
@@ -1551,6 +1549,14 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             cache_stats.put("LocalAOTAutogradCache")
         except BypassAOTAutogradCache as e:
             AOTAutogradCache._handle_save_error(e, remote, is_bypass=True)
+            return None
+        except OSError as e:
+            # The local cache root is shared across processes, so a concurrent
+            # AOTAutogradCache.clear() can remove the key's subdir between the
+            # temp write and the rename inside write_atomic(). Losing that race
+            # means we don't save the entry; it is not a bypass, and it is not a
+            # reason to fail the compile, so don't re-raise even in strict mode.
+            log.warning("AOTAutograd cache unable to write compiled graph: %s", e)
             return None
         except Exception as e:
             AOTAutogradCache._handle_save_error(e, remote, is_bypass=False)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1890,11 +1890,18 @@ class GuardedCache(Generic[T]):
             subdir = cls._get_tmp_dir_for_key(key)
             try:
                 names = sorted(os.listdir(subdir))
-            except OSError:
+            except FileNotFoundError:
                 # Nothing was ever written for this key, or another process cleared
                 # the cache out from under us. The local cache root is shared across
                 # processes, so checking os.path.exists() first would only narrow the
                 # race, not close it. Either way there are no candidates: a miss.
+                names = []
+            except OSError:
+                # Anything else (a bad mode on the cache dir, a dead mount) is not a
+                # race and is worth surfacing, but it still leaves no candidates.
+                log.warning(
+                    "%s unable to list cache entries", cls.__name__, exc_info=True
+                )
                 names = []
             for path in names:
                 if path.startswith("."):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1888,19 +1888,29 @@ class GuardedCache(Generic[T]):
     ) -> Generator[tuple[T, bytes, bool], None, None]:
         if local:
             subdir = cls._get_tmp_dir_for_key(key)
-            if os.path.exists(subdir):
-                for path in sorted(os.listdir(subdir)):
-                    if path.startswith("."):
-                        continue  # Skip temp files from concurrent write_atomic() calls
-                    try:
-                        with open(os.path.join(subdir, path), "rb") as f:
-                            content = f.read()
-                            yield pickle.loads(content), content, True
-                    except Exception:
-                        log.warning(
-                            "fx graph cache unable to load compiled graph",
-                            exc_info=True,
-                        )
+            try:
+                names = sorted(os.listdir(subdir))
+            except OSError:
+                # Nothing was ever written for this key, or another process cleared
+                # the cache out from under us. The local cache root is shared across
+                # processes, so checking os.path.exists() first would only narrow the
+                # race, not close it. Either way there are no candidates: a miss.
+                names = []
+            for path in names:
+                if path.startswith("."):
+                    continue  # Skip temp files from concurrent write_atomic() calls
+                try:
+                    with open(os.path.join(subdir, path), "rb") as f:
+                        content = f.read()
+                        yield pickle.loads(content), content, True
+                except FileNotFoundError:
+                    continue  # Raced with a concurrent cache clear
+                except Exception:
+                    log.warning(
+                        "%s unable to load compiled graph",
+                        cls.__name__,
+                        exc_info=True,
+                    )
 
         if remote_cache:
             try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196189

## Motivation
Parallel test runs randomly fail in `TestAOTAutogradWithCache` with a
`FileNotFoundError` escaping out of the AOTAutograd cache, reported in
intel/torch-xpu-ops#4936. It shows up two ways: `os.listdir()` raising during
lookup in `GuardedCache.iterate_over_candidates`, and the rename inside
`write_atomic()` raising during save, the latter surfacing as
`BackendCompilerFailed`.

## Solution
The root cause is that the local cache root is `/tmp/torchinductor_<username>`,
shared by every process of that user, while `verify_aot_autograd` calls
`AOTAutogradCache.clear()` -- an `rmtree` of that root -- at the start of every
test. Under a parallel runner, one worker's clear deletes the entries other
workers are mid-read or mid-write on. These tests set `strict_autograd_cache`,
which re-raises cache errors instead of degrading to a bypass, so losing the
race becomes a hard test failure rather than a recompile.

A concurrent clear is neither a bypass nor a compile error. It only means there
is nothing usable on disk, so both cache paths should degrade to a miss.

On lookup, `iterate_over_candidates` guarded the listing with
`os.path.exists(subdir)`. That check narrows the race but cannot close it:
another process can `rmtree` between the check and the listing. It now lists
unconditionally and treats `OSError` as an empty candidate set, and skips
individual entries that vanish between listing and open. This code lives in
`GuardedCache`, so the fix covers `FxGraphCache` as well as `AOTAutogradCache`.

On save, `_write_to_local_cache` created the key subdir itself before calling
`write_atomic()`, leaving the same window open between the `makedirs` and the
rename. It now defers directory creation to `write_atomic(make_dirs=True)`,
matching `FxGraphCache._write_to_local_cache`, and `AOTAutogradCache.save()`
logs and swallows `OSError` rather than routing it to `_handle_save_error`,
which would re-raise it under `strict_autograd_cache`.

Switches from `AOTAutogradCache.clear()` to
`fresh_cache()`, which removes the cross-worker interference at its source:
each process gets its own `TORCHINDUCTOR_CACHE_DIR` and stops deleting a root
it does not own.

## Test
Two regression tests inject a clear into the exact window each path races on.
`test_lookup_races_with_concurrent_clear` patches `os.listdir` so the root is
cleared after the key's subdir has been resolved but before it is listed, and
`test_save_races_with_concurrent_clear` makes `write_atomic()` raise
`FileNotFoundError`. Both run under `strict_autograd_cache=True`; reverting the
library change makes them fail with the tracebacks quoted in the issue.

Authored with the assistance of Claude Code.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98