### PR TITLE
Fix PagedAttention defaulting to CUDA on non-CUDA accelerators

### DIFF
--- a/torch/nn/attention/experimental/_paged_attention.py
+++ b/torch/nn/attention/experimental/_paged_attention.py
@@ -35,8 +35,11 @@ class PagedAttention:
         n_pages: int,
         page_size: int,
         max_batch_size: int,
-        device: str = "cuda",
+        device: str | torch.device | None = None,
     ) -> None:
+        if device is None:
+            device = torch.accelerator.current_accelerator() or torch.device("cpu")
+
         # number of pages
         self.n_pages = n_pages
 


### PR DESCRIPTION
## Summary

`PagedAttention.__init__` defaulted `device` to the literal string
`"cuda"`, even though nothing else in the class is CUDA-specific: every
tensor allocation already threads the `device` parameter through
generically (`torch.ones/zeros(..., device=device)`), and later methods
(`reserve`, `convert_logical_block_mask`) derive their device from
existing tensors rather than hardcoding anything.

The class is already exercised on CUDA, XPU, and MPS via
`instantiate_device_type_tests(..., allow_xpu=True, allow_mps=True)` in
`test/inductor/test_flex_attention.py`, and every call site in that test
file passes `device=` explicitly -- which is exactly why this never
surfaced: tests always override the default. A caller who instantiates
`PagedAttention(...)` directly on XPU/MPS/NPU without passing `device=`
gets pointed at CUDA and fails, even though the class works fine on
their hardware once given the right device string.

This PR replaces the hardcoded default with
`torch.accelerator.current_accelerator()` (falling back to CPU if no
accelerator is present).

## Test Plan

Verified both the new default and explicit overrides resolve correctly:

\`\`\`python
import torch
from torch.nn.attention.experimental._paged_attention import PagedAttention

pa = PagedAttention(n_pages=4, page_size=16, max_batch_size=2)
print(pa.page_table.device)  # now resolves to the local accelerator (mps:0 here), not cuda

pa2 = PagedAttention(n_pages=4, page_size=16, max_batch_size=2, device="cpu")
print(pa2.page_table.device)  # explicit override still respected
\`\`\`

