### PR TITLE
[dynamo] Type exact weak-key dictionaries

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +55,15 @@ class TorchtitanTestRunner(BaseRunner):
         with working_directory(self.work_directory):
             pip_install_packages(packages=["-e", "."])
             pip_install_packages(packages=["pytest", "pytest-cov"])
+            torch_constraint = Path("torch-constraint.txt")
+            torch_constraint.write_text(
+                f"torch=={version('torch')}\n", encoding="utf-8"
+            )
+            # This path is relative to the cloned TorchTitan checkout.
+            pip_install_packages(
+                requirements=".ci/docker/requirements-vlm.txt",
+                constraints=str(torch_constraint),
+            )
 
     def run(self):
         self.prepare()

--- a/torch/_dynamo/code_context.py
+++ b/torch/_dynamo/code_context.py
@@ -50,7 +50,9 @@ class CodeContext(TypedDict, total=False):
 
 class CodeContextDict:
     def __init__(self) -> None:
-        self.code_context: ExactWeakKeyDictionary = ExactWeakKeyDictionary()
+        self.code_context: ExactWeakKeyDictionary[CodeContext] = (
+            ExactWeakKeyDictionary()
+        )
 
     def has_context(self, code: types.CodeType) -> bool:
         return code in self.code_context

--- a/torch/_dynamo/mutation_guard.py
+++ b/torch/_dynamo/mutation_guard.py
@@ -12,11 +12,13 @@ The system ensures that Dynamo's optimizations remain valid by detecting and res
 to runtime changes in module state and structure.
 """
 
+from __future__ import annotations
+
 import functools
 import inspect
 import weakref
 from collections.abc import MutableMapping
-from typing import Any
+from typing import Any, Protocol
 
 import torch.nn
 from torch.nn import Module
@@ -28,12 +30,16 @@ from .utils import ExactWeakKeyDictionary, nn_module_has_global_hooks
 unpatched_nn_module_init = torch.nn.Module.__init__
 
 
+class Invalidatable(Protocol):
+    def invalidate(self, ref: weakref.ReferenceType[Invalidatable]) -> None: ...
+
+
 class MutationTracker:
-    db: ExactWeakKeyDictionary = ExactWeakKeyDictionary()
+    db: ExactWeakKeyDictionary[MutationTracker] = ExactWeakKeyDictionary()
 
     def __init__(self) -> None:
         self.mutation_count: int = 0
-        self.watchers: list[weakref.ReferenceType[Any]] = []
+        self.watchers: list[weakref.ReferenceType[Invalidatable]] = []
 
     def on_mutation(self, name: str) -> None:
         self.mutation_count += 1
@@ -44,11 +50,11 @@ class MutationTracker:
             if guarded is not None:
                 guarded.invalidate(ref)
 
-    def track(self, guarded_code: Any) -> None:
+    def track(self, guarded_code: Invalidatable) -> None:
         self.watchers.append(weakref.ref(guarded_code))
 
 
-def watch(obj: Any, guarded_code: Any) -> None:
+def watch(obj: object, guarded_code: Invalidatable) -> None:
     """invalidate guarded_code when obj is mutated"""
     ensure_patched(type(obj))
 
@@ -76,11 +82,11 @@ def ensure_patched(cls: Any) -> None:
 
 class GenerationTracker:
     generation: int = 0
-    dynamic_classes: ExactWeakKeyDictionary = ExactWeakKeyDictionary()
-    generation_values: ExactWeakKeyDictionary = ExactWeakKeyDictionary()
+    dynamic_classes: ExactWeakKeyDictionary[bool] = ExactWeakKeyDictionary()
+    generation_values: ExactWeakKeyDictionary[int] = ExactWeakKeyDictionary()
 
     @classmethod
-    def tag(cls, obj: Any) -> None:
+    def tag(cls, obj: object) -> None:
         cls.generation_values[obj] = cls.generation
 
     @staticmethod
@@ -90,13 +96,13 @@ class GenerationTracker:
         GenerationTracker.dynamic_classes[cls] = True
 
     @classmethod
-    def get_generation_value(cls, obj: Any) -> int:
+    def get_generation_value(cls, obj: object) -> int:
         if obj not in cls.generation_values:
             return -1
         return cls.generation_values[obj]
 
     @classmethod
-    def check(cls, obj: Any) -> bool:
+    def check(cls, obj: object) -> bool:
         return (
             obj in cls.generation_values
             and cls.generation_values[obj] == cls.generation
@@ -109,7 +115,7 @@ class GenerationTracker:
         cls.generation_values = ExactWeakKeyDictionary()
 
 
-def is_dynamic_nn_module(obj: Any, is_export: bool) -> bool:
+def is_dynamic_nn_module(obj: object, is_export: bool) -> bool:
     """Check for nn.Modules() created dynamically or mutated"""
     if isinstance(obj, torch.nn.Module) and (
         "forward" in obj.__dict__ or isinstance(obj, (dict, MutableMapping))

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -305,8 +305,12 @@ def _load_tuple_and_call(tup: tuple[object, ...]) -> list[Instruction]:
 
 
 class ContinueExecutionCache:
-    cache = ExactWeakKeyDictionary()
-    generated_code_metadata = ExactWeakKeyDictionary()
+    cache: ExactWeakKeyDictionary[dict[tuple[object, ...], types.CodeType]] = (
+        ExactWeakKeyDictionary()
+    )
+    generated_code_metadata: ExactWeakKeyDictionary[ResumeFunctionMetadata] = (
+        ExactWeakKeyDictionary()
+    )
 
     @classmethod
     def lookup(

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1107,23 +1107,29 @@ def nothing(*args: Any, **kwargs: Any) -> None:
     pass
 
 
-class ExactWeakKeyDictionary:
+class ExactWeakKeyDictionary(Generic[T]):
     """Similar to weakref.WeakKeyDictionary, but use `is`/`id` rather than `==` to compare equality"""
 
     def __init__(self) -> None:
-        self.values: dict[int, Any] = {}
-        self.refs: dict[int, weakref.ReferenceType[Any]] = {}
+        self.values: dict[int, T] = {}
+        self.refs: dict[int, weakref.ReferenceType[object]] = {}
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: object) -> T:
         return self.values[id(key)]
 
-    def get(self, key: Any, default: Any = None) -> Any:
+    @overload
+    def get(self, key: object) -> T | None: ...
+
+    @overload
+    def get(self, key: object, default: R) -> T | R: ...
+
+    def get(self, key: object, default: R | None = None) -> T | R | None:
         return self.values.get(id(key), default)
 
-    def __contains__(self, key: Any) -> bool:
+    def __contains__(self, key: object) -> bool:
         return id(key) in self.values
 
-    def __setitem__(self, key: Any, value: Any) -> None:
+    def __setitem__(self, key: object, value: T) -> None:
         idx = id(key)
         if idx not in self.refs:
             self.refs[idx] = weakref.ref(key, lambda ref: self._remove_id(idx))
@@ -2568,7 +2574,7 @@ class CleanupHook:
         _cleanup_owners.pop((id(scope), name), None)
 
 
-class CleanupManager(ExactWeakKeyDictionary):
+class CleanupManager(ExactWeakKeyDictionary[list[CleanupHook]]):
     count = 0
     instance: ClassVar[CleanupManager]
 
@@ -3986,7 +3992,7 @@ def disable_cache_limit() -> Generator[None, None, None]:
 
 
 # map from transformed code back to original user code
-orig_code_map = ExactWeakKeyDictionary()
+orig_code_map: ExactWeakKeyDictionary[CodeType] = ExactWeakKeyDictionary()
 
 # keep a record of code_obj -> list of guard failure reasons for logging
 guard_failures: collections.defaultdict[Any, list[Any]] = collections.defaultdict(list)
@@ -3996,7 +4002,7 @@ graph_break_reasons: list[torch._dynamo.output_graph.GraphCompileReason] = []
 
 # keep record of compiled code, if we are in "error if recompile"
 # to track code that dynamo has compiled previously
-seen_code_map = ExactWeakKeyDictionary()
+seen_code_map: ExactWeakKeyDictionary[bool] = ExactWeakKeyDictionary()
 
 
 # return same dir unless user changes config between calls


### PR DESCRIPTION
## Summary

- make `ExactWeakKeyDictionary` generic over its value type and type its keys and stored weak references as `object`
- preserve precise `get` return types with overloads and annotate each non-conflicting Dynamo map with its concrete value type
- describe mutation watchers with an `Invalidatable` protocol instead of the unrelated `GuardedCode` dataclass
- retain the recently landed `CodeContext` `TypedDict` and defer the overlapping `eval_frame.py` annotation
- install TorchTitan's VLM test requirements to unblock the existing qwen3.5 missing-`fla` failure on `viable/strict`

The Dynamo change is annotation-only. The CI prerequisite is isolated in its own commit, constrains `torch` to the installed development version so dependency resolution cannot replace the wheel under test, and avoids changing the content-hashed CI image.

## Test plan

- `pyrefly check torch/_dynamo/code_context.py torch/_dynamo/mutation_guard.py torch/_dynamo/resume_execution.py` (0 errors)
- broader Pyrefly comparison over the generic definition and direct consumers: 101 pre-existing errors on both the clean base and this change
- `UV_NO_CONFIG=1 UV_NATIVE_TLS=true HTTPS_PROXY=http://fwdproxy:8080 HTTP_PROXY=http://fwdproxy:8080 lintrunner -a --skip PYREFLY torch/_dynamo/utils.py torch/_dynamo/code_context.py torch/_dynamo/mutation_guard.py torch/_dynamo/resume_execution.py`
- `/home/bobren/local/b/pytorch-env/bin/python -m py_compile torch/_dynamo/utils.py torch/_dynamo/code_context.py torch/_dynamo/mutation_guard.py torch/_dynamo/resume_execution.py`
- isolated weak-map, code-context, mutation-watcher, and generation-tracker smoke test
- `UV_NO_CONFIG=1 UV_NATIVE_TLS=true HTTPS_PROXY=http://fwdproxy:8080 HTTP_PROXY=http://fwdproxy:8080 lintrunner -a --skip PYREFLY .ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py`
- `python -m py_compile .ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py`
- verified `.ci/docker/requirements-vlm.txt` exists in the pinned TorchTitan commit and includes `flash-linear-attention`

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
