### PR TITLE
[inductor] Support Triton module globals in user-defined kernels 

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -63,6 +63,11 @@ from torch.utils._triton import (
 )
 
 
+if has_triton_package():
+    import triton as source_triton
+    import triton.language as source_tl
+
+
 @contextlib.contextmanager
 def _dump_launch_params(value: str):
     launch_params_file = f"{os.path.abspath(sys.argv[0])}.launch_params"
@@ -1833,6 +1838,22 @@ def forward(self, x_1, output_1):
         if not triton_version_uses_attrs_dict():
             self.assertTrue(_triton_get_ast_equal_to_str(()) in sources[0])
         self.assertEqual(compiled_out, eager_out)
+
+    @unittest.skipUnless(has_triton_package(), "requires triton")
+    def test_triton_kernel_with_imported_module(self):
+        from torch._inductor.codegen.wrapper import (
+            user_defined_triton_kernel_transitive_closure_source_code,
+        )
+
+        @source_triton.jit
+        def kernel(out_ptr, BLOCK_SIZE):
+            offsets = source_tl.arange(0, BLOCK_SIZE)
+            value = source_triton.cdiv(BLOCK_SIZE, 2)
+            source_tl.store(out_ptr + offsets, value)
+
+        source = user_defined_triton_kernel_transitive_closure_source_code(kernel)
+        self.assertIn("import triton as source_triton", source)
+        self.assertIn("import triton.language as source_tl", source)
 
     @requires_gpu
     def test_triton_kernel_with_imported_symbol(self):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -460,6 +460,23 @@ def user_defined_triton_kernel_transitive_closure_source_code(
                     symbols_included.add(symbol_name)
                 elif (
                     symbol_name in unqualified_loads
+                    and symbol_name not in ("triton", "tl")
+                    and inspect.ismodule(symbol)
+                    and (
+                        # Include the root module for aliases such as
+                        # `import triton as triton_alias`.
+                        symbol.__name__ == "triton"
+                        or symbol.__name__.startswith("triton.")
+                    )
+                ):
+                    # Module objects have __name__ but not __module__, so they
+                    # need a qualified import rather than a from-import.
+                    compile_wrapper.writeline(
+                        f"import {symbol.__name__} as {symbol_name}"
+                    )
+                    symbols_included.add(symbol_name)
+                elif (
+                    symbol_name in unqualified_loads
                     and symbol_name != "tl"  # already imported
                     and hasattr(symbol, "__module__")
                     # only codegen imports from triton; JITFunctions


### PR DESCRIPTION
Inductor reconstructs user-defined Triton kernels in torch/_inductor/codegen/wrapper.py, inside user_defined_triton_kernel_transitive_closure_source_code().
The existing implementation handles imported Triton functions and symbols through their module attribute. Python module objects do not provide module, so aliases such as:

```python
import triton as source_triton
import triton.language as source_tl

@source_triton.jit
def kernel(out_ptr, BLOCK_SIZE):
    offsets = source_tl.arange(0, BLOCK_SIZE)
    value = source_triton.cdiv(BLOCK_SIZE, 2)
    source_tl.store(out_ptr + offsets, value)
```

were omitted from reconstructed kernel source, even when the kernel referenced source_triton or source_tl.
This change detects referenced module globals whose canonical names are triton or triton.* and emits qualified imports preserving their original aliases. Unrelated modules are ignored, and the standard triton and tl bindings remain unchanged.


Inductor now includes the global module when reconstructing this kernel.
Test coverage is provided by test_triton_kernel_with_imported_module() in test/inductor/test_triton_kernels.py. It verifies aliases for both the root Triton module and the triton.language submodule.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo