### PR TITLE
Sort/reverse c10::List<T> out of place instead of via its proxy iterator

### DIFF
--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -2000,8 +2000,12 @@ class ShapePropagator : public PropertyPropBase {
             /*const_inputs=*/{attr::dim, attr::keepdim})) {
       auto& tp = tensor_types.at(0);
       auto sizes = tp->sizes().concrete_sizes().value();
-      auto dims = node->get<c10::List<int64_t>>(attr::dim).value();
+      auto dims_list = node->get<c10::List<int64_t>>(attr::dim).value();
       bool keepdim = node->get<bool>(attr::keepdim).value();
+      // Materialized rather than reversed in place: List<T>'s iterator
+      // dereferences to a proxy, which some standard library ranges::reverse
+      // implementations (MSVC's, notably) refuse to accept as random-access.
+      std::vector<int64_t> dims = dims_list.vec();
       std::ranges::reverse(dims);
       for (int64_t dim : dims) {
         SHAPE_ASSERT(dim >= 0 && static_cast<size_t>(dim) < sizes.size());

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -71,24 +71,31 @@ template <>
 void listSort<at::Tensor>(Stack& stack) {
   bool reverse = pop(stack).toBool();
   c10::List<at::Tensor> list = pop(stack).toTensorList();
+  // Sorted out-of-place and written back through set(): List<T>'s iterator
+  // dereferences to a proxy, which some standard library ranges::sort
+  // implementations (MSVC's, notably) refuse to accept as random-access.
+  std::vector<at::Tensor> elements = list.vec();
   std::ranges::sort(
-      list, [reverse](const at::Tensor& a, const at::Tensor& b) -> bool {
+      elements, [reverse](const at::Tensor& a, const at::Tensor& b) -> bool {
         // "strict weak ordering" issue - see other sort
         if (a.getIntrusivePtr() == b.getIntrusivePtr()) {
           return false;
         }
         return (at::native::is_nonzero(a.lt(b))) ^ reverse;
       });
+  for (const auto i : c10::irange(elements.size())) {
+    list.set(i, std::move(elements[i]));
+  }
 }
 
 template <>
 void listCopyAndSort<at::Tensor>(Stack& stack) {
   c10::List<at::Tensor> list = pop(stack).toTensorList();
-  auto list_copied = list.copy();
-  std::ranges::sort(list_copied, [](const at::Tensor& a, const at::Tensor& b) {
+  std::vector<at::Tensor> elements = list.vec();
+  std::ranges::sort(elements, [](const at::Tensor& a, const at::Tensor& b) {
     return at::native::is_nonzero(a.lt(b));
   });
-  push(stack, list_copied);
+  push(stack, c10::List<at::Tensor>(elements));
 }
 
 template <>
@@ -187,7 +194,13 @@ void listAppend(Stack& stack) {
 void listReverse(Stack& stack) {
   c10::List<IValue> list = pop(stack).to<c10::List<IValue>>();
 
-  std::ranges::reverse(list);
+  // See the comment in listSort<at::Tensor>: List<T>'s iterator dereferences
+  // to a proxy, which some ranges implementations refuse as random-access.
+  std::vector<IValue> elements = list.vec();
+  std::ranges::reverse(elements);
+  for (const auto i : c10::irange(elements.size())) {
+    list.set(i, std::move(elements[i]));
+  }
 }
 
 void listPopImpl(Stack& stack, const char* empty_message) {

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -352,7 +352,11 @@ template <typename T>
 void listSort(Stack& stack) {
   bool reverse = pop(stack).toBool();
   c10::List<T> list = pop(stack).to<c10::List<T>>();
-  std::ranges::sort(list, [reverse](const T& a, const T& b) {
+  // Sorted out-of-place and written back through set(): List<T>'s iterator
+  // dereferences to a proxy, which some standard library ranges::sort
+  // implementations (MSVC's, notably) refuse to accept as random-access.
+  std::vector<T> elements = list.vec();
+  std::ranges::sort(elements, [reverse](const T& a, const T& b) {
     // FBCode errors without this check - "strict weak ordering"
     // TODO: remove when possible, since it just slows down
     // sorting and doesn't do anything useful
@@ -361,6 +365,9 @@ void listSort(Stack& stack) {
     }
     return (a < b) != reverse;
   });
+  for (const auto i : c10::irange(elements.size())) {
+    list.set(i, std::move(elements[i]));
+  }
 }
 
 // Specialization for at::Tensor
@@ -370,15 +377,15 @@ void listSort<at::Tensor>(Stack& stack);
 template <typename T>
 void listCopyAndSort(Stack& stack) {
   c10::List<T> list = pop(stack).to<c10::List<T>>();
-  auto list_copied = list.copy();
-  std::ranges::sort(list_copied, [](const T& a, const T& b) {
+  std::vector<T> elements = list.vec();
+  std::ranges::sort(elements, [](const T& a, const T& b) {
     // "strict weak ordering" issue - see other sort
     if (a == b) {
       return false;
     }
     return a < b;
   });
-  push(stack, list_copied);
+  push(stack, c10::List<T>(elements));
 }
 
 // Specialization for at::Tensor

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -171,7 +171,14 @@ void sort_op(Stack& stack) {
     } else {
       comparator = c10::getLessThanComparator(g_list.get(0));
     }
-    std::ranges::sort(g_list, comparator);
+    // Sorted out-of-place and written back through set(): List<T>'s iterator
+    // dereferences to a proxy, which some standard library ranges::sort
+    // implementations (MSVC's, notably) refuse to accept as random-access.
+    std::vector<IValue> elements = g_list.vec();
+    std::ranges::sort(elements, comparator);
+    for (const auto i : c10::irange(elements.size())) {
+      g_list.set(i, std::move(elements[i]));
+    }
   }
 
   if (copy_return_list) {
@@ -2575,7 +2582,15 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs1{
           } else {
             int64_t index = 0;
             auto iter = size.begin();
-            std::ranges::sort(axes);
+            // Sorted out-of-place and written back through set(): List<T>'s
+            // iterator dereferences to a proxy, which some standard library
+            // ranges::sort implementations (MSVC's, notably) refuse to
+            // accept as random-access.
+            std::vector<int64_t> sorted_axes = axes.vec();
+            std::ranges::sort(sorted_axes);
+            for (const auto i : c10::irange(sorted_axes.size())) {
+              axes.set(i, sorted_axes[i]);
+            }
             for (const auto& axis : axes) {
               // move iter to the next axis
               iter += axis - index;


### PR DESCRIPTION
std::ranges::sort/reverse called directly on a c10::List<T> dispatch random-access algorithms against an iterator whose reference type is a proxy (ListElementReference), not T&. GCC 16's libstdc++ accepts this; MSVC's STL doesn't -- its indirectly_readable check fails on common_reference_with<ListElementReference&&, T&>, breaking every one of the 8 call sites #196002 converted to std::ranges::sort/reverse (register_ops_utils.{h,cpp}, register_prim_ops.cpp, shape_analysis.cpp), as reported on a downstream Windows ARM64 build in #196002's comments.

Fixes all 8 by materializing into a plain std::vector<T> (via the existing List<T>::vec()), sorting/reversing that with real, non-proxy iterators, and writing the result back through set() where the mutation has to be visible in place (listSort, listReverse, sort_op, the ReductionSizes axes sort). listCopyAndSort and shape_analysis's dims don't need the write-back: the former already returns a fresh list built from the sorted vector directly, and the latter's dims is a local, unaliased copy only ever iterated afterward.

Test Plan:

No MSVC available here. Verified the vec()+set() round-trip's semantics (genuine in-place mutation visible through an alias, reverse, and that copy-and-sort leaves the original untouched) against the real List.h header with a standalone GCC 16 compile. CI covers the actual MSVC ARM64 configuration that reported this.

This PR was authored with the assistance of an AI coding assistant.