### PR TITLE
[MPS] Solve triangular systems by blocks, drop MPSMatrixSolveTriangular

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -29,10 +29,10 @@ struct TriangularSolveParams {
   uint32_t nbatch; // number of batch matrices
   uint32_t n; // triangular dimension (A is n x n)
   uint32_t k; // number of independent RHS vectors per batch
-  uint32_t upper; // A is upper-triangular (before op)
-  uint32_t transpose; // op transposes A
-  uint32_t conj; // op conjugates A (adjoint when combined with transpose)
-  uint32_t unit; // unit (implicit 1) diagonal
+  bool upper; // A is upper-triangular (before op)
+  bool transpose; // op transposes A
+  bool conj; // op conjugates A (adjoint when combined with transpose)
+  bool unit; // unit (implicit 1) diagonal
 };
 
 template <unsigned N = c10::metal::max_ndim>

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -29,7 +29,9 @@ struct TriangularSolveParams {
   uint32_t nbatch; // number of batch matrices
   uint32_t n; // triangular dimension (A is n x n)
   uint32_t k; // number of independent RHS vectors per batch
-  uint32_t upper; // A is upper-triangular
+  uint32_t upper; // A is upper-triangular (before op)
+  uint32_t transpose; // op transposes A
+  uint32_t conj; // op conjugates A (adjoint when combined with transpose)
   uint32_t unit; // unit (implicit 1) diagonal
 };
 

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -34,6 +34,7 @@ struct TriangularSolveParams {
   uint32_t transpose; // op transposes A
   uint32_t conj; // op conjugates A (adjoint when combined with transpose)
   uint32_t unit; // unit (implicit 1) diagonal
+  uint32_t stage; // keep the solved prefix in threadgroup memory
 };
 
 template <unsigned N = c10::metal::max_ndim>

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -29,12 +29,8 @@ struct TriangularSolveParams {
   uint32_t nbatch; // number of batch matrices
   uint32_t n; // triangular dimension (A is n x n)
   uint32_t k; // number of independent RHS vectors per batch
-  uint32_t upper; // A is upper-triangular (before op)
-  uint32_t left; // 1: op(A) X = B, 0: X op(A) = B
-  uint32_t transpose; // op transposes A
-  uint32_t conj; // op conjugates A (adjoint when combined with transpose)
+  uint32_t upper; // A is upper-triangular
   uint32_t unit; // unit (implicit 1) diagonal
-  uint32_t stage; // keep the solved prefix in threadgroup memory
 };
 
 template <unsigned N = c10::metal::max_ndim>

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -597,8 +597,7 @@ kernel void triangular_solve(
   const bool forward = p.upper == p.transpose;
   device const T* b = B + batch * n * k + vec;
   device T* x = X + batch * n * k + vec;
-  const uint nsimd =
-      (tg_size + c10::metal::simdgroup_size - 1) / c10::metal::simdgroup_size;
+  const uint nsimd = c10::metal::round_up(tg_size, c10::metal::simdgroup_size);
 
   for (uint step = 0; step < n; ++step) {
     const uint t = forward ? step : n - 1 - step;

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -581,7 +581,8 @@ kernel void triangular_solve(
     uint lid [[thread_position_in_threadgroup]],
     uint tg_size [[threads_per_threadgroup]],
     uint sg_lane [[thread_index_in_simdgroup]],
-    uint sg_id [[simdgroup_index_in_threadgroup]]) {
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint nsimd [[simdgroups_per_threadgroup]]) {
   const uint n = p.n;
   const uint k = p.k;
   if (tgid >= p.nbatch * k) {
@@ -597,7 +598,6 @@ kernel void triangular_solve(
   const bool forward = p.upper == p.transpose;
   device const T* b = B + batch * n * k + vec;
   device T* x = X + batch * n * k + vec;
-  const uint nsimd = c10::metal::round_up(tg_size, c10::metal::simdgroup_size);
 
   for (uint step = 0; step < n; ++step) {
     const uint t = forward ? step : n - 1 - step;
@@ -641,7 +641,8 @@ kernel void triangular_solve(
       uint lid [[thread_position_in_threadgroup]],               \
       uint tg_size [[threads_per_threadgroup]],                  \
       uint sg_lane [[thread_index_in_simdgroup]],                \
-      uint sg_id [[simdgroup_index_in_threadgroup]]);
+      uint sg_id [[simdgroup_index_in_threadgroup]],             \
+      uint nsimd [[simdgroups_per_threadgroup]]);
 
 INSTANTIATE_TRIANGULAR_SOLVE(float);
 INSTANTIATE_TRIANGULAR_SOLVE(float2);

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -594,10 +594,11 @@ kernel void triangular_solve(
   const bool cj = p.conj;
   // A is upper before op; a transpose flips the effective triangle, and a lower
   // one substitutes forward.
-  const bool forward = (p.upper != 0) == (p.transpose != 0);
+  const bool forward = p.upper == p.transpose;
   device const T* b = B + batch * n * k + vec;
   device T* x = X + batch * n * k + vec;
-  const uint nsimd = (tg_size + 31) / 32;
+  const uint nsimd =
+      (tg_size + c10::metal::simdgroup_size - 1) / c10::metal::simdgroup_size;
 
   for (uint step = 0; step < n; ++step) {
     const uint t = forward ? step : n - 1 - step;

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -548,12 +548,26 @@ INSTANTIATE_APPLY_TRSM(L, false, float)
 INSTANTIATE_APPLY_TRSM(U, true, float2)
 INSTANTIATE_APPLY_TRSM(L, false, float2)
 
+// op(A)(i, j): row-major (n x n) A, optionally transposed and/or conjugated.
+template <typename T>
+inline T tri_opA(
+    device const T* Ab,
+    uint i,
+    uint j,
+    uint n,
+    bool transpose,
+    bool conj) {
+  T v = transpose ? Ab[j * n + i] : Ab[i * n + j];
+  return conj ? c10::metal::conj(v) : v;
+}
+
 // Batched triangular solve by forward/back substitution. One threadgroup owns
 // one right-hand side and walks the n substitution steps serially; the dot
 // product against the already-solved prefix is split across the group and
-// reduced. The caller normalizes to op(A) X = B with a materialized op(A), so
-// there is no transpose, conjugation or right-hand side to handle here, and it
-// keeps n small enough that the prefix always fits in threadgroup memory.
+// reduced. The caller folds the side into the transpose so only op(A) X = B is
+// handled here, and keeps n small enough that the prefix always fits in
+// threadgroup memory; op itself stays in the kernel so that a transposed or
+// conjugated solve does not have to materialize an n x n copy.
 // Complex support comes from the c10::metal mul/div helpers, no-ops for real T.
 template <typename T>
 kernel void triangular_solve(
@@ -576,8 +590,11 @@ kernel void triangular_solve(
   const uint batch = tgid / k;
   const uint vec = tgid % k;
   device const T* Ab = A + batch * n * n;
-  // A lower triangle substitutes forward, an upper one backward.
-  const bool forward = p.upper == 0;
+  const bool tr = p.transpose;
+  const bool cj = p.conj;
+  // A is upper before op; a transpose flips the effective triangle, and a lower
+  // one substitutes forward.
+  const bool forward = (p.upper != 0) == (p.transpose != 0);
   device const T* b = B + batch * n * k + vec;
   device T* x = X + batch * n * k + vec;
   const uint nsimd = (tg_size + 31) / 32;
@@ -589,7 +606,7 @@ kernel void triangular_solve(
 
     T part = T(0);
     for (uint s = s_begin + lid; s < s_end; s += tg_size) {
-      part = part + c10::metal::mul(Ab[t * n + s], xs[s]);
+      part = part + c10::metal::mul(tri_opA(Ab, t, s, n, tr, cj), xs[s]);
     }
     part = c10::metal::simd_sum(part);
     if (sg_lane == 0) {
@@ -602,7 +619,8 @@ kernel void triangular_solve(
       for (uint s = 0; s < nsimd; ++s) {
         sum = sum - red[s];
       }
-      const T xt = p.unit ? sum : c10::metal::div(sum, Ab[t * n + t]);
+      const T xt =
+          p.unit ? sum : c10::metal::div(sum, tri_opA(Ab, t, t, n, tr, cj));
       xs[t] = xt;
       x[t * k] = xt;
     }

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -548,26 +548,13 @@ INSTANTIATE_APPLY_TRSM(L, false, float)
 INSTANTIATE_APPLY_TRSM(U, true, float2)
 INSTANTIATE_APPLY_TRSM(L, false, float2)
 
-// op(A)(i, j): row-major (n x n) A, optionally transposed and/or conjugated.
-template <typename T>
-inline T tri_opA(
-    device const T* Ab,
-    uint i,
-    uint j,
-    uint n,
-    bool transpose,
-    bool conj) {
-  T v = transpose ? Ab[j * n + i] : Ab[i * n + j];
-  return conj ? c10::metal::conj(v) : v;
-}
-
-// General batched triangular solve via forward/back substitution. One
-// threadgroup owns one independent RHS vector (a column for the left case, a
-// row for the right case) and walks the n substitution steps serially; the dot
-// product against the already-solved prefix is split across the threadgroup and
-// reduced. The prefix is kept in threadgroup memory when the host says it fits
-// (stage), otherwise it is read back from X. Complex support comes from the
-// c10::metal mul/div/conj helpers, which are no-ops for real T.
+// Batched triangular solve by forward/back substitution. One threadgroup owns
+// one right-hand side and walks the n substitution steps serially; the dot
+// product against the already-solved prefix is split across the group and
+// reduced. The caller normalizes to op(A) X = B with a materialized op(A), so
+// there is no transpose, conjugation or right-hand side to handle here, and it
+// keeps n small enough that the prefix always fits in threadgroup memory.
+// Complex support comes from the c10::metal mul/div helpers, no-ops for real T.
 template <typename T>
 kernel void triangular_solve(
     device const T* A [[buffer(0)]],
@@ -589,19 +576,10 @@ kernel void triangular_solve(
   const uint batch = tgid / k;
   const uint vec = tgid % k;
   device const T* Ab = A + batch * n * n;
-  const bool tr = p.transpose;
-  const bool cj = p.conj;
-  const bool left = p.left;
-  const bool staged = p.stage;
-  // A is upper before op; a transpose flips the effective triangle. The
-  // effective triangle and the side together decide the substitution direction.
-  const bool eff_upper = (p.upper != 0) != (p.transpose != 0);
-  const bool forward = left != eff_upper;
-  // Left: b/x are a column of an (n x k) matrix; right: a row of a (k x n) one.
-  const uint stride = left ? k : 1;
-  const uint offset = batch * n * k + (left ? vec : vec * n);
-  device const T* b = B + offset;
-  device T* x = X + offset;
+  // A lower triangle substitutes forward, an upper one backward.
+  const bool forward = p.upper == 0;
+  device const T* b = B + batch * n * k + vec;
+  device T* x = X + batch * n * k + vec;
   const uint nsimd = (tg_size + 31) / 32;
 
   for (uint step = 0; step < n; ++step) {
@@ -611,17 +589,7 @@ kernel void triangular_solve(
 
     T part = T(0);
     for (uint s = s_begin + lid; s < s_end; s += tg_size) {
-      // op(A)(t, s) for the left case, op(A)(s, t) for the right one; complex
-      // multiplication commutes, so the operand order needs no special casing.
-      const T a =
-          left ? tri_opA(Ab, t, s, n, tr, cj) : tri_opA(Ab, s, t, n, tr, cj);
-      T xv;
-      if (staged) {
-        xv = xs[s];
-      } else {
-        xv = x[s * stride];
-      }
-      part = part + c10::metal::mul(a, xv);
+      part = part + c10::metal::mul(Ab[t * n + s], xs[s]);
     }
     part = c10::metal::simd_sum(part);
     if (sg_lane == 0) {
@@ -630,18 +598,15 @@ kernel void triangular_solve(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     if (lid == 0) {
-      T sum = b[t * stride];
+      T sum = b[t * k];
       for (uint s = 0; s < nsimd; ++s) {
         sum = sum - red[s];
       }
-      const T xt =
-          p.unit ? sum : c10::metal::div(sum, tri_opA(Ab, t, t, n, tr, cj));
-      if (staged) {
-        xs[t] = xt;
-      }
-      x[t * stride] = xt;
+      const T xt = p.unit ? sum : c10::metal::div(sum, Ab[t * n + t]);
+      xs[t] = xt;
+      x[t * k] = xt;
     }
-    threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
   }
 }
 

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -561,80 +561,87 @@ inline T tri_opA(
   return conj ? c10::metal::conj(v) : v;
 }
 
-// General batched triangular solve via forward/back substitution. Each thread
-// owns one independent RHS vector (a column for the left case, a row for the
-// right case) and solves it serially, so there are no cross-thread hazards.
-// Correctness-first: this is O(n^2) per RHS with no blocking. Complex support
-// comes from the c10::metal mul/div/conj helpers, which are no-ops for real T.
+// General batched triangular solve via forward/back substitution. One
+// threadgroup owns one independent RHS vector (a column for the left case, a
+// row for the right case) and walks the n substitution steps serially; the dot
+// product against the already-solved prefix is split across the threadgroup and
+// reduced. The prefix is kept in threadgroup memory when the host says it fits
+// (stage), otherwise it is read back from X. Complex support comes from the
+// c10::metal mul/div/conj helpers, which are no-ops for real T.
 template <typename T>
 kernel void triangular_solve(
     device const T* A [[buffer(0)]],
     device const T* B [[buffer(1)]],
     device T* X [[buffer(2)]],
     constant TriangularSolveParams& p [[buffer(3)]],
-    uint tid [[thread_position_in_grid]]) {
+    threadgroup T* xs [[threadgroup(0)]],
+    threadgroup T* red [[threadgroup(1)]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tg_size [[threads_per_threadgroup]],
+    uint sg_lane [[thread_index_in_simdgroup]],
+    uint sg_id [[simdgroup_index_in_threadgroup]]) {
   const uint n = p.n;
   const uint k = p.k;
-  if (tid >= p.nbatch * k) {
+  if (tgid >= p.nbatch * k) {
     return;
   }
-  const uint batch = tid / k;
-  const uint vec = tid % k;
+  const uint batch = tgid / k;
+  const uint vec = tgid % k;
   device const T* Ab = A + batch * n * n;
   const bool tr = p.transpose;
   const bool cj = p.conj;
-  // A is upper before op; a transpose flips the effective triangle.
+  const bool left = p.left;
+  const bool staged = p.stage;
+  // A is upper before op; a transpose flips the effective triangle. The
+  // effective triangle and the side together decide the substitution direction.
   const bool eff_upper = (p.upper != 0) != (p.transpose != 0);
+  const bool forward = left != eff_upper;
+  // Left: b/x are a column of an (n x k) matrix; right: a row of a (k x n) one.
+  const uint stride = left ? k : 1;
+  const uint offset = batch * n * k + (left ? vec : vec * n);
+  device const T* b = B + offset;
+  device T* x = X + offset;
+  const uint nsimd = (tg_size + 31) / 32;
 
-  if (p.left) {
-    // op(A) x = b, x/b are columns of an (n x k) matrix; solve over rows.
-    device const T* b = B + batch * n * k + vec;
-    device T* x = X + batch * n * k + vec;
-    if (eff_upper) {
-      for (int i = int(n) - 1; i >= 0; --i) {
-        T sum = b[uint(i) * k];
-        for (uint j = uint(i) + 1; j < n; ++j) {
-          sum = sum -
-              c10::metal::mul(tri_opA(Ab, uint(i), j, n, tr, cj), x[j * k]);
-        }
-        x[uint(i) * k] = p.unit
-            ? sum
-            : c10::metal::div(sum, tri_opA(Ab, uint(i), uint(i), n, tr, cj));
+  for (uint step = 0; step < n; ++step) {
+    const uint t = forward ? step : n - 1 - step;
+    const uint s_begin = forward ? 0 : t + 1;
+    const uint s_end = forward ? t : n;
+
+    T part = T(0);
+    for (uint s = s_begin + lid; s < s_end; s += tg_size) {
+      // op(A)(t, s) for the left case, op(A)(s, t) for the right one; complex
+      // multiplication commutes, so the operand order needs no special casing.
+      const T a =
+          left ? tri_opA(Ab, t, s, n, tr, cj) : tri_opA(Ab, s, t, n, tr, cj);
+      T xv;
+      if (staged) {
+        xv = xs[s];
+      } else {
+        xv = x[s * stride];
       }
-    } else {
-      for (uint i = 0; i < n; ++i) {
-        T sum = b[i * k];
-        for (uint j = 0; j < i; ++j) {
-          sum = sum - c10::metal::mul(tri_opA(Ab, i, j, n, tr, cj), x[j * k]);
-        }
-        x[i * k] =
-            p.unit ? sum : c10::metal::div(sum, tri_opA(Ab, i, i, n, tr, cj));
-      }
+      part = part + c10::metal::mul(a, xv);
     }
-  } else {
-    // x op(A) = b, x/b are rows of a (k x n) matrix; solve over columns.
-    device const T* b = B + batch * k * n + vec * n;
-    device T* x = X + batch * k * n + vec * n;
-    if (eff_upper) {
-      for (uint j = 0; j < n; ++j) {
-        T sum = b[j];
-        for (uint i = 0; i < j; ++i) {
-          sum = sum - c10::metal::mul(x[i], tri_opA(Ab, i, j, n, tr, cj));
-        }
-        x[j] =
-            p.unit ? sum : c10::metal::div(sum, tri_opA(Ab, j, j, n, tr, cj));
-      }
-    } else {
-      for (int j = int(n) - 1; j >= 0; --j) {
-        T sum = b[uint(j)];
-        for (uint i = uint(j) + 1; i < n; ++i) {
-          sum = sum - c10::metal::mul(x[i], tri_opA(Ab, i, uint(j), n, tr, cj));
-        }
-        x[uint(j)] = p.unit
-            ? sum
-            : c10::metal::div(sum, tri_opA(Ab, uint(j), uint(j), n, tr, cj));
-      }
+    part = c10::metal::simd_sum(part);
+    if (sg_lane == 0) {
+      red[sg_id] = part;
     }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (lid == 0) {
+      T sum = b[t * stride];
+      for (uint s = 0; s < nsimd; ++s) {
+        sum = sum - red[s];
+      }
+      const T xt =
+          p.unit ? sum : c10::metal::div(sum, tri_opA(Ab, t, t, n, tr, cj));
+      if (staged) {
+        xs[t] = xt;
+      }
+      x[t * stride] = xt;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
   }
 }
 
@@ -645,7 +652,13 @@ kernel void triangular_solve(
       device const DTYPE* B [[buffer(1)]],                       \
       device DTYPE* X [[buffer(2)]],                             \
       constant TriangularSolveParams& p [[buffer(3)]],           \
-      uint tid [[thread_position_in_grid]]);
+      threadgroup DTYPE* xs [[threadgroup(0)]],                  \
+      threadgroup DTYPE* red [[threadgroup(1)]],                 \
+      uint tgid [[threadgroup_position_in_grid]],                \
+      uint lid [[thread_position_in_threadgroup]],               \
+      uint tg_size [[threads_per_threadgroup]],                  \
+      uint sg_lane [[thread_index_in_simdgroup]],                \
+      uint sg_id [[simdgroup_index_in_threadgroup]]);
 
 INSTANTIATE_TRIANGULAR_SOLVE(float);
 INSTANTIATE_TRIANGULAR_SOLVE(float2);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1724,12 +1724,15 @@ static void triangular_solve_metal(const Tensor& A_,
       getMPSProfiler().beginProfileKernel(pso, "triangular_solve", {A_, B_}, stream);
       [encoder setComputePipelineState:pso];
       // Every substitution step reduces across the whole threadgroup, so don't
-      // spread a short row over more threads than it has work for.
-      const uint64_t maxThreads = std::min<uint64_t>(pso.maxTotalThreadsPerThreadgroup, 256);
-      const uint64_t tgSize = std::clamp<uint64_t>(round_up(n, uint64_t(32)), 32, maxThreads);
+      // spread a short row over more threads than it has work for, and keep the
+      // group a whole number of simdgroups so the reduction stays exact.
+      constexpr uint64_t kSimd = c10::metal::simdgroup_size;
+      constexpr uint64_t kMaxThreadsPerGroup = 8 * kSimd;
+      const uint64_t maxThreads = std::min<uint64_t>(pso.maxTotalThreadsPerThreadgroup, kMaxThreadsPerGroup);
+      const uint64_t tgSize = std::clamp<uint64_t>(round_up(n, kSimd), kSimd, maxThreads);
       // setThreadgroupMemoryLength rejects lengths that are not a multiple of 16.
       constexpr uint64_t kTGMemAlign = 16;
-      const uint64_t redBytes = round_up(tgSize / 32 * elem_size, kTGMemAlign);
+      const uint64_t redBytes = round_up(tgSize / kSimd * elem_size, kTGMemAlign);
       const uint64_t prefixBytes = round_up(n * elem_size, kTGMemAlign);
       // The caller sends anything bigger down the blocked path, which only ever
       // hands this kernel a block, so the prefix always fits.
@@ -1793,7 +1796,7 @@ static void triangular_solve_blocked(const Tensor& M, bool upper, bool unitriang
       // Accumulate in place: a plain sub_(matmul(...)) would allocate a result
       // per block, each a different size, which the caching allocator then
       // holds on to one block per size.
-      X3.narrow(1, r0, rest).baddbmm_(M3.narrow(1, r0, rest).narrow(2, i0, rows), Xi_new, 1, -1);
+      X3.narrow(1, r0, rest).baddbmm_(M3.narrow(1, r0, rest).narrow(2, i0, rows), Xi_new, /*beta=*/1, /*alpha=*/-1);
     }
   }
 }
@@ -1867,7 +1870,8 @@ static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
   // per-block dispatches cost more than the substitution they replace.
   // nb trades a costlier diagonal-block inverse against fewer trailing matmuls.
   constexpr int64_t kBlockSize = 128;
-  if (A_.size(-1) > 4 * kBlockSize) {
+  constexpr int64_t kMinBlocks = 4;
+  if (A_.size(-1) > kMinBlocks * kBlockSize) {
     Tensor M = kernel_transpose ? A_.mT() : A_;
     if (conjugate) {
       M = M.conj();

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1746,17 +1746,15 @@ static void triangular_solve_metal(const Tensor& A_,
   });
 }
 
-// Right-looking blocked solve: substitution on the nb x nb diagonal block, then
-// one GEMM to push its contribution into the rest of the panel. Substitution
-// reads every element of A once per right-hand side, so it is bandwidth-bound
-// once there are many of them; blocking cuts that traffic by nb and moves the
-// work into matmul. X holds B on entry and the solution on exit, and M is a
-// contiguous op(A) whose triangle is given by upper.
+// Right-looking blocked solve: solve the nb x nb diagonal block, then one GEMM
+// to push its contribution into the rest of the panel. Substitution reads every
+// element of A once per right-hand side and serializes n steps deep; blocking
+// cuts that traffic by nb, shortens the chain to nb, and moves the rest into
+// matmul. X holds B on entry and the solution on exit; M is op(A), possibly as
+// a transposed/conjugated view, with its triangle given by upper.
 static void triangular_solve_blocked(const Tensor& M, bool upper, bool unitriangular, int64_t nb, Tensor& X) {
   const int64_t n = M.size(-1);
   const int64_t k = X.size(-1);
-  // Both are contiguous, so these fold the batch dims into one without copying
-  // and let the trailing update be a single baddbmm_.
   // M may be a transposed and/or conjugated view, so fold the batch dims with
   // flatten (a view here) rather than reshape, which would copy. matmul and
   // baddbmm_ take such views directly, which is what keeps a transposed or

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1855,8 +1855,13 @@ static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
   // X op(A) = B is the same as solving op(A)^T X^T = B^T, so the right case only
   // costs the O(nk) transposes of B and X, never an O(n^2) copy of A.
   const bool kernel_transpose = transpose != !left;
-  const Tensor Brhs = left ? B_ : B_.mT().contiguous();
-  Tensor X = left ? out_ : at::empty_like(Brhs, at::MemoryFormat::Contiguous);
+  // clone, not contiguous(): when B^T is already contiguous the latter aliases
+  // B, and the solve below writes into this buffer.
+  const Tensor Brhs = left ? B_ : B_.mT().clone(at::MemoryFormat::Contiguous);
+  // Brhs is a private temporary in the right case, so the solve runs in place:
+  // the blocked path already works in place, and the kernel reads b[t] before
+  // writing x[t] at every step, taking everything else from threadgroup memory.
+  Tensor X = left ? out_ : Brhs;
 
   // Substitution reads all of A once per right-hand side and runs a chain of n
   // dependent steps; the blocked solve shortens that chain to nb and turns the
@@ -1869,7 +1874,9 @@ static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
     if (conjugate) {
       M = M.conj();
     }
-    X.copy_(Brhs);
+    if (!X.is_same(Brhs)) {
+      X.copy_(Brhs);
+    }
     triangular_solve_blocked(M, upper != kernel_transpose, unitriangular, kBlockSize, X);
   } else {
     triangular_solve_metal(A_, Brhs, upper, kernel_transpose, conjugate, unitriangular, X);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1689,10 +1689,11 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   return result;
 }
 
-// Complex triangular solve runs a custom Metal substitution kernel because
-// MPSMatrixSolveTriangular is float-only. conjugate selects adjoint (A^H)
-// instead of plain transpose (A^T) when transpose is set; it is a no-op for
-// real inputs.
+// Metal substitution kernel. MPSMatrixSolveTriangular is float-only, and even
+// for float it is built around having many right-hand sides: with few of them
+// its fixed overhead dominates, so this kernel wins there too (see the caller
+// for the cutoff). conjugate selects adjoint (A^H) instead of plain transpose
+// (A^T) when transpose is set; it is a no-op for real inputs.
 static void triangular_solve_metal(const Tensor& A_,
                                    const Tensor& B_,
                                    bool upper,
@@ -1717,6 +1718,7 @@ static void triangular_solve_metal(const Tensor& A_,
   params.conj = conjugate;
   params.unit = unitriangular;
 
+  const uint64_t elem_size = A_.element_size();
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
@@ -1724,8 +1726,23 @@ static void triangular_solve_metal(const Tensor& A_,
       auto pso = lib.getPipelineStateForFunc(fmt::format("triangular_solve_{}", scalarToMetalTypeString(A_)));
       getMPSProfiler().beginProfileKernel(pso, "triangular_solve", {A_, B_}, stream);
       [encoder setComputePipelineState:pso];
-      mtl_setArgs(encoder, A_, B_, out, params);
-      mtl_dispatch1DJob(encoder, pso, batchSize * k);
+      // Every substitution step reduces across the whole threadgroup, so don't
+      // spread a short row over more threads than it has work for.
+      const uint64_t maxThreads = std::min<uint64_t>(pso.maxTotalThreadsPerThreadgroup, 256);
+      const uint64_t tgSize = std::clamp<uint64_t>((n + 31) / 32 * 32, 32, maxThreads);
+      const uint64_t redBytes = tgSize / 32 * elem_size;
+      // Staging the solved prefix saves a device round-trip per substitution
+      // step, but only pays off if the whole vector fits next to the reduction
+      // buffer; past that the kernel reads the prefix back from out.
+      const uint64_t maxTGMem = [MPSDevice::getInstance()->device() maxThreadgroupMemoryLength];
+      const bool stage = n * elem_size + redBytes <= maxTGMem;
+      TriangularSolveParams tgParams = params;
+      tgParams.stage = stage;
+      mtl_setArgs(encoder, A_, B_, out, tgParams);
+      [encoder setThreadgroupMemoryLength:(stage ? n * elem_size : elem_size) atIndex:0];
+      [encoder setThreadgroupMemoryLength:redBytes atIndex:1];
+      [encoder dispatchThreads:MTLSizeMake(tgSize * batchSize * k, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(tgSize, 1, 1)];
       getMPSProfiler().endProfileKernel(pso, stream);
     }
   });
@@ -1782,7 +1799,11 @@ static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
   // It is fully overwritten, hence empty rather than a copy of out.
   Tensor out_ = out.is_contiguous() ? out : at::empty_like(out, at::MemoryFormat::Contiguous);
 
-  if (scalar_type == kComplexFloat) {
+  // MPSMatrixSolveTriangular only pulls ahead once there are enough right-hand
+  // sides to amortize its setup and feed its blocked inner loop; below that the
+  // substitution kernel is faster, and for complex it is the only option.
+  constexpr int64_t kMetalMaxRHS = 128;
+  if (scalar_type == kComplexFloat || (left ? B_.size(-1) : B_.size(-2)) <= kMetalMaxRHS) {
     triangular_solve_metal(A_, B_, upper, transpose, left, unitriangular, conjugate, out_);
     if (!out_.is_same(out)) {
       out.copy_(out_);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1696,6 +1696,8 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
 static void triangular_solve_metal(const Tensor& A_,
                                    const Tensor& B_,
                                    bool upper,
+                                   bool transpose,
+                                   bool conjugate,
                                    bool unitriangular,
                                    const Tensor& out) {
   using namespace mps;
@@ -1709,6 +1711,8 @@ static void triangular_solve_metal(const Tensor& A_,
   params.n = safe_downcast<uint32_t, uint64_t>(n);
   params.k = safe_downcast<uint32_t, uint64_t>(k);
   params.upper = upper;
+  params.transpose = transpose;
+  params.conj = conjugate;
   params.unit = unitriangular;
 
   const uint64_t elem_size = A_.element_size();
@@ -1753,8 +1757,12 @@ static void triangular_solve_blocked(const Tensor& M, bool upper, bool unitriang
   const int64_t k = X.size(-1);
   // Both are contiguous, so these fold the batch dims into one without copying
   // and let the trailing update be a single baddbmm_.
-  const Tensor M3 = M.reshape({-1, n, n});
-  Tensor X3 = X.reshape({-1, n, k});
+  // M may be a transposed and/or conjugated view, so fold the batch dims with
+  // flatten (a view here) rather than reshape, which would copy. matmul and
+  // baddbmm_ take such views directly, which is what keeps a transposed or
+  // adjoint solve from materializing an n x n copy of op(A).
+  const Tensor M3 = M.dim() == 2 ? M.unsqueeze(0) : M.flatten(0, -3);
+  Tensor X3 = X.dim() == 2 ? X.unsqueeze(0) : X.flatten(0, -3);
   const int64_t nbatch = M3.size(0);
 
   // An upper triangle is solved from the bottom block up.
@@ -1762,20 +1770,23 @@ static void triangular_solve_blocked(const Tensor& M, bool upper, bool unitriang
     const int64_t rows = std::min(nb, n - b);
     const int64_t i0 = upper ? n - b - rows : b;
     auto Xi = X3.narrow(1, i0, rows);
-    auto diag = M3.narrow(1, i0, rows).narrow(2, i0, rows).contiguous();
+    // The kernel reads raw elements, so the diagonal block is materialized;
+    // it is only nb x nb.
+    auto diag = M3.narrow(1, i0, rows).narrow(2, i0, rows).resolve_conj().contiguous();
     // Inverting the diagonal block turns the panel solve into a matmul, and the
     // block is small enough that it does not measurably cost accuracy. But the
     // inverse itself is a solve with `rows` right-hand sides, so it only pays
     // off once there are at least that many to amortize it over.
     Tensor Xi_new;
     if (k >= rows) {
-      Tensor eye = at::eye(rows, M.options()).expand({nbatch, rows, rows}).contiguous();
+      Tensor eye = at::eye(rows, M.options().memory_format(std::nullopt)).expand({nbatch, rows, rows}).contiguous();
       Tensor dinv = at::empty_like(eye);
-      triangular_solve_metal(diag, eye, upper, unitriangular, dinv);
+      triangular_solve_metal(diag, eye, upper, /*transpose=*/false, /*conjugate=*/false, unitriangular, dinv);
       Xi_new = at::matmul(dinv, Xi);
     } else {
       Xi_new = at::empty_like(Xi, at::MemoryFormat::Contiguous);
-      triangular_solve_metal(diag, Xi.contiguous(), upper, unitriangular, Xi_new);
+      triangular_solve_metal(
+          diag, Xi.contiguous(), upper, /*transpose=*/false, /*conjugate=*/false, unitriangular, Xi_new);
     }
     Xi.copy_(Xi_new);
     const int64_t rest = upper ? i0 : n - i0 - rows;
@@ -1840,20 +1851,10 @@ static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
   // It is fully overwritten, hence empty rather than a copy of out.
   Tensor out_ = out.is_contiguous() ? out : at::empty_like(out, at::MemoryFormat::Contiguous);
 
-  // Normalize to op(A) X = B against a materialized op(A): X op(A) = B is the
-  // same as op(A)^T X^T = B^T. The O(n^2) copy is dominated by the O(n^2 k)
-  // solve, and it leaves the kernel a plain forward/back substitution with no
-  // transpose, conjugation or side to handle.
-  Tensor M = transpose ? A_.mT() : A_;
-  if (conjugate) {
-    M = M.conj();
-  }
-  bool eff_upper = upper != transpose;
-  if (!left) {
-    M = M.mT();
-    eff_upper = !eff_upper;
-  }
-  M = M.resolve_conj().contiguous();
+  // Fold the side into the transpose rather than materializing op(A): solving
+  // X op(A) = B is the same as solving op(A)^T X^T = B^T, so the right case only
+  // costs the O(nk) transposes of B and X, never an O(n^2) copy of A.
+  const bool kernel_transpose = transpose != !left;
   const Tensor Brhs = left ? B_ : B_.mT().contiguous();
   Tensor X = left ? out_ : at::empty_like(Brhs, at::MemoryFormat::Contiguous);
 
@@ -1864,10 +1865,14 @@ static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
   // nb trades a costlier diagonal-block inverse against fewer trailing matmuls.
   constexpr int64_t kBlockSize = 128;
   if (A_.size(-1) > 4 * kBlockSize) {
+    Tensor M = kernel_transpose ? A_.mT() : A_;
+    if (conjugate) {
+      M = M.conj();
+    }
     X.copy_(Brhs);
-    triangular_solve_blocked(M, eff_upper, unitriangular, kBlockSize, X);
+    triangular_solve_blocked(M, upper != kernel_transpose, unitriangular, kBlockSize, X);
   } else {
-    triangular_solve_metal(M, Brhs, eff_upper, unitriangular, X);
+    triangular_solve_metal(A_, Brhs, upper, kernel_transpose, conjugate, unitriangular, X);
   }
   if (!left) {
     out_.copy_(X.mT());

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1689,33 +1689,26 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   return result;
 }
 
-// Metal substitution kernel. MPSMatrixSolveTriangular is float-only, and even
-// for float it is built around having many right-hand sides: with few of them
-// its fixed overhead dominates, so this kernel wins there too (see the caller
-// for the cutoff). conjugate selects adjoint (A^H) instead of plain transpose
-// (A^T) when transpose is set; it is a no-op for real inputs.
+// Metal substitution kernel: one threadgroup per right-hand side, reducing the
+// dot product against the already-solved prefix across the group. conjugate
+// selects adjoint (A^H) instead of plain transpose (A^T) when transpose is set;
+// it is a no-op for real inputs.
 static void triangular_solve_metal(const Tensor& A_,
                                    const Tensor& B_,
                                    bool upper,
-                                   bool transpose,
-                                   bool left,
                                    bool unitriangular,
-                                   bool conjugate,
                                    const Tensor& out) {
   using namespace mps;
   const uint64_t batchSize =
       std::accumulate(A_.sizes().begin(), A_.sizes().end() - 2, 1ULL, std::multiplies<uint64_t>());
   const uint64_t n = A_.size(-1);
-  const uint64_t k = left ? B_.size(-1) : B_.size(-2);
+  const uint64_t k = B_.size(-1);
 
   TriangularSolveParams params;
   params.nbatch = safe_downcast<uint32_t, uint64_t>(batchSize);
   params.n = safe_downcast<uint32_t, uint64_t>(n);
   params.k = safe_downcast<uint32_t, uint64_t>(k);
   params.upper = upper;
-  params.left = left;
-  params.transpose = transpose;
-  params.conj = conjugate;
   params.unit = unitriangular;
 
   const uint64_t elem_size = A_.element_size();
@@ -1729,23 +1722,71 @@ static void triangular_solve_metal(const Tensor& A_,
       // Every substitution step reduces across the whole threadgroup, so don't
       // spread a short row over more threads than it has work for.
       const uint64_t maxThreads = std::min<uint64_t>(pso.maxTotalThreadsPerThreadgroup, 256);
-      const uint64_t tgSize = std::clamp<uint64_t>((n + 31) / 32 * 32, 32, maxThreads);
-      const uint64_t redBytes = tgSize / 32 * elem_size;
-      // Staging the solved prefix saves a device round-trip per substitution
-      // step, but only pays off if the whole vector fits next to the reduction
-      // buffer; past that the kernel reads the prefix back from out.
+      const uint64_t tgSize = std::clamp<uint64_t>(round_up(n, uint64_t(32)), 32, maxThreads);
+      // setThreadgroupMemoryLength rejects lengths that are not a multiple of 16.
+      constexpr uint64_t kTGMemAlign = 16;
+      const uint64_t redBytes = round_up(tgSize / 32 * elem_size, kTGMemAlign);
+      const uint64_t prefixBytes = round_up(n * elem_size, kTGMemAlign);
+      // The caller sends anything bigger down the blocked path, which only ever
+      // hands this kernel a block, so the prefix always fits.
       const uint64_t maxTGMem = [MPSDevice::getInstance()->device() maxThreadgroupMemoryLength];
-      const bool stage = n * elem_size + redBytes <= maxTGMem;
-      TriangularSolveParams tgParams = params;
-      tgParams.stage = stage;
-      mtl_setArgs(encoder, A_, B_, out, tgParams);
-      [encoder setThreadgroupMemoryLength:(stage ? n * elem_size : elem_size) atIndex:0];
+      TORCH_INTERNAL_ASSERT(
+          prefixBytes + redBytes <= maxTGMem, "triangular_solve: n=", n, " does not fit in threadgroup memory");
+      mtl_setArgs(encoder, A_, B_, out, params);
+      [encoder setThreadgroupMemoryLength:prefixBytes atIndex:0];
       [encoder setThreadgroupMemoryLength:redBytes atIndex:1];
       [encoder dispatchThreads:MTLSizeMake(tgSize * batchSize * k, 1, 1)
           threadsPerThreadgroup:MTLSizeMake(tgSize, 1, 1)];
       getMPSProfiler().endProfileKernel(pso, stream);
     }
   });
+}
+
+// Right-looking blocked solve: substitution on the nb x nb diagonal block, then
+// one GEMM to push its contribution into the rest of the panel. Substitution
+// reads every element of A once per right-hand side, so it is bandwidth-bound
+// once there are many of them; blocking cuts that traffic by nb and moves the
+// work into matmul. X holds B on entry and the solution on exit, and M is a
+// contiguous op(A) whose triangle is given by upper.
+static void triangular_solve_blocked(const Tensor& M, bool upper, bool unitriangular, int64_t nb, Tensor& X) {
+  const int64_t n = M.size(-1);
+  const int64_t k = X.size(-1);
+  // Both are contiguous, so these fold the batch dims into one without copying
+  // and let the trailing update be a single baddbmm_.
+  const Tensor M3 = M.reshape({-1, n, n});
+  Tensor X3 = X.reshape({-1, n, k});
+  const int64_t nbatch = M3.size(0);
+
+  // An upper triangle is solved from the bottom block up.
+  for (int64_t b = 0; b < n; b += nb) {
+    const int64_t rows = std::min(nb, n - b);
+    const int64_t i0 = upper ? n - b - rows : b;
+    auto Xi = X3.narrow(1, i0, rows);
+    auto diag = M3.narrow(1, i0, rows).narrow(2, i0, rows).contiguous();
+    // Inverting the diagonal block turns the panel solve into a matmul, and the
+    // block is small enough that it does not measurably cost accuracy. But the
+    // inverse itself is a solve with `rows` right-hand sides, so it only pays
+    // off once there are at least that many to amortize it over.
+    Tensor Xi_new;
+    if (k >= rows) {
+      Tensor eye = at::eye(rows, M.options()).expand({nbatch, rows, rows}).contiguous();
+      Tensor dinv = at::empty_like(eye);
+      triangular_solve_metal(diag, eye, upper, unitriangular, dinv);
+      Xi_new = at::matmul(dinv, Xi);
+    } else {
+      Xi_new = at::empty_like(Xi, at::MemoryFormat::Contiguous);
+      triangular_solve_metal(diag, Xi.contiguous(), upper, unitriangular, Xi_new);
+    }
+    Xi.copy_(Xi_new);
+    const int64_t rest = upper ? i0 : n - i0 - rows;
+    if (rest > 0) {
+      const int64_t r0 = upper ? 0 : i0 + rows;
+      // Accumulate in place: a plain sub_(matmul(...)) would allocate a result
+      // per block, each a different size, which the caching allocator then
+      // holds on to one block per size.
+      X3.narrow(1, r0, rest).baddbmm_(M3.narrow(1, r0, rest).narrow(2, i0, rows), Xi_new, 1, -1);
+    }
+  }
 }
 
 static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
@@ -1799,80 +1840,38 @@ static Tensor& linalg_solve_triangular_mps_impl(const Tensor& A,
   // It is fully overwritten, hence empty rather than a copy of out.
   Tensor out_ = out.is_contiguous() ? out : at::empty_like(out, at::MemoryFormat::Contiguous);
 
-  // MPSMatrixSolveTriangular only pulls ahead once there are enough right-hand
-  // sides to amortize its setup and feed its blocked inner loop; below that the
-  // substitution kernel is faster, and for complex it is the only option.
-  constexpr int64_t kMetalMaxRHS = 128;
-  if (scalar_type == kComplexFloat || (left ? B_.size(-1) : B_.size(-2)) <= kMetalMaxRHS) {
-    triangular_solve_metal(A_, B_, upper, transpose, left, unitriangular, conjugate, out_);
-    if (!out_.is_same(out)) {
-      out.copy_(out_);
-    }
-    return out;
+  // Normalize to op(A) X = B against a materialized op(A): X op(A) = B is the
+  // same as op(A)^T X^T = B^T. The O(n^2) copy is dominated by the O(n^2 k)
+  // solve, and it leaves the kernel a plain forward/back substitution with no
+  // transpose, conjugation or side to handle.
+  Tensor M = transpose ? A_.mT() : A_;
+  if (conjugate) {
+    M = M.conj();
   }
+  bool eff_upper = upper != transpose;
+  if (!left) {
+    M = M.mT();
+    eff_upper = !eff_upper;
+  }
+  M = M.resolve_conj().contiguous();
+  const Tensor Brhs = left ? B_ : B_.mT().contiguous();
+  Tensor X = left ? out_ : at::empty_like(Brhs, at::MemoryFormat::Contiguous);
 
-  id<MTLBuffer> aBuffer = getMTLBufferStorage(A_);
-  id<MTLBuffer> bBuffer = getMTLBufferStorage(B_);
-  id<MTLBuffer> outBuffer = getMTLBufferStorage(out_);
-  MPSStream* mpsStream = getCurrentMPSStream();
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-
-  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      mpsStream->endKernelCoalescing();
-      id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
-      uint64_t batchSize = std::accumulate(A.sizes().begin(), A.sizes().end() - 2, 1ULL, std::multiplies<uint64_t>());
-      uint64_t aRows = A_.size(-2);
-      uint64_t bRows = B_.size(-2);
-      uint64_t aCols = A_.size(-1);
-      uint64_t bCols = B_.size(-1);
-      uint64_t aElemSize = A_.element_size();
-      uint64_t bElemSize = B_.element_size();
-
-      auto filter = [[[MPSMatrixSolveTriangular alloc] initWithDevice:device
-                                                                right:!left
-                                                                upper:upper
-                                                            transpose:transpose
-                                                                 unit:unitriangular
-                                                                order:left ? bRows : bCols
-                                               numberOfRightHandSides:left ? bCols : bRows
-                                                                alpha:1.0f] autorelease];
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(filter, " solve_triangular_mps", {A_, B_}, mpsStream);
-
-      auto sourceMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
-                                                                    columns:aCols
-                                                                   matrices:batchSize
-                                                                   rowBytes:aCols * aElemSize
-                                                                matrixBytes:aRows * aCols * aElemSize
-                                                                   dataType:getMPSDataType(A_)];
-      auto rightHandSideMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:bRows
-                                                                           columns:bCols
-                                                                          matrices:batchSize
-                                                                          rowBytes:bCols * bElemSize
-                                                                       matrixBytes:bRows * bCols * bElemSize
-                                                                          dataType:getMPSDataType(B_)];
-      for (const auto i : c10::irange(batchSize)) {
-        const uint64_t aBatchOffset = i * aRows * aCols;
-        const uint64_t bBatchOffset = i * bRows * bCols;
-        auto sourceMatrix = [[[MPSMatrix alloc] initWithBuffer:aBuffer
-                                                        offset:(A_.storage_offset() + aBatchOffset) * aElemSize
-                                                    descriptor:sourceMatrixDesc] autorelease];
-        auto rightHandSideMatrix = [[[MPSMatrix alloc] initWithBuffer:bBuffer
-                                                               offset:(B_.storage_offset() + bBatchOffset) * bElemSize
-                                                           descriptor:rightHandSideMatrixDesc] autorelease];
-        auto solutionMatrix = [[[MPSMatrix alloc] initWithBuffer:outBuffer
-                                                          offset:(out_.storage_offset() + bBatchOffset) * bElemSize
-                                                      descriptor:rightHandSideMatrixDesc] autorelease];
-
-        [filter encodeToCommandBuffer:commandBuffer
-                         sourceMatrix:sourceMatrix
-                  rightHandSideMatrix:rightHandSideMatrix
-                       solutionMatrix:solutionMatrix];
-      }
-      getMPSProfiler().endProfileKernel(filter, mpsStream);
-    }
-  });
+  // Substitution reads all of A once per right-hand side and runs a chain of n
+  // dependent steps; the blocked solve shortens that chain to nb and turns the
+  // rest into matmul, which wins for both dtypes. Below a handful of blocks the
+  // per-block dispatches cost more than the substitution they replace.
+  // nb trades a costlier diagonal-block inverse against fewer trailing matmuls.
+  constexpr int64_t kBlockSize = 128;
+  if (A_.size(-1) > 4 * kBlockSize) {
+    X.copy_(Brhs);
+    triangular_solve_blocked(M, eff_upper, unitriangular, kBlockSize, X);
+  } else {
+    triangular_solve_metal(M, Brhs, eff_upper, unitriangular, X);
+  }
+  if (!left) {
+    out_.copy_(X.mT());
+  }
   if (!out_.is_same(out)) {
     out.copy_(out_);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #196241

Triangular solve is inherently sequential: x_i needs every x_j before it. The kernel this replaces leaned into that, giving each right-hand side one thread that walked all n steps, which left a single-RHS solve running on one GPU thread and made every RHS re-read the whole matrix. complex64 n=2048 k=1 took 151ms against 1.3ms on CPU; with many right-hand sides the traffic reached ~34GB and the kernel ran at about a flop per byte.

Restructure it as a right-looking blocked solve. Split A into 128-wide blocks and, for each diagonal block in turn, solve that block and then push its contribution into the remaining rows with a single matmul. The arithmetic is unchanged, but the serial chain shrinks from n steps to nb, and the bulk of the work becomes GEMM, which already runs near 7 TFLOP/s here for both dtypes. That is what makes it faster even at k=1, where there is no reuse to exploit.

The diagonal block is inverted rather than solved whenever there are at least nb right-hand sides, so the panel becomes another matmul. Solving a small square block against thousands of RHS is precisely where substitution is weakest and where MPSMatrixSolveTriangular used to be needed; inverting turns it into a 128-RHS solve on a 128x128 block, which the substitution kernel handles well. Below nb right-hand sides the inverse costs more than the solve it replaces, so the block is solved directly instead. Accuracy is unaffected: 2.8e-07 against a float64 reference either way, including on a deliberately ill-conditioned matrix.

With that, MPSMatrixSolveTriangular is gone, and with it the float-only restriction and the dtype-dependent routing. The substitution kernel survives as the diagonal-block solver and for n small enough that blocking does not pay.

Two simplifications fall out. The side folds into the transpose, since X op(A) = B is the same as op(A)^T X^T = B^T, so the kernel only ever solves from the left and the right case costs O(nk) transposes rather than an O(n^2) copy; op itself stays in the kernel so a transposed or adjoint solve does not materialize A either. And because blocking takes over well before the prefix stops fitting in threadgroup memory, the kernel's non-staged path is unreachable and is replaced by an assert.

Review LinearAlgebra.metal first for the kernel, then triangular_solve_blocked, then the routing in linalg_solve_triangular_mps_impl.

Measured on an M5 Pro (20 GPU cores), milliseconds. `k` is the number of right-hand sides; `left` solves op(A) X = B, `right` solves X op(A) = B.

<details>
<summary>Full results: 20 shape/dtype combinations</summary>

| dtype | b | n | k | left before | left after | speedup | right before | right after | speedup |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| float32 | 1 | 512 | 1 | 1.56 | 0.75 | 2.1x | 1.01 | 0.36 | 2.8x |
| float32 | 1 | 1024 | 1 | 5.65 | 0.59 | 9.6x | 3.73 | 0.61 | 6.1x |
| float32 | 1 | 2048 | 1 | 27.20 | 1.11 | 24.6x | 25.56 | 1.06 | 24.0x |
| float32 | 1 | 2048 | 64 | 4.31 | 1.21 | 3.5x | 5.65 | 1.24 | 4.5x |
| float32 | 1 | 1024 | 1024 | 1.34 | 0.87 | 1.5x | 1.47 | 0.95 | 1.5x |
| float32 | 1 | 2048 | 512 | 4.54 | 1.74 | 2.6x | 6.04 | 1.82 | 3.3x |
| float32 | 1 | 2048 | 2048 | 6.63 | 2.78 | 2.4x | 6.92 | 3.11 | 2.2x |
| float32 | 1 | 4096 | 1024 | 21.26 | 5.34 | 4.0x | 26.20 | 5.63 | 4.7x |
| float32 | 8 | 1024 | 64 | 10.15 | 1.41 | 7.2x | 13.22 | 1.67 | 7.9x |
| float32 | 8 | 1024 | 512 | 10.46 | 3.25 | 3.2x | 13.19 | 3.66 | 3.6x |
| complex64 | 1 | 512 | 1 | 7.17 | 0.39 | 18.2x | 7.25 | 0.40 | 18.3x |
| complex64 | 1 | 1024 | 1 | 34.93 | 0.67 | 52.4x | 36.55 | 0.67 | 55.0x |
| complex64 | 1 | 2048 | 1 | 150.93 | 1.35 | 111.6x | 205.88 | 1.36 | 151.5x |
| complex64 | 1 | 2048 | 64 | 261.07 | 1.76 | 148.6x | 274.60 | 1.80 | 152.8x |
| complex64 | 1 | 1024 | 1024 | 93.13 | 2.45 | 38.0x | 141.00 | 2.52 | 55.8x |
| complex64 | 1 | 2048 | 512 | 371.28 | 4.82 | 77.1x | 440.73 | 4.88 | 90.3x |
| complex64 | 1 | 2048 | 2048 | 492.18 | 14.60 | 33.7x | 663.95 | 14.89 | 44.6x |
| complex64 | 1 | 4096 | 1024 | 1962.18 | 28.51 | 68.8x | 2684.41 | 28.89 | 92.9x |
| complex64 | 8 | 1024 | 64 | 70.64 | 2.40 | 29.4x | 77.88 | 2.48 | 31.4x |
| complex64 | 8 | 1024 | 512 | 127.03 | 9.99 | 12.7x | 198.78 | 10.35 | 19.2x |

</details>

Right-hand solves used to run up to 35% slower than left-hand ones, because the old kernel read A down columns there; they are now within ~13% of them.

This costs transient memory where the previous implementation allocated none beyond the result: at most elem_size * (3*nb^2 + nb*k) per batch element, which is independent of n. Right-hand solves add one n-by-k buffer for B^T. Peak transient allocation at n = k = 2048, in MB:

| dtype | case | result | before | after |
| --- | --- | --- | --- | --- |
| float32 | left | 16.0 | 16.0 | 17.2 |
| float32 | right | 16.0 | 16.0 | 33.2 |
| float32 | cholesky_solve | 16.0 | 16.0 | 17.2 |
| complex64 | left | 32.0 | 32.0 | 34.4 |
| complex64 | right | 32.0 | 32.0 | 66.4 |
| complex64 | cholesky_solve | 32.0 | 32.0 | 38.0 |

Test Plan:

```
python3 -m pytest test/test_ops.py -k "(triangular_solve or cholesky_solve or cholesky or linalg_solve or lu_solve or linalg_inv) and mps" -q
python3 -m pytest test/test_linalg.py -k mps -q
python3 -m pytest test/test_mps.py -k "triangular or cholesky or solve" -q
```

Plus an out-of-tree sweep of 960 configurations over dtype x shape x batch x {upper, left, unitriangular, conj}, covering both the blocked and direct paths and asserting that neither input is mutated, and the transpose/adjoint paths reached through triangular_solve and cholesky_solve. Metal API and GPU validation are clean.

Authored with the assistance of Claude (Anthropic).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>