### PR TITLE
Reject non-CPU tensors in the legacy fbgemm_* ops instead of segfaulting

### DIFF
--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -63,6 +63,11 @@ Tensor fbgemm_linear_int8_weight_fp32_activation(
 
   TORCH_WARN_ONCE("fbgemm_linear_int8_weight_fp32_activation is deprecated "
                   "and will be removed in a future PyTorch release.")
+  TORCH_CHECK(input.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors, got ", input.device());
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors, got ", weight.device());
+  TORCH_CHECK(packed.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors, got ", packed.device());
+  TORCH_CHECK(col_offsets.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors, got ", col_offsets.device());
+  TORCH_CHECK(bias.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors, got ", bias.device());
 
   const Tensor input_contig = input.contiguous();
   const float* input_ptr = input_contig.const_data_ptr<float>();
@@ -232,6 +237,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_linear_quantize_weight only supports CPU tensors, got ", weight.device());
   const Tensor weight_contig = weight.contiguous();
 
   // Calculate weight statistics
@@ -298,6 +304,7 @@ Tensor fbgemm_pack_quantized_matrix(const Tensor& weight) {
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_pack_quantized_matrix only supports CPU tensors, got ", weight.device());
   const int64_t K = weight.size(1);
   const int64_t N = weight.size(0);
   const Tensor weight_contig = weight.contiguous();
@@ -383,6 +390,7 @@ Tensor fbgemm_pack_gemm_matrix_fp16(const Tensor& weight) {
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_pack_gemm_matrix_fp16 only supports CPU tensors, got ", weight.device());
 
   const int64_t K = weight.size(1);
   const int64_t N = weight.size(0);
@@ -419,6 +427,9 @@ Tensor fbgemm_linear_fp16_weight_fp32_activation(
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(input.is_cpu(), "fbgemm_linear_fp16_weight_fp32_activation only supports CPU tensors, got ", input.device());
+  TORCH_CHECK(packed_weight.is_cpu(), "fbgemm_linear_fp16_weight_fp32_activation only supports CPU tensors, got ", packed_weight.device());
+  TORCH_CHECK(output.is_cpu(), "fbgemm_linear_fp16_weight_fp32_activation only supports CPU tensors, got ", output.device());
 
   const Tensor input_contig = input.contiguous();
   const float* input_ptr = input_contig.const_data_ptr<float>();

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -3697,6 +3697,32 @@ class TestDynamicQuantizedOps(TestCase):
         self.assertTrue(torch.equal(w_fp16, w_unpacked_fp16[0]))
 
     @skipIfNoFBGEMM
+    @unittest.skipIf(not TEST_CUDA, "No CUDA")
+    def test_fbgemm_legacy_ops_reject_non_cpu_tensors(self):
+        w = torch.randn(4, 8)
+        w_int8, col_offsets, w_scale, w_zp = torch.fbgemm_linear_quantize_weight(w)
+        packed_int8 = torch.fbgemm_pack_quantized_matrix(w_int8)
+        packed_fp16 = torch.fbgemm_pack_gemm_matrix_fp16(w)
+        x = torch.randn(2, 8)
+        bias = torch.zeros(4)
+        cuda = torch.zeros(2, 8, device="cuda")
+        cases = [
+            lambda: torch.fbgemm_linear_quantize_weight(cuda),
+            lambda: torch.fbgemm_pack_quantized_matrix(cuda.to(torch.int8)),
+            lambda: torch.fbgemm_pack_gemm_matrix_fp16(cuda),
+            lambda: torch.fbgemm_linear_int8_weight_fp32_activation(cuda, w_int8, packed_int8, col_offsets, w_scale, w_zp, bias),
+            lambda: torch.fbgemm_linear_int8_weight_fp32_activation(x, w_int8, packed_int8.cuda(), col_offsets, w_scale, w_zp, bias),
+            lambda: torch.fbgemm_linear_int8_weight_fp32_activation(x, w_int8, packed_int8, col_offsets.cuda(), w_scale, w_zp, bias),
+            lambda: torch.fbgemm_linear_int8_weight_fp32_activation(x, w_int8, packed_int8, col_offsets, w_scale, w_zp, bias.cuda()),
+            lambda: torch.fbgemm_linear_fp16_weight_fp32_activation(cuda, packed_fp16, None),
+            lambda: torch.fbgemm_linear_fp16_weight_fp32_activation(x, packed_fp16, None, torch.empty(0, device="cuda")),
+            lambda: torch.fbgemm_linear_fp16_weight(x, packed_fp16.cuda(), bias),
+        ]
+        for fn in cases:
+            with self.assertRaisesRegex(RuntimeError, "only supports CPU tensors"):
+                fn()
+
+    @skipIfNoFBGEMM
     def test_qlinear_dynamic_fp16(self):
 
         options = itertools.product(


### PR DESCRIPTION
Fixes #173495

The torch.fbgemm_* ops (fbgemm_linear_quantize_weight, fbgemm_pack_quantized_matrix, fbgemm_pack_gemm_matrix_fp16, fbgemm_linear_int8_weight_fp32_activation, fbgemm_linear_fp16_weight_fp32_activation and their wrappers) are registered as CompositeImplicitAutograd, so a tensor on any device reaches them. They then hand the raw data pointer to FBGEMM, which reads it on the CPU. With a CUDA tensor that is a device address and the process dies with SIGSEGV instead of raising.

This adds a TORCH_CHECK(t.is_cpu(), ...) for every tensor argument the kernels dereference, right after the existing fbgemmSupportedCPU() check, so a CUDA tensor now gives a catchable RuntimeError. CPU inputs are unchanged. bias in the fp16 path is left alone since it goes through add_, which already errors on a device mismatch.

Same direction as #180162, which was approved but went stale, plus the output tensor of the fp16 .out overload and the offending device in the message. The test needs a real non-CPU storage (a meta tensor already fails earlier with a different error), so it is CUDA only. Note test/quantization/ is not run by the default CI shards right now, so I ran it locally on a CUDA box: fails with SIGSEGV before, passes after.