### PR TITLE
[Inductor] Make pad_mm device-agnostic instead of cuda/xpu-only

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -1,20 +1,26 @@
 # Owner(s): ["module: inductor"]
 import unittest
+from types import SimpleNamespace
 
 import torch
 import torch._inductor.config as inductor_config
 from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import counters
+from torch._inductor import utils as inductor_utils
 from torch._inductor.fx_passes.pad_mm import (
+    _pad_mm_trace_device,
     can_pad,
+    check_device,
     get_alignment_size,
     get_pad_cache,
     get_padded_length,
+    is_mm_compute_bound,
     should_pad_mm_bf16,
 )
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache, is_big_gpu, run_and_get_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU_AND_TRITON
 
 
@@ -716,6 +722,141 @@ class PadMMTest(TestCase):
         compiled = torch.compile(fn)(x, y)
         self.assertEqual(compiled, expected)
         self.assertEqual(compiled.stride(), expected.stride())
+
+
+class PadMMDeviceAgnosticTest(TestCase):
+    """
+    The pad decisions in pad_mm must key off the device of the tensors being
+    compiled, not off which accelerators happen to be visible to the process.
+    These cases run anywhere, including on CPU-only machines.
+    """
+
+    hw_classification = HardwareClassification.GENERIC
+
+    # Mirrors test_pad_mm_bf16: bf16, K > M, K > N, N odd and K above the pad
+    # threshold, so the only thing left to decide is the device.
+    M, K, N = 2, 15691904, 13
+    PAD_OPTIONS = {"pad_aten_mm_pass": {"k_threshold_to_pad": 8388608}}
+
+    def test_check_device_accepts_any_accelerator(self):
+        # check_device only reads `.device.type`, so these stand-ins keep the
+        # accelerator cases free of hardware.
+        def tensor_on(device_type):
+            return SimpleNamespace(device=SimpleNamespace(type=device_type))
+
+        for device_type in ("cuda", "xpu", "npu", "privateuseone"):
+            same_device = check_device(tensor_on(device_type), tensor_on(device_type))
+            self.assertTrue(same_device, f"{device_type} tensors should be paddable")
+        self.assertFalse(check_device(tensor_on("cuda"), tensor_on("cpu")))
+        self.assertFalse(check_device(tensor_on("npu"), tensor_on("cuda")))
+
+        # Real tensors: cpu never pads, and neither does the meta device that
+        # pattern-matcher inputs carry.
+        self.assertFalse(check_device(torch.empty(4, 4), torch.empty(4, 4)))
+        meta = torch.empty(4, 4, device="meta")
+        self.assertFalse(check_device(meta, meta))
+
+    @inductor_config.patch(post_grad_fusion_options=PAD_OPTIONS)
+    def test_should_pad_mm_bf16_asks_only_the_compiled_device(self):
+        args = (torch.bfloat16, self.M, self.N, self.K)
+        with (
+            unittest.mock.patch(
+                "torch.cuda.get_device_capability", return_value=(8, 0)
+            ) as cuda_cap,
+            unittest.mock.patch("torch.xpu.is_available", return_value=True) as xpu_ok,
+        ):
+            self.assertTrue(should_pad_mm_bf16(*args, device_type="cuda"))
+            self.assertEqual(cuda_cap.call_count, 1)
+            self.assertEqual(xpu_ok.call_count, 0)
+            # xpu answers from the device table; every other accelerator takes
+            # the default of "this regression was never seen here".
+            self.assertTrue(should_pad_mm_bf16(*args, device_type="xpu"))
+            self.assertFalse(should_pad_mm_bf16(*args, device_type="npu"))
+            self.assertFalse(should_pad_mm_bf16(*args, device_type="privateuseone"))
+            self.assertEqual(cuda_cap.call_count, 1)
+            self.assertEqual(xpu_ok.call_count, 0)
+
+    @inductor_config.patch(post_grad_fusion_options=PAD_OPTIONS)
+    def test_should_pad_mm_bf16_skips_pad_on_hopper(self):
+        args = (torch.bfloat16, self.M, self.N, self.K)
+        with unittest.mock.patch(
+            "torch.cuda.get_device_capability", return_value=(9, 0)
+        ):
+            self.assertFalse(should_pad_mm_bf16(*args, device_type="cuda"))
+
+    @inductor_config.patch(post_grad_fusion_options=PAD_OPTIONS)
+    def test_should_pad_mm_bf16_defaults_to_process_wide_probe(self):
+        # Callers with no device to ask (e.g. test_pad_mm_bf16) keep the
+        # historical behavior of probing every accelerator in the process.
+        args = (torch.bfloat16, self.M, self.N, self.K)
+        xpu_available = "torch.xpu.is_available"
+        cuda_capability = "torch.cuda.get_device_capability"
+        with (
+            unittest.mock.patch(cuda_capability, return_value=(9, 0)) as cuda_cap,
+            unittest.mock.patch(xpu_available, return_value=True) as xpu_ok,
+        ):
+            self.assertTrue(should_pad_mm_bf16(*args))
+        self.assertEqual(cuda_cap.call_count, 0)
+        self.assertEqual(xpu_ok.call_count, 1)
+
+    def test_is_mm_compute_bound_bf16_large_k_is_device_specific(self):
+        # These rates make the shape bandwidth bound, so a True can only come
+        # from the device-specific bf16 large-K override.
+        args = (self.M, self.K, self.N, torch.bfloat16)
+        tflops = unittest.mock.patch.object(
+            inductor_utils, "get_device_tflops", return_value=100.0
+        )
+        gbps = unittest.mock.patch.object(
+            inductor_utils, "get_gpu_dram_gbps", return_value=2000.0
+        )
+        with tflops, gbps:
+            with unittest.mock.patch(
+                "torch.cuda.get_device_capability", return_value=(8, 0)
+            ) as cuda_cap:
+                self.assertTrue(is_mm_compute_bound(*args, device_type="cuda"))
+                self.assertFalse(is_mm_compute_bound(*args, device_type="npu"))
+                self.assertEqual(cuda_cap.call_count, 1)
+            with unittest.mock.patch(
+                "torch.cuda.get_device_capability", return_value=(9, 0)
+            ):
+                self.assertFalse(is_mm_compute_bound(*args, device_type="cuda"))
+            with unittest.mock.patch(
+                "torch.xpu.is_available", return_value=True
+            ) as xpu_ok:
+                self.assertTrue(is_mm_compute_bound(*args, device_type="xpu"))
+                self.assertFalse(is_mm_compute_bound(*args, device_type="npu"))
+                self.assertEqual(xpu_ok.call_count, 0)
+
+    def test_pad_mm_trace_device_uses_default_accelerator(self):
+        # current_accelerator() is patched throughout for determinism: on a GPU
+        # machine it answers cuda before the probe chain gets a turn.
+        accelerator = "torch.accelerator.current_accelerator"
+        none = unittest.mock.patch(accelerator, return_value=None)
+        # torch.device("npu") needs torch_npu loaded, so ask about the generic
+        # PrivateUse1 name instead; only the device type is read here.
+        with unittest.mock.patch(
+            accelerator, return_value=torch.device("privateuseone")
+        ):
+            self.assertEqual(_pad_mm_trace_device(), "privateuseone")
+
+        with (
+            none,
+            unittest.mock.patch("torch.cuda.is_available", return_value=True),
+            unittest.mock.patch("torch.xpu.is_available", return_value=True),
+        ):
+            self.assertEqual(_pad_mm_trace_device(), "cuda")
+        with (
+            none,
+            unittest.mock.patch("torch.cuda.is_available", return_value=False),
+            unittest.mock.patch("torch.xpu.is_available", return_value=True),
+        ):
+            self.assertEqual(_pad_mm_trace_device(), "xpu")
+        with (
+            none,
+            unittest.mock.patch("torch.cuda.is_available", return_value=False),
+            unittest.mock.patch("torch.xpu.is_available", return_value=False),
+        ):
+            self.assertEqual(_pad_mm_trace_device(), "cpu")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -78,11 +78,33 @@ def get_alignment_size_dtype(dtype: torch.dtype) -> int:
 
 
 def check_device(a: Tensor, b: Tensor) -> bool:
