### PR TITLE
Add NativeAotStubs.h and NativeAotStubs.cpp to build.bzl

### DIFF
--- a/build.bzl
+++ b/build.bzl
@@ -158,6 +158,7 @@ GENERATED_H = [
     "Functions.h",
     "NativeFunctions.h",
     "NativeMetaFunctions.h",
+    "NativeAotStubs.h",
     "FunctionalInverses.h",
     "RedispatchFunctions.h",
     "RegistrationDeclarations.h",
@@ -212,6 +213,7 @@ GENERATED_CPP_MTIA = [
 
 GENERATED_CPP = [
     "Functions.cpp",
+    "NativeAotStubs.cpp",
     "RegisterBackendSelect.cpp",
     "RegisterCPU_0.cpp",
     "RegisterCPU_1.cpp",


### PR DESCRIPTION

This PR adds:
- `NativeAotStubs.h` to `GENERATED_H`
- `NativeAotStubs.cpp` to `GENERATED_CPP`
