### PR TITLE
Fix CPU cumsum signed zero

### DIFF
--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -86,8 +86,9 @@ void cumsum_cpu_kernel(const Tensor& result, const Tensor& self, int64_t dim) {
       scalar_t* result_data, auto result_dim_stride,
       const scalar_t* self_data, auto self_dim_stride, scalar_t init_val) {
         // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-        auto cum_number = (at::acc_type<scalar_t, false>)init_val;
-        for (const auto i : c10::irange(self_dim_size)) {
+        auto cum_number = (at::acc_type<scalar_t, false>)self_data[0];
+        result_data[0] = (scalar_t)cum_number;
+        for (const auto i : c10::irange(1, self_dim_size)) {
           cum_number += self_data[i * self_dim_stride];
           result_data[i * result_dim_stride] = (scalar_t)cum_number;
         }

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -3766,6 +3766,12 @@ class TestReductionsOnCPU(TestCase):
     def test_cumsum_integer_upcast(self):
         self._test_reduce_integer_upcast(lambda x, **kwargs: torch.cumsum(x, 0, **kwargs))
 
+    def test_cumsum_preserves_signed_zero(self):
+        for dtype in (torch.half, torch.bfloat16, torch.float, torch.double):
+            x = torch.tensor([-0.0, -0.0, 1.0], dtype=dtype)
+            result = torch.cumsum(x, 0)
+            self.assertEqual(torch.signbit(result), torch.tensor([True, True, False]))
+
     def test_cumprod_integer_upcast(self):
         self._test_reduce_integer_upcast(lambda x, **kwargs: torch.cumprod(x, 0, **kwargs))
 


### PR DESCRIPTION
Fixes #195851

### Summary

`torch.cumsum` on CPU currently loses the sign of IEEE-754 `-0.0`
because the cumulative sum starts from a `+0.0` initializer.

Initialize the cumsum accumulator from the first input element instead,
then continue accumulating from the second element. This preserves the
signed zero of the first element.

### Testing

- `python -m pytest test/test_reductions.py -k "cumsum"`
- `python -m pytest test/test_reductions.py -k test_cumsum_preserves_signed_zero`

Both pass.

The regression test covers float16, bfloat16, float32, and float64.

### Notes

I investigated this issue after coordinating with the issue author and
@abhinav-phi, who were also looking into the root cause.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01