### PR TITLE
[PERFORMANCE] [NN] Change `torch._C._get_tracing_state()` to `torch._C._is_tracing()` for around 15% improved performance of `module.py` `_call_impl()`

### DIFF
--- a/pt_ops.bzl
+++ b/pt_ops.bzl
@@ -586,6 +586,7 @@ PT_OPS_PRIM = [
     "aten::as_tensor.list",
     "aten::_pack_sequence",
     "aten::_get_tracing_state",
+    "aten::_is_tracing",
     "aten::is_scripting",
     "aten::_no_grad_uniform_",
     "aten::_no_grad_normal_",

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -612,11 +612,11 @@ class TestProfilerTree(TestCase):
                   aten::fill_
               nn.Module: MyModule_0
                 torch/nn/modules/module.py(...): _call_impl
-                  <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                  <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                   test_profiler_tree.py(...): forward
                     nn.Module: ReLU_0
                       torch/nn/modules/module.py(...): _call_impl
-                        <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                        <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                         torch/nn/modules/activation.py(...): forward
                           torch/nn/functional.py(...): relu
                             <built-in function _has_torch_function_unary>
@@ -625,7 +625,7 @@ class TestProfilerTree(TestCase):
                                 aten::clamp_min
                     nn.Module: Linear_0
                       torch/nn/modules/module.py(...): _call_impl
-                        <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                        <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                         torch/nn/modules/linear.py(...): forward
                           torch/nn/modules/module.py(...): __getattr__
                           torch/nn/modules/module.py(...): __getattr__
@@ -645,7 +645,7 @@ class TestProfilerTree(TestCase):
                               aten::_unsafe_view
                     nn.Module: ReLU_1
                       torch/nn/modules/module.py(...): _call_impl
-                        <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                        <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                         torch/nn/modules/activation.py(...): forward
                           torch/nn/functional.py(...): relu
                             <built-in function _has_torch_function_unary>
@@ -658,11 +658,11 @@ class TestProfilerTree(TestCase):
                   aten::fill_
               nn.Module: MyModule_0
                 torch/nn/modules/module.py(...): _call_impl
-                  <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                  <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                   test_profiler_tree.py(...): forward
                     nn.Module: ReLU_0
                       torch/nn/modules/module.py(...): _call_impl
-                        <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                        <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                         torch/nn/modules/activation.py(...): forward
                           torch/nn/functional.py(...): relu
                             <built-in function _has_torch_function_unary>
@@ -671,7 +671,7 @@ class TestProfilerTree(TestCase):
                                 aten::clamp_min
                     nn.Module: Linear_0
                       torch/nn/modules/module.py(...): _call_impl
-                        <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                        <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                         torch/nn/modules/linear.py(...): forward
                           torch/nn/modules/module.py(...): __getattr__
                           torch/nn/modules/module.py(...): __getattr__
@@ -691,7 +691,7 @@ class TestProfilerTree(TestCase):
                               aten::_unsafe_view
                     nn.Module: ReLU_1
                       torch/nn/modules/module.py(...): _call_impl
-                        <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                        <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                         torch/nn/modules/activation.py(...): forward
                           torch/nn/functional.py(...): relu
                             <built-in function _has_torch_function_unary>
@@ -984,7 +984,7 @@ class TestProfilerTree(TestCase):
                       cudaLaunchKernel
                         void at::native::vectorized_elementwise_kernel<...>(...)
                 nn.Module: Linear_0
-                  <built-in method _get_tracing_state of PyCapsule object at 0xXXXXXXXXXXXX>
+                  <built-in method _is_tracing of PyCapsule object at 0xXXXXXXXXXXXX>
                   torch/nn/modules/linear.py(...): forward
                     torch/nn/modules/module.py(...): __getattr__
                     torch/nn/modules/module.py(...): __getattr__

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -789,6 +789,7 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch._C._get_nested_int",
         "torch._C._get_tensor_metadata",
         "torch._C._get_tracing_state",
+        "torch._C._is_tracing",
         "torch._C._get_upgrader_ranges",
         "torch._C._get_upgraders_entry_map",
         "torch._C._get_upgraders_map_size",

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -328,6 +328,7 @@ def tracing_state_functions() -> dict[Callable[[], Any], bool | None]:
         torch.jit.is_scripting: False,
         torch.jit.is_tracing: False,
         torch._C._get_tracing_state: None,
+        torch._C._is_tracing: False,
         torch.fx._symbolic_trace.is_fx_tracing: False,
         torch.fx._symbolic_trace.is_fx_symbolic_tracing: False,
         torch.onnx.is_in_onnx_export: False,

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -378,6 +378,10 @@ RegisterOperators reg({
         [](Stack& stack) { push(stack, false); },
         aliasAnalysisFromSchema()),
     OperatorGenerator(
+        TORCH_SELECTIVE_SCHEMA("aten::_is_tracing() -> bool"),
+        [](Stack& stack) { push(stack, false); },
+        aliasAnalysisFromSchema()),
+    OperatorGenerator(
         TORCH_SELECTIVE_SCHEMA("aten::is_scripting() -> bool"),
         [](Stack& stack) { push(stack, true); },
         aliasAnalysisFromSchema()),

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -112,6 +112,7 @@ _builtin_ops = [
     (torch.nn.init._no_grad_uniform_, "aten::_no_grad_uniform_"),
     (torch.nn.init._no_grad_zero_, "aten::_no_grad_zero_"),
     (torch._C._get_tracing_state, "aten::_get_tracing_state"),
+    (torch._C._is_tracing, "aten::_is_tracing"),
     (torch._C._get_cpu_capability, "aten::_get_cpu_capability"),
     (warnings.warn, "aten::warn"),
     (torch._VF.stft, "aten::stft"),  # type: ignore[attr-defined]

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1789,7 +1789,7 @@ class Module:
     # torchrec tests the code consistency with the following code
     # fmt: off
     def _call_impl(self, *args, **kwargs):
-        forward_call = (self._slow_forward if torch._C._get_tracing_state() else self.forward)
+        forward_call = (self._slow_forward if torch._C._is_tracing() else self.forward)
         # If we don't have any hooks, we want to skip the rest of the logic in
         # this function, and just call forward.
         if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks


### PR DESCRIPTION
**Important note**: I was not able to test every change in this PR because I can't create the whole repo on my PC, but I've benchmarked the specific change mentioned below.

# Summary
Please read the important note above. This pull request implements #178072 by replacing `torch._C._get_tracing_state()` with `torch._C._is_tracing()` in `torch/nn/modules/module.py` inside `_call_impl()`, avoiding unnecessary object overhead and leading to a performance boost by around 15% (see benchmark results down below) and reopens #178072 which was closed due to inactivity.

# Explanation
In the original implementation of PyTorch we used `torch._C._get_tracing_state()` which returns a full tracing state object. For the purpose of checking whether tracing is active (and we do not use the object itself anymore later on), this is unnecessary overhead. Replacing it with `torch._C._is_tracing()` directly returns a boolean, avoiding usage of the object itself and instead only checking the returned boolean via `torch._C._is_tracing()`. The benchmark results (down below) confirm a ~15% performance improvement for `module.py` `_call_impl()`.

# Benchmarks
I've tested the suggested change with the following scripts:

`torchcontroller.py`

```python
import subprocess
import statistics
import math
import time

pythontorch_A = r"C:\Users\User\pythontorch\PCbuild\amd64\python.exe"
pythontorch_B = r"C:\Users\User\pythontorch_patch\PCbuild\amd64\python.exe"
benchmark_script = r"C:\Users\User\Desktop\testtorchperf.py"

runs = 100

results_A = []
results_B = []

for i in range(runs):
    out_A = subprocess.check_output([pythontorch_A, benchmark_script])
    time_A = float(out_A.strip())
    results_A.append(time_A)
    print(f"Run {i+1}/{runs} completed for PyTorch A | Time: {time_A} s")
    
    out_B = subprocess.check_output([pythontorch_B, benchmark_script])
    time_B = float(out_B.strip())
    results_B.append(time_B)
    print(f"Run {i+1}/{runs} completed for PyTorch B | Time: {time_B} s")

def summarize(data, label):
    n = len(data)
    mean = statistics.mean(data)
    stdev = statistics.stdev(data)
    median = statistics.median(data)

    z = 1.96
    margin = z * (stdev / math.sqrt(n))
    ci_lower = mean - margin
    ci_upper = mean + margin

    print(f"\n--- {label} ---")
    print(f"Mean: {mean:.6f} s")
    print(f"Median: {median:.6f} s")
    print(f"Std Dev: {stdev:.6f} s")
    print(f"95% CI: [{ci_lower:.6f}, {ci_upper:.6f}] s")

print("\n===== STATS =====")
summarize(results_A, "PyTorch")
summarize(results_B, "PyTorch PATCH")

speedup = statistics.mean(results_A) / statistics.mean(results_B)
print(f"\nSpeedup A/B: {speedup:.4f}x")

```

`testtorchperf.py`

```python
import torch
import torch.nn as nn
import time

class TestModule(nn.Module):
    def forward(self, x):
        return x

def main():
    device = torch.device('cpu')
    model = TestModule().to(device)
    x = torch.tensor([[1.0, 2.0]], device=device)
    num_iter = 200_000

    start = time.perf_counter()
    for _ in range(num_iter):
        model(x)
    end = time.perf_counter()

    elapsed = end - start
    print(f"{elapsed:.6f}")
    
if __name__ == "__main__":
    main()
```

# Results

The full log is available online here (https://justpaste.it/fqjqe) because it's way too long (100 runs each script (for both (PyTorch itself and PyTorch with the patch))) for pasting it on GitHub, but you can visit the link above and view all results.

Summary (for full log see https://justpaste.it/fqjqe):

    --- PyTorch ---
    Mean: 0.255768 s
    Median: 0.252001 s
    Std Dev: 0.011083 s
    95% CI: [0.253596, 0.257940] s

    --- PyTorch PATCH ---
    Mean: 0.220687 s
    Median: 0.217648 s
    Std Dev: 0.009732 s
    95% CI: [0.218780, 0.222594] s

    Speedup A/B: 1.1590x

Contributed by **Benedikt Johannes**

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @jerryzh168 @Lucaskabela