### PR TITLE
[dynamo] Support torch.cuda.stream(None)

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -466,6 +466,25 @@ class TestStreamsGeneric(torch._dynamo.test_case.TestCase):
         res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent(device="cpu"))
         self.assertEqual(res, torch.ones(2))
 
+    def test_stream_none(self):
+        def fn(x):
+            with torch.cuda.stream(None):
+                return x + 1
+
+        x = torch.ones(2)
+        self.assertEqual(torch.compile(fn, backend="eager", fullgraph=True)(x), fn(x))
+
+    def test_stream_context_none_as_input(self):
+        def fn(x, ctx):
+            with ctx:
+                return x + 1
+
+        x = torch.ones(2)
+        ctx = torch.cuda.stream(None)
+        self.assertEqual(
+            torch.compile(fn, backend="eager", fullgraph=True)(x, ctx), fn(x, ctx)
+        )
+
 
 @requires_accelerator
 class TestStreams(torch._dynamo.test_case.TestCase):

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -20,7 +20,7 @@ from ..graph_bytecode_inputs import (
 from ..source import CurrentStreamSource
 from .base import GetSet, Method, readonly_setter, VariableTracker
 from .constant import ConstantVariable
-from .ctx_manager import FxTracebackAnnotateVariable
+from .ctx_manager import FxTracebackAnnotateVariable, NullContextVariable
 from .lazy import LazyVariableTracker
 
 
@@ -325,9 +325,14 @@ class StreamContextVariable(FxTracebackAnnotateVariable):
     @staticmethod
     def create(
         tx: "InstructionTranslatorBase",
-        stream_to_enter: "StreamVariable",
+        stream_to_enter: "StreamVariable | ConstantVariable",
         **kwargs: dict[str, Any],
-    ) -> "StreamContextVariable":
+    ) -> "StreamContextVariable | NullContextVariable":
+        if (
+            isinstance(stream_to_enter, ConstantVariable)
+            and stream_to_enter.value is None
+        ):
+            return NullContextVariable(**kwargs)
         return StreamContextVariable(
             stream_to_enter,
             **kwargs,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1005,6 +1005,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             ConstantVariable,
             GradModeVariable,
             InferenceModeVariable,
+            NullContextVariable,
             StreamContextVariable,
             SymNodeVariable,
             TensorVariable,
@@ -1744,8 +1745,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
         )
         def handle_device_interface_stream(
-            self, tx: "InstructionTranslatorBase", stream: "StreamVariable"
-        ) -> StreamContextVariable:
+            self,
+            tx: "InstructionTranslatorBase",
+            stream: "StreamVariable | ConstantVariable",
+        ) -> "StreamContextVariable | NullContextVariable":
             return StreamContextVariable.create(tx, stream)
 
         @register(torch.from_numpy)


### PR DESCRIPTION
Dynamo represents None passed to torch.cuda.stream as a ConstantVariable, but StreamContextVariable assumed every argument was a StreamVariable and accessed user_object_index. This caused an InternalTorchDynamoError during full-graph capture.

Represent ConstantVariable(None) as a NullContextVariable to preserve the eager no-op behavior. Cover both direct construction and passing the stream context as a compiled function input.

#196193

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98