### PR TITLE
[Testcase Refactoring] Decouple ShardedTensor basic test classes from hardcoded CUDA (1/4)

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -40,6 +40,11 @@ from torch.distributed._shard.sharding_spec import (
     ShardMetadata,
 )
 from torch.distributed.remote_device import _remote_device
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
@@ -47,10 +52,9 @@ from torch.testing._internal.common_distributed import (
     tp_transports,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
-    skip_but_pass_in_sandcastle_if,
     skipIfRocm,
-    TEST_CUDA,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
 )
@@ -73,27 +77,29 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestShardedTensorMetadata(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_serialize_and_deserialize(self):
         shard_metadatas = [
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
+                placement="rank:0/cpu",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
+                placement="rank:1/cpu",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
+                placement="rank:2/cpu",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
+                placement="rank:3/cpu",
             ),
         ]
 
@@ -146,8 +152,9 @@ class TestShardedTensorMetadata(TestCase):
 
 
 class TestCreateTensorFromParams(TestCase):
-    @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "CUDA GPU is needed")
-    def test_empty(self):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_empty(self, device):
         expected_dtype = torch.double
         tensor_properties = TensorProperties(
             dtype=expected_dtype,
@@ -156,7 +163,7 @@ class TestCreateTensorFromParams(TestCase):
             pin_memory=False,
             memory_format=torch.contiguous_format,
         )
-        local_device = torch.device("cuda:0")
+        local_device = torch.device(self.device_type, 0)
         local_tensor = _create_tensor_from_params(
             5, 10, local_device=local_device, tensor_properties=tensor_properties
         )
