### PR TITLE
[Testcase Refactoring] Decouple ShardedTensorChunked test class from hardcoded CUDA with dynamic backend resolution (3/4)

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -40,6 +40,11 @@ from torch.distributed._shard.sharding_spec import (
     ShardMetadata,
 )
 from torch.distributed.remote_device import _remote_device
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
@@ -47,6 +52,7 @@ from torch.testing._internal.common_distributed import (
     tp_transports,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     skipIfRocm,
@@ -460,17 +466,19 @@ class TestLocalTensor(ShardedTensorTestBase):
 
 
 class TestShardedTensorChunked(ShardedTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_sharded_tensor_metadata(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_sharded_tensor_metadata(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
@@ -512,16 +520,16 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skipIfRocm
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_complete_world_size(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_complete_world_size(self, device):
         for dim in [0, -2]:
             spec = ChunkShardingSpec(
                 dim=dim,
                 placements=[
-                    "rank:0/cuda:0",
-                    "rank:1/cuda:1",
-                    "rank:2/cuda:2",
-                    "rank:3/cuda:3",
+                    f"rank:0/{self.device_type}:0",
+                    f"rank:1/{self.device_type}:1",
+                    f"rank:2/{self.device_type}:2",
+                    f"rank:3/{self.device_type}:3",
                 ],
             )
             st = sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
@@ -530,7 +538,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             local_shards = st.local_shards()
             self.assertEqual(1, len(local_shards))
             local_shard = local_shards[0].tensor
-            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+            self.assertEqual(
+                torch.device(self.device_type, self.rank), local_shard.device
+            )
             if self.rank == 3:
                 self.assertEqual((1, 20), local_shard.size())
             else:
@@ -548,7 +558,8 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 else:
                     self.assertEqual([3, 20], shard_metadata.shard_sizes)
                 self.assertEqual(
-                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                    f"rank:{rank}/{self.device_type}:{rank}",
+                    str(shard_metadata.placement),
                 )
 
             # Validate remote shards.
@@ -561,7 +572,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                     self.assertEqual(rpc_rank, remote_shard.owner().id)
                     shard = remote_shard.to_here()
                     self.assertEqual(
-                        f"rank:{rpc_rank}/cuda:{rpc_rank}",
+                        f"rank:{rpc_rank}/{self.device_type}:{rpc_rank}",
                         str(shard.metadata.placement),
                     )
                     if rpc_rank == 3:
@@ -571,17 +582,17 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_create_sharded_tensor_with_ones(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_create_sharded_tensor_with_ones(self, device):
         """Test sharded_tensor.ones(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         h, w = 10, 20
@@ -591,7 +602,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(1, len(local_shards))
         local_shard = local_shards[0].tensor
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+        self.assertEqual(torch.device(self.device_type, self.rank), local_shard.device)
         # The split: for rank!=3 ceil(h/4)=3  for rank=3 1
         expected_h = 1 if self.rank == 3 else math.ceil(h / 4)
         self.assertEqual((expected_h, w), local_shard.size())
@@ -599,17 +610,17 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_gather_even(self) -> None:
+    @requires_capabilities(Capability.distributed.backend)
+    def test_gather_even(self, device) -> None:
         """Test _sharded_tensor.gather(...) with evenly distributed._shards"""
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         h, w = 10, 20
@@ -621,7 +632,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             full_tensor = torch.zeros(
                 h,
                 w,
-                device=torch.device(f"cuda:{dst}"),
+                device=torch.device(self.device_type, dst),
             )
         st.gather(dst, full_tensor)
 
@@ -632,18 +643,18 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_gather_uneven(self) -> None:
+    @requires_capabilities(Capability.distributed.backend)
+    def test_gather_uneven(self, device) -> None:
         """Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
+                f"rank:0/{self.device_type}:0",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
             ],
         )
         h, w = 10, 20
@@ -655,7 +666,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             full_tensor = torch.zeros(
                 h,
                 w,
-                device=torch.device(f"cuda:{dst}"),
+                device=torch.device(self.device_type, dst),
             )
         st.gather(dst, full_tensor)
 
@@ -666,17 +677,17 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_create_sharded_tensor_with_zeros(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_create_sharded_tensor_with_zeros(self, device):
         """Test sharded_tensor.zeros(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         h, w = 10, 20
@@ -686,7 +697,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(1, len(local_shards))
         local_shard = local_shards[0].tensor
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+        self.assertEqual(torch.device(self.device_type, self.rank), local_shard.device)
         # The split: for rank!=3 ceil(h/4)=3  for rank=3 1
         expected_h = 1 if self.rank == 3 else math.ceil(h / 4)
         self.assertEqual((expected_h, w), local_shard.size())
@@ -694,24 +705,24 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_create_sharded_tensor_with_rand(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_create_sharded_tensor_with_rand(self, device):
         """Test sharded_tensor.rand(...)/randn(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         h, w = 8, 2
         seed = 1234
 
         expected_h = 2
-        expected_device = torch.device(f"cuda:{self.rank}")
+        expected_device = torch.device(self.device_type, self.rank)
         dtype = torch.double
         torch.manual_seed(seed)
         # Test sharded_tensor.rand creation
@@ -745,17 +756,17 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_create_sharded_tensor_with_full(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_create_sharded_tensor_with_full(self, device):
         """Test sharded_tensor.full(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         h, w = 10, 20
@@ -768,7 +779,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(1, len(local_shards))
         local_shard = local_shards[0].tensor
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+        self.assertEqual(torch.device(self.device_type, self.rank), local_shard.device)
         # The split: for rank!=3 ceil(h/4)=3  for rank=3 1
         expected_h = 1 if self.rank == 3 else math.ceil(h / 4)
         self.assertEqual((expected_h, w), local_shard.size())
@@ -779,24 +790,24 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_create_sharded_tensor_like(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_create_sharded_tensor_like(self, device):
         """Test tensor like methods, i.e. torch.zeros_like(...), torch.full_like, etc."""
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         h, w = 8, 8
         expected_h = 2
         seed = 1234
         dtype = torch.double
-        expected_device = torch.device(f"cuda:{self.rank}")
+        expected_device = torch.device(self.device_type, self.rank)
         st = sharded_tensor.rand(spec, (h, w), dtype=dtype)
         tensor_like_ops = {
             torch.zeros_like: torch.zeros,
@@ -833,13 +844,13 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skipIfRocm
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_partial_world_size(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_partial_world_size(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         st = sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
@@ -849,7 +860,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         if self.rank >= 2:
             self.assertEqual(1, len(local_shards))
             local_shard = local_shards[0].tensor
-            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+            self.assertEqual(
+                torch.device(self.device_type, self.rank), local_shard.device
+            )
             self.assertEqual((5, 20), local_shard.size())
         else:
             self.assertEqual(0, len(local_shards))
@@ -863,7 +876,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             self.assertEqual([shard_rank * 5, 0], shard_metadata.shard_offsets)
             self.assertEqual([5, 20], shard_metadata.shard_sizes)
             self.assertEqual(
-                f"rank:{shard_rank + 2}/cuda:{shard_rank + 2}",
+                f"rank:{shard_rank + 2}/{self.device_type}:{shard_rank + 2}",
                 str(shard_metadata.placement),
             )
 
@@ -880,20 +893,21 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
                 shard = remote_shard.to_here()
                 self.assertEqual(
-                    f"rank:{rpc_rank}/cuda:{rpc_rank}", str(shard.metadata.placement)
+                    f"rank:{rpc_rank}/{self.device_type}:{rpc_rank}",
+                    str(shard.metadata.placement),
                 )
                 self.assertEqual((5, 20), shard.tensor.size())
 
     @skipIfRocm
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_new_group(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_new_group(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
@@ -905,7 +919,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         if self.rank >= 2:
             self.assertEqual(1, len(local_shards))
             local_shard = local_shards[0].tensor
-            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+            self.assertEqual(
+                torch.device(self.device_type, self.rank), local_shard.device
+            )
             self.assertEqual((5, 20), local_shard.size())
         else:
             self.assertEqual(0, len(local_shards))
@@ -919,7 +935,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             self.assertEqual([shard_rank * 5, 0], shard_metadata.shard_offsets)
             self.assertEqual([5, 20], shard_metadata.shard_sizes)
             self.assertEqual(
-                f"rank:{shard_rank + 2}/cuda:{shard_rank + 2}",
+                f"rank:{shard_rank + 2}/{self.device_type}:{shard_rank + 2}",
                 str(shard_metadata.placement),
             )
 
@@ -936,26 +952,27 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
                 self.assertEqual(
-                    f"rank:{rpc_rank}/cuda:{rpc_rank}", str(shard.metadata.placement)
+                    f"rank:{rpc_rank}/{self.device_type}:{rpc_rank}",
+                    str(shard.metadata.placement),
                 )
                 self.assertEqual((5, 20), shard.tensor.size())
 
     @skipIfRocm
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_multiple_local_shards(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_multiple_local_shards(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         st = sharded_tensor.empty(spec, 16, 20, init_rrefs=True)
@@ -965,7 +982,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual(2, len(local_shards))
         for local_shard in local_shards:
             self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+                torch.device(self.device_type, self.rank), local_shard.tensor.device
             )
             self.assertEqual((2, 20), local_shard.tensor.size())
 
@@ -978,7 +995,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             self.assertEqual([shard_idx * 2, 0], shard_metadata.shard_offsets)
             self.assertEqual([2, 20], shard_metadata.shard_sizes)
             self.assertEqual(
-                f"rank:{shard_idx % 4}/cuda:{shard_idx % 4}",
+                f"rank:{shard_idx % 4}/{self.device_type}:{shard_idx % 4}",
                 str(shard_metadata.placement),
             )
 
@@ -993,18 +1010,18 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
 
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_sharding_columns(self):
-        self.init_pg()
+    @requires_capabilities(Capability.distributed.backend)
+    def test_sharding_columns(self, device):
+        self.init_pg(backend=self.backend)
 
         for dim in [1, -1]:
             spec = ChunkShardingSpec(
                 dim=dim,
                 placements=[
-                    "rank:0/cuda:0",
-                    "rank:1/cuda:1",
-                    "rank:2/cuda:2",
-                    "rank:3/cuda:3",
+                    f"rank:0/{self.device_type}:0",
+                    f"rank:1/{self.device_type}:1",
+                    f"rank:2/{self.device_type}:2",
+                    f"rank:3/{self.device_type}:3",
                 ],
             )
 
@@ -1014,7 +1031,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             local_shards = st.local_shards()
             self.assertEqual(1, len(local_shards))
             local_shard = local_shards[0].tensor
-            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+            self.assertEqual(
+                torch.device(self.device_type, self.rank), local_shard.device
+            )
             self.assertEqual((10, 8), local_shard.size())
 
             # Validate global metadata.
@@ -1026,32 +1045,37 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 self.assertEqual([0, rank * 8], shard_metadata.shard_offsets)
                 self.assertEqual([10, 8], shard_metadata.shard_sizes)
                 self.assertEqual(
-                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                    f"rank:{rank}/{self.device_type}:{rank}",
+                    str(shard_metadata.placement),
                 )
 
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_invalid_sharding(self):
-        self.init_pg()
+    @requires_capabilities(Capability.distributed.backend)
+    def test_invalid_sharding(self, device):
+        self.init_pg(backend=self.backend)
 
         with self.assertRaisesRegex(
             NotImplementedError, "does not support named dimension"
         ):
-            spec = ChunkShardingSpec(dim="H", placements=["rank:1/cuda:1"])
+            spec = ChunkShardingSpec(
+                dim="H", placements=[f"rank:1/{self.device_type}:1"]
+            )
             sharded_tensor.empty(spec, 10, 20)
 
         for dim in [2, 3, 4, -3, -4, -5]:
-            spec = ChunkShardingSpec(dim=dim, placements=["rank:1/cuda:1"])
+            spec = ChunkShardingSpec(
+                dim=dim, placements=[f"rank:1/{self.device_type}:1"]
+            )
             with self.assertRaisesRegex(ValueError, "Invalid sharding dim"):
                 sharded_tensor.empty(spec, 10, 20)
 
-        spec = ChunkShardingSpec(dim=0, placements=["rank:5/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"rank:5/{self.device_type}:1"])
         with self.assertRaisesRegex(
             ValueError, "Global rank 5 does not exist in input process group"
         ):
             sharded_tensor.empty(spec, 10, 20)
 
-        spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"rank:0/{self.device_type}:1"])
         st = sharded_tensor.empty(spec, 10, 20)
         tensor = torch.empty(10, 20)
         with self.assertRaisesRegex(
@@ -1059,26 +1083,26 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         ):
             torch.add(st, tensor)
 
-        spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"rank:0/{self.device_type}:1"])
         with self.assertRaisesRegex(
             ValueError, "Only torch.strided layout is currently supported"
         ):
             sharded_tensor.empty(spec, 10, 20, layout=torch.sparse_coo)
 
-        spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"rank:0/{self.device_type}:1"])
         with self.assertRaisesRegex(
             ValueError,
             "Only torch.contiguous_format memory_format is currently supported",
         ):
             sharded_tensor.empty(spec, 10, 20, memory_format=torch.channels_last)
 
-        spec = ChunkShardingSpec(dim=0, placements=["worker0/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"worker0/{self.device_type}:1"])
         with self.assertRaisesRegex(
             RuntimeError, "RPC framework needs to be initialized"
         ):
             sharded_tensor.empty(spec, 10, 20)
 
-        spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"rank:0/{self.device_type}:1"])
         with self.assertRaisesRegex(
             RuntimeError, "RPC Framework needs to be initialized"
         ):
@@ -1091,14 +1115,14 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             st.remote_shards()
 
         self.init_rpc()
-        spec = ChunkShardingSpec(dim=0, placements=["workerfoo/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"workerfoo/{self.device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Invalid worker name"):
             sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_invalid_pg_rpc_ranks(self):
-        self.init_pg()
+    @requires_capabilities(Capability.distributed.backend)
+    def test_invalid_pg_rpc_ranks(self, device):
+        self.init_pg(backend=self.backend)
 
         # Init RPC with different ranks.
         rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
@@ -1113,24 +1137,24 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             rpc_backend_options=rpc_backend_options,
         )
 
-        spec = ChunkShardingSpec(dim=0, placements=["rank:1/cuda:1"])
+        spec = ChunkShardingSpec(dim=0, placements=[f"rank:1/{self.device_type}:1"])
         with self.assertRaisesRegex(
             ValueError, "Default ProcessGroup and RPC ranks must be the same"
         ):
             sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_insufficient_sharding_dims(self):
-        self.init_pg()
+    @requires_capabilities(Capability.distributed.backend)
+    def test_insufficient_sharding_dims(self, device):
+        self.init_pg(backend=self.backend)
 
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
         st = sharded_tensor.empty(spec, 2, 20)
@@ -1140,12 +1164,16 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         if self.rank <= 1:
             self.assertEqual(1, len(local_shards))
             local_shard = local_shards[0].tensor
-            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+            self.assertEqual(
+                torch.device(self.device_type, self.rank), local_shard.device
+            )
             self.assertEqual((1, 20), local_shard.size())
         else:
             self.assertEqual(1, len(local_shards))
             local_shard = local_shards[0].tensor
-            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.device)
+            self.assertEqual(
+                torch.device(self.device_type, self.rank), local_shard.device
+            )
             self.assertEqual(local_shard.numel(), 0)
 
         # Validate global metadata.
@@ -1156,7 +1184,8 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_rank, 0], shard_metadata.shard_offsets)
             self.assertEqual(
-                f"rank:{shard_rank}/cuda:{shard_rank}", str(shard_metadata.placement)
+                f"rank:{shard_rank}/{self.device_type}:{shard_rank}",
+                str(shard_metadata.placement),
             )
             if shard_rank <= 1:
                 self.assertEqual([1, 20], shard_metadata.shard_sizes)
@@ -1165,15 +1194,15 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_sharded_tensor_sizes(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_sharded_tensor_sizes(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
@@ -1220,15 +1249,15 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_state_dict(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_state_dict(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
@@ -1266,15 +1295,15 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_state_dict_new_group(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_state_dict_new_group(self, device):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:2/cuda:0",
-                "rank:3/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:2/{self.device_type}:0",
+                f"rank:3/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
@@ -1307,8 +1336,8 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_state_dict_no_sharded_tensors(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_state_dict_no_sharded_tensors(self, device):
         # Verify hooks don't affect modules with no ShardedTensors.
         m = torch.nn.Linear(10, 10)
 
@@ -1332,12 +1361,12 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual(m.bias, module_load.bias)
 
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_load_state_dict_errors(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_load_state_dict_errors(self, device):
         self.init_rpc()
 
         dist.init_process_group(
-            backend="nccl",
+            backend=self.backend,
             world_size=self.world_size,
             rank=self.rank,
             init_method=f"file://{self.file_name}",
@@ -1346,10 +1375,10 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
-                "rank:1/cuda:1",
-                "rank:2/cuda:2",
-                "rank:3/cuda:3",
+                f"rank:0/{self.device_type}:0",
+                f"rank:1/{self.device_type}:1",
+                f"rank:2/{self.device_type}:2",
+                f"rank:3/{self.device_type}:3",
             ],
         )
 
@@ -1387,16 +1416,16 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
     @with_comms
     @skip_if_lt_x_gpu(4)
-    @requires_nccl()
-    def test_cleanup(self):
+    @requires_capabilities(Capability.distributed.backend)
+    def test_cleanup(self, device):
         def create_tensors():
             spec = ChunkShardingSpec(
                 dim=0,
                 placements=[
-                    "rank:0/cuda:0",
-                    "rank:1/cuda:1",
-                    "rank:2/cuda:2",
-                    "rank:3/cuda:3",
+                    f"rank:0/{self.device_type}:0",
+                    f"rank:1/{self.device_type}:1",
+                    f"rank:2/{self.device_type}:2",
+                    f"rank:3/{self.device_type}:3",
                 ],
             )
             sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
@@ -3530,6 +3559,11 @@ class TestCreateTensorNoProcessGroupMode(TestCase):
             local_shards=st_local_shards,
             sharded_tensor_metadata=st_metadata,
         )
+
+
+instantiate_device_type_tests(
+    TestShardedTensorChunked, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Third batch of the test-class-by-test-class decoupling series for
`test/distributed/_shard/sharded_tensor/test_sharded_tensor.py` (each batch
based on main, independently verifiable and mergeable). This batch covers
`TestShardedTensorChunked` — the largest test class (22 methods), which also
carries the file's only manual process-group setups and the only hardcoded
`backend="nccl"` parameter.

For the covered class this PR:

- Replaces all hardcoded CUDA with `self.device_type` (injected per device
  variant by `instantiate_device_type_tests`).
- Switches all `@requires_nccl()` to
  `@requires_capabilities(Capability.distributed.backend)`.
- Resolves the backend dynamically:
  - 4 manual `self.init_pg()` calls → `self.init_pg(backend=self.backend)`
    (`test_sharding_columns`, `test_invalid_sharding`,
    `test_invalid_pg_rpc_ranks`, `test_insufficient_sharding_dims`).
  - `@with_comms(..., backend="nccl")` in `test_load_state_dict_errors` →
    `backend=self.backend`.
- Adds `hw_classification` (ACCELERATOR) and registers the class with
  `instantiate_device_type_tests(..., except_for="cpu", allow_xpu=True)`.

The other 13 classes are untouched in this PR.

This is part of the test case refactoring initiative (#185590).

## Changes

- **TestShardedTensorChunked** (22 methods):
  - All CUDA device strings → `self.device_type`.
  - All `@requires_nccl()` → `@requires_capabilities(Capability.distributed.backend)`.
  - All test methods gain a `device` parameter.
  - 4 manual `self.init_pg()` → `self.init_pg(backend=self.backend)` — these
    methods do not use `@with_comms`, so the backend must be resolved
    explicitly via the `ShardedTensorTestBase.backend` property (common PR
    #194992), which resolves to the accelerator's native backend.
  - `test_load_state_dict_errors`: `backend="nccl"` → `backend=self.backend`.
- **File-level**: 1 `instantiate_device_type_tests(..., except_for="cpu",
  allow_xpu=True)` call appended; imports add `Capability`,
  `requires_capabilities`, `instantiate_device_type_tests`,
  `HardwareClassification` (legacy imports kept — other classes still use
  them in their own batches).

## Depends on

- **#187650**: `skip_if_lt_x_gpu` hardware-agnostic refactoring.
- **#190991**: `HardwareClassification` enum.
- **#191919**: `Capability` class + `requires_capabilities` decorator.
- **#193080**: `PrivateUse1TestBase._capabilities()` override.
- **#194992**: `ShardedTensorTestBase.backend` property and `with_comms`
  dynamic backend resolution (with the `getattr(self, "device_type", None)`
  fallback).

Batches of this series touch the same file — merging in batch order 1→4
keeps conflicts trivial.

## Not changed

- The other 13 classes — byte-identical to the original, verified zero diff.
- `@with_comms` / `@skip_if_lt_x_gpu` / method control flow — unchanged
  (only backend resolution and device references generalized).

## Test plan

- CUDA (A100): 74 tests, 74 passed, no regression.
- NPU (Ascend 910B3, 4 cards): Chunked's 22 methods executed as NPU
  variants. Expected: 4 known tensorpipe RPC failures
  (`test_complete_world_size`, `test_multiple_local_shards`, `test_new_group`,
  `test_partial_world_size`); the 4 manual-init_pg methods
  (`test_sharding_columns`, `test_invalid_sharding`,
  `test_invalid_pg_rpc_ranks`, `test_insufficient_sharding_dims`) must PASS
  (verifies `self.init_pg(backend=self.backend)` resolves hccl on NPU).
  Exact numbers to be filled after measurement.
- CPU: 5 GENERIC passed; Chunked CPU variants excluded by `except_for="cpu"`.