### PR TITLE
Fix GradScaler defaulting to CUDA on non-CUDA accelerators

### DIFF
--- a/torch/amp/grad_scaler.py
+++ b/torch/amp/grad_scaler.py
@@ -105,9 +105,11 @@ class GradScaler:
     iterations.  After that, step skipping should occur rarely (once every few hundred or thousand iterations).
 
     Args:
-        device (str, optional, default="cuda"): Device type to use. Possible values are: 'cuda' and 'cpu'.
+        device (str, optional, default=None): Device type to use, e.g. 'cuda', 'cpu', 'xpu'.
             The type is the same as the `type` attribute of a :class:`torch.device`.
             Thus, you may obtain the device type of a tensor using `Tensor.device.type`.
+            Default: ``None``, which resolves to :func:`torch.accelerator.current_accelerator`
+            if an accelerator is present, else ``'cpu'``.
         init_scale (float, optional, default=2.**16):  Initial scale factor.
         growth_factor (float, optional, default=2.0):  Factor by which the scale is multiplied during
             :meth:`update` if no inf/NaN gradients occur for ``growth_interval`` consecutive iterations.
@@ -122,13 +124,16 @@ class GradScaler:
 
     def __init__(
         self,
-        device: str = "cuda",
+        device: str | None = None,
         init_scale: float = 2.0**16,
         growth_factor: float = 2.0,
         backoff_factor: float = 0.5,
         growth_interval: int = 2000,
         enabled: bool = True,
     ) -> None:
+        if device is None:
+            accel = torch.accelerator.current_accelerator()
+            device = accel.type if accel is not None else "cpu"
         self._device = device
         self._enabled = enabled
         if self._device == "cuda":


### PR DESCRIPTION
## Summary

`GradScaler.__init__` defaulted `device` to the literal string `"cuda"`.
The class body is otherwise fully generic: the internal scale tensor is
lazily created on whichever device the real loss/output tensor lives on
(`_lazy_init_scale_growth_tracker` is called with `outputs.device`, not
`self._device`), and `self._device` is only used to (a) gate a
CUDA-availability check, and (b) validate a user-supplied `new_scale`
tensor's device.

That first use is a real bug, not just a stale default: an XPU user who
doesn't pass `device="xpu"` explicitly keeps `self._device == "cuda"` by
default. On a CUDA-less XPU-only machine,
`torch.cuda.amp.common.amp_definitely_not_available()` returns `True`,
which **silently sets `self._enabled = False`** and gradient scaling (the
NaN/inf overflow safety net for fp16/bf16 mixed-precision training) gets
disabled entirely, with only an easy-to-miss warning buried in training
logs. XPU is a real, CI-tested use of this class already
(`test/test_xpu.py` calls `torch.amp.GradScaler("xpu", ...)` directly),
so this isn't a hypothetical code path.

This PR replaces the hardcoded default with
`torch.accelerator.current_accelerator()` (falling back to CPU if no
accelerator is present), the same fix already applied to
`PagedAttention`'s device default. Also updates the docstring, which
claimed `'cuda'`/`'cpu'` were the only possible values despite `'xpu'`
already being tested.

## Test Plan

Verified both the new default and explicit overrides resolve correctly:

\`\`\`python
import torch
from torch.amp.grad_scaler import GradScaler

g = GradScaler()
print(g._device)  # now resolves to the local accelerator (mps here), not cuda

g2 = GradScaler(device="xpu")
print(g2._device, g2._enabled)  # explicit override respected, stays enabled
\`\`\`



cc @mcarilli @ptrblck @leslie-fang-intel @jgong5