### PR TITLE
Fix learning rate calculations in nested SequentiaLR scheduler

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -871,6 +871,61 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs=2)
         self.opt = old_opt
 
+    def test_nested_sequentiallr_does_not_skip_an_epoch(self):
+        """A nested SequentialLR runs the same schedule as it does on its own."""
+        epochs = 8
+        # The first five values are exactly what the inner scheduler produces
+        # when it is used directly: two epochs of ConstantLR, then ExponentialLR
+        # from its epoch 0. Nesting must not consume one of those epochs.
+        inner_targets = [0.5, 0.5, 1.0, 0.9, 0.81]
+        outer_targets = [1.0, 1.0, 0.5]
+        single_targets = inner_targets + outer_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        inner = SequentialLR(
+            self.opt,
+            schedulers=[
+                ConstantLR(self.opt, factor=0.5, total_iters=2),
+                ExponentialLR(self.opt, gamma=0.9),
+            ],
+            milestones=[2],
+        )
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
+            milestones=[5],
+        )
+        self._test(scheduler, targets, epochs)
+
+    def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
+        """A nested ChainedScheduler runs the same schedule as it does on its own."""
+        epochs = 8
+        # The first five values are exactly what the chained scheduler produces
+        # when it is used directly: ConstantLR and ExponentialLR both scaling
+        # the lr from its epoch 0. Nesting must not apply either of them twice.
+        inner_targets = [0.5, 0.45, 0.81, 0.729, 0.6561]
+        outer_targets = [1.0, 1.0, 0.5]
+        single_targets = inner_targets + outer_targets
+        targets = [
+            [0.05 * x for x in single_targets],
+            [0.5 * x for x in single_targets],
+        ]
+        inner = ChainedScheduler(
+            [
+                ConstantLR(self.opt, factor=0.5, total_iters=2),
+                ExponentialLR(self.opt, gamma=0.9),
+            ],
+            optimizer=self.opt,
+        )
+        scheduler = SequentialLR(
+            self.opt,
+            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
+            milestones=[5],
+        )
+        self._test(scheduler, targets, epochs)
+
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [
             LinearLR(self.opt, start_factor=0.4, total_iters=3),

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -880,62 +880,51 @@ class TestLRScheduler(TestCase):
         return lrs
 
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
+        def make_scheduler(optimizer):
+            """Construct the SequentialLR used at both nesting depths."""
+            return SequentialLR(
+                optimizer,
+                [
+                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ConstantLR(optimizer, factor=0.2, total_iters=10),
+                ],
+                milestones=[2],
+            )
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
-            [
-                SequentialLR(
-                    two_level_optimizer,
-                    [
-                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
-                        ConstantLR(two_level_optimizer, factor=0.2, total_iters=10),
-                    ],
-                    milestones=[2],
-                ),
-            ],
+            [make_scheduler(two_level_optimizer)],
             milestones=[],
         )
 
         one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        # Same schedule as above, with one composite level instead of two.
-        one_level_scheduler = SequentialLR(
-            one_level_optimizer,
-            [
-                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
-                ConstantLR(one_level_optimizer, factor=0.2, total_iters=10),
-            ],
-            milestones=[2],
-        )
+        one_level_scheduler = make_scheduler(one_level_optimizer)
 
         two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
+        def make_scheduler(optimizer):
+            """Construct the ChainedScheduler used at both nesting depths."""
+            return ChainedScheduler(
+                [
+                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ExponentialLR(optimizer, gamma=0.9),
+                ],
+                optimizer=optimizer,
+            )
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
-            [
-                ChainedScheduler(
-                    [
-                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
-                        ExponentialLR(two_level_optimizer, gamma=0.9),
-                    ],
-                    optimizer=two_level_optimizer,
-                ),
-            ],
+            [make_scheduler(two_level_optimizer)],
             milestones=[],
         )
 
         one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        # Same schedule as above, with one composite level instead of two.
-        one_level_scheduler = ChainedScheduler(
-            [
-                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
-                ExponentialLR(one_level_optimizer, gamma=0.9),
-            ],
-            optimizer=one_level_optimizer,
-        )
+        one_level_scheduler = make_scheduler(one_level_optimizer)
 
         two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -871,60 +871,73 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs=2)
         self.opt = old_opt
 
