### PR TITLE
[MPS] Regenerate embedded Metal shaders when `c10/metal` changes

### DIFF
--- a/cmake/Metal.cmake
+++ b/cmake/Metal.cmake
@@ -39,7 +39,7 @@ function(metal_to_metallib_h SHADER)
     cmake_path(APPEND_STRING SHADER_HDR "_metallib.h")
 
     add_custom_command(COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/write_metallib_headers.py ${SHADER_ABSOLUTE} ${SHADER_HDR}
-                       DEPENDS ${SHADER_ABSOLUTE} ${CMAKE_SOURCE_DIR}/scripts/write_metallib_headers.py
+                       DEPENDS ${SHADER_ABSOLUTE} ${CMAKE_SOURCE_DIR}/scripts/write_metallib_headers.py ${METAL_HEADER_DEPS}
                        OUTPUT ${SHADER_HDR}
                        COMMENT "Generating metallib wrapper header for ${SHADER}"
                        VERBATIM)


### PR DESCRIPTION
On Mac with only CommandLineTools installed, Metal shaders are compiled at the runtime and `write_metallib_headers.py` inlines the ncluded headers into the embedded shader source, but that rule depends only on the the .metal file and the script itself. Add `${METAL_HEADER_DEPS}` as target dependency to mimic `.air` files generation.

This PR was authored with the help of an AI assistant (Claude).
