### PR TITLE
Filter globally valid kwargs when formatting invalid argument errors

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -737,6 +737,18 @@ class TestReductions(TestCase):
                            [0, 1, 1],
                            [1, 1, 1]], device=device, dtype=torch.uint8))
 
+    def test_invalid_keyword_error_lists_only_unknown_keywords(self, device):
+        x = torch.randn(3, 3, device=device)
+        with self.assertRaises(TypeError) as context:
+            torch.mean(x, dims=(0, 1), keepdim=True)
+        incorrect_keyword_lines = [
+            line
+            for line in str(context.exception).splitlines()
+            if "some of the keywords were incorrect:" in line
+        ]
+        self.assertEqual(len(incorrect_keyword_lines), 1)
+        self.assertTrue(incorrect_keyword_lines[0].rstrip().endswith(": dims"))
+
     def test_numpy_named_args(self, device):
         x1 = torch.randn(10, device=device)
         x2 = torch.randn(10, device=device)

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace torch {
 
@@ -394,6 +395,7 @@ std::string format_invalid_args(
     std::vector<std::string> unmatched_kwargs;
     if (has_kwargs)
       unmatched_kwargs = _tryMatchKwargs(option, kwargs);
+
     if (!unmatched_kwargs.empty()) {
       error_msg += "got unrecognized keyword arguments: ";
       for (auto& kwarg : unmatched_kwargs)
@@ -410,6 +412,13 @@ std::string format_invalid_args(
       error_msg += option_str;
     }
   } else {
+    std::unordered_set<std::string> globally_valid_kwargs;
+    for (const auto& option_str : options) {
+      auto pair = _parseOption(option_str, kwargs);
+      for (const auto& argument : pair.first.arguments)
+        globally_valid_kwargs.insert(argument.name);
+    }
+
     error_msg += "got ";
     error_msg += _argDesc(args, kwargs);
     error_msg += ", but expected one of:\n";
@@ -422,8 +431,24 @@ std::string format_invalid_args(
       error_msg += '\n';
       if (_argcountMatch(option, args, kwargs)) {
         std::vector<std::string> unmatched_kwargs;
-        if (has_kwargs)
+        if (has_kwargs) {
           unmatched_kwargs = _tryMatchKwargs(option, kwargs);
+          unmatched_kwargs.erase(
+              std::remove_if(
+                  unmatched_kwargs.begin(),
+                  unmatched_kwargs.end(),
+                  [&option, &globally_valid_kwargs](const std::string& kwarg) {
+                    const bool defined_in_option = std::any_of(
+                        option.arguments.begin(),
+                        option.arguments.end(),
+                        [&kwarg](const Argument& argument) {
+                          return argument.name == kwarg;
+                        });
+                    return !defined_in_option &&
+                        globally_valid_kwargs.count(kwarg) > 0;
+                  }),
+              unmatched_kwargs.end());
+        }
         if (!unmatched_kwargs.empty()) {
           error_msg +=
               "      didn't match because some of the keywords were incorrect: ";


### PR DESCRIPTION
Fixes #87031.

### Summary
When C++ function overload resolution fails in `format_invalid_args()`, candidate signature options printed "some of the keywords were incorrect: <kwarg>" even when `<kwarg>` was valid for another candidate signature option (e.g. `dims` vs `dim`).

### Fix
Collect `globally_valid_kwargs` across all candidate overload options and exclude them from candidate-specific unrecognized keyword reports so that only truly unrecognized keywords are flagged as incorrect for that overload option.

### Test Plan
Added `test_invalid_keyword_error_lists_only_unknown_keywords` in `test/test_reductions.py` verifying that invalid keyword error formatting omits keywords valid in alternate overload signatures.