### PR TITLE
[Distributed] Preserve _op_index across save and load in MemoryTracker

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,5 +1,8 @@
 # Owner(s): ["oncall: distributed"]
+import contextlib
+import io
 import os
+import pickle
 import unittest
 
 import torch
@@ -10,6 +13,51 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class TestMemoryTracker(TestCase):
     @unittest.skipIf(not torch.accelerator.is_available(), "no accelerator")
+    def test_save_load_restores_op_index(self):
+        tracker = MemoryTracker()
+        tracker.memories_allocated = {0: ("op", 1.0), 1: ("op", 2.0)}
+        tracker.memories_active = {0: ("op", 1.0), 1: ("op", 2.0)}
+        tracker.memories_reserved = {0: ("op", 1.0), 1: ("op", 2.0)}
+        tracker._op_index = 2
+
+        path = "memory_test.trace"
+        try:
+            tracker.save_stats(path)
+            loaded = MemoryTracker()
+            loaded.load(path)
+
+            self.assertEqual(loaded._op_index, tracker._op_index)
+            self.assertEqual(loaded.memories_allocated, tracker.memories_allocated)
+            with contextlib.redirect_stdout(io.StringIO()) as output:
+                loaded.summary()
+            self.assertIn("op: 1.0MB", output.getvalue())
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_load_legacy_stats_reconstructs_op_index(self):
+        tracker = MemoryTracker()
+        tracker.memories_allocated = {0: ("op", 1.0), 1: ("op", 2.0)}
+        tracker.memories_active = {0: ("op", 1.0), 1: ("op", 2.0)}
+        tracker.memories_reserved = {0: ("op", 1.0), 1: ("op", 2.0)}
+
+        path = "memory_legacy.trace"
+        try:
+            tracker.save_stats(path)
+            with open(path, "rb") as file:
+                stats = pickle.load(file)
+            stats.pop("op_index")
+            with open(path, "wb") as file:
+                pickle.dump(stats, file, pickle.HIGHEST_PROTOCOL)
+
+            loaded = MemoryTracker()
+            loaded.load(path)
+
+            self.assertEqual(loaded._op_index, len(loaded.memories_allocated))
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
     def test_local_model(self):
         """
         Minimal test case to check the memory tracker can collect the expected

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -211,6 +211,7 @@ class MemoryTracker:
             "memories_active": self.memories_active,
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
+            "op_index": self._op_index,
             "num_alloc_retries": self._num_alloc_retries,
         }
 
@@ -226,6 +227,9 @@ class MemoryTracker:
         self.memories_active = stats["memories_active"]
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
+        self._op_index = stats.get(
+            "op_index", max(self.memories_allocated, default=-1) + 1
+        )
         self._num_alloc_retries = stats["num_alloc_retries"]
 
     def _create_pre_forward_hook(self, name: str) -> Callable:


### PR DESCRIPTION
### Summary
When serializing stats in `torch.distributed._tools.memory_tracker.MemoryTracker.save_stats()`, `op_index` was excluded from the saved dictionary. When loading the trace back using `load()`, `_op_index` was reset to 0, causing subsequent tracked operations to overwrite existing entries in `memories_allocated`.

### Fix
- Include `op_index` in the dictionary exported by `save_stats()`.
- Restore `_op_index` in `load()`, with fallback to `max(self.memories_allocated, default=-1) + 1` for legacy trace files.

### Test Plan
Added unit tests in `test/distributed/_tools/test_memory_tracker.py`:
1. `test_save_load_restores_op_index`: verifies `_op_index` and memory dicts are preserved after `save_stats` and `load`.
2. `test_load_legacy_stats_reconstructs_op_index`: verifies legacy traces without `op_index` correctly reconstruct `_op_index` from allocated entries.