@@ -167,21 +174,23 @@ class TestCreateTensorFromParams(TestCase):
 
 
 class TestShardParameter(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_shard_parameter(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_shard_parameter(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
-        fc = torch.nn.Linear(12, 12).cuda(self.rank)
+        fc = torch.nn.Linear(12, 12).to(self.device_type)
         weight_og = fc.weight.clone()
         shard_parameter(fc, "weight", spec)
 
@@ -198,19 +207,19 @@ class TestShardParameter(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_shard_parameter_errors(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_shard_parameter_errors(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
-        fc = torch.nn.Linear(12, 12).cuda(self.rank)
+        fc = torch.nn.Linear(12, 12).to(self.device_type)
         with self.assertRaisesRegex(ValueError, "does not match with src_rank"):
             shard_parameter(fc, "weight", spec, src_rank=self.rank)
 
@@ -225,16 +234,16 @@ class TestShardParameter(ShardedTensorTestBase):
             shard_parameter(fc, "bias", spec)
 
         with self.assertRaisesRegex(ValueError, "not a contiguous Tensor"):
-            fc.bias = torch.rand(10, 10).cuda(self.rank).t()
+            fc.bias = torch.rand(10, 10).to(self.device_type).t()
             shard_parameter(fc, "bias", spec)
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:{self.rank}/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:{self.rank}/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         with self.assertRaisesRegex(ValueError, "does not match with sharding_spec"):
@@ -245,12 +254,12 @@ class TestShardParameter(ShardedTensorTestBase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
+                    placement=f"rank:0/{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
+                    placement=f"rank:1/{self.device_type}:1",
                 ),
             ]
         )
@@ -259,20 +268,22 @@ class TestShardParameter(ShardedTensorTestBase):
 
 
 class TestShardTensor(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_shard_tensor(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_shard_tensor(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
-        tensor = torch.rand(12, 12).cuda(self.rank)
+        tensor = torch.rand(12, 12).to(self.device_type)
         st = _shard_tensor(tensor, spec)
 
         # Verify.
@@ -284,18 +295,18 @@ class TestShardTensor(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_shard_tensor_with_empty_shard(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_shard_tensor_with_empty_shard(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
-        tensor = torch.rand(9, 12).cuda(self.rank)
+        tensor = torch.rand(9, 12).to(self.device_type)
         st = _shard_tensor(tensor, spec)
 
         # Verify.
@@ -315,33 +326,33 @@ class TestShardTensor(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_shard_tensor_errors(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_shard_tensor_errors(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
-        tensor = torch.rand(12, 12).cuda(self.rank)
+        tensor = torch.rand(12, 12).to(self.device_type)
 
         with self.assertRaisesRegex(ValueError, "does not match with src_rank"):
             _shard_tensor(tensor, spec, src_rank=self.rank)
 
         with self.assertRaisesRegex(ValueError, "not a contiguous Tensor"):
-            tensor_t = torch.rand(12, 12).cuda(self.rank).t()
+            tensor_t = torch.rand(12, 12).to(self.device_type).t()
             _shard_tensor(tensor_t, spec)
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                f"rank:{self.rank}/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:{self.rank}/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         with self.assertRaisesRegex(ValueError, "does not match with sharding_spec"):
@@ -352,12 +363,12 @@ class TestShardTensor(ShardedTensorTestBase):
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
+                    placement=f"rank:0/{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
+                    placement=f"rank:1/{self.device_type}:1",
                 ),
             ]
         )
@@ -366,6 +377,8 @@ class TestShardTensor(ShardedTensorTestBase):
 
 
 class TestModuleHookApi(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     class DummyNNModule(torch.nn.Module):
         def __init__(self, spec, tensor_size):
             super().__init__()
@@ -376,8 +389,8 @@ class TestModuleHookApi(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_reshard_output(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_reshard_output(self, device):
         specs = _chunk_sharding_specs_list_for_test([0, 1], seed=5)
         spec, reshard_spec = specs[0], specs[1]
         test_module = self.DummyNNModule(spec, [24, 12])
@@ -401,8 +414,8 @@ class TestModuleHookApi(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_collect_local_shard(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_collect_local_shard(self, device):
         specs = _chunk_sharding_specs_list_for_test([0], seed=5)
         spec = specs[0]
         test_module = self.DummyNNModule(spec, [23, 15])
@@ -415,17 +428,19 @@ class TestModuleHookApi(ShardedTensorTestBase):
 
 
 class TestLocalTensor(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_local_tensor(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_local_tensor(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         st = sharded_tensor.rand(spec, 24, 12)
@@ -435,21 +450,21 @@ class TestLocalTensor(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_local_tensor_error(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_local_tensor_error(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:1/cuda:1",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:2/cuda:2",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:1/{self.device_type}:1",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:2/{self.device_type}:2",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         st = sharded_tensor.rand(spec, 24, 12)
@@ -3419,6 +3434,8 @@ class TestShardMetadata(ShardedTensorTestBase):
 
 
 class TestShardedTensorSubGroupInit(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @spawn_threads_and_init_comms(world_size=4)
     def test_sub_process_group_sharded_tensor_init(self):
         world_pg = dist.GroupMember.WORLD
@@ -3465,11 +3482,13 @@ class TestShardedTensorSubGroupInit(TestCase):
 
         for r in sub_pg_ranks:
             _parse_and_validate_remote_device(
-                sub_pg, _remote_device(f"rank:{r}/cuda:{r % sub_group_sz}")
+                sub_pg, _remote_device(f"rank:{r}/meta:{r % sub_group_sz}")
             )
 
 
 class TestCreateTensorNoProcessGroupMode(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_init_from_local_shards_and_global_metadata(self):
         st_metadata: ShardedTensorMetadata = ShardedTensorMetadata(
             shards_metadata=[
@@ -3530,6 +3549,23 @@ class TestCreateTensorNoProcessGroupMode(TestCase):
             local_shards=st_local_shards,
             sharded_tensor_metadata=st_metadata,
         )
+
+
+instantiate_device_type_tests(
+    TestCreateTensorFromParams, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestShardParameter, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestShardTensor, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestModuleHookApi, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestLocalTensor, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`test/distributed/_shard/sharded_tensor/test_sharded_tensor.py` hardcodes CUDA
throughout: `"rank:X/cuda:Y"` placement strings, `.cuda()` device moves,
`torch.device("cuda", ...)` constructions, and `@requires_nccl()` admission
decorators. This silently skips the ShardedTensor distributed suite on non-CUDA
accelerators even when sufficient devices and a compatible distributed backend
are available.

This PR is the first of a series that decouples the file test-class by
test-class, so each PR touches a small set of complete classes and every
committed revision stays runnable. This batch covers 8 of the 14 classes
(15 test methods): the 3 GENERIC classes and the 5 small ACCELERATOR classes.

For each covered class this PR:

- Replaces all hardcoded CUDA with `self.device_type` (injected per device
  variant by `instantiate_device_type_tests`).
- Switches `@requires_nccl()` to
  `@requires_capabilities(Capability.distributed.backend)` — admission by
  device-declared capabilities instead of hardcoded backend name lists.
- Adds `hw_classification` labels and registers the 5 ACCELERATOR classes
  with `instantiate_device_type_tests(..., except_for="cpu")`.

The remaining 6 classes (ShardedTensorChunked / Enumerable /
FromLocalTensor / FromLocalShards / CustomOps / ShardMetadata) are untouched
in this PR and keep their original CUDA form; they are covered by follow-up
PRs in this series.

This is part of the test case refactoring initiative (#185590).

## Changes

- **3 GENERIC classes** (`TestShardedTensorMetadata`,
  `TestShardedTensorSubGroupInit`, `TestCreateTensorNoProcessGroupMode`):
  - Serialization test placements `"rank:X/cuda:X"` → `"rank:X/cpu"`
    (pure metadata serialization, no accelerator needed).
  - `TestShardedTensorSubGroupInit`: the placement-validation test data
    string `"rank:{r}/cuda:{r % sub_group_sz}"` →
    `"rank:{r}/meta:{r % sub_group_sz}"` (this GENERIC class is not
    instantiated and has no `self.device_type`; `meta` is parseable on all
    environments and consistent with the sibling test's meta placement).
    `TestCreateTensorNoProcessGroupMode`: label only.
  - Methods keep `def test_X(self):` (GENERIC classes are not instantiated).

- **5 ACCELERATOR classes** (`TestCreateTensorFromParams`,
  `TestShardParameter`, `TestShardTensor`, `TestModuleHookApi`,
  `TestLocalTensor`):
  - All CUDA device strings → `self.device_type`.
  - All `@requires_nccl()` →
    `@requires_capabilities(Capability.distributed.backend)`.
  - All test methods gain a `device` parameter (injected by
    `instantiate_device_type_tests`).
  - `TestCreateTensorFromParams`: removed
    `@skip_but_pass_in_sandcastle_if(not TEST_CUDA, ...)` — the class is now
    admitted via `@requires_capabilities` on any accelerator with a
    distributed backend, and its `hw_classification` label is ACCELERATOR.

- **File-level**:
  - Added `instantiate_device_type_tests(..., except_for="cpu",
    allow_xpu=True)` for the 5 ACCELERATOR classes. `allow_xpu=True`
    preserves the original coverage intent: the original
    `skip_if_lt_x_gpu` carried an explicit `TEST_XPU` branch, so running on
    XPU with sufficient devices was the original author's intent, and the
    instantiation opt-in default (`allow_xpu=False`) must not be stricter
    than that. `allow_mps` is NOT added — the original
    `skip_if_lt_x_gpu` has no MPS branch.
  - Imports: added `Capability`, `requires_capabilities`,
    `instantiate_device_type_tests`, `HardwareClassification`; removed
    `TEST_CUDA` and `skip_but_pass_in_sandcastle_if` (their only user was
    `TestCreateTensorFromParams`). `requires_nccl` is kept — the 6
    not-yet-decoupled classes still use it.

## Depends on

This PR relies on the following upstream PRs (submitted but not yet merged):

- **#187650**: `skip_if_lt_x_gpu` hardware-agnostic refactoring.
- **#190991**: `HardwareClassification` enum.
- **#191919**: `Capability` class + `requires_capabilities` decorator.
- **#193080**: `PrivateUse1TestBase._capabilities()` override (registers
  `Capability.distributed.backend` for PrivateUse1 backends — without it
  the decoupled tests degrade to skip on NPU, not fail).
- **#194992**: `ShardedTensorTestBase.backend` property and `with_comms`
  dynamic backend resolution.

The capability mechanism's skip-on-missing-capability degradation means this
PR can be merged before #193080 safely.

## Not changed

- The 6 remaining classes — byte-identical to the original (still
  `"cuda"` + `@requires_nccl()`), verified zero diff.
- `@skip_if_lt_x_gpu` — kept (already hardware-agnostic via #187650).
- `@with_comms` — uses default (resolves to `self.backend` dynamically via
  #194992).
- XPU variants — generated (`allow_xpu=True`) to preserve the original
  coverage intent: the original `skip_if_lt_x_gpu` carried an explicit
  `TEST_XPU` branch, so XPU with sufficient devices was the original
  author's intent; the historical 0 actual XPU executions came from the
  `@with_comms` backend hard-coding (fixed by #194992), not from intent.
  The execution chain is already accelerator-generic end to end —
  `skip_if_lt_x_gpu` passes on XPU devices (#187650, `torch.accelerator`
  based), `@requires_capabilities` reads XPU-declared capabilities, and
  `@with_comms` resolves the backend dynamically — so XPU variants run
  wherever an XPU runner with 4 devices and a working distributed backend
  exists. On CUDA/CPU/NPU CI the XPU variants are skipped by the same
  admission chain, so this adds zero CI risk. XPU execution itself will be
  confirmed by XPU CI / follow-up testing.
- Method control flow — unchanged (only device references generalized).

## Test plan

- CUDA (A100, 4 cards visible): 74 tests, 74 passed, 0 failed — decoupled
  classes resolve `self.device_type="cuda"`; untouched classes still use
  `"cuda"` literals. No regression. XPU variants are not generated on
  CUDA-only machines (variant generation requires device availability), so
  `allow_xpu=True` adds zero effect here.
- NPU (torch_npu 2.13.0, Ascend 910B3, 4 cards): 74 tests, 16 passed
  (5 GENERIC + 10 decoupled ACCELERATOR methods admitted via
  `@requires_capabilities` + 1 gloo-path method), 1 error (pre-existing,
  see below), 57 skipped. `HCCL_NPU_SOCKET_PORT_RANGE=16000-17000` required.
  - The 1 error is `test_st_base_init_from_local_shards_and_global_metadata`
    (in `TestShardedTensorFromLocalShards`, an untouched class in this batch):
    it hardcodes `device=f"cuda:{rank}"` without `@requires_nccl` — same
    behavior as the original code, fixed when PR 2 decouples that class.
- CPU: 64 tests, 5 passed (GENERIC), 59 skipped, 0 failed — PR1's ACCELERATOR
  CPU variants are excluded by `except_for="cpu"`; untouched ACCELERATOR
  classes are collected (not instantiated) and skipped by `@requires_nccl`.