### PR TITLE
[Elastic] Fix UnboundLocalError on socket creation failure in find_free_port

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -8,10 +8,11 @@
 import os
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -20,6 +21,28 @@ if os.getenv("CIRCLECI"):
 
 
 class EtcdServerTest(unittest.TestCase):
+    @mock.patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_find_free_port_socket_creation_failure(self, mock_socket):
+        mock_socket.side_effect = OSError("socket creation failed")
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to create a socket"):
+            find_free_port()
+
+    @mock.patch("torch.distributed.elastic.rendezvous.etcd_server.socket.getaddrinfo")
+    @mock.patch("torch.distributed.elastic.rendezvous.etcd_server.socket.socket")
+    def test_find_free_port_fallback(self, mock_socket, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+            (10, 1, 6, "", ("::1", 0)),
+        ]
+        s2 = mock.MagicMock()
+        mock_socket.side_effect = [OSError("socket failed"), s2]
+
+        sock = find_free_port()
+        self.assertEqual(sock, s2)
+        s2.bind.assert_called_once_with(("localhost", 0))
+        s2.listen.assert_called_once_with(0)
+
     def test_etcd_server_start_stop(self):
         server = EtcdServer()
         server.start()

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
Fixes #191395.

### Summary
`find_free_port()` in `torch.distributed.elastic.rendezvous.etcd_server` called `s.close()` in its `except OSError` block without guaranteeing that `s` was assigned. If `socket.socket()` raised an `OSError` on the first address family, `s` was unbound, causing `UnboundLocalError` and masking the underlying socket error.

### Fix
Initialize `s = None` prior to socket creation and check `if s is not None:` before calling `s.close()`.

### Test Plan
Added unit tests in `test/distributed/elastic/rendezvous/etcd_server_test.py`:
1. `test_find_free_port_socket_creation_failure`: verifies that when socket creation fails on all attempts, a `RuntimeError` is raised without raising `UnboundLocalError`.
2. `test_find_free_port_fallback`: verifies that when the first address family socket creation fails with `OSError`, the function safely tries subsequent addresses and succeeds.