+    def _get_lrs(self, scheduler):
+        lrs = []
+        for _ in range(5):
+            lrs.append(scheduler.get_last_lr())
+            scheduler.optimizer.step()
+            scheduler.step()
+        return lrs
+
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
-        """A nested SequentialLR runs the same schedule as it does on its own."""
-        epochs = 8
-        # The first five values are exactly what the inner scheduler produces
-        # when it is used directly: two epochs of ConstantLR, then ExponentialLR
-        # from its epoch 0. Nesting must not consume one of those epochs.
-        inner_targets = [0.5, 0.5, 1.0, 0.9, 0.81]
-        outer_targets = [1.0, 1.0, 0.5]
-        single_targets = inner_targets + outer_targets
-        targets = [
-            [0.05 * x for x in single_targets],
-            [0.5 * x for x in single_targets],
-        ]
-        inner = SequentialLR(
-            self.opt,
-            schedulers=[
-                ConstantLR(self.opt, factor=0.5, total_iters=2),
-                ExponentialLR(self.opt, gamma=0.9),
+        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        nested_scheduler = SequentialLR(
+            nested_optimizer,
+            [
+                SequentialLR(
+                    nested_optimizer,
+                    [
+                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
+                        ConstantLR(nested_optimizer, factor=0.2, total_iters=10),
+                    ],
+                    milestones=[2],
+                ),
+            ],
+            milestones=[],
+        )
+
+        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        standalone_scheduler = SequentialLR(
+            standalone_optimizer,
+            [
+                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
+                ConstantLR(standalone_optimizer, factor=0.2, total_iters=10),
             ],
             milestones=[2],
         )
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
-            milestones=[5],
-        )
-        self._test(scheduler, targets, epochs)
+
+        nested_lrs = self._get_lrs(nested_scheduler)
+        standalone_lrs = self._get_lrs(standalone_scheduler)
+        self.assertEqual(nested_lrs, standalone_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
-        """A nested ChainedScheduler runs the same schedule as it does on its own."""
-        epochs = 8
-        # The first five values are exactly what the chained scheduler produces
-        # when it is used directly: ConstantLR and ExponentialLR both scaling
-        # the lr from its epoch 0. Nesting must not apply either of them twice.
-        inner_targets = [0.5, 0.45, 0.81, 0.729, 0.6561]
-        outer_targets = [1.0, 1.0, 0.5]
-        single_targets = inner_targets + outer_targets
-        targets = [
-            [0.05 * x for x in single_targets],
-            [0.5 * x for x in single_targets],
-        ]
-        inner = ChainedScheduler(
+        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        nested_scheduler = SequentialLR(
+            nested_optimizer,
             [
-                ConstantLR(self.opt, factor=0.5, total_iters=2),
-                ExponentialLR(self.opt, gamma=0.9),
+                ChainedScheduler(
+                    [
+                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
+                        ExponentialLR(nested_optimizer, gamma=0.9),
+                    ],
+                    optimizer=nested_optimizer,
+                ),
             ],
-            optimizer=self.opt,
+            milestones=[],
         )
-        scheduler = SequentialLR(
-            self.opt,
-            schedulers=[inner, StepLR(self.opt, step_size=2, gamma=0.5)],
-            milestones=[5],
+
+        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        standalone_scheduler = ChainedScheduler(
+            [
+                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
+                ExponentialLR(standalone_optimizer, gamma=0.9),
+            ],
+            optimizer=standalone_optimizer,
         )
-        self._test(scheduler, targets, epochs)
+
+        nested_lrs = self._get_lrs(nested_scheduler)
+        standalone_lrs = self._get_lrs(standalone_scheduler)
+        self.assertEqual(nested_lrs, standalone_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -891,6 +891,9 @@ class TestLRScheduler(TestCase):
                 milestones=[2],
             )
 
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        one_level_scheduler = make_scheduler(one_level_optimizer)
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
@@ -898,11 +901,8 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        one_level_scheduler = make_scheduler(one_level_optimizer)
-
-        two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
@@ -916,6 +916,9 @@ class TestLRScheduler(TestCase):
                 optimizer=optimizer,
             )
 
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        one_level_scheduler = make_scheduler(one_level_optimizer)
+
         two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
         two_level_scheduler = SequentialLR(
             two_level_optimizer,
@@ -923,11 +926,8 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        one_level_scheduler = make_scheduler(one_level_optimizer)
-
-        two_level_lrs = self._get_lrs(two_level_scheduler)
         one_level_lrs = self._get_lrs(one_level_scheduler)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
         self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -880,15 +880,15 @@ class TestLRScheduler(TestCase):
         return lrs
 
     def test_nested_sequentiallr_does_not_skip_an_epoch(self):
-        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        nested_scheduler = SequentialLR(
-            nested_optimizer,
+        two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        two_level_scheduler = SequentialLR(
+            two_level_optimizer,
             [
                 SequentialLR(
-                    nested_optimizer,
+                    two_level_optimizer,
                     [
-                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
-                        ConstantLR(nested_optimizer, factor=0.2, total_iters=10),
+                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
+                        ConstantLR(two_level_optimizer, factor=0.2, total_iters=10),
                     ],
                     milestones=[2],
                 ),
@@ -896,48 +896,50 @@ class TestLRScheduler(TestCase):
             milestones=[],
         )
 
-        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        standalone_scheduler = SequentialLR(
-            standalone_optimizer,
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        # Same schedule as above, with one composite level instead of two.
+        one_level_scheduler = SequentialLR(
+            one_level_optimizer,
             [
-                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
-                ConstantLR(standalone_optimizer, factor=0.2, total_iters=10),
+                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
+                ConstantLR(one_level_optimizer, factor=0.2, total_iters=10),
             ],
             milestones=[2],
         )
 
-        nested_lrs = self._get_lrs(nested_scheduler)
-        standalone_lrs = self._get_lrs(standalone_scheduler)
-        self.assertEqual(nested_lrs, standalone_lrs)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
+        one_level_lrs = self._get_lrs(one_level_scheduler)
+        self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_nested_chained_scheduler_does_not_skip_an_epoch(self):
-        nested_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        nested_scheduler = SequentialLR(
-            nested_optimizer,
+        two_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        two_level_scheduler = SequentialLR(
+            two_level_optimizer,
             [
                 ChainedScheduler(
                     [
-                        ConstantLR(nested_optimizer, factor=0.5, total_iters=2),
-                        ExponentialLR(nested_optimizer, gamma=0.9),
+                        ConstantLR(two_level_optimizer, factor=0.5, total_iters=2),
+                        ExponentialLR(two_level_optimizer, gamma=0.9),
                     ],
-                    optimizer=nested_optimizer,
+                    optimizer=two_level_optimizer,
                 ),
             ],
             milestones=[],
         )
 
-        standalone_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
-        standalone_scheduler = ChainedScheduler(
+        one_level_optimizer = SGD([Parameter(torch.zeros(1))], lr=0.1)
+        # Same schedule as above, with one composite level instead of two.
+        one_level_scheduler = ChainedScheduler(
             [
-                ConstantLR(standalone_optimizer, factor=0.5, total_iters=2),
-                ExponentialLR(standalone_optimizer, gamma=0.9),
+                ConstantLR(one_level_optimizer, factor=0.5, total_iters=2),
+                ExponentialLR(one_level_optimizer, gamma=0.9),
             ],
-            optimizer=standalone_optimizer,
+            optimizer=one_level_optimizer,
         )
 
-        nested_lrs = self._get_lrs(nested_scheduler)
-        standalone_lrs = self._get_lrs(standalone_scheduler)
-        self.assertEqual(nested_lrs, standalone_lrs)
+        two_level_lrs = self._get_lrs(two_level_scheduler)
+        one_level_lrs = self._get_lrs(one_level_scheduler)
+        self.assertEqual(two_level_lrs, one_level_lrs)
 
     def test_chained_lr2_get_last_lr_before_step(self):
         schedulers = [

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -885,8 +885,8 @@ class TestLRScheduler(TestCase):
             return SequentialLR(
                 optimizer,
                 [
-                    ConstantLR(optimizer, factor=0.5, total_iters=2),
-                    ConstantLR(optimizer, factor=0.2, total_iters=10),
+                    ConstantLR(optimizer, factor=0.2),
+                    ConstantLR(optimizer, factor=0.5),
                 ],
                 milestones=[2],
             )
@@ -910,7 +910,7 @@ class TestLRScheduler(TestCase):
             """Construct the ChainedScheduler used at both nesting depths."""
             return ChainedScheduler(
                 [
-                    ConstantLR(optimizer, factor=0.5, total_iters=2),
+                    ConstantLR(optimizer, factor=0.5),
                     ExponentialLR(optimizer, gamma=0.9),
                 ],
                 optimizer=optimizer,

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1165,10 +1165,13 @@ class SequentialLR(LRScheduler):
         self.recursive_undo()
 
         # Perform the initial step for only the scheduler meant to run at step 0.
+        self._initial_step()
+
+    def _initial_step(self) -> None:
         idx = bisect_right(self._milestones, 0)
         self._schedulers[idx]._initial_step()
 
-        self._last_lr = schedulers[idx].get_last_lr()
+        self._last_lr = self._schedulers[idx].get_last_lr()
 
     def recursive_undo(self, sched=None) -> None:
         """
@@ -1534,6 +1537,17 @@ class ChainedScheduler(LRScheduler):
                 )
         self._schedulers = schedulers
         self.optimizer = optimizer
+        # Unlike the other schedulers, this does not end with
+        # `self._initial_step()`: every scheduler in `schedulers` already took
+        # its own initial step when it was constructed, and those compose into
+        # the chained learning rate. Calling it here would apply each factor a
+        # second time. `_initial_step` is for an enclosing composite scheduler
+        # to call once it has undone those constructor steps.
+        self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
+
+    def _initial_step(self) -> None:
+        for scheduler in self._schedulers:
+            scheduler._initial_step()
         self._last_lr = _param_groups_val_list(self._schedulers[-1].optimizer, "lr")
 
     def step(self) -> None:  # type: ignore[override]


### PR DESCRIPTION
Fixes #196243

Video overview to hopefully save you some time and hassle reviewing the PR: https://youtu.be/XEuD-306PjU

Wrapping a `SequentialLR` or `ChainedScheduler` in another `SequentialLR` advances the wrapped scheduler during construction. This changes its learning rates even when the outer scheduler has only one child and no milestones, and therefore should behave as a transparent wrapper.

The extra step also emits a warning that `lr_scheduler.step()` was called before `optimizer.step()`, although the user has not called either method.

The tables compare the same composite scheduler at one and two nesting levels.

`SequentialLR`:

|                            | Epoch 0 | Epoch 1  | Epoch 2 | Epoch 3 | Epoch 4 |
|----------------------------|---------|----------|---------|---------|---------|
| One level                  | 0.02    | 0.02     | 0.05    | 0.05    | 0.05    |
| Two levels before this fix | 0.02    | **0.05** | 0.05    | 0.05    | 0.05    |
| Two levels after this fix  | 0.02    | 0.02     | 0.05    | 0.05    | 0.05    |

`ChainedScheduler`:

|                            | Epoch 0   | Epoch 1    | Epoch 2     | Epoch 3      | Epoch 4      |
|----------------------------|-----------|------------|-------------|--------------|--------------|
| One level                  | 0.05      | 0.045      | 0.0405      | 0.03645      | 0.032805     |
| Two levels before this fix | **0.045** | **0.0405** | **0.03645** | **0.032805** | **0.059049** |
| Two levels after this fix  | 0.05      | 0.045      | 0.0405      | 0.03645      | 0.032805     |

For `SequentialLR`, the extra initialization step makes the wrapped scheduler reach its milestone one user step early. For `ChainedScheduler`, it performs a normal chained step during construction; in the tested schedule, this applies `ExponentialLR`'s decay at epoch 0.

The cause is `SequentialLR.__init__` calling `_initial_step()` on its active scheduler. Both composite schedulers inherit `LRScheduler._initial_step()`, which calls `self.step()`. That initializes a leaf scheduler, but advances a composite scheduler's children. `SequentialLR.recursive_undo()` cannot compensate because it only adjusts the leaf schedulers' `last_epoch` values.

## The fix

Give both composite schedulers an `_initial_step()` implementation that initializes their state without advancing the schedule:

- `SequentialLR._initial_step()` contains the initialization that was previously inline at the end of its constructor. Its constructor and an enclosing `SequentialLR` can now use the same operation.
- `ChainedScheduler._initial_step()` initializes each child scheduler. Its constructor does not call this method because its children have already performed their initial steps when they were constructed.

Schedulers used without this additional nesting level are unchanged. Code that nests either composite scheduler in a `SequentialLR` will now receive the same schedule as the equivalent one-level scheduler.

## Test plan

The two regression tests construct the same composite scheduler with fresh optimizers at one and two nesting levels, collect five learning rates from each, and assert that the complete schedules are equal. Both tests fail on `main` and pass with this change.

```
python test/test_optim.py -k test_nested_sequentiallr_does_not_skip_an_epoch
python test/test_optim.py -k test_nested_chained_scheduler_does_not_skip_an_epoch
```

The full `TestLRScheduler` suite passes: 194 tests, with one expected failure.

Sample code can be found on https://github.com/pupeno/pytorch-workspace/tree/main/196242_nested_lr_scheduler_initial_step
