### PR TITLE
Give ListElementReference a basic_common_reference so List<T>'s iterator satisfies indirectly_readable everywhere

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -267,14 +267,15 @@ struct basic_common_reference<
 };
 } // namespace std
 
-namespace c10 {
-namespace impl {
+namespace c10::impl {
 
 template<class T> List<T> toTypedList(List<IValue> list);
 template<class T> List<IValue> toList(List<T>&& list);
 template<class T> List<IValue> toList(const List<T>& list);
 const IValue* ptr_to_first_element(const List<IValue>& list);
-}
+} // namespace c10::impl
+
+namespace c10 {
 
 /**
  * An object of this class stores a list of values of type T.

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -233,10 +233,8 @@ private:
 } // namespace impl
 } // namespace c10
 
-// Lets indirectly_readable's common_reference_with<ListElementReference&&,
-// T&> hold consistently instead of depending on each stdlib's own fallback
-// for the pair: MSVC's STL doesn't accept it (see #196002, #196245), while
-// libstdc++ and libc++ happen to.
+// MSVC's STL, unlike libstdc++/libc++, needs this to satisfy
+// indirectly_readable's common_reference_with check (#196002, #196245).
 namespace std {
 template <
     class T,

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -11,6 +11,7 @@
 #include <compare>
 #include <iterator>
 #include <optional>
+#include <type_traits>
 #include <vector>
 
 namespace at {
@@ -228,6 +229,48 @@ private:
   friend class ListIterator<T, typename c10::detail::ListImpl::list_type::iterator>;
   friend class List<T>;
 };
+
+} // namespace impl
+} // namespace c10
+
+// Lets indirectly_readable's common_reference_with<ListElementReference&&,
+// T&> hold consistently instead of depending on each stdlib's own fallback
+// for the pair: MSVC's STL doesn't accept it (see #196002, #196245), while
+// libstdc++ and libc++ happen to.
+namespace std {
+template <
+    class T,
+    class Iterator,
+    template <class>
+    class TQual,
+    template <class>
+    class UQual>
+struct basic_common_reference<
+    T,
+    c10::impl::ListElementReference<T, Iterator>,
+    TQual,
+    UQual> {
+  using type = T;
+};
+
+template <
+    class T,
+    class Iterator,
+    template <class>
+    class TQual,
+    template <class>
+    class UQual>
+struct basic_common_reference<
+    c10::impl::ListElementReference<T, Iterator>,
+    T,
+    TQual,
+    UQual> {
+  using type = T;
+};
+} // namespace std
+
+namespace c10 {
+namespace impl {
 
 template<class T> List<T> toTypedList(List<IValue> list);
 template<class T> List<IValue> toList(List<T>&& list);

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/jit_type_base.h>
 #include <ATen/core/ivalue.h>
+#include <type_traits>
 
 namespace c10 {
 
@@ -364,3 +365,47 @@ void List<T>::unsafeSetElementType(TypePtr t) {
 }
 
 }
+
+// ListElementReference converts to T (or const T&), but the two are
+// otherwise-unrelated types, so std::common_reference's "simple common
+// reference" rule (same type up to cv/ref-qualification) never applies to
+// the pair, and indirectly_readable requires
+// common_reference_with<ListElementReference&&, T&> (among others) to hold.
+// Some standard libraries' fallback for that case tries the proxy's
+// conversion operator through a conditional-expression-like check and
+// succeeds; others don't. basic_common_reference is the standard's sanctioned
+// extension point for exactly this situation, and is checked before that
+// fallback, so it makes the outcome the same everywhere: a value common
+// reference is always obtainable (the proxy can materialize a T), just not a
+// real reference to one, so T is what this resolves to.
+namespace std {
+template <
+    class T,
+    class Iterator,
+    template <class>
+    class TQual,
+    template <class>
+    class UQual>
+struct basic_common_reference<
+    T,
+    c10::impl::ListElementReference<T, Iterator>,
+    TQual,
+    UQual> {
+  using type = T;
+};
+
+template <
+    class T,
+    class Iterator,
+    template <class>
+    class TQual,
+    template <class>
+    class UQual>
+struct basic_common_reference<
+    c10::impl::ListElementReference<T, Iterator>,
+    T,
+    TQual,
+    UQual> {
+  using type = T;
+};
+} // namespace std

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -2,7 +2,6 @@
 
 #include <ATen/core/jit_type_base.h>
 #include <ATen/core/ivalue.h>
-#include <type_traits>
 
 namespace c10 {
 
@@ -365,37 +364,3 @@ void List<T>::unsafeSetElementType(TypePtr t) {
 }
 
 }
-
-// Lets indirectly_readable's common_reference_with<ListElementReference&&,
-// T&> hold consistently, instead of depending on each stdlib's own fallback.
-namespace std {
-template <
-    class T,
-    class Iterator,
-    template <class>
-    class TQual,
-    template <class>
-    class UQual>
-struct basic_common_reference<
-    T,
-    c10::impl::ListElementReference<T, Iterator>,
-    TQual,
-    UQual> {
-  using type = T;
-};
-
-template <
-    class T,
-    class Iterator,
-    template <class>
-    class TQual,
-    template <class>
-    class UQual>
-struct basic_common_reference<
-    c10::impl::ListElementReference<T, Iterator>,
-    T,
-    TQual,
-    UQual> {
-  using type = T;
-};
-} // namespace std

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -366,11 +366,8 @@ void List<T>::unsafeSetElementType(TypePtr t) {
 
 }
 
-// ListElementReference and T are unrelated types, so common_reference's
-// "simple common reference" rule never applies; indirectly_readable needs
-// common_reference_with<ListElementReference&&, T&>, which some standard
-// libraries' fallback satisfies via the proxy's conversion operator and
-// others don't. This specialization makes the outcome the same everywhere.
+// Lets indirectly_readable's common_reference_with<ListElementReference&&,
+// T&> hold consistently, instead of depending on each stdlib's own fallback.
 namespace std {
 template <
     class T,

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -366,18 +366,11 @@ void List<T>::unsafeSetElementType(TypePtr t) {
 
 }
 
-// ListElementReference converts to T (or const T&), but the two are
-// otherwise-unrelated types, so std::common_reference's "simple common
-// reference" rule (same type up to cv/ref-qualification) never applies to
-// the pair, and indirectly_readable requires
-// common_reference_with<ListElementReference&&, T&> (among others) to hold.
-// Some standard libraries' fallback for that case tries the proxy's
-// conversion operator through a conditional-expression-like check and
-// succeeds; others don't. basic_common_reference is the standard's sanctioned
-// extension point for exactly this situation, and is checked before that
-// fallback, so it makes the outcome the same everywhere: a value common
-// reference is always obtainable (the proxy can materialize a T), just not a
-// real reference to one, so T is what this resolves to.
+// ListElementReference and T are unrelated types, so common_reference's
+// "simple common reference" rule never applies; indirectly_readable needs
+// common_reference_with<ListElementReference&&, T&>, which some standard
+// libraries' fallback satisfies via the proxy's conversion operator and
+// others don't. This specialization makes the outcome the same everywhere.
 namespace std {
 template <
     class T,

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -22,15 +22,9 @@ static_assert(list_iterators_conform<
               at::Tensor,
               std::optional<std::string>>);
 
-// The random_access_iterator check above alone doesn't prove the
-// basic_common_reference specialization in List.h is doing anything: on
-// libstdc++/libc++, common_reference_t<ListElementReference&&, T&> already
-// resolves to T via the stdlib's own fallback, specialization or not. Only
-// MSVC's STL lacks that fallback (see #196002, #196245), which this
-// translation unit can't exercise -- but instantiating the specialization's
-// ::type directly does verify it exists and is well-formed: the primary
-// basic_common_reference template has no ::type member, so this fails to
-// compile if the specialization is ever removed.
+// The random_access_iterator check above passes via a stdlib fallback on
+// libstdc++/libc++ even without the specialization; this instantiates
+// basic_common_reference's ::type directly so removing it fails to compile.
 template <class T>
 using ListRef =
     c10::impl::ListElementReference<T, c10::detail::ListImpl::list_type::iterator>;

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -21,6 +21,43 @@ static_assert(list_iterators_conform<
               int64_t,
               at::Tensor,
               std::optional<std::string>>);
+
+// The random_access_iterator check above alone doesn't prove the
+// basic_common_reference specialization in List.h is doing anything: on
+// libstdc++/libc++, common_reference_t<ListElementReference&&, T&> already
+// resolves to T via the stdlib's own fallback, specialization or not. Only
+// MSVC's STL lacks that fallback (see #196002, #196245), which this
+// translation unit can't exercise -- but instantiating the specialization's
+// ::type directly does verify it exists and is well-formed: the primary
+// basic_common_reference template has no ::type member, so this fails to
+// compile if the specialization is ever removed.
+template <class T>
+using ListRef =
+    c10::impl::ListElementReference<T, c10::detail::ListImpl::list_type::iterator>;
+
+template <class... Ts>
+constexpr bool list_element_reference_has_basic_common_reference =
+    ((std::is_same_v<
+          typename std::basic_common_reference<
+              Ts,
+              ListRef<Ts>,
+              std::type_identity_t,
+              std::type_identity_t>::type,
+          Ts> &&
+      std::is_same_v<
+          typename std::basic_common_reference<
+              ListRef<Ts>,
+              Ts,
+              std::type_identity_t,
+              std::type_identity_t>::type,
+          Ts>) &&
+     ...);
+
+static_assert(list_element_reference_has_basic_common_reference<
+              c10::IValue,
+              int64_t,
+              at::Tensor,
+              std::optional<std::string>>);
 } // namespace
 
 using std::string;


### PR DESCRIPTION
ListElementReference and T are unrelated types, so common_reference's "simple common reference" rule never applies to the pair, and whether indirectly_readable's common_reference_with<ListElementReference&&, T&> holds falls to each stdlib's own fallback (a conditional-expression check against the proxy's conversion operator). libstdc++ and libc++ both accept that; MSVC's STL doesn't, so std::ranges::sort/reverse called directly on a c10::List<T> fails to compile there -- reported on a downstream Windows ARM64 build in #196002's comments.

Fixes the root cause with a basic_common_reference specialization (the standard's extension point for this, checked before that fallback) instead of routing the 8 affected call sites around it.

Test Plan:

No MSVC available here. static_assert'd indirectly_readable and random_access_iterator (plus that common_reference_t resolves to T) for T = int64_t, at::Tensor, IValue, std::string, and that std::ranges::sort/reverse compile directly on a c10::List<T> again, against both GCC 16/libstdc++ and Clang/libc++.

Real MSVC confirmation still needed -- the ciflow/win-arm64 label triggers the job that reported this.

This PR was authored with the assistance of an AI coding assistant.