-    return (a.is_cuda and b.is_cuda) or (a.is_xpu and b.is_xpu)
+    # Any accelerator both operands agree on; cpu and meta can't run the padded
+    # mm. FakeTensor inputs report their target device, so this is the old set
+    # plus every other accelerator, without naming any of them.
+    a_device = a.device.type
+    return a_device == b.device.type and a_device not in ("cpu", "meta")
 
 
 def check_dtype(a: Tensor, b: Tensor) -> bool:
     return a.is_floating_point() and b.is_floating_point()
+
+
+def _bf16_large_k_needs_pad(device_type: str | None = None) -> bool:
+    """
+    Large-K bf16 matmuls regress without padding on XPU and on NVIDIA GPUs
+    older than Hopper (sm90); other accelerators have not shown the regression.
+
+    device_type is the device the matmul is compiled for, so that we only ever
+    probe the hardware we are deciding about. None keeps the historical
+    process-wide probe for callers that have no device to ask.
+    """
+    if device_type is None:
+        return torch.xpu.is_available() or torch.cuda.get_device_capability() < (9, 0)
+    if device_type == "xpu":
+        return True
+    if device_type == "cuda":
+        return torch.cuda.get_device_capability() < (9, 0)
+    return False
 
 
 def hint_symbols(
@@ -287,7 +309,9 @@ def addmm_replace(
     )
 
 
-def is_mm_compute_bound(M: int, K: int, N: int, dtype: torch.dtype) -> bool:
+def is_mm_compute_bound(
+    M: int, K: int, N: int, dtype: torch.dtype, device_type: str | None = None
+) -> bool:
     denominator = M * K + N * K + M * N
     if denominator == 0:
         return False
@@ -298,7 +322,7 @@ def is_mm_compute_bound(M: int, K: int, N: int, dtype: torch.dtype) -> bool:
         dtype is torch.bfloat16
         and K > M
         and K > N
-        and (torch.xpu.is_available() or torch.cuda.get_device_capability() < (9, 0))
+        and _bf16_large_k_needs_pad(device_type)
     ):  # doesn't repro on h100s:
         return True
 
