### PR TITLE
[Testcase Refactoring] Decouple ShardedTensor local-shards/custom-ops/metadata test classes from hardcoded CUDA (2/4)

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -40,6 +40,11 @@ from torch.distributed._shard.sharding_spec import (
     ShardMetadata,
 )
 from torch.distributed.remote_device import _remote_device
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
@@ -47,6 +52,7 @@ from torch.testing._internal.common_distributed import (
     tp_transports,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     skipIfRocm,
@@ -2291,6 +2297,8 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
 
 class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _generate_st_from_chunk_local_tensor(self, st_size, sharding_spec):
         tensor_meta = sharding_spec.build_metadata(st_size, TensorProperties())
         pg = dist.distributed_c10d._get_default_group()
@@ -2323,7 +2331,9 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
         # Verify local shard.
         local_shard = st.local_shards()[0]
         self.assertEqual(st.local_tensor(), local_tensor)
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(
+            torch.device(self.device_type, self.rank), local_shard.tensor.device
+        )
 
         # Verify local shard metadata.
         self.assertEqual(
@@ -2356,8 +2366,8 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
     @skipIfRocm
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_tensor(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_tensor(self, device):
         chunk_specs = _chunk_sharding_specs_list_for_test([0, 1, 1, 0], seed=31)
         for spec in chunk_specs:
             self._generate_st_from_chunk_local_tensor([20, 10], spec)
@@ -2367,24 +2377,24 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_tensor_errors(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_tensor_errors(self, device):
         enumerable_sharding_spec = EnumerableShardingSpec(
             [
                 ShardMetadata(
                     shard_offsets=[0, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
+                    placement=f"rank:0/{self.device_type}:0",
                 ),
                 ShardMetadata(
                     shard_offsets=[5, 0],
                     shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
+                    placement=f"rank:1/{self.device_type}:1",
                 ),
             ]
         )
         st_size = [24, 12]
-        local_tensor = torch.rand(*st_size).cuda(self.rank)
+        local_tensor = torch.rand(*st_size).to(self.device_type)
         with self.assertRaisesRegex(ValueError, "do not cover the entire tensor"):
             ShardedTensor._init_from_local_tensor(
                 local_tensor,
@@ -2403,18 +2413,20 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
 
 
 class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_local_shards(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_local_shards(self, device):
         shard_offsets = [(self.rank // 2) * 5, (self.rank % 2) * 5]
         local_shard_metadata = ShardMetadata(
             shard_offsets=shard_offsets,
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
-        local_tensor = torch.randn(5, 5, device=f"cuda:{self.rank}")
+        local_tensor = torch.randn(5, 5, device=f"{self.device_type}:{self.rank}")
         local_shard = sharded_tensor.Shard(local_tensor, local_shard_metadata)
         local_shard_from_offsets = sharded_tensor.Shard.from_tensor_and_offsets(
             local_tensor, shard_offsets=shard_offsets, rank=self.rank
@@ -2424,7 +2436,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         wrong_local_shard_metadata = ShardMetadata(
             shard_offsets=shard_offsets,
             shard_sizes=[6, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
         with self.assertRaisesRegex(ValueError, "Shard tensor size does not match"):
             sharded_tensor.Shard(local_tensor, metadata=wrong_local_shard_metadata)
@@ -2432,17 +2444,18 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
     @skipIfRocm
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards(self, device):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         local_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
         ]
 
@@ -2454,7 +2467,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(
+            torch.device(self.device_type, self.rank), local_shard.tensor.device
+        )
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
@@ -2464,7 +2479,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         )
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
         self.assertEqual(
-            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+            f"rank:{self.rank}/{self.device_type}:{self.rank}",
+            str(local_shard.metadata.placement),
         )
 
         # Verify global metadata.
@@ -2475,7 +2491,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
             )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{rank}/{self.device_type}:{rank}", str(shard_metadata.placement)
+            )
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2491,19 +2509,21 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
     @skipIfRocm
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_recalc_for_metadata(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_recalc_for_metadata(self, device):
         shard_sizes = [0, 5]  # test 2 different shard sizes
         for shard_size in shard_sizes:
             local_shard_metadata = ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[shard_size, shard_size],
-                placement=f"rank:{self.rank}/cuda:{self.rank}",
+                placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
             )
 
             local_shards = [
                 sharded_tensor.Shard(
-                    torch.randn(shard_size, shard_size, device=f"cuda:{self.rank}"),
+                    torch.randn(
+                        shard_size, shard_size, device=f"{self.device_type}:{self.rank}"
+                    ),
                     local_shard_metadata,
                 )
             ]
@@ -2515,7 +2535,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             # Verify local shard.
             local_shard = st.local_shards()[0]
             self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+                torch.device(self.device_type, self.rank), local_shard.tensor.device
             )
             self.assertEqual((shard_size, shard_size), local_shard.tensor.size())
 
@@ -2526,7 +2546,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             )
             self.assertEqual((shard_size, shard_size), local_shard.metadata.shard_sizes)
             self.assertEqual(
-                f"rank:{self.rank}/cuda:{self.rank}",
+                f"rank:{self.rank}/{self.device_type}:{self.rank}",
                 str(local_shard.metadata.placement),
             )
 
@@ -2537,7 +2557,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 self.assertEqual((rank * shard_size, 0), shard_metadata.shard_offsets)
                 self.assertEqual((shard_size, shard_size), shard_metadata.shard_sizes)
                 self.assertEqual(
-                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                    f"rank:{rank}/{self.device_type}:{rank}",
+                    str(shard_metadata.placement),
                 )
 
             with self.assertRaises(ValueError):
@@ -2546,17 +2567,17 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
     @skipIfRocm
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_with_different_glb_size(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_with_different_glb_size(self, device):
         wrong_offset_local_shard_metadata = ShardMetadata(
             shard_offsets=[0, 0],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         wrong_offset_local_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"),
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
                 wrong_offset_local_shard_metadata,
             )
         ]
@@ -2566,12 +2587,13 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[self.rank * 5, 0],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         local_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
         ]
         with self.assertRaises(ValueError):
@@ -2580,17 +2602,18 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
     @skipIfRocm
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_non_rw_sharded_recalc_for_metadata(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_non_rw_sharded_recalc_for_metadata(self, device):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         local_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
         ]
 
@@ -2613,7 +2636,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         )
 
     @skip_if_lt_x_gpu(4)
-    def test_st_base_init_from_local_shards_and_global_metadata(self):
+    def test_st_base_init_from_local_shards_and_global_metadata(self, device):
         world_size = 4
         shards_metadata = []
         shards = []
@@ -2621,12 +2644,13 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             local_shard_metadata = ShardMetadata(
                 shard_offsets=[(rank // 2) * 5, (rank % 2) * 5],
                 shard_sizes=[5, 5],
-                placement=f"rank:{rank}/cuda:{rank}",
+                placement=f"rank:{rank}/{self.device_type}:{rank}",
             )
             shards_metadata.append(local_shard_metadata)
             shards.append(
                 sharded_tensor.Shard(
-                    torch.randn(5, 5, device=f"cuda:{rank}"), local_shard_metadata
+                    torch.randn(5, 5, device=f"{self.device_type}:{rank}"),
+                    local_shard_metadata,
                 )
             )
 
@@ -2651,7 +2675,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         # Verify local shard of st_base
         local_shard = st_base.local_shards()[0]
-        self.assertEqual(torch.device("cuda:0"), local_shard.tensor.device)
+        self.assertEqual(torch.device(self.device_type, 0), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
@@ -2660,7 +2684,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             local_shard.metadata.shard_offsets,
         )
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual("rank:0/cuda:0", str(local_shard.metadata.placement))
+        self.assertEqual(
+            f"rank:0/{self.device_type}:0", str(local_shard.metadata.placement)
+        )
 
         # Verify global metadata.
         shards_metadata = st_base.metadata().shards_metadata
@@ -2670,17 +2696,19 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
             )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{rank}/{self.device_type}:{rank}", str(shard_metadata.placement)
+            )
 
     @skipIfRocm
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_and_global_metadata_with_all_zeros(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_and_global_metadata_with_all_zeros(self, device):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[0, 0],
             shard_sizes=[0, 0],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         shards_metadata = []
@@ -2692,13 +2720,14 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                     ShardMetadata(
                         shard_offsets=[0, 0],
                         shard_sizes=[0, 0],
-                        placement=f"rank:{r}/cuda:{r}",
+                        placement=f"rank:{r}/{self.device_type}:{r}",
                     )
                 )
 
         local_shards = [
             sharded_tensor.Shard(
-                torch.randn(0, 0, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(0, 0, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
         ]
 
@@ -2726,7 +2755,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(
+            torch.device(self.device_type, self.rank), local_shard.tensor.device
+        )
         self.assertEqual((0, 0), local_shard.tensor.size())
 
         # Verify local shard metadata.
@@ -2736,7 +2767,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         )
         self.assertEqual((0, 0), local_shard.metadata.shard_sizes)
         self.assertEqual(
-            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+            f"rank:{self.rank}/{self.device_type}:{self.rank}",
+            str(local_shard.metadata.placement),
         )
 
         # Verify global metadata.
@@ -2745,20 +2777,22 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         for rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual((0, 0), shard_metadata.shard_offsets)
             self.assertEqual((0, 0), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{rank}/{self.device_type}:{rank}", str(shard_metadata.placement)
+            )
 
     @skipIfRocm
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_and_global_metadata_with_local_view(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_and_global_metadata_with_local_view(self, device):
         # testing cases where we create ST with local view, meaning we initialize other rank's metadata with 0s
         shard_offsets = [0, 1]  # valid, invalid
         for shard_offset in shard_offsets:
             local_shard_metadata = ShardMetadata(
                 shard_offsets=[shard_offset, 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:{self.rank}/cuda:{self.rank}",
+                placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
             )
 
             shards_metadata = []
@@ -2770,13 +2804,14 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                         ShardMetadata(
                             shard_offsets=[0 if r < self.rank else 5, 0],
                             shard_sizes=[0, 0],
-                            placement=f"rank:{r}/cuda:{r}",
+                            placement=f"rank:{r}/{self.device_type}:{r}",
                         )
                     )
 
             local_shards = [
                 sharded_tensor.Shard(
-                    torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                    torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                    local_shard_metadata,
                 )
             ]
 
@@ -2814,7 +2849,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             # Verify local shard.
             local_shard = st.local_shards()[0]
             self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+                torch.device(self.device_type, self.rank), local_shard.tensor.device
             )
             self.assertEqual((5, 5), local_shard.tensor.size())
 
@@ -2825,7 +2860,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             )
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
             self.assertEqual(
-                f"rank:{self.rank}/cuda:{self.rank}",
+                f"rank:{self.rank}/{self.device_type}:{self.rank}",
                 str(local_shard.metadata.placement),
             )
 
@@ -2841,18 +2876,19 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 else:
                     self.assertEqual((0, 0), shard_metadata.shard_sizes)
                 self.assertEqual(
-                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                    f"rank:{rank}/{self.device_type}:{rank}",
+                    str(shard_metadata.placement),
                 )
 
     @skipIfRocm
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_and_global_metadata(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_and_global_metadata(self, device):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         shards_metadata = []
@@ -2864,13 +2900,14 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                     ShardMetadata(
                         shard_offsets=[(r // 2) * 5, (r % 2) * 5],
                         shard_sizes=[5, 5],
-                        placement=f"rank:{r}/cuda:{r}",
+                        placement=f"rank:{r}/{self.device_type}:{r}",
                     )
                 )
 
         local_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
         ]
 
@@ -2898,7 +2935,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(
+            torch.device(self.device_type, self.rank), local_shard.tensor.device
+        )
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
@@ -2908,7 +2947,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         )
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
         self.assertEqual(
-            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+            f"rank:{self.rank}/{self.device_type}:{self.rank}",
+            str(local_shard.metadata.placement),
         )
 
         # Verify global metadata.
@@ -2919,7 +2959,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
             )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{rank}/{self.device_type}:{rank}", str(shard_metadata.placement)
+            )
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2934,19 +2976,20 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_new_group(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_new_group(self, device):
         new_pg = dist.new_group(ranks=[1, 2, 3])
 
         if self.rank != 0:
             local_shard_metadata = ShardMetadata(
                 shard_offsets=[5 * (self.rank - 1), 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:{self.rank}/cuda:{self.rank}",
+                placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
             )
             local_shards = [
                 sharded_tensor.Shard(
-                    torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                    torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                    local_shard_metadata,
                 )
             ]
 
@@ -2957,7 +3000,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             # Verify local shard.
             local_shard = st.local_shards()[0]
             self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+                torch.device(self.device_type, self.rank), local_shard.tensor.device
             )
             self.assertEqual((5, 5), local_shard.tensor.size())
 
@@ -2967,7 +3010,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             )
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
             self.assertEqual(
-                f"rank:{self.rank}/cuda:{self.rank}",
+                f"rank:{self.rank}/{self.device_type}:{self.rank}",
                 str(local_shard.metadata.placement),
             )
 
@@ -2979,23 +3022,24 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 self.assertEqual((rank * 5, 0), shard_metadata.shard_offsets)
                 self.assertEqual((5, 5), shard_metadata.shard_sizes)
                 self.assertEqual(
-                    f"rank:{rank + 1}/cuda:{rank + 1}", str(shard_metadata.placement)
+                    f"rank:{rank + 1}/{self.device_type}:{rank + 1}",
+                    str(shard_metadata.placement),
                 )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_invalid_local_shards(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_invalid_local_shards(self, device):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         indices = [[0, 1, 1], [2, 0, 2]]
         values = [3.2, 4.5, 5.8]
         sparse_tensor = torch.sparse_coo_tensor(
-            indices, values, (5, 5), device=f"cuda:{self.rank}"
+            indices, values, (5, 5), device=f"{self.device_type}:{self.rank}"
         )
 
         empty_local_shards = []
@@ -3016,7 +3060,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         wrong_memory_format_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}").t(),
+                local_shard_metadata,
             )
         ]
         with self.assertRaisesRegex(
@@ -3029,7 +3074,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         with self.assertRaisesRegex(ValueError, "Shard tensor size does not match"):
             sharded_tensor.Shard(
-                torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(2, 3, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
 
         with self.assertRaisesRegex(
@@ -3039,17 +3085,18 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_invalid_property_cross_ranks(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_invalid_property_cross_ranks(self, device):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
         tensor_overall_size = [10, 10] if self.rank == 0 else [10, 5]
         wrong_dtype_shards = [
             sharded_tensor.Shard(
-                torch.ones(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.ones(5, 5, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
         ]
         with self.assertRaisesRegex(
@@ -3063,7 +3110,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         tensor_dtype = torch.int if self.rank == 0 else torch.float32
         wrong_dtype_shards = [
             sharded_tensor.Shard(
-                torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=tensor_dtype),
+                torch.ones(
+                    5, 5, device=f"{self.device_type}:{self.rank}", dtype=tensor_dtype
+                ),
                 local_shard_metadata,
             )
         ]
@@ -3079,7 +3128,10 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         wrong_requires_grad_shards = [
             sharded_tensor.Shard(
                 torch.randn(
-                    5, 5, device=f"cuda:{self.rank}", requires_grad=tensor_requires_grad
+                    5,
+                    5,
+                    device=f"{self.device_type}:{self.rank}",
+                    requires_grad=tensor_requires_grad,
                 ),
                 local_shard_metadata,
             )
@@ -3100,7 +3152,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend="gloo")
     @skip_if_lt_x_gpu(4)
-    def test_init_from_local_shards_invalid_pin_memory(self):
+    def test_init_from_local_shards_invalid_pin_memory(self, device):
         # pin memory can only be on dense cpu
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
@@ -3138,18 +3190,18 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_invalid_shards_overlap(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_invalid_shards_overlap(self, device):
         local_shard_size = [5, 5] if self.rank != 0 else [6, 6]
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=local_shard_size,
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         local_shards = [
             sharded_tensor.Shard(
-                torch.randn(local_shard_size, device=f"cuda:{self.rank}"),
+                torch.randn(local_shard_size, device=f"{self.device_type}:{self.rank}"),
                 local_shard_metadata,
             )
         ]
@@ -3161,18 +3213,18 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_invalid_shards_gaps(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_invalid_shards_gaps(self, device):
         local_shard_size = [5, 5] if self.rank != 0 else [4, 4]
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=local_shard_size,
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         local_shards = [
             sharded_tensor.Shard(
-                torch.randn(local_shard_size, device=f"cuda:{self.rank}"),
+                torch.randn(local_shard_size, device=f"{self.device_type}:{self.rank}"),
                 local_shard_metadata,
             )
         ]
@@ -3184,12 +3236,12 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_init_from_local_shards_and_global_metadata_invalid_shards(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_init_from_local_shards_and_global_metadata_invalid_shards(self, device):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/{self.device_type}:{self.rank}",
         )
 
         shards_metadata = []
@@ -3201,7 +3253,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                     ShardMetadata(
                         shard_offsets=[(r // 2) * 5, (r % 2) * 5],
                         shard_sizes=[5, 5],
-                        placement=f"rank:{r}/cuda:{r}",
+                        placement=f"rank:{r}/{self.device_type}:{r}",
                     )
                 )
 
@@ -3229,10 +3281,12 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         wrong_num_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             ),
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             ),
         ]
         with self.assertRaisesRegex(
@@ -3246,7 +3300,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             ValueError, "Shard tensor size does not match with metadata.shard_lengths"
         ):
             sharded_tensor.Shard(
-                torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata
+                torch.randn(2, 3, device=f"{self.device_type}:{self.rank}"),
+                local_shard_metadata,
             )
 
         with self.assertRaisesRegex(
@@ -3257,7 +3312,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         wrong_dtype_shards = [
             sharded_tensor.Shard(
-                torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=torch.int),
+                torch.ones(
+                    5, 5, device=f"{self.device_type}:{self.rank}", dtype=torch.int
+                ),
                 local_shard_metadata,
             )
         ]
@@ -3271,7 +3328,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         indices = [[0, 1, 1], [2, 0, 2]]
         values = [3.2, 4.5, 5.8]
         sparse_tensor = torch.sparse_coo_tensor(
-            indices, values, (5, 5), device=f"cuda:{self.rank}"
+            indices, values, (5, 5), device=f"{self.device_type}:{self.rank}"
         )
 
         wrong_layout_shards = [
@@ -3286,7 +3343,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         wrong_requires_grad_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=True),
+                torch.randn(
+                    5, 5, device=f"{self.device_type}:{self.rank}", requires_grad=True
+                ),
                 local_shard_metadata,
             )
         ]
@@ -3300,7 +3359,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         wrong_memory_format_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata
+                torch.randn(5, 5, device=f"{self.device_type}:{self.rank}").t(),
+                local_shard_metadata,
             )
         ]
         with self.assertRaisesRegex(
@@ -3326,10 +3386,12 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
 
 class TestShardedTensorCustomOps(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_custom_op(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_custom_op(self, device):
         @custom_sharded_op_impl(torch.asin)
         def my_sharded_asin(types, args, kwargs, process_group):
             return torch.asin(args[0].local_shards()[0].tensor)
@@ -3337,10 +3399,10 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
@@ -3350,9 +3412,9 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_custom_op_override(self):
-        t = torch.rand(10, 10).cuda(self.rank)
+    @requires_capabilities(Capability.distributed.backend)
+    def test_custom_op_override(self, device):
+        t = torch.rand(10, 10).to(self.device_type)
 
         from torch.distributed._shard.sharding_spec.api import custom_sharding_spec_op
 
@@ -3363,22 +3425,22 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
-        m = torch.nn.Linear(32, 16).cuda(self.rank)
+        m = torch.nn.Linear(32, 16).to(self.device_type)
         shard_parameter(m, "weight", spec)
 
-        result = m(torch.rand(15, 32).cuda(self.rank))
+        result = m(torch.rand(15, 32).to(self.device_type))
         self.assertEqual(t, result)
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_custom_op_errors(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_custom_op_errors(self, device):
         with self.assertRaisesRegex(TypeError, "expects signature"):
 
             @custom_sharded_op_impl(torch.nn.functional.linear)
@@ -3393,9 +3455,11 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
 
 
 class TestShardMetadata(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
-    @requires_nccl()
-    def test_shard_metadata_init(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_shard_metadata_init(self, device):
         pg = dist.distributed_c10d._get_default_group()
 
         md = ShardMetadata([10], [0])
@@ -3411,8 +3475,8 @@ class TestShardMetadata(ShardedTensorTestBase):
         self.assertEqual(device, torch.device("cpu"))
 
     @with_comms
-    @requires_nccl()
-    def test_create_shard_with_no_placement(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_create_shard_with_no_placement(self, device):
         md = ShardMetadata([0], [10])
         shard = Shard(torch.zeros(10), md)
         self.assertIsNone(shard.metadata.placement)
@@ -3530,6 +3594,20 @@ class TestCreateTensorNoProcessGroupMode(TestCase):
             local_shards=st_local_shards,
             sharded_tensor_metadata=st_metadata,
         )
+
+
+instantiate_device_type_tests(
+    TestShardedTensorFromLocalTensor, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestShardedTensorFromLocalShards, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestShardedTensorCustomOps, globals(), except_for="cpu", allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestShardMetadata, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -2312,7 +2312,7 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
             )
             rank_to_metadata[rank] = shard_metadata
             if rank == self.rank:
-                local_tensor = torch.rand(shard_metadata.shard_sizes).cuda(device)
+                local_tensor = torch.rand(shard_metadata.shard_sizes).to(device)
                 local_shard_metadata = shard_metadata
 
         # TODO: figure out what the API should behave when some rank have no shard


### PR DESCRIPTION
## Summary

`test/distributed/_shard/sharded_tensor/test_sharded_tensor.py` hardcodes CUDA
throughout: `"rank:X/cuda:Y"` placement strings, `.cuda()` device moves,
`torch.device("cuda", ...)` constructions, and `@requires_nccl()` admission
decorators. This silently skips the ShardedTensor distributed suite on
non-CUDA accelerators even when sufficient devices and a compatible
distributed backend are available.

This PR is one batch of a series that decouples the file test-class by
test-class: each PR in the series is based on main, touches a small set of
complete classes, and is independently verifiable and mergeable. This batch
covers 4 ACCELERATOR classes (22 test methods):
`TestShardedTensorFromLocalTensor`, `TestShardedTensorFromLocalShards`,
`TestShardedTensorCustomOps`, `TestShardMetadata`.

For each covered class this PR:

- Replaces all hardcoded CUDA with `self.device_type` (injected per device
  variant by `instantiate_device_type_tests`).
- Switches `@requires_nccl()` to
  `@requires_capabilities(Capability.distributed.backend)` — admission by
  device-declared capabilities instead of hardcoded backend name lists.
- Adds `hw_classification` labels (ACCELERATOR) and registers the classes
  with `instantiate_device_type_tests(..., except_for="cpu", allow_xpu=True)`.

This batch also fixes a pre-existing NPU failure in the original code:
`test_st_base_init_from_local_shards_and_global_metadata` hardcodes
`device=f"cuda:{rank}"` without `@requires_nccl`, so it executes on NPU even
before this series and fails there — decoupling it to `self.device_type`
fixes that.

The other 10 classes are untouched in this PR and keep their original CUDA
form; they are covered by the other batches of the series.

This is part of the test case refactoring initiative (#185590).

## Changes

- **TestShardedTensorFromLocalTensor** (2 methods): CUDA device strings →
  `self.device_type`; `@requires_nccl()` → `@requires_capabilities`;
  `device` parameter; ACCELERATOR label; instantiate registration;
  `_generate_st_from_chunk_local_tensor`: `torch.rand(...).cuda(device)` →
  `.to(device)` (device is the `torch.device` parsed from the shard
  placement — `Tensor.cuda()` is CUDA-specific).

- **TestShardedTensorFromLocalShards** (15 methods): same pattern. Notable:
  - `test_st_base_init_from_local_shards_and_global_metadata`: replaced
    `torch.randn(5, 5, device=f"cuda:{rank}")` with
    `device=f"{self.device_type}:{rank}"` — fixes the pre-existing NPU error.
  - `test_init_from_local_shards_invalid_pin_memory`: kept
    `@with_comms(init_rpc=False, backend="gloo")` and `@skip_if_lt_x_gpu(4)`
    — `pin_memory=True` requires an accelerator to be present, so it is not
    a pure CPU test; no `@requires_nccl` needed (gloo path).

- **TestShardedTensorCustomOps** (3 methods) / **TestShardMetadata**
  (2 methods): same decoupling pattern.

- **File-level**:
  - 4 `instantiate_device_type_tests(..., except_for="cpu", allow_xpu=True)`
    calls appended. XPU variants are enabled to preserve the original
    coverage intent (the original `skip_if_lt_x_gpu` carried an explicit
    `TEST_XPU` branch); `allow_mps` is NOT added (no MPS branch in the
    original function).
  - Imports: added `Capability`, `requires_capabilities`,
    `instantiate_device_type_tests`, `HardwareClassification`.
    `requires_nccl` is kept — the untouched classes still use it;
    `TEST_CUDA`/`skip_but_pass_in_sandcastle_if` are kept — their only user
    (`TestCreateTensorFromParams`) is untouched in this batch.

## Depends on

This PR relies on the following upstream PRs (submitted but not yet merged):

- **#187650**: `skip_if_lt_x_gpu` hardware-agnostic refactoring.
- **#190991**: `HardwareClassification` enum.
- **#191919**: `Capability` class + `requires_capabilities` decorator.
- **#193080**: `PrivateUse1TestBase._capabilities()` override.
- **#194992**: `ShardedTensorTestBase.backend` property and `with_comms`
  dynamic backend resolution (with the `getattr(self, "device_type", None)`
  fallback so partially-instantiated files work).

The capability mechanism's skip-on-missing-capability degradation means this
PR can be merged before #193080 safely. Batches of this series touch the
same file (import block and file-end instantiate calls overlap slightly) —
merging in batch order 1→4 keeps conflicts trivial.

## Not changed

- The other 10 classes — byte-identical to the original (still `"cuda"` +
  `@requires_nccl()`), verified zero diff (6 classes including
  `TestShardedTensorChunked`/`TestShardedTensorEnumerable` are covered by
  batches 3/4; the 8 classes of batch 1 by that PR).
- `@skip_if_lt_x_gpu` — kept (already hardware-agnostic via #187650).
- `@with_comms` — uses default (resolves to `self.backend` dynamically via
  #194992).
- pin_memory test placement — kept in its ACCELERATOR class (see above).
- Method control flow — unchanged (only device references generalized).

## Test plan

- CUDA (A100): 74 tests, 74 passed — batch-2 classes resolve
  `self.device_type="cuda"`; untouched classes unchanged; no regression.
- NPU (Ascend 910B3, 4 cards): batch-2 classes now admitted via
  `@requires_capabilities` and executed as NPU variants. The pre-existing
  `test_st_base_init...` error is fixed; `to_here()` tensorpipe RPC tests in
  FromLocalShards fail with the known NPU limitation (no `npu_ipc` channel,
  tracked in a separate issue). Exact pass/fail split to be filled after
  measurement.
- CPU: 5 tests, 5 passed (GENERIC) — batch-2 ACCELERATOR CPU variants are
  excluded by `except_for="cpu"`; untouched ACCELERATOR classes are skipped
  by `@requires_nccl`.