### PR TITLE
[MPS] Fix GPU hang in scatter_reduce/index_reduce with NaN

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -287,14 +287,16 @@ struct IndexReduceOp {
     return a + b;
   }
 
+  // Qualified so these resolve to the NaN-propagating c10 helpers rather than
+  // metal::min/max, which drop NaN and would disagree with CPU.
   template <typename T>
   static T amin(T a, T b) {
-    return min(a, b);
+    return ::c10::metal::min(a, b);
   }
 
   template <typename T>
   static T amax(T a, T b) {
-    return max(a, b);
+    return ::c10::metal::max(a, b);
   }
 };
 

--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -287,8 +287,11 @@ struct IndexReduceOp {
     return a + b;
   }
 
-  // Qualified so these resolve to the NaN-propagating c10 helpers rather than
-  // metal::min/max, which drop NaN and would disagree with CPU.
+  // Qualified so these resolve to the NaN-propagating c10 helpers. Unqualified,
+  // both `using namespace metal` and `using namespace c10::metal` are in scope
+  // and the Metal shader builtins win; those follow fmin/fmax and return the
+  // non-NaN operand, so index_reduce_ would answer -inf or inf where CPU
+  // answers nan.
   template <typename T>
   static T amin(T a, T b) {
     return ::c10::metal::min(a, b);

--- a/c10/metal/atomic.h
+++ b/c10/metal/atomic.h
@@ -28,6 +28,29 @@ static inline void atomic_binary_op_helper(
       ::metal::memory_order_relaxed));
 }
 
+// atomic_compare_exchange on ::metal::atomic<float> compares its operands as
+// floats, so once a NaN is stored the expected value never compares equal to
+// itself and the CAS loop in atomic_binary_op_helper spins forever, hanging the
+// GPU. Comparing the bit patterns instead is what the uint-backed overload
+// further down already does for half and bfloat.
+static inline void atomic_binary_op_bitwise_helper(
+    device ::metal::atomic<float>* data,
+    long offset,
+    float value,
+    float (*op)(float, float)) {
+  auto ptr = reinterpret_cast<device ::metal::atomic<uint>*>(data) + offset;
+  auto old = ::metal::atomic_load_explicit(ptr, ::metal::memory_order_relaxed);
+  uint desired;
+  do {
+    desired = as_type<uint>(op(as_type<float>(old), value));
+  } while (!::metal::atomic_compare_exchange_weak_explicit(
+      ptr,
+      &old,
+      desired,
+      ::metal::memory_order_relaxed,
+      ::metal::memory_order_relaxed));
+}
+
 template <>
 struct AtomicType<float> {
   using type = ::metal::atomic<float>;
@@ -40,7 +63,7 @@ struct AtomicType<float> {
       long offset,
       float value,
       float (*op)(float, float)) {
-    atomic_binary_op_helper(data, offset, value, op);
+    atomic_binary_op_bitwise_helper(data, offset, value, op);
   }
 };
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9039,6 +9039,37 @@ class TestMPS(TestCaseMPS):
         helper(do_add=False)
 
     # Test pytorch scatter_reduce
+    def test_scatter_reduce_nan(self):
+        # amax/amin/prod go through a compare-and-swap loop; comparing floats
+        # rather than bit patterns made that loop never terminate once a NaN was
+        # stored, which hung the GPU rather than returning a wrong answer.
+        src_cpu = torch.tensor([float('nan'), -1.39, 2.37, float('nan'), -8.15, 5.01, 1.36])
+        idx_cpu = torch.tensor([0, 2, 4, 1, 4, 0, 3])
+        for reduce_str in ["amax", "amin", "prod", "sum", "mean"]:
+            for include_self in [False, True]:
+                for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+                    out_cpu = torch.zeros(5, dtype=dtype)
+                    out_mps = torch.zeros(5, dtype=dtype, device='mps')
+                    out_cpu.scatter_reduce_(0, idx_cpu, src_cpu.to(dtype), reduce_str,
+                                            include_self=include_self)
+                    out_mps.scatter_reduce_(0, idx_cpu.to('mps'), src_cpu.to(dtype).to('mps'),
+                                            reduce_str, include_self=include_self)
+                    self.assertEqual(out_cpu, out_mps, equal_nan=True)
+
+    def test_index_reduce_nan(self):
+        # Same compare-and-swap loop as test_scatter_reduce_nan, reached through
+        # index_reduce_ instead.
+        src_cpu = torch.tensor([float('nan'), 2.0, -3.0, float('nan')])
+        idx_cpu = torch.tensor([0, 1, 1, 2])
+        for reduce_str in ["amax", "amin", "prod", "mean"]:
+            for include_self in [False, True]:
+                out_cpu = torch.zeros(3)
+                out_mps = torch.zeros(3, device='mps')
+                out_cpu.index_reduce_(0, idx_cpu, src_cpu, reduce_str, include_self=include_self)
+                out_mps.index_reduce_(0, idx_cpu.to('mps'), src_cpu.to('mps'), reduce_str,
+                                      include_self=include_self)
+                self.assertEqual(out_cpu, out_mps, equal_nan=True)
+
     def test_scatter_reduce(self):
         def helper(shape, dim, idx_shape, src_shape, idx_dtype=torch.int64, reduce_str="sum"):
             cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)


### PR DESCRIPTION
`atomic_compare_exchange_weak_explicit` on `::metal::atomic<float>` compares its
expected operand as a float, so once a NaN is stored the exchange never succeeds
and the CAS loop in `atomic_binary_op_helper`, which implements amax/amin/prod,
spins forever. `scatter_reduce_` and `index_reduce_` hang the GPU rather than
returning a wrong value or raising. Isolating the loop with
`torch.mps.compile_shader` and counting iterations, with a NaN already stored:

```
cas_float  iters= 100001 (guard tripped, never converges)
cas_bits   iters=      1
```

The fix does the exchange on the bit pattern through `atomic<uint>`, as the
uint-backed overload in the same header already does for half and bfloat. sum and
mean use atomic_fetch_add and were unaffected.

With the hang gone, `index_reduce_` still disagreed with CPU: `IndexReduceOp`
called unqualified min/max, which resolve to `metal::` and drop NaN, while the
equivalent functors in ScatterGather.metal qualify them as `::c10::metal::`. MPS
returned -inf, inf or 0.0 where CPU returns nan.

Test Plan:

```
python test/test_mps.py TestMPS.test_scatter_reduce_nan TestMPS.test_index_reduce_nan -v
python test/test_mps.py TestMPS TestGatherScatter TestAdvancedIndexing -q
```

The new tests cover amax/amin/prod/sum/mean, both values of include_self and
float32/float16/bfloat16. The suite is 1660 tests with one failure,
test_mps_allocator_module, which asserts nothing is allocated when it starts and
fails identically with these tests removed.

This PR was authored with the help of an AI assistant (Claude).