@@ -449,7 +473,9 @@ def is_padded_faster(key: str, ori_time: float, pad_time: float) -> bool:
     return padded_is_faster
 
 
-def should_pad_mm_bf16(dtype: torch.dtype, M: int, N: int, K: int) -> bool:
+def should_pad_mm_bf16(
+    dtype: torch.dtype, M: int, N: int, K: int, device_type: str | None = None
+) -> bool:
     # always force pad for mm with bf16 when the following are satisfied to avoid perf regression
     large_k_threshold_to_pad = torch._inductor.config.post_grad_fusion_options[
         "pad_aten_mm_pass"
@@ -460,7 +486,7 @@ def should_pad_mm_bf16(dtype: torch.dtype, M: int, N: int, K: int) -> bool:
         and K > N
         and N % 2 == 1
         and K >= large_k_threshold_to_pad
-        and (torch.xpu.is_available() or torch.cuda.get_device_capability() < (9, 0))
+        and _bf16_large_k_needs_pad(device_type)
     ):  # doesn't repro on h100s:
         return True
     return False
@@ -545,12 +571,16 @@ def _should_pad(
         # Performance heuristic for bf16 large K scenarios
         if (
             "pad_aten_mm_pass" in torch._inductor.config.post_grad_fusion_options
-            and should_pad_mm_bf16(mat1.dtype, m_concrete, n_concrete, k_concrete)
+            and should_pad_mm_bf16(
+                mat1.dtype, m_concrete, n_concrete, k_concrete, mat1.device.type
+            )
         ):
             return True
 
         # Check if operation is compute bound (performance check)
-        if not is_mm_compute_bound(m_concrete, k_concrete, n_concrete, mat1.dtype):
+        if not is_mm_compute_bound(
+            m_concrete, k_concrete, n_concrete, mat1.dtype, mat1.device.type
+        ):
             return False
 
         # We don't want to look up the cache for cases that are trivially false
@@ -629,7 +659,7 @@ def _should_pad(
 
         if op is torch.ops.aten.addmm:
             input_pad = None
-            if input is not None and (input.is_cuda or input.is_xpu):
+            if input is not None and check_device(input, mat1):
                 input_pad = torch.randn_like(input)
             fns.append(
                 lambda: pad_addmm(
@@ -943,6 +973,24 @@ def bmm_replace(mat1: Tensor, mat2: Tensor) -> Tensor:
     )
 
 
+def _pad_mm_trace_device() -> str:
+    """
+    Device used to trace the example pad_mm patterns when the caller has no
+    device to give us. The default accelerator first, then the historical
+    cuda -> xpu probe, then cpu.
+    """
+    # Tracing these patterns on cpu mis-resolves the beta/alpha relationship,
+    # see https://github.com/pytorch/pytorch/issues/97894.
+    accelerator = torch.accelerator.current_accelerator(check_available=True)
+    if accelerator is not None:
+        return accelerator.type
+    for device_type in ("cuda", "xpu"):
+        module = getattr(torch, device_type, None)
+        if module is not None and module.is_available():
+            return device_type
+    return "cpu"
+
+
 @functools.cache
 def _pad_mm_init(input_device: torch.device | None = None) -> None:
     from .joint_graph import patterns
@@ -950,13 +998,7 @@ def _pad_mm_init(input_device: torch.device | None = None) -> None:
     if input_device:
         device = str(input_device)
     else:
-        if torch.cuda.is_available():
-            # workaround https://github.com/pytorch/pytorch/issues/97894
-            device = "cuda"
-        elif torch.xpu.is_available():
-            device = "xpu"
-        else:
-            device = "cpu"
+        device = _pad_mm_trace_device()
 
     # sizes/values don't actually matter for initial trace
     # once we get a possible match we re-trace with the actual values and verify the match still holds


### PR DESCRIPTION
## Summary

`pad_mm` is the shape-padding pass for `aten.mm/addmm/bmm`. Every device
decision in it is a hard-coded CUDA/XPU check, so an out-of-tree backend
registered via `PrivateUse1` (e.g. NPU) is silently excluded from the pass:
`check_device()` only ever returns True for cuda/xpu, the bf16 large-K
heuristic calls `torch.cuda.get_device_capability()` regardless of which
device it is deciding about, and the benchmark/roofline that decide padding
are read off whatever accelerator the *process* happens to see. The order
matters: relaxing `check_device()` alone would let the heuristics and the
benchmark evaluate a foreign device's numbers, so all the device gates in this
file move together and are made per-operand.

This changes no CUDA/XPU/CPU decision. It makes the same decisions readable for
a device that is not in the name list, and it scopes the Triton gate, the
benchmark timing device, and the roofline lookup to the *operand's* device so
that a host with some other accelerator cannot pad a matmul whose backend cannot
run or time the result.

## Changes

**`torch/utils/_triton.py`** (+38):
- Adds `has_triton_for_device(device_type)`: the same conjunction `has_triton()`
  already applies per interface (package present, `is_available()`,
  `is_triton_capable()`, `raise_if_triton_unavailable()`, the device-detection
  off switch), but scoped to one device instead of "does this process have any
  Triton accelerator". `cpu` is False, mirroring `has_triton()`'s default
  (`include_cpu=True` stays the explicit opt-in). `has_triton()` itself is
  unchanged; unknown/unregistered devices are False. Result is cached for the
  process lifetime, so it is meant to be called after backends are imported.

**`torch/_inductor/fx_passes/pad_mm.py`**:
- `check_device()` compares `a.device.type == b.device.type` and rejects
  cpu/meta, instead of enumerating cuda/xpu.
- `can_pad()` now gates on `has_triton_for_device(mat1.device.type)` rather than
  the process-wide `has_triton()`. So a backend that is not a Triton-capable
  backend for *that device* cannot reach the pass: mps/lazy/xla/hpu on a CUDA
  host are unreachable, and an out-of-tree backend opts in by overriding
  `is_triton_capable()` / `raise_if_triton_unavailable()` on its
  `DeviceInterface` (the same registry the rest of inductor keys off).
- The bf16 large-K / compute-bound heuristics take a **required** `device_type`
  (no silent process-wide probe). `_bf16_large_k_needs_pad` is a device-name
  table by design: it encodes *measured* regressions (XPU, NVIDIA < sm90) and
  defaults every other device, including out-of-tree ones, to "no known
  regression", i.e. heuristics are per-device-explicit; reachability and
  hardware probing are device-agnostic.
- The eager benchmark request now passes `device_type=mat1.device.type` through
  `get_do_bench()`, so the Inductor/TorchProfiler benchmarkers put the L2-flush
  buffer and timing events on the operand device. (TritonBenchmarker ignores the
  kwarg, which is fine now that only backend-built devices reach the benchmark.)
- `is_mm_compute_bound` asks the device-generic roofline helpers
  (`utils.get_device_tflops(dtype, device_type)` /
  `utils.get_device_dram_gbps(device_type)`) about the operand device instead
  of reading the process-wide CUDA numbers, and defers to the measured
  benchmark (`return True`) when either has no roofline info for that device.
  (`torch/_inductor/utils.py` itself is unchanged here: it already gained the
  device-generic TFLOPS/DRAM APIs on main.)
- `_pad_mm_trace_device()` keeps the historical `cuda -> xpu -> cpu` order and
  deliberately does **not** consult `torch.accelerator.current_accelerator()`:
  a backend can register a C++ accelerator hook before its `torch.<name>`
  Python module exists, and the process-wide probe would then raise during
  pattern init (and would silently move the macOS/NPU-host trace device off
  cpu). Pattern tracing is orthogonal to per-operand padding.

**`test/inductor/test_pad_mm.py`**:
- New `PadMMDeviceAgnosticTest` with CPU-runnable cases that call the production
  symbols directly: `can_pad` is asserted to ask about the *operand* device and
  obey the answer; the gate's registry contract (not-capable / missing-backend /
  backend-built / unknown / cpu) is pinned via `register_interface_for_device`;
  the roofline decision is pinned to defer to the measured benchmark when the
  device-generic lookups have no info for the asked device, and to never probe
  another device's capability APIs (`call_count` deltas). Tensors are built
  under `FakeTensorMode` (repo convention) rather than duck-typed stand-ins.
- The module runs `run_tests()` unconditionally; the accelerator requirement is
  now a class-level `@unittest.skipIf(not HAS_GPU_AND_TRITON)` on `PadMMTest`
  (matching `test_op_completeness` / `test_minifier_utils`). Previously the
  module-level guard made the CPU-only CI shard collect zero tests and exit 0,
  so these cases never ran there.

## Notes

- Reachability for out-of-tree backends is now *capability-gated*, not
  name-list-gated: an OOT device reaches the pad pass exactly when its
  `DeviceInterface` declares `is_triton_capable()` and its Triton backend is
  actually built. On this NPU (torch_npu) the interface does not declare the
  capability on master yet (a companion torch_npu change to declare it is in
  review; this PR does not depend on it), so `can_pad` stays False for npu
  tensors until the backend opts in; declaring it flips the gate open
  (verified on 910B4, see Test Plan). No in-tree backend's reachable set
  changes.
- `mtia`: `MtiaInterface.is_triton_capable()` returns True, so an mtia tensor is
  reachable when mtia is the (available, backend-built) operand device. That is
  the intended consequence of the capability model. MTIA owners: this is the
  opt-in surface; the gate asks your declared capability, not a device name.
- The CUDA-eager `beta == 0` quirk guard in `should_pad_addmm`
  (`input.is_cuda`) is deliberately kept: it encodes CUDA-eager behavior, not a
  device identity check.
- Follow-ups (pre-existing, filed here rather than silently fixed): the pad
  benchmark cache key (`should_pad_bench_key`) does not include the device, so
  on a heterogeneous host two same-shape mms on different devices could share a
  decision; and NPU-class devices have no datasheet entries yet, so they take
  the measured-benchmark path until one is added.

## Test Plan

CPU (2.15.0.dev CPU wheel, patched files overlaid):
```bash
python test/inductor/test_pad_mm.py            # Ran 29, OK (skipped=21)  -- new cases actually run now
pytest test/inductor/test_pad_mm.py -q         # 8 passed, 21 skipped, 5 subtests
pytest test/inductor/test_pad_mm.py -k "can_pad_asks or triton_for_device or check_device or is_mm_compute_bound"  # all pass
pytest test/inductor/test_pattern_matcher.py -k serialized_patterns_up_to_date   # 1 passed
ruff check / ruff format --diff on the three files
```
`PadMMTest` (the 20 hardware cases) are skips, not errors, on a CPU shard.

NPU (Ascend 910B4, CANN 9.1.0, torch_npu, triton 3.5.0, patched files overlaid):
```bash
has_triton_for_device("npu")  # False   (torch_npu NpuInterface does not declare is_triton_capable yet)
can_pad(npu 64x13 @ 13x64)    # False   (unreachable until the backend opts in)
# after the DeviceInterface declares is_triton_capable()/raise_if_triton_unavailable():
has_triton_for_device("npu")  # True
can_pad(npu 64x13 @ 13x64)    # True
# end-to-end with the opt-in in place (bf16 64x1025 @ 1025x64, shape_padding=True):
torch.compile(lambda a, b: a @ b)(x, w)   # counters["inductor"]["pad_mm_bench"] == 1
torch.testing.assert_close(r, x @ w, rtol=1e-2, atol=1e-2)   # numerics pass on device
```
The padded-matmul path was exercised on real NPU hardware once the backend
declared the capability (pad benchmark ran, results match eager), confirming
the capability-gated opt-in works end to end. No CUDA/XPU decision changes:
the process-wide call sites still pass no `device_type`, and the explicit
cuda/xpu path reproduces the same values (the new CPU tests assert an
explicit-device decision never probes another device).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
