### PR TITLE
[Inductor] Add FlyDSL hgemm template integration

### DIFF
--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -1,0 +1,72 @@
+# Owner(s): ["module: inductor"]
+import unittest
+
+import torch
+
+from torch._inductor.test_case import TestCase
+
+
+try:
+    import flydsl  # noqa: F401
+
+    HAS_FLYDSL = True
+except ImportError:
+    HAS_FLYDSL = False
+
+if HAS_FLYDSL:
+    from torch._inductor.codegen.flydsl import flydsl_utils
+    from torch._inductor.codegen.flydsl.flydsl_kernel import FlyDSLTemplateKernel
+
+
+class TestFlyDSLTemplate(TestCase):
+    def test_gen_imports(self):
+        if not HAS_FLYDSL:
+            self.skipTest("requires flydsl")
+
+        kernel = FlyDSLTemplateKernel(
+            kernel_name="test_kernel",
+            input_nodes=[],
+            output_node=None,
+        )
+
+        imports = kernel.gen_imports()
+
+        self.assertIn("import torch", imports)
+        self.assertIn("import flydsl.compiler as flyc", imports)
+        self.assertIn("import flydsl.expr as fx", imports)
+
+    @unittest.skipUnless(HAS_FLYDSL, "requires flydsl")
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+    )
+    def test_flydsl_hgemm_transposed_rhs_e2e(self):
+        from torch._inductor.utils import run_and_get_code
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        def fn(a, b):
+            return torch.mm(a, b.t())
+
+        a = torch.randn(32, 128, device="cuda", dtype=torch.float16)
+        b = torch.randn(128, 128, device="cuda", dtype=torch.float16)
+
+        compiled_fn = torch.compile(fn, backend="inductor")
+        result, (code,) = run_and_get_code(compiled_fn, a, b)
+
+        self.assertIn("async_compile.flydsl", code)
+        self.assertIn("_hgemm_splitk_mm", code)
+        self.assertIn("TILE_M: fx.Constexpr", code)
+        self.assertIn("STAGES: fx.Constexpr", code)
+        self.assertIn("BLOCK_N_WARPS: fx.Constexpr", code)
+        self.assertIn("BLOCK_K_WARPS: fx.Constexpr", code)
+        self.assertTrue(torch.allclose(result, fn(a, b), atol=1e-2, rtol=1e-2))
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -698,6 +698,65 @@ class AsyncCompile:
 
             return CuteDSLKernelWrapper(getattr(mod, main_func_name), kernel_path=path)
 
+    def flydsl(self, kernel_name: str, source_code: str, precompile_metadata=None):
+        """
+        Compile FlyDSL kernels.
+
+        FlyDSL generated source is written through PyCodeCache so the module can
+        be imported and its `{kernel_name}_main` entry point can be wrapped for
+        Inductor's `.run(...)` call convention.
+        """
+        from torch._inductor.codegen.flydsl.flydsl_kernel import (
+            FlyDSLKernelWrapper,
+            MAIN_SUFFIX,
+        )
+
+        kernel_code_log.info("FlyDSL Kernel:\n%s", source_code)
+        _compile_start()
+
+        is_parallel = self.use_process_pool()
+
+        if is_parallel:
+            env_vars = ["TORCHINDUCTOR_CACHE_DIR", "FLYDSL_RUNTIME_CACHE_DIR"]
+            extra_env = {v: os.environ[v] for v in env_vars if v in os.environ}
+
+            subprocess_task = self.process_pool().submit(
+                _worker_compile_pycodecache_kernel,
+                kernel_name,
+                source_code,
+                MAIN_SUFFIX,
+                extra_env,
+                precompile_metadata,
+            )
+
+            def get_result() -> FlyDSLKernelWrapper:
+                try:
+                    key, path, elapsed_us = subprocess_task.result()
+                except SubprocException as e:
+                    raise e.with_name(kernel_name) from e
+                log.debug(
+                    "FlyDSL kernel %s compiled in subprocess in %dus",
+                    kernel_name,
+                    elapsed_us,
+                )
+                return self._load_kernel_wrapper(
+                    kernel_name, MAIN_SUFFIX, FlyDSLKernelWrapper, key, path
+                )
+
+            return LambdaFuture(get_result, future=subprocess_task)
+        else:
+            key, path = torch._inductor.codecache.PyCodeCache.write(source_code)
+            mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
+
+            main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
+            if not hasattr(mod, main_func_name):
+                available = [name for name in dir(mod) if callable(getattr(mod, name))]
+                raise RuntimeError(
+                    f"Could not find FlyDSL main kernel function '{main_func_name}'. Available callables: {available}"
+                )
+
+            return FlyDSLKernelWrapper(getattr(mod, main_func_name), kernel_path=path)
+
     def pallas(self, kernel_name: str, source_code: str):
         """
         Compile Pallas (JAX experimental) kernels.

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1262,6 +1262,50 @@ class CuteDSLBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
         return run_kernel
 
 
+class FlyDSLBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
+    """Benchmark request for FlyDSL kernels."""
+
+    def __init__(
+        self,
+        kernel_name: str,
+        input_tensor_meta: TensorMeta | list[TensorMeta],
+        output_tensor_meta: TensorMeta | list[TensorMeta],
+        extra_args: tuple[Any, ...],
+        source_code: PartialRender,
+    ) -> None:
+        super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
+        self.source_code = source_code.finalize_all()
+        self.module_cache_key, self.module_path = PyCodeCache.write(self.source_code)
+
+    def make_run_fn(
+        self, *input_tensors: torch.Tensor, out: torch.Tensor
+    ) -> Callable[[], None]:
+        mod = PyCodeCache.load_by_key_path(
+            self.module_cache_key,
+            self.module_path,
+            set_sys_modules=False,
+        )
+
+        from .codegen.flydsl.flydsl_kernel import MAIN_SUFFIX
+
+        main_func_name = f"{self.kernel_name}_{MAIN_SUFFIX}"
+
+        if not hasattr(mod, main_func_name):
+            available = [name for name in dir(mod) if callable(getattr(mod, name))]
+            raise RuntimeError(
+                f"Could not find FlyDSL main kernel function '{main_func_name}'. Available callables: {available}"
+            )
+
+        kernel_func = getattr(mod, main_func_name)
+
+        def run_kernel():
+            device_interface = get_interface_for_device("cuda")
+            stream = device_interface.get_raw_stream(out.device.index)
+            return kernel_func(*input_tensors, out, *self.extra_args, stream=stream)
+
+        return run_kernel
+
+
 @functools.cache
 def get_tuning_process_pool() -> TuningProcessPool:
     pool = TuningProcessPool()

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -678,7 +678,7 @@ class DeferredTritonCallWrapper:
             wrapper.device_codegen.cpp_kernel_type()
         )
 
-        # JIT-only: static CUfunction and embedded Triton source
+        # JIT-only: static hipFunction_t and embedded Triton source
         prefix.writeline_jit(f"static {kernel_type} {kernel_name} = nullptr;")
         kernel_source_str = self.kernel_name_to_body.get(kernel_name, "")
         kernel_body = f'R"TRITON(\n{kernel_source_str}\n)TRITON"'
@@ -853,7 +853,7 @@ class DeferredTritonCallWrapper:
                 ]
 
             # In AOTI mode on CUDA/HIP, pass the loaded_modules_ vector so
-            # CUmodule handles are tracked and can be unloaded on destruction,
+            # hipModule_t handles are tracked and can be unloaded on destruction,
             # preventing GPU code object leaks. XPU is excluded because its
             # loadKernel returns std::unique_ptr<sycl::kernel> and manages
             # cleanup via RAII.
@@ -1090,7 +1090,7 @@ class CppWrapperGpu(CppWrapperCpu):
         if self.device == "cuda":
             buffer.writeline(
                 maybe_hipify_code_wrapper(
-                    "AOTI_RUNTIME_CUDA_CHECK(cudaDeviceSynchronize());"
+                    "AOTI_RUNTIME_CUDA_CHECK(hipDeviceSynchronize());"
                 )
             )
             return
@@ -1322,7 +1322,7 @@ static inline void ensure_triton_kernel_compiles_started() {{
         self.writeline(f"alignas(64) CUtensorMap {desc_name};")
 
         # `source` is in the form of `&var_x`, where `var_x` is the data pointer
-        # (CUdeviceptr); we dereference `source` and cast to `void*` to pass to
+        # (hipDeviceptr_t); we dereference `source` and cast to `void*` to pass to
         # the data pointer of the source tensor to the helper function
         # `init{1,2}DTMADescriptor`
         ptr = f"reinterpret_cast<void*>(*({source}))"

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -47,9 +47,9 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
 
     def kernel_header(self) -> str:
         source_codes = """
-        #include <c10/cuda/CUDAGuard.h>
-        #include <c10/cuda/CUDAStream.h>
-        #include <ATen/cuda/EmptyTensor.h>
+        #include <c10/hip/HIPGuard.h>
+        #include <c10/hip/HIPStream.h>
+        #include <ATen/hip/EmptyTensor.h>
         """
         return source_codes
 
@@ -61,66 +61,66 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         source_codes = """
             #define CUDA_DRIVER_CHECK(EXPR)                    \\
             do {                                               \\
-                CUresult code = EXPR;                          \\
+                hipError_t code = EXPR;                          \\
                 const char *msg;                               \\
-                CUresult code_get_error = cuGetErrorString(code, &msg); \\
-                if (code_get_error != CUDA_SUCCESS) {          \\
+                hipError_t code_get_error = hipDrvGetErrorString(code, &msg); \\
+                if (code_get_error != hipSuccess) {          \\
                     throw std::runtime_error(                  \\
                         std::string("CUDA driver error: ") +   \\
                         std::string("invalid error code!"));   \\
                 }                                              \\
-                if (code != CUDA_SUCCESS) {                    \\
+                if (code != hipSuccess) {                    \\
                     throw std::runtime_error(                  \\
                         std::string("CUDA driver error: ") +   \\
                         std::string(msg));                     \\
                 }                                              \\
             } while (0);
 
-            static inline CUfunction loadKernel(
+            static inline hipFunction_t loadKernel(
                     std::string filePath,
                     const std::string &funcName,
                     uint32_t sharedMemBytes,
                     const std::optional<std::string> &cubinDir = std::nullopt,
-                    std::vector<CUmodule>* loaded_modules = nullptr) {
+                    std::vector<hipModule_t>* loaded_modules = nullptr) {
                 if (cubinDir) {
                     std::filesystem::path p1{*cubinDir};
                     std::filesystem::path p2{filePath};
                     filePath = (p1 / p2.filename()).string();
                 }
 
-                CUmodule mod;
-                CUfunction func;
-                CUDA_DRIVER_CHECK(cuModuleLoad(&mod, filePath.c_str()));
+                hipModule_t mod;
+                hipFunction_t func;
+                CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
                 if (loaded_modules) {
                     loaded_modules->push_back(mod);
                 }
-                CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
+                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
-                    CUDA_DRIVER_CHECK(cuFuncSetAttribute(
+                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
                         func,
-                        CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                        hipFuncAttributeMaxDynamicSharedMemorySize,
                         sharedMemBytes
                     ))
                 }
                 return func;
             }
 
-            static inline CUfunction loadKernel(
+            static inline hipFunction_t loadKernel(
                     const void* start,
                     const std::string &funcName,
                     uint32_t sharedMemBytes,
-                    std::vector<CUmodule>* loaded_modules = nullptr) {
-                CUmodule mod;
-                CUfunction func;
-                CUDA_DRIVER_CHECK(cuModuleLoadData(&mod, start));
+                    std::vector<hipModule_t>* loaded_modules = nullptr) {
+                hipModule_t mod;
+                hipFunction_t func;
+                CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, start));
                 if (loaded_modules) {
                     loaded_modules->push_back(mod);
                 }
-                CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
+                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
-                    CUDA_DRIVER_CHECK(cuFuncSetAttribute(
+                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
                         func,
-                        CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                        hipFuncAttributeMaxDynamicSharedMemorySize,
                         sharedMemBytes
                     ))
                 }
@@ -128,15 +128,15 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
             }
 
             static inline void launchKernel(
-                    CUfunction func,
+                    hipFunction_t func,
                     uint32_t gridX,
                     uint32_t gridY,
                     uint32_t gridZ,
                     uint32_t numWarps,
                     uint32_t sharedMemBytes,
                     void* args[],
-                    cudaStream_t stream) {
-                CUDA_DRIVER_CHECK(cuLaunchKernel(
+                    hipStream_t stream) {
+                CUDA_DRIVER_CHECK(hipModuleLaunchKernel(
                     func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
                 ));
             }
@@ -161,7 +161,7 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         # New APIs (fillTMADescriptor):
         # https://github.com/triton-lang/triton/blob/main/third_party/nvidia/backend/driver.c#L283
         return """
-            #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+            #if !defined(USE_ROCM) && defined(TORCH_HIP_VERSION) && TORCH_HIP_VERSION >= 12000
             [[maybe_unused]] static void init1DTMADescriptor(
                     CUtensorMap* m,
                     void* globalAddress,
@@ -337,16 +337,16 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         """
 
     def cpp_stream_type(self) -> str:
-        return "cudaStream_t"
+        return "hipStream_t"
 
     def aoti_get_stream(self) -> str:
         return "aoti_torch_get_current_cuda_stream"
 
     def cpp_kernel_type(self) -> str:
-        return "CUfunction"
+        return "hipFunction_t"
 
     def cpp_device_ptr(self) -> str:
-        return "CUdeviceptr"
+        return "hipDeviceptr_t"
 
     def cpp_scratch(
         self, idx: int, workspace: TritonScratchWorkspace, prefix: str | None = None
@@ -372,12 +372,12 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                         f"{workspace.generate_dtype_str()}, {device_type}, {device_idx}, &{var_name}_handle));"
                     ),
                     f"RAIIAtenTensorHandle {var_name}_tensor({var_name}_handle);",
-                    f"CUdeviceptr {var_name} = reinterpret_cast<CUdeviceptr>({var_name}_tensor.data_ptr());",
+                    f"hipDeviceptr_t {var_name} = reinterpret_cast<hipDeviceptr_t>({var_name}_tensor.data_ptr());",
                 ],
                 var_name,
             )
         else:
-            return [f"CUdeviceptr {var_name} = 0;"], var_name
+            return [f"hipDeviceptr_t {var_name} = 0;"], var_name
 
 
 register_device_op_overrides("cuda", CUDADeviceOpOverrides())

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -16,6 +16,7 @@ from ..scheduler import (
 )
 from .cutedsl.cutedsl_scheduling import CuteDSLScheduling
 from .cutlass.scheduling import CUTLASSScheduling
+from .flydsl.flydsl_scheduling import FlyDSLScheduling
 from .nv_universal_gemm.nv_universal_gemm_scheduling import NVUniversalGemmScheduling
 from .rocm.rocm_cpp_scheduling import ROCmCPPScheduling
 from .triton import TritonScheduling
@@ -53,6 +54,7 @@ class CUDACombinedScheduling(BaseScheduling):
         self._cutlass_scheduling = CUTLASSScheduling(scheduler)
         self._rocm_cpp_scheduling = ROCmCPPScheduling(scheduler)
         self._cutedsl_scheduling = CuteDSLScheduling(scheduler)
+        self._flydsl_scheduling = FlyDSLScheduling(scheduler)
         self._nv_universal_gemm_scheduling = NVUniversalGemmScheduling(scheduler)
 
     def get_backend_features(self, device: torch.device) -> OrderedSet[BackendFeature]:
@@ -65,6 +67,8 @@ class CUDACombinedScheduling(BaseScheduling):
             return self._rocm_cpp_scheduling
         if self._cutedsl_scheduling.is_cutedsl_template(node):
             return self._cutedsl_scheduling
+        if self._flydsl_scheduling.is_flydsl_template(node):
+            return self._flydsl_scheduling
         if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(node):
             return self._nv_universal_gemm_scheduling
         if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_fused_template(node):
@@ -84,6 +88,10 @@ class CUDACombinedScheduling(BaseScheduling):
         elif self._cutedsl_scheduling.is_cutedsl_template(
             node1
         ) or self._cutedsl_scheduling.is_cutedsl_template(node2):
+            return False
+        elif self._flydsl_scheduling.is_flydsl_template(
+            node1
+        ) or self._flydsl_scheduling.is_flydsl_template(node2):
             return False
         # Only intercept when node1 is the NVGEMM template (epilogue direction).
         # Prologue direction (node1=pointwise, node2=template) must fall through to
@@ -118,6 +126,10 @@ class CUDACombinedScheduling(BaseScheduling):
                 )  # always False at the moment
             if self._cutedsl_scheduling.is_cutedsl_template(node):
                 return self._cutedsl_scheduling.can_fuse_horizontal(
+                    node1, node2
+                )  # always False at the moment
+            if self._flydsl_scheduling.is_flydsl_template(node):
+                return self._flydsl_scheduling.can_fuse_horizontal(
                     node1, node2
                 )  # always False at the moment
             if self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(
@@ -166,6 +178,14 @@ class CUDACombinedScheduling(BaseScheduling):
             if prologue_nodes:
                 raise AssertionError("cutedsl template does not support prologue nodes")
             return self._cutedsl_scheduling.codegen_template(
+                template_node, epilogue_nodes, prologue_nodes
+            )
+        elif self._flydsl_scheduling.is_flydsl_template(template_node):
+            if epilogue_nodes:
+                raise AssertionError("flydsl template does not support epilogue nodes")
+            if prologue_nodes:
+                raise AssertionError("flydsl template does not support prologue nodes")
+            return self._flydsl_scheduling.codegen_template(
                 template_node, epilogue_nodes, prologue_nodes
             )
         elif self._nv_universal_gemm_scheduling.is_nv_universal_gemm_template(

--- a/torch/_inductor/codegen/flydsl/__init__.py
+++ b/torch/_inductor/codegen/flydsl/__init__.py
@@ -1,0 +1,3 @@
+from .flydsl_template import FlyDSLTemplate, FlyDSLTemplateCaller
+
+__all__ = ["FlyDSLTemplate", "FlyDSLTemplateCaller"]

--- a/torch/_inductor/codegen/flydsl/flydsl_kernel.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_kernel.py
@@ -1,0 +1,186 @@
+# mypy: allow-untyped-defs
+import contextlib
+import logging
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import patch
+
+import torch
+
+from torch._inductor.codegen.common import IndentedBuffer, Kernel
+from torch._inductor.ir import BaseView, Buffer, ExternKernel, MutableBox, ReinterpretView
+from torch._inductor.utils import OrderedSet
+from torch._inductor.virtualized import V
+
+
+MAIN_SUFFIX = "main"
+
+log = logging.getLogger(__name__)
+kernel_code_log = torch._logging.getArtifactLogger(__name__, "kernel_code")
+
+
+class FlyDSLKernelWrapper:
+    """Wrapper to provide the `.run()` interface expected by Inductor."""
+
+    def __init__(self, kernel_fn: Callable[..., Any], kernel_path: str | None = None):
+        self.kernel_fn = kernel_fn
+        self.kernel_path = kernel_path
+        kernel_code_log.info("FlyDSL kernel path: %s", kernel_path)
+
+    def run(self, *args, stream=None, **kwargs):
+        return self.kernel_fn(*args, stream=stream, **kwargs)
+
+
+class FlyDSLTemplateKernel(Kernel):
+    """Minimal template kernel implementation for FlyDSL Inductor demos."""
+
+    def __init__(
+        self,
+        kernel_name: str,
+        input_nodes: list[Buffer],
+        output_node: Buffer,
+        subgraphs: list[Buffer] | None = None,
+    ) -> None:
+        super().__init__()
+        self.kernel_name = kernel_name
+        self.input_nodes = input_nodes
+        self.output_node = output_node
+        self.subgraphs = subgraphs
+        self.render_hooks: dict[str, Callable[[], str]] = {}
+        self.prologue_fused_inputs: OrderedSet[str] = OrderedSet()
+        self.prologue_fused_inputs_preserve_zero: OrderedSet[str] = OrderedSet()
+        self._template_input_args: list[tuple[str, Buffer]] = []
+        self._seen_input_args: OrderedSet[str] = OrderedSet()
+
+    @contextlib.contextmanager
+    def _patch_get_dtype_for_args(self):
+        original_get_dtype = V.graph.get_dtype
+
+        def get_dtype(name: str) -> torch.dtype:
+            for arg_name, input_node in self._template_input_args:
+                if name == arg_name:
+                    return input_node.get_dtype()
+            return original_get_dtype(name)
+
+        with patch.object(V.graph, "get_dtype", get_dtype):
+            yield
+
+    @staticmethod
+    def _get_reinterpret_view(node) -> ReinterpretView | None:
+        while isinstance(node, MutableBox):
+            node = node.data
+        if isinstance(node, BaseView):
+            return ExternKernel.convert_to_reinterpret_view(node)
+        return None
+
+    def gen_imports(self) -> str:
+        imports = IndentedBuffer()
+        imports.splice(
+            """
+            import torch
+            import flydsl.compiler as flyc
+            import flydsl.expr as fx
+            """
+        )
+        return imports.getvalue()
+
+    def gen_defines(self, **kwargs) -> str:
+        params = IndentedBuffer()
+        for name, val in kwargs.items():
+            params.writeline(f"{name}: fx.Constexpr = {val!r}")
+        return params.getvalue()
+
+    def render(self, template, **kwargs):
+        from torch._inductor.select_algorithm import PartialRender
+
+        self._template_kwargs = dict(kwargs)
+        template_env = {
+            "def_kernel": self.def_kernel,
+            "gen_defines": lambda: self.gen_defines(**kwargs),
+            "get_output": self.get_output,
+        }
+
+        rendered_code = template.render(
+            kernel_name=self.kernel_name,
+            input_nodes=self.input_nodes,
+            output_node=self.output_node,
+            **template_env,
+            **kwargs,
+        )
+        return PartialRender(self.gen_imports() + rendered_code, self.render_hooks)
+
+    def def_kernel(self, *argnames):
+        renames = IndentedBuffer(initial_indent=1)
+        self._template_input_args = []
+        self._seen_input_args = OrderedSet()
+
+        for i, input_node in enumerate(self.input_nodes):
+            buf_name = input_node.get_name()
+            self.args.input(buf_name)
+            if i < len(argnames):
+                template_name = argnames[i]
+                arg_name = f"arg_{template_name}"
+                self.args.input_buffers[buf_name] = arg_name
+                renames.writeline(f"{template_name} = {arg_name}")
+                self._template_input_args.append((arg_name, input_node))
+                self._seen_input_args.add(arg_name)
+
+        if self.output_node:
+            self.args.output(self.output_node.get_name())
+
+        def hook():
+            code = IndentedBuffer()
+            params = [arg_name for arg_name, _ in self._template_input_args]
+            with self._patch_get_dtype_for_args():
+                arg_defs, _, _, _ = self.args.python_argdefs()
+            for arg_def in arg_defs:
+                if arg_def.full_name() not in self._seen_input_args:
+                    params.append(arg_def.full_name())
+            params.append("stream")
+            code.writeline(
+                f"def {self.kernel_name}_{MAIN_SUFFIX}({', '.join(params)}):"
+            )
+            with code.indent():
+                code.splice(renames.getvalue())
+            return code.getvalue()
+
+        if "<DEF_KERNEL>" in self.render_hooks:
+            raise AssertionError("<DEF_KERNEL> hook already registered")
+        self.render_hooks["<DEF_KERNEL>"] = hook
+        return "<DEF_KERNEL>"
+
+    def get_output(self):
+        if not self.output_node:
+            raise AssertionError("Output node must exist to get output buffer name")
+        output = self.args.output_buffers.get(self.output_node.get_name(), None)
+        if output is None:
+            raise ValueError(f"Output buffer '{self.output_node.get_name()}' not found")
+        return output
+
+    def call_kernel(self, name: str, node=None):
+        wrapper = V.graph.wrapper_code
+        call_args = []
+        arg_types = []
+
+        for _, input_node in self._template_input_args:
+            reinterpret_view = self._get_reinterpret_view(input_node)
+            call_args.append(
+                reinterpret_view.codegen_reference()
+                if reinterpret_view is not None
+                else input_node.get_name()
+            )
+            arg_types.append(V.graph.get_dtype(input_node.get_name()))
+
+        with self._patch_get_dtype_for_args():
+            orig_arg_defs, orig_call_args, _, orig_arg_types = (
+                self.args.python_argdefs()
+            )
+        for arg_def, call_arg, arg_type in zip(
+            orig_arg_defs, orig_call_args, orig_arg_types
+        ):
+            if arg_def.full_name() in self._seen_input_args:
+                continue
+            call_args.append(call_arg)
+            arg_types.append(arg_type)
+
+        wrapper.generate_kernel_call(name, call_args, triton=True, arg_types=arg_types)

--- a/torch/_inductor/codegen/flydsl/flydsl_scheduling.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_scheduling.py
@@ -1,0 +1,124 @@
+# mypy: allow-untyped-defs
+import hashlib
+import logging
+from collections.abc import Sequence
+from typing import cast
+
+from torch._inductor.utils import Placeholder
+from torch.utils._ordered_set import OrderedSet
+
+from ... import config
+from ...codecache import code_hash, get_path
+from ...ir import FlyDSLTemplateBuffer
+from ...scheduler import (
+    BaseSchedulerNode,
+    BaseScheduling,
+    FusedSchedulerNode,
+    SchedulerNode,
+)
+from ...select_algorithm import PartialRender
+from ...utils import get_fused_kernel_name, get_kernel_metadata
+from ...virtualized import V
+from ..common import BackendFeature, IndentedBuffer
+
+
+log = logging.getLogger(__name__)
+
+
+class FlyDSLScheduling(BaseScheduling):
+    """Scheduling implementation for FlyDSL template kernels."""
+
+    @classmethod
+    def get_backend_features(cls, device) -> OrderedSet[BackendFeature]:
+        return OrderedSet()
+
+    @staticmethod
+    def is_flydsl_template(node: BaseSchedulerNode) -> bool:
+        return isinstance(node, SchedulerNode) and isinstance(
+            node.node, FlyDSLTemplateBuffer
+        )
+
+    def is_flydsl_fused_template(self, node: BaseSchedulerNode) -> bool:
+        return isinstance(node, FusedSchedulerNode) and self.is_flydsl_template(node)
+
+    def can_fuse_vertical(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        return False
+
+    def can_fuse_horizontal(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        return False
+
+    def define_kernel(self, src_code_str: str, node_schedule) -> str:
+        wrapper = V.graph.wrapper_code
+
+        if src_code_str in wrapper.src_to_kernel:
+            kernel_name = wrapper.src_to_kernel[src_code_str]
+        else:
+            fused_name = (
+                get_fused_kernel_name(node_schedule, config.triton.descriptive_names)
+                if config.triton.descriptive_names
+                else ""
+            )
+
+            kernel_hash = hashlib.sha256(src_code_str.encode("utf-8")).hexdigest()[:8]
+            if fused_name == "fused":
+                kernel_name = f"flydsl_{kernel_hash}"
+            else:
+                kernel_name = f"flydsl_{fused_name}_{kernel_hash}"
+            wrapper.src_to_kernel[src_code_str] = kernel_name
+            src_code_str = src_code_str.replace(
+                str(Placeholder.KERNEL_NAME), kernel_name
+            )
+
+            _, _, kernel_path = get_path(code_hash(src_code_str), "py")
+
+            compile_wrapper = IndentedBuffer()
+            compile_wrapper.writeline(f"async_compile.flydsl({kernel_name!r}, r'''")
+            compile_wrapper.splice(src_code_str, strip=True)
+            compile_wrapper.writeline("''')")
+
+            metadata_comment = f"# kernel path: {kernel_path}"
+            origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
+            metadata_comment += "\n" + origins + "\n" + detailed_origins
+            wrapper.define_kernel(
+                kernel_name, compile_wrapper.getvalue(), metadata_comment
+            )
+        return kernel_name
+
+    def codegen_template(
+        self,
+        template_node: BaseSchedulerNode,
+        epilogue_nodes: Sequence[BaseSchedulerNode],
+        prologue_nodes: Sequence[BaseSchedulerNode],
+    ):
+        if not self.is_flydsl_template(template_node):
+            raise AssertionError(
+                "Template node passed to FlyDSLScheduling.codegen_template must be a "
+                "SchedulerNode that wraps a FlyDSLTemplateBuffer"
+            )
+        if epilogue_nodes:
+            raise AssertionError("FlyDSL doesn't support epilogue fusion yet")
+        if prologue_nodes:
+            raise AssertionError("FlyDSL doesn't support prologue fusion yet")
+
+        template_node = cast(SchedulerNode, template_node)
+        ftb: FlyDSLTemplateBuffer = cast(FlyDSLTemplateBuffer, template_node.node)
+
+        kernel, render = ftb.make_kernel_render(ftb)  # type: ignore[misc]
+        template_node.mark_run()
+        src_code = render()
+        if isinstance(src_code, PartialRender):
+            src_code_str = src_code.finalize_all()
+        else:
+            src_code_str = src_code
+
+        with V.set_kernel_handler(kernel):
+            node_schedule = [template_node]
+            kernel_name = self.define_kernel(src_code_str, node_schedule)
+        self.codegen_comment(node_schedule, kernel_name)
+        kernel.call_kernel(kernel_name, ftb)
+        V.graph.removed_buffers |= kernel.removed_buffers
+        self.free_buffers_in_scheduler()

--- a/torch/_inductor/codegen/flydsl/flydsl_template.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_template.py
@@ -1,0 +1,202 @@
+# mypy: allow-untyped-defs
+import functools
+import itertools
+from collections.abc import Iterable
+from typing import Any
+from unittest.mock import patch
+
+from torch._inductor.utils import Placeholder
+from torch._inductor.virtualized import V
+from torch._logging import getArtifactLogger
+
+from ...autotune_process import FlyDSLBenchmarkRequest, TensorMeta
+from ...ir import Buffer, ChoiceCaller, FlyDSLTemplateBuffer, IRNode, Layout, TensorBox
+from ..common import KernelTemplate
+from .flydsl_kernel import FlyDSLTemplateKernel
+
+
+log = getArtifactLogger(__name__, "output_code")
+
+
+class FlyDSLTemplate(KernelTemplate):
+    """Template for generating FlyDSL kernels."""
+
+    kernel_type: type[Any] = FlyDSLTemplateKernel
+    caller_type: type[Any] | None = None
+    index_counter = itertools.count()
+    all_templates: dict[str, "FlyDSLTemplate"] = {}
+
+    def __init__(self, name: str, source: str) -> None:
+        super().__init__(name)
+        self.source = source
+        self.template = FlyDSLTemplate._template_from_string(source)
+        if name in self.all_templates:
+            raise AssertionError(f"duplicate template name, {name}")
+        FlyDSLTemplate.all_templates[name] = self
+
+    @staticmethod
+    @functools.lru_cache(None)
+    # pyrefly: ignore [bad-override]
+    def _template_from_string(source: str) -> Any:
+        return KernelTemplate._template_from_string(source)
+
+    def maybe_append_choice(
+        self, choices: list[Any], **kwargs: Any
+    ) -> NotImplementedError | None:
+        try:
+            choices.append(self.generate(**kwargs))
+            return None
+        except NotImplementedError as e:
+            log.debug("FlyDSL template choice generation failed: %s", e)
+            return e
+        except Exception as e:
+            log.debug("FlyDSL template choice generation error: %s", e)
+            return NotImplementedError(f"FlyDSL template failed: {e}")
+
+    def generate(self, **kwargs: Any) -> ChoiceCaller:
+        input_nodes = kwargs.pop("input_nodes")
+        layout = kwargs.pop("layout")
+        mutated_inputs = kwargs.pop("mutated_inputs", None)
+        template_kwargs = dict(kwargs)
+        kernel_name = f"flydsl_{self.name}_{next(self.index_counter)}"
+
+        if self.template is None:
+            raise RuntimeError("Template compilation failed (Jinja2 required)")
+
+        self.output_node: Buffer = Buffer(name="buf_out", layout=layout)
+        with patch.object(
+            V.graph, "get_dtype", KernelTemplate._fake_get_dtype(self.output_node)
+        ):
+            kernel = self.kernel_type(
+                kernel_name=kernel_name,
+                input_nodes=input_nodes,
+                output_node=self.output_node,
+            )
+            code = kernel.render(self.template, **kwargs)
+            log.debug("Generated FlyDSL Code:\n%s", code)
+
+            input_call_args = tuple(kernel.args.input_buffers.keys())
+            expected_input_args = tuple(x.get_name() for x in input_nodes)
+            if input_call_args[: len(expected_input_args)] != expected_input_args:
+                raise RuntimeError(
+                    "FlyDSL template input registration order changed. "
+                    f"Got {input_call_args}, expected prefix {expected_input_args}."
+                )
+
+            with kernel._patch_get_dtype_for_args():
+                arg_defs, call_args, _, _ = kernel.args.python_argdefs()
+            expected_args = list(input_call_args)
+            expected_args.append(self.output_node.get_name())
+            if list(call_args)[: len(expected_args)] != expected_args:
+                raise RuntimeError(
+                    "FlyDSL template benchmark argument order changed. "
+                    f"Expected prefix {expected_args}, got {list(call_args)}."
+                )
+            extra_args = tuple(
+                V.graph.sizevars.optimization_hints(call_args[len(expected_args) :])
+            )
+
+            bmreq = FlyDSLBenchmarkRequest(
+                kernel_name=kernel_name,
+                input_tensor_meta=TensorMeta.from_irnodes(input_nodes),
+                output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
+                extra_args=extra_args,
+                source_code=code,
+            )
+
+            def make_kernel_render(out_node, hint_override: int | None = None):
+                render_kernel = self.kernel_type(
+                    kernel_name=str(Placeholder.KERNEL_NAME),
+                    input_nodes=input_nodes,
+                    output_node=out_node,
+                )
+
+                def render():
+                    return render_kernel.render(self.template, **kwargs)
+
+                return render_kernel, render
+
+            caller_type = self.caller_type or FlyDSLTemplateCaller
+            return caller_type(
+                name=kernel_name,
+                input_nodes=input_nodes,
+                layout=layout,
+                make_kernel_render=make_kernel_render,
+                bmreq=bmreq,
+                template=self,
+                mutated_inputs=mutated_inputs,
+                template_kwargs=template_kwargs,
+            )
+
+
+class FlyDSLTemplateCaller(ChoiceCaller):
+    """Caller for FlyDSL templates."""
+
+    def __init__(
+        self,
+        name: str,
+        input_nodes: list[Buffer],
+        layout: Layout,
+        make_kernel_render: Any,
+        bmreq: FlyDSLBenchmarkRequest,
+        template: "FlyDSLTemplate",
+        mutated_inputs: Iterable[IRNode] | None = None,
+        template_kwargs: dict[str, Any] | None = None,
+    ):
+        description = self._build_description(name, template_kwargs)
+        super().__init__(
+            name=name,
+            input_nodes=input_nodes,
+            layout=layout,
+            description=description,
+        )
+        self.make_kernel_render = make_kernel_render
+        self.bmreq = bmreq
+        self.template = template
+        self.mutated_inputs = mutated_inputs
+
+    @staticmethod
+    def _build_description(
+        name: str, template_kwargs: dict[str, Any] | None
+    ) -> str:
+        if not template_kwargs:
+            return f"FlyDSL template {name}"
+        kwargs_desc = ", ".join(f"{k}={v}" for k, v in template_kwargs.items())
+        return f"FlyDSL template {name} ({kwargs_desc})"
+
+    def __str__(self) -> str:
+        return f"FlyDSLTemplateCaller({self.name})"
+
+    def benchmark(self, *args, out) -> float:
+        return self.bmreq.benchmark(*args, out=out)
+
+    def output_node(self) -> TensorBox:
+        buffer = FlyDSLTemplateBuffer(
+            layout=self.layout,
+            inputs=self.input_nodes,
+            make_kernel_render=self.make_kernel_render,
+            template=self.template,
+            mutated_inputs=self.mutated_inputs,
+        )
+        return TensorBox.create(buffer)
+
+    def call_name(self) -> str:
+        return self.name
+
+    def to_callable(self) -> Any:
+        return self.make_kernel_render
+
+    def hash_key(self) -> str:
+        return "-".join(
+            [
+                self.name.rsplit("_", 1)[0],
+                self.bmreq.module_cache_key,
+            ]
+        )
+
+    def info_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "backend": "FlyDSL",
+            "template": self.template.name,
+        }

--- a/torch/_inductor/codegen/flydsl/flydsl_utils.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_utils.py
@@ -1,0 +1,72 @@
+import functools
+import importlib.machinery
+import importlib.util
+import logging
+import subprocess
+from pathlib import Path
+
+from torch.backends import cuda as _cuda
+
+
+log = logging.getLogger(__name__)
+
+
+def _flydsl_runtime_unavailable_reason() -> str | None:
+    flydsl_spec = importlib.util.find_spec("flydsl")
+    if flydsl_spec is None or flydsl_spec.submodule_search_locations is None:
+        return "missing optional dependency `flydsl`"
+
+    # Query the package paths directly so this availability check does not
+    # import flydsl as a side effect during regular torch imports.
+    mlir_spec = importlib.machinery.PathFinder.find_spec(
+        "_mlir",
+        list(flydsl_spec.submodule_search_locations),
+    )
+    if mlir_spec is None:
+        return "missing optional dependency `flydsl._mlir`"
+
+    runtime_so = (
+        Path(next(iter(flydsl_spec.submodule_search_locations)))
+        / "_mlir"
+        / "_mlir_libs"
+        / "libfly_jit_runtime.so"
+    )
+    if not runtime_so.exists():
+        return f"missing FlyDSL runtime shared library `{runtime_so}`"
+
+    try:
+        ldd = subprocess.run(
+            ["ldd", str(runtime_so)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError as e:
+        return f"could not inspect FlyDSL runtime shared library dependencies: {e}"
+
+    ldd_output = f"{ldd.stdout}\n{ldd.stderr}"
+    if ldd.returncode != 0 or "not found" in ldd_output:
+        return (
+            "unresolved FlyDSL runtime shared library dependencies: "
+            + "; ".join(line.strip() for line in ldd_output.splitlines() if "not found" in line)
+        )
+
+    return None
+
+
+@functools.cache
+def runtime_available() -> bool:
+    if not _cuda.is_built():
+        return False
+
+    import torch
+
+    if torch.version.hip is None:
+        return False
+
+    reason = _flydsl_runtime_unavailable_reason()
+    if reason is not None:
+        log.debug("FlyDSL Inductor templates are unavailable: %s", reason)
+        return False
+
+    return True

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -611,11 +611,12 @@ multi_kernel_hints: list[int] = []
 
 
 # Specify candidate backends for gemm autotune.
-# Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, NVGEMM, CK, CKTILE, CPP.
+# Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, FLYDSL, NVGEMM, CK, CKTILE, CPP.
 # ATen: default Pytorch ATen kernels.
 # Triton: Triton templates defined in torch inductor (AMD and NVidia GPUs).
 # CUTLASS: Cutlass templates and kernels (NVidia GPUs only).
 # CUTEDSL: CuteDSL templates for Blackwell GPUs (NVidia SM100-SM109 only).
+# FLYDSL: FlyDSL templates for ROCm GPUs (experimental).
 # NVGEMM: NVIDIA Universal GEMM via cutlass_api (NVidia GPUs only).
 # CK: Composable Kernel templates and kernels (AMD Instinct GPUs only).
 # CKTILE: Composable Kernel templates and kernels, new API (AMD Instinct GPUs only).

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6439,6 +6439,38 @@ class CuteDSLTemplateBuffer(TemplateBuffer):
         return self.outputs
 
 
+class FlyDSLTemplateBuffer(TemplateBuffer):
+    """
+    Buffer for FlyDSL template kernels.
+    Similar to CuteDSLTemplateBuffer but routed through FlyDSL scheduling.
+    """
+
+    def __init__(
+        self,
+        layout: Layout,
+        inputs: Sequence[IRNode],
+        make_kernel_render: Callable[_P, _T],
+        template: Any,
+        mutated_inputs: Iterable[IRNode] | None = None,
+    ) -> None:
+        super().__init__(layout, inputs, make_kernel_render)
+        self.template = template
+        self.mutated_inputs = mutated_inputs
+        self.outputs: list[Buffer] = [self]
+
+        if mutated_inputs is not None:
+            if not isinstance(self.inputs[0], IRNode):
+                raise AssertionError(type(self.inputs[0]))
+            device = self.inputs[0].get_device()
+            self.outputs += [
+                MutationOutput(NoneLayout(device=device), buf, self)
+                for buf in mutated_inputs
+            ]
+
+    def get_outputs(self) -> list[Buffer]:
+        return self.outputs
+
+
 class NVUniversalGemmBuffer(TemplateBuffer):
     """
     Buffer for NVIDIA Universal GEMM kernels.

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -22,6 +22,7 @@ from torch.utils._ordered_set import OrderedSet
 
 from .. import config as inductor_config, distributed_autotune
 from ..codegen.cutlass.gemm_template import CUTLASS2xGemmTemplate, CUTLASS3xGemmTemplate
+from ..codegen.flydsl.flydsl_template import FlyDSLTemplate
 from ..codegen.rocm.ck_tile_universal_gemm_template import CKTileGemmTemplate
 from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from ..codegen.subgraph import SubgraphChoiceCaller, SubgraphTemplate
@@ -124,6 +125,11 @@ scaled_mm_device_tma_main_loop_scaling_template = TritonTemplate(
     source=load_kernel_template("triton_main_loop_scaled_mm"),
 )
 
+flydsl_mm_template = FlyDSLTemplate(
+    name="mm_flydsl",
+    source=load_kernel_template("flydsl_mm"),
+)
+
 blackwell_ws_persistent_device_tma_mm_template = TritonTemplate(
     name="blackwell_ws_persistent_device_tma",
     grid=persistent_mm_grid,
@@ -204,6 +210,87 @@ def check_supported_striding(mat_a, mat_b) -> None:
         is_col_major(mat_b.get_stride()) or has_zero_dim(mat_b.get_size()),
         lambda: f"mat_b must be col_major, got stride {mat_b.get_stride()}",
     )
+
+
+def _static_int_or_none(x) -> int | None:
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        try:
+            return int(V.graph.sizevars.size_hint(x))
+        except (TypeError, ValueError):
+            return None
+
+
+def get_flydsl_mm_template_kwargs(
+    layout, mat1, mat2, static_shape, is_nonzero
+) -> list[dict[str, Any]]:
+    from ..template_heuristics.flydsl_gemm import get_hgemm_configs
+
+    if not (
+        static_shape
+        and is_nonzero
+        and (inductor_config.max_autotune or inductor_config.max_autotune_gemm)
+        and "FLYDSL"
+        in [
+            x.strip().upper()
+            for x in inductor_config.max_autotune_gemm_backends.split(",")
+        ]
+    ):
+        return []
+
+    if torch.version.hip is None:
+        return []
+
+    if layout.device.type != "cuda":
+        return []
+
+    if len(mat1.get_size()) != 2 or len(mat2.get_size()) != 2:
+        return []
+
+    sizevars = V.graph.sizevars
+    mat1_stride = mat1.get_stride()
+    mat2_stride = mat2.get_stride()
+    out_stride = layout.stride
+
+    if not sizevars.statically_known_equals(mat1_stride[1], 1):
+        return []
+    if not sizevars.statically_known_equals(out_stride[1], 1):
+        return []
+
+    try:
+        from ..codegen.flydsl import flydsl_utils
+    except Exception:
+        log.debug("Could not import flydsl_utils for Inductor FlyDSL gate", exc_info=True)
+        return []
+
+    if not flydsl_utils.runtime_available():
+        return []
+
+    dtype = mat1.get_dtype()
+    if mat2.get_dtype() != dtype or layout.dtype != dtype:
+        return []
+
+    if dtype not in (torch.float16, torch.bfloat16):
+        return []
+
+    # hgemm_splitk consumes B as [N, K]. In aten.mm(A, B.T), Inductor sees
+    # the RHS as a [K, N] transpose view with stride[0] == 1.
+    if not sizevars.statically_known_equals(mat2_stride[0], 1):
+        return []
+
+    m = mat1.get_size()[0]
+    _, n = mat2.get_size()
+    k = mat1.get_size()[1]
+    m_static = _static_int_or_none(m)
+    n_static = _static_int_or_none(n)
+    k_static = _static_int_or_none(k)
+    if m_static is None or n_static is None or k_static is None:
+        return []
+    if n_static % 128 != 0 or k_static % 64 != 0:
+        return []
+
+    return get_hgemm_configs(m_static, n_static, k_static)
 
 
 aten_bias_addmm = ExternKernelChoice(bias_addmm, None)
@@ -465,6 +552,18 @@ def tuned_mm(mat1, mat2, out_dtype=None, *, layout=None):
         CKGemmTemplate.add_ck_gemm_choices(choices, layout, kernel_inputs.nodes())
     if out_dtype is None and is_nonzero and use_ck_tile_gemm_template(layout, m, n, k):
         CKTileGemmTemplate.add_choices(choices, layout, kernel_inputs.nodes())
+
+    flydsl_configs = get_flydsl_mm_template_kwargs(
+        layout, mat1, mat2, static_shape, is_nonzero
+    )
+    if out_dtype is None:
+        for flydsl_kwargs in flydsl_configs:
+            flydsl_mm_template.maybe_append_choice(
+                choices,
+                input_nodes=kernel_inputs.nodes(),
+                layout=layout,
+                **flydsl_kwargs,
+            )
 
     if (
         out_dtype is None

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -1,0 +1,84 @@
+import functools
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+    SPLIT_K_SEMAPHORE_MAX_LEN,
+    compile_hgemm_kernel,
+)
+from torch._inductor.kernel.vendored_templates.flydsl.kernels.tensor_shim import (
+    _run_compiled,
+)
+
+{{gen_defines()}}
+
+
+@functools.lru_cache(maxsize=128)
+def _get_hgemm_semaphore(stream, device):
+    semaphore = torch.zeros(
+        (SPLIT_K_SEMAPHORE_MAX_LEN,), dtype=torch.int32, device=device
+    )
+    signal = torch.zeros(
+        (SPLIT_K_SEMAPHORE_MAX_LEN,), dtype=torch.int32, device=device
+    )
+    return semaphore, signal
+
+
+def _hgemm_splitk_mm(output, mat1, mat2, stream):
+    k = mat1.shape[-1]
+    if mat2.shape[-1] == k:
+        mat2_nk = mat2
+    elif mat2.shape[0] == k:
+        mat2_nk = mat2.transpose(0, 1)
+    else:
+        raise AssertionError(
+            f"Expected RHS shape [N, {k}] or [{k}, N], got {tuple(mat2.shape)}"
+        )
+
+    hgemm_kwargs = {
+        "TILE_M": TILE_M,
+        "TILE_N": TILE_N,
+        "TILE_K": TILE_K,
+        "STAGES": STAGES,
+        "SPLIT_K": SPLIT_K,
+        "BLOCK_M_WARPS": BLOCK_M_WARPS,
+        "BLOCK_N_WARPS": BLOCK_N_WARPS,
+        "BLOCK_K_WARPS": BLOCK_K_WARPS,
+        "B_TO_LDS": B_TO_LDS,
+        "HAS_BIAS": False,
+    }
+
+    semaphore, signal = _get_hgemm_semaphore(stream, mat1.device)
+    mat1_mk = mat1.view(-1, k)
+    m = mat1_mk.shape[0]
+    n = mat2_nk.shape[0]
+    output_mn = output.view(-1, n)
+    bias_tensor = mat1_mk
+
+    if mat2_nk.shape[1] != k:
+        raise AssertionError(f"Expected mat2_nk.shape[1] == k, got {mat2_nk.shape[1]} and {k}")
+    if output_mn.shape[0] != m:
+        raise AssertionError(f"Expected output_mn.shape[0] == m, got {output_mn.shape[0]} and {m}")
+
+    if mat1_mk.dtype == torch.half:
+        exe = compile_hgemm_kernel("f16", n, k, **hgemm_kwargs)
+    elif mat1_mk.dtype == torch.bfloat16:
+        exe = compile_hgemm_kernel("bf16", n, k, **hgemm_kwargs)
+    else:
+        raise NotImplementedError(f"Unsupported dtype for FlyDSL hgemm: {mat1_mk.dtype}")
+
+    _run_compiled(
+        exe,
+        output_mn,
+        mat1_mk,
+        mat2_nk,
+        bias_tensor,
+        m,
+        semaphore,
+        signal,
+        stream,
+    )
+    return output
+
+
+{{def_kernel("mat1", "mat2")}}
+    output = {{get_output()}}
+    return _hgemm_splitk_mm(output, mat1, mat2, stream)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/__init__.py
@@ -1,0 +1,1 @@
+# FlyDSL vendored template kernels.

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -1,0 +1,3 @@
+from .hgemm_splitk import SPLIT_K_SEMAPHORE_MAX_LEN, compile_hgemm_kernel
+
+__all__ = ["SPLIT_K_SEMAPHORE_MAX_LEN", "compile_hgemm_kernel"]

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/hgemm_splitk.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/hgemm_splitk.py
@@ -1,0 +1,1068 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import functools
+from abc import ABC, abstractmethod
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, memref, scf
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import (
+    arith,
+    buffer_ops,
+    const_expr,
+    gpu,
+    range_constexpr,
+    rocdl,
+    vector,
+)
+from flydsl.expr.typing import T
+from flydsl.runtime.device import get_rocm_arch
+from flydsl.utils.smem_allocator import SMEM_CAPACITY_MAP, SmemAllocator, SmemPtr
+
+from .tensor_shim import GTensor, STensor, get_dtype_in_kernel
+
+SPLIT_K_SEMAPHORE_MAX_LEN = 256
+
+
+def swizzle_xor16(row, col_in_bytes, k_blocks16):
+    return col_in_bytes ^ ((row % k_blocks16) * 16)
+
+
+class WmmaHalfBase(ABC):
+    @abstractmethod
+    def __init__(self, dtype: str):
+        pass
+
+    @abstractmethod
+    def __call__(self, a_frag, b_frag, c_frag):
+        pass
+
+
+class WmmaHalf_m16n16k16(WmmaHalfBase):
+    WMMA_M = 16
+    WMMA_N = 16
+    WMMA_K = 16
+    WMMA_A_FRAG_VALUES = 4
+    WMMA_B_FRAG_VALUES = 4
+    WMMA_C_FRAG_VALUES = 4
+
+    def __init__(self, dtype: str):
+        self.dtype = dtype
+
+    def __call__(self, a_frag, b_frag, c_frag):
+        if self.dtype == "bf16":
+            a_frag_vi16 = vector.bitcast(T.vec(self.WMMA_A_FRAG_VALUES, T.i16), a_frag)
+            b_frag_vi16 = vector.bitcast(T.vec(self.WMMA_B_FRAG_VALUES, T.i16), b_frag)
+            return rocdl.mfma_f32_16x16x16bf16_1k(
+                T.f32x4, [a_frag_vi16, b_frag_vi16, c_frag, 0, 0, 0]
+            )
+        return rocdl.mfma_f32_16x16x16f16(
+            T.vec(self.WMMA_C_FRAG_VALUES, T.f32), [a_frag, b_frag, c_frag, 0, 0, 0]
+        )
+
+
+class WmmaHalf_m16n16k32(WmmaHalfBase):
+    WMMA_M = 16
+    WMMA_N = 16
+    WMMA_K = 32
+    WMMA_A_FRAG_VALUES = 8
+    WMMA_B_FRAG_VALUES = 8
+    WMMA_C_FRAG_VALUES = 4
+
+    def __init__(self, dtype: str):
+        self.dtype = dtype
+
+    def __call__(self, a_frag, b_frag, c_frag):
+        if self.dtype == "bf16":
+            return rocdl.mfma_f32_16x16x32_bf16(
+                T.vec(self.WMMA_C_FRAG_VALUES, T.f32), [a_frag, b_frag, c_frag, 0, 0, 0]
+            )
+        return rocdl.mfma_f32_16x16x32_f16(
+            T.vec(self.WMMA_C_FRAG_VALUES, T.f32), [a_frag, b_frag, c_frag, 0, 0, 0]
+        )
+
+
+class OnlineScheduler:
+    def __init__(self, total_signals: int, init_count: int = 0):
+        self.total_signals = total_signals
+        self.current_signal_id = init_count
+        self.remaining = init_count
+
+    def release(self, count: int):
+        count = min(count, self.total_signals - self.current_signal_id)
+        self.current_signal_id += count
+        self.remaining += count
+
+    def consume(self, count: int):
+        count = min(count, self.remaining)
+        self.remaining -= count
+        return count
+
+
+@functools.lru_cache(maxsize=16384)
+def compile_hgemm_kernel(
+    dtype: str,
+    n: int,
+    k: int,
+    TILE_M: int = 128,
+    TILE_N: int = 128,
+    TILE_K: int = 64,
+    STAGES: int = 2,
+    SPLIT_K: int = 1,
+    BLOCK_M_WARPS: int = 2,
+    BLOCK_N_WARPS: int = 2,
+    BLOCK_K_WARPS: int = 1,
+    B_TO_LDS: bool = False,
+    HAS_BIAS: bool = False,
+):
+    assert BLOCK_M_WARPS * BLOCK_N_WARPS * BLOCK_K_WARPS <= 16
+    assert TILE_M * TILE_N * TILE_K <= 256 * 256 * 64
+    if (TILE_M == 256) and (TILE_N == 256):
+        assert (TILE_K == 64) and (SPLIT_K == 1) and (STAGES == 2)
+    assert STAGES >= 2
+    N_BLOCKS = n // TILE_N
+    assert (N_BLOCKS >= 1) and (n % TILE_N == 0)
+    IS_SPLIT_K = SPLIT_K > 1
+    IS_SLICE_K = BLOCK_K_WARPS > 1
+    BLOCK_K = TILE_K
+    assert (k % SPLIT_K == 0) and (k // SPLIT_K >= 1)
+    ks = k // SPLIT_K
+    assert (ks % BLOCK_K == 0) and (ks // BLOCK_K >= 1)
+    assert BLOCK_K >= 32
+    GPU_ARCH = get_rocm_arch()
+    if GPU_ARCH == "gfx942":
+        WMMA_IMPL = WmmaHalf_m16n16k16(dtype)
+        DMA_BYTES = 4
+        MFMA_PER_WARP_K = 2
+        ASYNC_COPY = True
+    else:
+        WMMA_IMPL = WmmaHalf_m16n16k32(dtype)
+        DMA_BYTES = 16
+        MFMA_PER_WARP_K = 1
+        ASYNC_COPY = True
+
+    # Fixed parameters:
+    WARP_SIZE = 64
+    DTYPE_BYTES = 2
+    LDG_VEC_SIZE = 8
+
+    # Propagated parameters:
+    WMMA_M = WMMA_IMPL.WMMA_M
+    WMMA_N = WMMA_IMPL.WMMA_N
+    WMMA_K = WMMA_IMPL.WMMA_K
+    WMMA_A_FRAG_VALUES = WMMA_IMPL.WMMA_A_FRAG_VALUES
+    WMMA_B_FRAG_VALUES = WMMA_IMPL.WMMA_B_FRAG_VALUES
+    WMMA_C_FRAG_VALUES = WMMA_IMPL.WMMA_C_FRAG_VALUES
+    WARP_ATOM_M = WMMA_M
+    WARP_ATOM_N = WMMA_N
+    WARP_ATOM_K = WMMA_K * MFMA_PER_WARP_K
+    BLOCK_K_LOOPS = ks // BLOCK_K
+    assert BLOCK_K_LOOPS >= STAGES
+    WARP_GROUP_K = BLOCK_K_WARPS * WARP_ATOM_K
+    WARP_K_STEPS = BLOCK_K // WARP_GROUP_K
+    assert (BLOCK_K % WARP_GROUP_K == 0) and (WARP_K_STEPS >= 1)
+    K_SLICE = BLOCK_K // BLOCK_K_WARPS
+    assert K_SLICE % WARP_ATOM_K == 0
+    BLOCK_THREADS = BLOCK_M_WARPS * BLOCK_N_WARPS * BLOCK_K_WARPS * WARP_SIZE
+    BLOCK_MN_WARPS = BLOCK_M_WARPS * BLOCK_N_WARPS
+    WARP_M_STEPS = TILE_M // BLOCK_M_WARPS // WARP_ATOM_M
+    WARP_N_STEPS = TILE_N // BLOCK_N_WARPS // WARP_ATOM_N
+    assert (WARP_M_STEPS >= 1) and (WARP_N_STEPS >= 1)
+    assert TILE_M % (BLOCK_M_WARPS * WARP_ATOM_M) == 0
+    assert TILE_N % (BLOCK_N_WARPS * WARP_ATOM_N) == 0
+    WARP_M = WARP_M_STEPS * WARP_ATOM_M
+    WARP_N = WARP_N_STEPS * WARP_ATOM_N
+    BLOCK_M = BLOCK_M_WARPS * WARP_M
+    BLOCK_N = BLOCK_N_WARPS * WARP_N
+    assert (n >= BLOCK_N) and (n % BLOCK_N == 0)
+    BLOCK_MK_SIZE = BLOCK_M * BLOCK_K
+    BLOCK_NK_SIZE = BLOCK_N * BLOCK_K
+    BLOCK_MN_SIZE = BLOCK_M * BLOCK_N
+    LDG_A_X_THREADS = BLOCK_K // LDG_VEC_SIZE
+    # LDG_B_X_THREADS = BLOCK_K // LDG_VEC_SIZE
+    LDG_C_X_THREADS = BLOCK_N // LDG_VEC_SIZE
+    BLOCK_VECS = LDG_VEC_SIZE * BLOCK_THREADS
+    LDG_REG_A_COUNT = BLOCK_MK_SIZE // BLOCK_VECS
+    LDG_REG_B_COUNT = BLOCK_NK_SIZE // BLOCK_VECS
+    LDG_REG_C_COUNT = BLOCK_MN_SIZE // BLOCK_VECS
+    assert (LDG_REG_A_COUNT >= 1) and (LDG_REG_B_COUNT >= 1) and (LDG_REG_C_COUNT >= 1)
+    assert BLOCK_MK_SIZE % BLOCK_VECS == 0
+    assert BLOCK_NK_SIZE % BLOCK_VECS == 0
+    assert BLOCK_MN_SIZE % BLOCK_VECS == 0
+    BLOCK_K_BYTES = BLOCK_K * DTYPE_BYTES
+
+    # LDS parameters:
+    allocator = SmemAllocator(None, arch=GPU_ARCH, global_sym_name="smem")
+    smem_a_offset = allocator._align(allocator.ptr, 16)
+    AS_BYTES = STAGES * BLOCK_M * BLOCK_K * DTYPE_BYTES
+    allocator.ptr = smem_a_offset + AS_BYTES
+    SMEM_USE = AS_BYTES
+    if B_TO_LDS:
+        smem_b_offset = allocator._align(allocator.ptr, 16)
+        allocator.ptr = smem_b_offset + STAGES * BLOCK_N * BLOCK_K * DTYPE_BYTES
+        SMEM_USE += STAGES * BLOCK_N * BLOCK_K * DTYPE_BYTES
+        assert ASYNC_COPY
+    SMEM_USE_ = max(SMEM_USE, BLOCK_K_WARPS * BLOCK_M * BLOCK_N * DTYPE_BYTES)
+    allocator.ptr += SMEM_USE_ - SMEM_USE
+    assert SMEM_USE_ <= SMEM_CAPACITY_MAP[GPU_ARCH]
+    LDG_ASYNC_VEC_SIZE = DMA_BYTES // DTYPE_BYTES
+    LDG_A_X_THREADS_AS = BLOCK_K // LDG_ASYNC_VEC_SIZE
+    LDG_REG_A_COUNT_AS = BLOCK_MK_SIZE // LDG_ASYNC_VEC_SIZE // BLOCK_THREADS
+    LDG_B_X_THREADS_AS = BLOCK_K // LDG_ASYNC_VEC_SIZE
+    LDG_REG_B_COUNT_AS = BLOCK_NK_SIZE // LDG_ASYNC_VEC_SIZE // BLOCK_THREADS
+    LDG_WAIT_COUNT = LDG_REG_B_COUNT_AS + LDG_REG_A_COUNT_AS
+    assert ((STAGES - 2) * LDG_WAIT_COUNT) < 63
+
+    USE_8WAVE_PIPE = (
+        ASYNC_COPY
+        and B_TO_LDS
+        and BLOCK_M == 256
+        and BLOCK_N == 256
+        and BLOCK_K == 64
+        and LDG_REG_A_COUNT_AS == 4
+        and LDG_REG_B_COUNT_AS == 4
+        and MFMA_PER_WARP_K == 1
+    )
+    USE_8WAVE_PIPE = (
+        USE_8WAVE_PIPE
+        and BLOCK_M_WARPS == 2
+        and BLOCK_N_WARPS == 4
+        and BLOCK_K_WARPS == 1
+    )
+
+    KERNEL_NAME = f"hgemm_{dtype}_{BLOCK_M}x{BLOCK_N}x{BLOCK_K}x{STAGES}_SPK{SPLIT_K}_W{BLOCK_M_WARPS}x{BLOCK_N_WARPS}x{BLOCK_K_WARPS}_BLDS{int(B_TO_LDS)}_TN"
+    KERNEL_NAME += "_AS0" if not ASYNC_COPY else "_AS1"
+    if HAS_BIAS:
+        KERNEL_NAME += "_BIAS"
+
+    @flyc.kernel(known_block_size=[BLOCK_THREADS, 1, 1])
+    def hgemm_kernel(
+        C: fx.Pointer,
+        A: fx.Pointer,
+        B: fx.Pointer,
+        BIAS: fx.Pointer,
+        m: fx.Int32,
+        semaphore: fx.Pointer,
+        signal: fx.Pointer,
+    ):
+        dtype_ = get_dtype_in_kernel(dtype)
+        c_zero_d = arith.constant(0.0, type=dtype_)
+        acc_init = arith.constant_vector(0.0, T.vec(WMMA_C_FRAG_VALUES, T.f32))
+
+        A_ = GTensor(A, dtype=dtype_, shape=(-1, k))
+        B_ = GTensor(B, dtype=dtype_, shape=(n, k))
+        C_ = GTensor(C, dtype=dtype_, shape=(-1, n))
+        if const_expr(HAS_BIAS):
+            BIAS_ = GTensor(BIAS, dtype=dtype_, shape=(n,))
+        base_ptr = allocator.get_base()
+        smem_a_ptr = SmemPtr(
+            base_ptr, smem_a_offset, dtype_, shape=(STAGES * BLOCK_M * BLOCK_K,)
+        )
+        as_ = STensor(smem_a_ptr, dtype_, shape=(STAGES, BLOCK_M, BLOCK_K))
+        if const_expr(B_TO_LDS):
+            smem_b_ptr = SmemPtr(
+                base_ptr, smem_b_offset, dtype_, shape=(STAGES * BLOCK_N * BLOCK_K,)
+            )
+            bs_ = STensor(smem_b_ptr, dtype_, shape=(STAGES, BLOCK_N, BLOCK_K))
+        smem_c_ptr = SmemPtr(
+            base_ptr, smem_a_offset, dtype_, shape=(BLOCK_K_WARPS * BLOCK_M * BLOCK_N,)
+        )
+        cs_ = STensor(smem_c_ptr, dtype_, shape=(BLOCK_K_WARPS, BLOCK_M, BLOCK_N))
+        if const_expr(IS_SPLIT_K):
+            semaphore_ = GTensor(semaphore, dtype=T.i32, shape=(-1,))
+            signal_ = GTensor(signal, dtype=T.i32, shape=(-1,))
+            signal_idx = fx.Int32(fx.block_idx.x)
+
+        tid = fx.thread_idx.x
+        wid = tid // WARP_SIZE
+        wid_mn = wid % BLOCK_MN_WARPS
+        wid_k = wid // BLOCK_MN_WARPS
+        w_tid = tid % WARP_SIZE
+
+        def swizzle_for_cache_reuse(pid):
+            # Do nothing currently
+            return pid // N_BLOCKS, pid % N_BLOCKS
+
+        block_m_idx, block_n_idx = swizzle_for_cache_reuse(fx.block_idx.x)
+        ks_idx = fx.Index(fx.block_idx.y)
+        ks_begin = arith.index_cast(T.i32, ks_idx * ks)
+
+        m_offset = fx.Index(block_m_idx * BLOCK_M)
+        n_offset = fx.Index(block_n_idx * BLOCK_N)
+        k_blocks16 = fx.Int32(BLOCK_K_BYTES // 16)
+
+        warp_m_idx = wid_mn // BLOCK_N_WARPS * WARP_M
+        warp_n_idx = wid_mn % BLOCK_N_WARPS * WARP_N
+        ldmatrix_a_m_idx = w_tid % WMMA_M
+        ldmatrix_a_k_vec_idx = w_tid // WMMA_M * WMMA_A_FRAG_VALUES * MFMA_PER_WARP_K
+        ldmatrix_b_n_idx = w_tid % WMMA_N
+        ldmatrix_b_k_vec_idx = w_tid // WMMA_N * WMMA_B_FRAG_VALUES * MFMA_PER_WARP_K
+        warp_k_slice_base = wid_k * K_SLICE
+        C_FRAGS_LEN = WARP_M_STEPS * WARP_N_STEPS
+        c_frags = [acc_init] * C_FRAGS_LEN
+
+        def __barrier(vmcnt=0, use_s_barrier=True):
+            if const_expr(use_s_barrier):
+                asm = f"s_waitcnt vmcnt({vmcnt})\n\ts_barrier"
+            else:
+                asm = f"s_waitcnt vmcnt({vmcnt})"
+            llvm.InlineAsmOp(None, [], asm, "", has_side_effects=True)
+
+        def get_llvm_ptr(
+            ptr, offset, dtype_bytes, ptr_type=ir.Type.parse("!llvm.ptr<1>")
+        ):
+            base_ptr = arith.index_cast(T.i64, fx.ptrtoint(ptr))
+            byte_offset = arith.index_cast(
+                T.i64, fx.Index(offset) * fx.Index(dtype_bytes)
+            )
+            llvm_ptr = llvm.AddOp(
+                base_ptr, byte_offset, llvm.IntegerOverflowFlags(0)
+            ).result
+            llvm_ptr = llvm.IntToPtrOp(ptr_type, llvm_ptr).result
+            ptr_v = (
+                llvm_ptr._value if const_expr(hasattr(llvm_ptr, "_value")) else llvm_ptr
+            )
+            return ptr_v
+
+        def zero_c():
+            # zero c if current block is the first block
+            is_t0_cond = arith.cmpi(arith.CmpIPredicate.eq, fx.Index(tid), fx.Index(0))
+            cond_ks0 = arith.cmpi(arith.CmpIPredicate.eq, ks_idx, fx.Index(0))
+            cond_ks0_if = scf.IfOp(cond_ks0, results_=[], has_else=False)
+            with ir.InsertionPoint(cond_ks0_if.then_block):
+                zero_vec = vector.broadcast(T.vec(LDG_VEC_SIZE, dtype_), c_zero_d)
+                for i in range_constexpr(LDG_REG_C_COUNT):
+                    global_tid = BLOCK_THREADS * i + tid
+                    m_local_idx = global_tid // LDG_C_X_THREADS
+                    n_local_idx = global_tid % LDG_C_X_THREADS * LDG_VEC_SIZE
+                    row_idx = m_offset + fx.Index(m_local_idx)
+                    init_vec = zero_vec
+                    if const_expr(HAS_BIAS):
+                        init_vec = BIAS_.vec_load(
+                            (n_offset + n_local_idx,), LDG_VEC_SIZE
+                        )
+                    cond_boundary = arith.cmpi(
+                        arith.CmpIPredicate.ult, row_idx, fx.Index(m)
+                    )
+                    cond_boundary_if = scf.IfOp(
+                        cond_boundary, results_=[], has_else=False
+                    )
+                    with ir.InsertionPoint(cond_boundary_if.then_block):
+                        bytes_offset = C_.linear_offset(
+                            (row_idx, n_offset + n_local_idx)
+                        )
+                        bytes_offset_i32 = arith.index_cast(T.i32, bytes_offset)
+                        c_ptr = get_llvm_ptr(C, bytes_offset_i32, DTYPE_BYTES)
+                        llvm.InlineAsmOp(
+                            None,
+                            [c_ptr, init_vec],
+                            "global_store_dwordx4 $0, $1, off sc0 sc1",
+                            "v,v",
+                            has_side_effects=True,
+                        )
+                        scf.YieldOp([])
+                gpu.barrier()
+                # trigger signal when zeroc is done by the first arrived block
+                is_t0_cond_if = scf.IfOp(is_t0_cond, results_=[], has_else=False)
+                with ir.InsertionPoint(is_t0_cond_if.then_block):
+                    signal_ptr = get_llvm_ptr(signal, signal_idx, 4)
+                    llvm.InlineAsmOp(
+                        None,
+                        [signal_ptr, arith.constant(1, type=T.i32)],
+                        "global_store_dword $0, $1, off sc0 sc1",
+                        "v,v",
+                        has_side_effects=True,
+                    )
+                    scf.YieldOp([])
+                gpu.barrier()
+                scf.YieldOp([])
+
+        def split_k_barrier():
+            # spin-wait until signal triggered
+            is_t0_cond = arith.cmpi(arith.CmpIPredicate.eq, fx.Index(tid), fx.Index(0))
+            is_t0_cond_if = scf.IfOp(is_t0_cond, results_=[], has_else=False)
+            with ir.InsertionPoint(is_t0_cond_if.then_block):
+                init_cur = arith.constant(0, type=T.i32)
+                w = scf.WhileOp([T.i32], [init_cur])
+                before = ir.Block.create_at_start(w.before, [T.i32])
+                after = ir.Block.create_at_start(w.after, [T.i32])
+                with ir.InsertionPoint(before):
+                    cur = before.arguments[0]
+                    need_wait = arith.CmpIOp(
+                        arith.CmpIPredicate.eq, cur, arith.constant(0, type=T.i32)
+                    ).result
+                    scf.ConditionOp(need_wait, [cur])
+                with ir.InsertionPoint(after):
+                    signal_ptr = get_llvm_ptr(signal, signal_idx, 4)
+                    data = llvm.InlineAsmOp(
+                        T.i32,
+                        [signal_ptr],
+                        "global_load_dword $0, $1, off sc1",
+                        "=v,v",
+                        has_side_effects=True,
+                    ).result
+                    rocdl.s_waitcnt(0)
+                    scf.YieldOp([data])
+                scf.YieldOp([])
+            rocdl.sched_barrier(0)
+            gpu.barrier()
+            # clean semaphore and signal if this is the last block within split-k group
+            is_t0_cond_if = scf.IfOp(is_t0_cond, results_=[], has_else=False)
+            with ir.InsertionPoint(is_t0_cond_if.then_block):
+                semaphore_ptr = get_llvm_ptr(semaphore, signal_idx, 4)
+                arrive_idx = llvm.AtomicRMWOp(
+                    llvm.AtomicBinOp.add,
+                    semaphore_ptr,
+                    arith.constant(1, type=T.i32),
+                    llvm.AtomicOrdering.monotonic,
+                    syncscope="agent",
+                    alignment=4,
+                ).result
+                cond_ksl = arith.cmpi(
+                    arith.CmpIPredicate.eq, fx.Index(arrive_idx), fx.Index(SPLIT_K - 1)
+                )
+                cond_ksl_if = scf.IfOp(cond_ksl, results_=[], has_else=False)
+                with ir.InsertionPoint(cond_ksl_if.then_block):
+                    semaphore_[signal_idx] = arith.constant(0, type=T.i32)
+                    signal_[signal_idx] = arith.constant(0, type=T.i32)
+                    scf.YieldOp([])
+                scf.YieldOp([])
+            gpu.barrier()
+
+        def ldg_a(k_offset):
+            vecs = []
+            for i in range_constexpr(LDG_REG_A_COUNT):
+                global_tid = BLOCK_THREADS * i + tid
+                m_local_idx = global_tid // LDG_A_X_THREADS
+                k_local_idx = global_tid % LDG_A_X_THREADS * LDG_VEC_SIZE
+                row_idx = m_offset + fx.Index(m_local_idx)
+                safe_row_idx = arith.select(
+                    arith.cmpi(arith.CmpIPredicate.ult, row_idx, fx.Index(m)),
+                    row_idx,
+                    fx.Index(0),
+                )
+                col_idx = fx.Index(k_offset + k_local_idx)
+                vec = A_.vec_load((safe_row_idx, col_idx), LDG_VEC_SIZE)
+                vecs.append(vec)
+            return vecs
+
+        def sts_a(vecs, lds_stage):
+            for i in range_constexpr(LDG_REG_A_COUNT):
+                global_tid = BLOCK_THREADS * i + tid
+                m_local_idx = global_tid // LDG_A_X_THREADS
+                k_local_idx = global_tid % LDG_A_X_THREADS * LDG_VEC_SIZE
+                col_in_bytes = k_local_idx * DTYPE_BYTES
+                col_in_bytes = swizzle_xor16(m_local_idx, col_in_bytes, k_blocks16)
+                as_.vec_store(
+                    (fx.Index(lds_stage), m_local_idx, col_in_bytes // DTYPE_BYTES),
+                    vecs[i],
+                    LDG_VEC_SIZE,
+                )
+
+        def get_dma_copy_warp_offset():
+            warp_offset = rocdl.readfirstlane(
+                T.i64,
+                arith.index_cast(
+                    T.i64,
+                    fx.Index(wid) * arith.constant(WARP_SIZE * DMA_BYTES, index=True),
+                ),
+            )
+            return warp_offset
+
+        def buffer_load_lds_inline(rsrc, lds_ptr, global_offset):
+            if const_expr(DMA_BYTES == 16):
+                asm = "s_mov_b32 m0, $0\n\tbuffer_load_dwordx4 $1, $2, 0 offen sc0 lds"
+            elif const_expr(DMA_BYTES == 8):
+                asm = "s_mov_b32 m0, $0\n\tbuffer_load_dwordx2 $1, $2, 0 offen sc0 lds"
+            elif const_expr(DMA_BYTES == 4):
+                asm = "s_mov_b32 m0, $0\n\tbuffer_load_dword $1, $2, 0 offen sc0 lds"
+            else:
+                raise NotImplementedError(f"DMA_BYTES={DMA_BYTES} not supported")
+            llvm.InlineAsmOp(
+                None,
+                [lds_ptr, global_offset, rsrc],
+                asm,
+                "s,v,s",
+                has_side_effects=True,
+            )
+
+        def ldg_sts_a_async_one(ii, k_offset, write_stage, lds_ptr=None):
+            global_tid = BLOCK_THREADS * ii + tid
+            m_local_idx = global_tid // LDG_A_X_THREADS_AS
+            k_local_idx = global_tid % LDG_A_X_THREADS_AS * LDG_ASYNC_VEC_SIZE
+            col_in_bytes = k_local_idx * DTYPE_BYTES
+            col_in_bytes = swizzle_xor16(m_local_idx, col_in_bytes, k_blocks16)
+            row_idx = m_offset + fx.Index(m_local_idx)
+            safe_row_idx = arith.select(
+                arith.cmpi(arith.CmpIPredicate.ult, row_idx, fx.Index(m)),
+                row_idx,
+                fx.Index(0),
+            )
+            col_idx = fx.Index(k_offset + col_in_bytes // DTYPE_BYTES)
+            global_offset = A_.linear_offset((safe_row_idx, col_idx)) * DTYPE_BYTES
+            global_offset = arith.index_cast(T.i32, global_offset)
+            if const_expr(lds_ptr is None):
+                lds_offset = (
+                    as_.linear_offset((fx.Index(write_stage), 0, 0)) * DTYPE_BYTES
+                )
+                lds_base = (
+                    memref.extract_aligned_pointer_as_index(as_.memptr) + lds_offset
+                )
+                lds_ptr_base = buffer_ops.create_llvm_ptr(
+                    arith.index_cast(T.i64, lds_base), address_space=3
+                )
+                lds_ptr = buffer_ops.get_element_ptr(lds_ptr_base, warp_offset)
+            else:
+                lds_ptr = buffer_ops.get_element_ptr(
+                    lds_ptr, static_byte_offset=BLOCK_THREADS * DMA_BYTES
+                )
+            buffer_load_lds_inline(A_.rsrc, lds_ptr, global_offset)
+            return lds_ptr
+
+        def ldg_sts_a_async(k_offset, lds_stage):
+            lds_ptr = None
+            for i in range_constexpr(LDG_REG_A_COUNT_AS):
+                lds_ptr = ldg_sts_a_async_one(
+                    i, k_offset, lds_stage, lds_ptr if i > 0 else None
+                )
+
+        def ldg_sts_b_async_one(ii, k_offset, write_stage, lds_ptr=None):
+            global_tid = BLOCK_THREADS * ii + tid
+            n_local_idx = global_tid // LDG_B_X_THREADS_AS
+            k_local_idx = global_tid % LDG_B_X_THREADS_AS * LDG_ASYNC_VEC_SIZE
+            col_in_bytes = k_local_idx * DTYPE_BYTES
+            col_in_bytes = swizzle_xor16(n_local_idx, col_in_bytes, k_blocks16)
+            row_idx = n_offset + fx.Index(n_local_idx)
+            safe_row_idx = arith.select(
+                arith.cmpi(arith.CmpIPredicate.ult, row_idx, fx.Index(n)),
+                row_idx,
+                fx.Index(0),
+            )
+            col_idx = fx.Index(k_offset + col_in_bytes // DTYPE_BYTES)
+            global_offset = B_.linear_offset((safe_row_idx, col_idx)) * DTYPE_BYTES
+            global_offset = arith.index_cast(T.i32, global_offset)
+            if const_expr(lds_ptr is None):
+                lds_offset = (
+                    bs_.linear_offset((fx.Index(write_stage), 0, 0)) * DTYPE_BYTES
+                )
+                lds_base = (
+                    memref.extract_aligned_pointer_as_index(bs_.memptr) + lds_offset
+                )
+                lds_ptr_base = buffer_ops.create_llvm_ptr(
+                    arith.index_cast(T.i64, lds_base), address_space=3
+                )
+                lds_ptr = buffer_ops.get_element_ptr(lds_ptr_base, warp_offset)
+            else:
+                lds_ptr = buffer_ops.get_element_ptr(
+                    lds_ptr, static_byte_offset=BLOCK_THREADS * DMA_BYTES
+                )
+            buffer_load_lds_inline(B_.rsrc, lds_ptr, global_offset)
+            return lds_ptr
+
+        def ldg_sts_b_async(k_offset, lds_stage):
+            lds_ptr = None
+            for i in range_constexpr(LDG_REG_B_COUNT_AS):
+                lds_ptr = ldg_sts_b_async_one(
+                    i, k_offset, lds_stage, lds_ptr if i > 0 else None
+                )
+
+        def ldg_matrix_b(k_offset):
+            vecs = []
+            for kk in range_constexpr(WARP_K_STEPS):
+                for ii in range_constexpr(WARP_N_STEPS):
+                    warp_atom_n_idx = warp_n_idx + ii * WARP_ATOM_N
+                    warp_atom_k_idx = warp_k_slice_base + kk * WARP_ATOM_K
+                    n_idx = n_offset + warp_atom_n_idx + ldmatrix_b_n_idx
+                    k_idx = k_offset + warp_atom_k_idx + ldmatrix_b_k_vec_idx
+                    vec = B_.vec_load(
+                        (n_idx, k_idx), WMMA_B_FRAG_VALUES * MFMA_PER_WARP_K
+                    )
+                    vecs.append(vec)
+            return vecs
+
+        def ldmatrix_compute_tile_streaming(lds_stage, c_frags, initial_b_frags=None):
+            s = fx.Index(lds_stage)
+            c_frags_new = [cx for cx in c_frags]
+            for kk in range_constexpr(WARP_K_STEPS):
+                warp_atom_k_idx = warp_k_slice_base + kk * WARP_ATOM_K
+                if const_expr(initial_b_frags is None):
+                    b_frags = [0] * WARP_N_STEPS
+                    for ii in range_constexpr(WARP_N_STEPS):
+                        warp_atom_n_idx = warp_n_idx + ii * WARP_ATOM_N
+                        row = warp_atom_n_idx + ldmatrix_b_n_idx
+                        col_in_bytes = (
+                            warp_atom_k_idx + ldmatrix_b_k_vec_idx
+                        ) * DTYPE_BYTES
+                        col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
+                        vec = bs_.vec_load(
+                            (s, row, col_in_bytes // DTYPE_BYTES),
+                            WMMA_B_FRAG_VALUES * MFMA_PER_WARP_K,
+                        )
+                        b_frags[ii] = vec
+                else:
+                    b_frags = [
+                        initial_b_frags[i]
+                        for i in range_constexpr(
+                            kk * WARP_N_STEPS, (kk + 1) * WARP_N_STEPS
+                        )
+                    ]
+                a_frags = [0] * WARP_M_STEPS
+                for ii in range_constexpr(WARP_M_STEPS):
+                    warp_atom_m_idx = warp_m_idx + ii * WARP_ATOM_M
+                    row = warp_atom_m_idx + ldmatrix_a_m_idx
+                    col_in_bytes = (
+                        warp_atom_k_idx + ldmatrix_a_k_vec_idx
+                    ) * DTYPE_BYTES
+                    col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
+                    vec = as_.vec_load(
+                        (s, row, col_in_bytes // DTYPE_BYTES),
+                        WMMA_A_FRAG_VALUES * MFMA_PER_WARP_K,
+                    )
+                    a_frags[ii] = vec
+                rocdl.sched_barrier(0)
+                for ii in range_constexpr(WARP_M_STEPS):
+                    a_frag = a_frags[ii]
+                    for jj in range_constexpr(WARP_N_STEPS):
+                        b_frag = b_frags[jj]
+                        if const_expr(MFMA_PER_WARP_K == 2):
+                            # split a
+                            a_i64x2 = vector.bitcast(T.i64x2, a_frag)
+                            a0_i64 = vector.extract(
+                                a_i64x2, static_position=[0], dynamic_position=[]
+                            )
+                            a1_i64 = vector.extract(
+                                a_i64x2, static_position=[1], dynamic_position=[]
+                            )
+                            a_v0 = vector.bitcast(
+                                T.f16x4, vector.from_elements(T.vec(1, T.i64), [a0_i64])
+                            )
+                            a_v1 = vector.bitcast(
+                                T.f16x4, vector.from_elements(T.vec(1, T.i64), [a1_i64])
+                            )
+                            # split b
+                            b_i64x2 = vector.bitcast(T.i64x2, b_frag)
+                            b0_i64 = vector.extract(
+                                b_i64x2, static_position=[0], dynamic_position=[]
+                            )
+                            b1_i64 = vector.extract(
+                                b_i64x2, static_position=[1], dynamic_position=[]
+                            )
+                            b_v0 = vector.bitcast(
+                                T.f16x4, vector.from_elements(T.vec(1, T.i64), [b0_i64])
+                            )
+                            b_v1 = vector.bitcast(
+                                T.f16x4, vector.from_elements(T.vec(1, T.i64), [b1_i64])
+                            )
+                            # wmma
+                            c_idx = ii * WARP_N_STEPS + jj
+                            acc_in = c_frags_new[c_idx]
+                            acc_mid = WMMA_IMPL(a_v0, b_v0, acc_in)
+                            c_frags_new[c_idx] = WMMA_IMPL(a_v1, b_v1, acc_mid)
+                        elif const_expr(MFMA_PER_WARP_K == 1):
+                            c_idx = ii * WARP_N_STEPS + jj
+                            c_frags_new[c_idx] = WMMA_IMPL(
+                                a_frag, b_frag, c_frags_new[c_idx]
+                            )
+                        else:
+                            raise NotImplementedError(
+                                f"MFMA_PER_WARP_K={MFMA_PER_WARP_K} not supported"
+                            )
+            return c_frags_new
+
+        def async_copy_ldmatrix_compute_tile_streaming(
+            lds_stage,
+            c_frags,
+            k_offset_next_tile,
+            write_stage,
+        ):
+            assert LDG_REG_A_COUNT_AS == 4
+            assert LDG_REG_B_COUNT_AS == 4
+            assert MFMA_PER_WARP_K == 1
+            assert WARP_M_STEPS % 2 == 0
+            assert WARP_N_STEPS % 2 == 0
+
+            M_HALF_STEPS = WARP_M_STEPS // 2
+            N_HALF_STEPS = WARP_N_STEPS // 2
+
+            s = fx.Index(lds_stage)
+            c_frags_new = [cx for cx in c_frags]
+            lds_ptr_a = None
+            lds_ptr_b = None
+
+            def load_b_frag(n_step, warp_atom_k_idx):
+                warp_atom_n_idx = warp_n_idx + n_step * WARP_ATOM_N
+                row = warp_atom_n_idx + ldmatrix_b_n_idx
+                col_in_bytes = (warp_atom_k_idx + ldmatrix_b_k_vec_idx) * DTYPE_BYTES
+                col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
+                return bs_.vec_load(
+                    (s, row, col_in_bytes // DTYPE_BYTES),
+                    WMMA_B_FRAG_VALUES * MFMA_PER_WARP_K,
+                )
+
+            def load_a_frag(m_step, warp_atom_k_idx):
+                warp_atom_m_idx = warp_m_idx + m_step * WARP_ATOM_M
+                row = warp_atom_m_idx + ldmatrix_a_m_idx
+                col_in_bytes = (warp_atom_k_idx + ldmatrix_a_k_vec_idx) * DTYPE_BYTES
+                col_in_bytes = swizzle_xor16(row, col_in_bytes, k_blocks16)
+                return as_.vec_load(
+                    (s, row, col_in_bytes // DTYPE_BYTES),
+                    WMMA_A_FRAG_VALUES * MFMA_PER_WARP_K,
+                )
+
+            for kk in range_constexpr(WARP_K_STEPS):
+                warp_atom_k_idx = kk * WARP_ATOM_K
+                b0_frags = [0] * N_HALF_STEPS  # 2
+                b1_frags = [0] * N_HALF_STEPS
+                a0_frags = [0] * M_HALF_STEPS  # 4
+                a1_frags = [0] * M_HALF_STEPS
+                if const_expr(kk == 0):
+                    lds_ptr_b = ldg_sts_b_async_one(
+                        0, k_offset_next_tile, write_stage, lds_ptr_b
+                    )
+                    lds_ptr_b = ldg_sts_b_async_one(
+                        1, k_offset_next_tile, write_stage, lds_ptr_b
+                    )
+                for ni in range_constexpr(N_HALF_STEPS):
+                    b0_frags[ni] = load_b_frag(ni, warp_atom_k_idx)
+                for mi in range_constexpr(M_HALF_STEPS):
+                    a0_frags[mi] = load_a_frag(mi, warp_atom_k_idx)
+                if const_expr(kk == 0):
+                    rocdl.s_setprio(1)
+                for mi in range_constexpr(M_HALF_STEPS):
+                    for ni in range_constexpr(N_HALF_STEPS):
+                        c_idx = mi * WARP_N_STEPS + ni
+                        c_frags_new[c_idx] = WMMA_IMPL(
+                            a0_frags[mi],
+                            b0_frags[ni],
+                            c_frags_new[c_idx],
+                        )
+                if const_expr(kk == 0):
+                    rocdl.s_setprio(0)
+                if const_expr(kk == 0):
+                    lds_ptr_a = ldg_sts_a_async_one(
+                        0, k_offset_next_tile, write_stage, lds_ptr_a
+                    )
+                    lds_ptr_a = ldg_sts_a_async_one(
+                        1, k_offset_next_tile, write_stage, lds_ptr_a
+                    )
+                for ni in range_constexpr(N_HALF_STEPS):
+                    b1_frags[ni] = load_b_frag(N_HALF_STEPS + ni, warp_atom_k_idx)
+                if const_expr(kk == 0):
+                    rocdl.s_setprio(1)
+                for mi in range_constexpr(M_HALF_STEPS):
+                    for ni in range_constexpr(N_HALF_STEPS):
+                        c_idx = mi * WARP_N_STEPS + N_HALF_STEPS + ni
+                        c_frags_new[c_idx] = WMMA_IMPL(
+                            a0_frags[mi],
+                            b1_frags[ni],
+                            c_frags_new[c_idx],
+                        )
+                if const_expr(kk == 0):
+                    rocdl.s_setprio(0)
+                    lds_ptr_b = ldg_sts_b_async_one(
+                        2, k_offset_next_tile, write_stage, lds_ptr_b
+                    )
+                    lds_ptr_b = ldg_sts_b_async_one(
+                        3, k_offset_next_tile, write_stage, lds_ptr_b
+                    )
+                for mi in range_constexpr(M_HALF_STEPS):
+                    a1_frags[mi] = load_a_frag(M_HALF_STEPS + mi, warp_atom_k_idx)
+                if const_expr(kk == 0):
+                    rocdl.s_setprio(1)
+                for mi in range_constexpr(M_HALF_STEPS):
+                    for ni in range_constexpr(N_HALF_STEPS):
+                        c_idx = (M_HALF_STEPS + mi) * WARP_N_STEPS + ni
+                        c_frags_new[c_idx] = WMMA_IMPL(
+                            a1_frags[mi],
+                            b0_frags[ni],
+                            c_frags_new[c_idx],
+                        )
+                if const_expr(kk == 0):
+                    rocdl.s_setprio(0)
+                    lds_ptr_a = ldg_sts_a_async_one(
+                        2, k_offset_next_tile, write_stage, lds_ptr_a
+                    )
+                    lds_ptr_a = ldg_sts_a_async_one(
+                        3, k_offset_next_tile, write_stage, lds_ptr_a
+                    )
+                    rocdl.s_setprio(1)
+                for mi in range_constexpr(M_HALF_STEPS):
+                    for ni in range_constexpr(N_HALF_STEPS):
+                        c_idx = (M_HALF_STEPS + mi) * WARP_N_STEPS + N_HALF_STEPS + ni
+                        c_frags_new[c_idx] = WMMA_IMPL(
+                            a1_frags[mi],
+                            b1_frags[ni],
+                            c_frags_new[c_idx],
+                        )
+                if const_expr(kk == 0):
+                    rocdl.s_setprio(0)
+            return c_frags_new
+
+        warp_offset = get_dma_copy_warp_offset()
+
+        if const_expr(IS_SPLIT_K):
+            zero_c()
+
+        if const_expr(B_TO_LDS):
+
+            for s in range_constexpr(STAGES - 1):
+                ldg_sts_b_async(ks_begin + s * BLOCK_K, s)
+                ldg_sts_a_async(ks_begin + s * BLOCK_K, s)
+            rocdl.sched_barrier(0)
+
+            def hot_loop_scheduler():
+                # ================ Ordered ================
+                if const_expr(USE_8WAVE_PIPE):
+                    for ki in range_constexpr(WARP_K_STEPS):
+                        if const_expr(ki == 0):
+                            rocdl.sched_vmem(2)
+                        rocdl.sched_dsrd(2)
+                        rocdl.sched_dsrd(4)
+                        rocdl.sched_mfma(8)
+                        if const_expr(ki == 0):
+                            rocdl.sched_vmem(2)
+                        rocdl.sched_dsrd(2)
+                        rocdl.sched_mfma(8)
+                        if const_expr(ki == 0):
+                            rocdl.sched_vmem(2)
+                        rocdl.sched_dsrd(4)
+                        rocdl.sched_mfma(8)
+                        if const_expr(ki == 0):
+                            rocdl.sched_vmem(2)
+                        rocdl.sched_mfma(8)
+                else:
+                    for i in range_constexpr(LDG_REG_B_COUNT_AS):
+                        rocdl.sched_vmem(1)  # ldg_sts_b_async next
+                    for i in range_constexpr(LDG_REG_A_COUNT_AS):
+                        rocdl.sched_vmem(1)  # ldg_sts_a_async next
+                    for ki in range_constexpr(WARP_K_STEPS):
+                        for i in range_constexpr(WARP_N_STEPS):
+                            rocdl.sched_dsrd(1)  # lds_matrix_b current
+                        for i in range_constexpr(WARP_M_STEPS):
+                            rocdl.sched_dsrd(1)  # lds_matrix_a current
+                        for i in range_constexpr(WARP_M_STEPS):
+                            rocdl.sched_mfma(WARP_N_STEPS)
+                # ================ Reordered ================
+                rocdl.sched_barrier(0)
+
+            init_state = [ks_begin, arith.constant(0, index=True)] + c_frags
+            for bki, state in range(
+                0, BLOCK_K_LOOPS - (STAGES - 1), 1, init=init_state
+            ):
+                k_offset = state[0]
+                current_stage = fx.Index(state[1])
+                c_frags = state[2:]
+                next_stage = (current_stage + 1) % STAGES
+                write_stage = (current_stage + STAGES - 1) % STAGES
+                __barrier((STAGES - 2) * LDG_WAIT_COUNT)
+                if const_expr(USE_8WAVE_PIPE):
+                    c_frags_new = async_copy_ldmatrix_compute_tile_streaming(
+                        current_stage,
+                        c_frags,
+                        k_offset + (STAGES - 1) * BLOCK_K,
+                        write_stage,
+                    )
+                else:
+                    ldg_sts_b_async(k_offset + (STAGES - 1) * BLOCK_K, write_stage)
+                    ldg_sts_a_async(k_offset + (STAGES - 1) * BLOCK_K, write_stage)
+                    c_frags_new = ldmatrix_compute_tile_streaming(
+                        current_stage, c_frags
+                    )
+                k_offset_next = k_offset + fx.Int32(BLOCK_K)
+                hot_loop_scheduler()
+                results = yield [k_offset_next, next_stage] + c_frags_new
+            current_stage = fx.Index(results[1])
+            c_frags = results[2:]
+            for s in range_constexpr(0, STAGES - 1):
+                __barrier((STAGES - 2 - s) * LDG_WAIT_COUNT)
+                c_frags = ldmatrix_compute_tile_streaming(current_stage, c_frags)
+                current_stage = (current_stage + 1) % STAGES
+
+        else:
+
+            assert STAGES == 2
+            sts_a(ldg_a(ks_begin), 0)
+            b_frags_next = ldg_matrix_b(ks_begin)
+            rocdl.sched_barrier(0)
+            __barrier()
+
+            def hot_loop_scheduler():
+                LDG_REG_A_COUNT_ = (
+                    LDG_REG_A_COUNT_AS if const_expr(ASYNC_COPY) else LDG_REG_A_COUNT
+                )
+                LDG_TOTAL = LDG_REG_A_COUNT_ + WARP_K_STEPS * WARP_N_STEPS
+                # ================ Ordered ================
+                for i in range_constexpr(LDG_TOTAL):
+                    rocdl.sched_vmem(1)
+                for ki in range_constexpr(WARP_K_STEPS):
+                    for i in range_constexpr(WARP_M_STEPS):
+                        rocdl.sched_dsrd(1)
+                    for i in range_constexpr(WARP_M_STEPS):
+                        rocdl.sched_mfma(WARP_N_STEPS)
+                # ================ Reordered ================
+                rocdl.sched_barrier(0)
+
+            init_state = (
+                [ks_begin, arith.constant(0, index=True)] + c_frags + b_frags_next
+            )
+            for bki, state in range(1, BLOCK_K_LOOPS, init=init_state):
+                k_offset = state[0]
+                current_stage = fx.Index(state[1])
+                next_stage = 1 - current_stage
+                c_frags = state[2 : 2 + C_FRAGS_LEN]
+                b_frags = state[2 + C_FRAGS_LEN :]
+                if const_expr(ASYNC_COPY):
+                    ldg_sts_a_async(k_offset + BLOCK_K, next_stage)
+                else:
+                    a_regs_next = ldg_a(k_offset + BLOCK_K)
+                b_frags_next = ldg_matrix_b(k_offset + BLOCK_K)
+                c_frags_new = ldmatrix_compute_tile_streaming(
+                    current_stage, c_frags, b_frags
+                )
+                if const_expr(not ASYNC_COPY):
+                    sts_a(a_regs_next, next_stage)
+                k_offset = k_offset + fx.Int32(BLOCK_K)
+                hot_loop_scheduler()
+                __barrier()
+                results = yield [k_offset, next_stage] + c_frags_new + b_frags_next
+            current_stage = fx.Index(results[1])
+            c_frags = results[2 : 2 + C_FRAGS_LEN]
+            b_frags = results[2 + C_FRAGS_LEN :]
+            c_frags = ldmatrix_compute_tile_streaming(current_stage, c_frags, b_frags)
+
+        # write to lds
+        stmatrix_c_m_vec_idx = w_tid // WMMA_N * WMMA_C_FRAG_VALUES
+        stmatrix_c_n_idx = w_tid % WMMA_N
+        gpu.barrier()
+        for ii in range_constexpr(WARP_M_STEPS):
+            warp_atom_m_idx = warp_m_idx + ii * WARP_ATOM_M
+            for jj in range_constexpr(WARP_N_STEPS):
+                warp_atom_n_idx = warp_n_idx + jj * WARP_ATOM_N
+                for kk in range_constexpr(WMMA_C_FRAG_VALUES):
+                    lds_m_idx = fx.Index(warp_atom_m_idx + stmatrix_c_m_vec_idx + kk)
+                    lds_n_idx = fx.Index(warp_atom_n_idx + stmatrix_c_n_idx)
+                    val = vector.extract(
+                        c_frags[ii * WARP_N_STEPS + jj],
+                        static_position=[kk],
+                        dynamic_position=[],
+                    )
+                    val = val.truncf(dtype_)
+                    if const_expr(IS_SLICE_K):
+                        cs_[wid_k, lds_m_idx, lds_n_idx] = val
+                    else:
+                        cs_[0, lds_m_idx, lds_n_idx] = val
+
+        # write back to global
+        if const_expr(IS_SPLIT_K):
+            split_k_barrier()
+            for i in range_constexpr(LDG_REG_C_COUNT):
+                global_tid = BLOCK_THREADS * i + tid
+                m_local_idx = fx.Index(global_tid // LDG_C_X_THREADS)
+                n_local_idx = fx.Index(global_tid % LDG_C_X_THREADS * LDG_VEC_SIZE)
+                m_global_idx = m_offset + m_local_idx
+                n_global_idx = n_offset + n_local_idx
+                cond_boundary = arith.cmpi(
+                    arith.CmpIPredicate.ult, m_global_idx, fx.Index(m)
+                )
+                cond_boundary_if = scf.IfOp(cond_boundary, results_=[], has_else=False)
+                with ir.InsertionPoint(cond_boundary_if.then_block):
+                    pk_val = cs_.vec_load((0, m_local_idx, n_local_idx), LDG_VEC_SIZE)
+                    for ksi in range_constexpr(1, BLOCK_K_WARPS):
+                        pk_val += cs_.vec_load(
+                            (ksi, m_local_idx, n_local_idx), LDG_VEC_SIZE
+                        )
+                    linear_offset_c = C_.linear_offset((m_global_idx, n_global_idx))
+                    # split to vec2s
+                    vec2_ty = T.vec(2, dtype_)
+                    for vec_idx in range_constexpr(LDG_VEC_SIZE // 2):
+                        e0 = vector.extract(
+                            pk_val, static_position=[vec_idx * 2], dynamic_position=[]
+                        )
+                        e1 = vector.extract(
+                            pk_val,
+                            static_position=[vec_idx * 2 + 1],
+                            dynamic_position=[],
+                        )
+                        pair = vector.from_elements(vec2_ty, [e0, e1])
+                        pair_v = (
+                            pair._value if const_expr(hasattr(pair, "_value")) else pair
+                        )
+                        pair_ptr_v = get_llvm_ptr(
+                            C, fx.Int32(linear_offset_c + vec_idx * 2), DTYPE_BYTES
+                        )
+                        llvm.AtomicRMWOp(
+                            llvm.AtomicBinOp.fadd,
+                            pair_ptr_v,
+                            pair_v,
+                            llvm.AtomicOrdering.monotonic,
+                            syncscope="agent",
+                            alignment=4,
+                        )
+                    scf.YieldOp([])
+        else:
+            gpu.barrier()
+            for i in range_constexpr(LDG_REG_C_COUNT):
+                global_tid = BLOCK_THREADS * i + tid
+                m_local_idx = fx.Index(global_tid // LDG_C_X_THREADS)
+                n_local_idx = fx.Index(global_tid % LDG_C_X_THREADS * LDG_VEC_SIZE)
+                m_global_idx = m_offset + m_local_idx
+                cond_boundary = arith.cmpi(
+                    arith.CmpIPredicate.ult, m_global_idx, fx.Index(m)
+                )
+                cond_boundary_if = scf.IfOp(cond_boundary, results_=[], has_else=False)
+                with ir.InsertionPoint(cond_boundary_if.then_block):
+                    vec = cs_.vec_load((0, m_local_idx, n_local_idx), LDG_VEC_SIZE)
+                    for ksi in range_constexpr(1, BLOCK_K_WARPS):
+                        vec += cs_.vec_load(
+                            (ksi, m_local_idx, n_local_idx), LDG_VEC_SIZE
+                        )
+                    if const_expr(HAS_BIAS):
+                        bias_vec = BIAS_.vec_load(
+                            (n_offset + n_local_idx,), LDG_VEC_SIZE
+                        )
+                        vec = vec + bias_vec
+                    C_.vec_store(
+                        (m_global_idx, n_offset + n_local_idx), vec, LDG_VEC_SIZE
+                    )
+                    scf.YieldOp([])
+        return
+
+    @flyc.jit
+    def launch_hgemm_kernel(
+        C: fx.Pointer,
+        A: fx.Pointer,
+        B: fx.Pointer,
+        BIAS: fx.Pointer,
+        m: fx.Int32,
+        semaphore: fx.Pointer,
+        signal: fx.Pointer,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bm = (m + BLOCK_M - 1) // BLOCK_M
+        hgemm_kernel._func.__name__ = KERNEL_NAME
+        value_attrs = (
+            {
+                "rocdl.waves_per_eu": 2,
+                "rocdl.flat_work_group_size": f"{BLOCK_THREADS},{BLOCK_THREADS}",
+            }
+            if USE_8WAVE_PIPE
+            else None
+        )
+        hgemm_kernel(C, A, B, BIAS, m, semaphore, signal).launch(
+            grid=(bm * N_BLOCKS, SPLIT_K, 1),
+            block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+            value_attrs=value_attrs,
+        )
+
+    return launch_hgemm_kernel

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/tensor_shim.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/tensor_shim.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from abc import ABC, abstractmethod
+from itertools import product
+
+import numpy as np
+import torch
+
+import flydsl.compiler as flyc
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import fly, llvm
+from flydsl.compiler.protocol import extract_to_ir_values
+from flydsl.expr import arith, buffer_ops, range_constexpr, vector
+from flydsl.expr.typing import T
+
+
+def _run_compiled(exe, *args):
+    """First call: ``flyc.compile(exe, *args)`` compiles **and** executes the kernel.
+    Subsequent calls: fast dispatch via the cached ``CompiledFunction``.
+    """
+    cf = getattr(exe, "_cf", None)
+    if cf is None:
+        cf = flyc.compile(exe, *args)
+        exe._cf = cf
+    else:
+        cf(*args)
+
+
+def _to_raw(v):
+    """Convert ArithValue / Numeric (Int32, Boolean, …) to raw ir.Value."""
+    if isinstance(v, ir.Value):
+        return v
+    if hasattr(v, "ir_value"):
+        return _to_raw(v.ir_value())
+    return ir.Value._CAPICreate(v._CAPIPtr)
+
+
+def get_dtype_str(dtype):
+    if dtype == torch.float:
+        return "f32"
+    elif dtype == torch.half:
+        return "f16"
+    elif dtype == torch.bfloat16:
+        return "bf16"
+
+
+def get_dtype_in_kernel(dtype: str):
+    if dtype == "f32":
+        return T.f32
+    elif dtype == "f16":
+        return T.f16
+    elif dtype == "bf16":
+        return T.bf16
+
+
+def get_dtype_vec_size(dtype: str):
+    if dtype == "f32":
+        return 4
+    elif dtype == "f16":
+        return 8
+    elif dtype == "bf16":
+        return 8
+
+
+def get_dtype_bytes(dtype: str):
+    if dtype == "f32":
+        return 4
+    elif dtype == "f16":
+        return 2
+    elif dtype == "bf16":
+        return 2
+
+
+class TensorView:
+    def __init__(self, dtype, shape, stride, base_offset, load_impl, store_impl):
+        self.dtype = dtype
+        self.shape = shape
+        if stride is None:
+            self.stride = tuple(
+                (
+                    np.cumprod(shape[::-1])[::-1].tolist()
+                    + [
+                        1,
+                    ]
+                )[1:]
+            )
+        else:
+            self.stride = stride
+        self.base_offset = base_offset
+        self.load_impl = load_impl
+        self.store_impl = store_impl
+
+    def _linear_offset(self, idxs):
+        slice_shape = []
+        slice_stride = []
+        d_offset = self.base_offset
+        for i in range_constexpr(len(idxs)):
+            md_id = idxs[i]
+            if md_id is None:
+                slice_shape.append(self.shape[i])
+                slice_stride.append(self.stride[i])
+            elif isinstance(md_id, int):
+                d_offset = d_offset + md_id * self.stride[i]
+            else:
+                d_offset = d_offset + md_id * self.stride[i]
+        if len(slice_shape) > 0:
+            return d_offset, tuple(slice_shape), tuple(slice_stride)
+        else:
+            return (d_offset,)
+
+    def _lazy_init(self):
+        pass
+
+    def __repr__(self):
+        return f"TensorView(offset={self.base_offset}, shape={self.shape}, stride={self.stride}, dtype={self.dtype})"
+
+    def __getitem__(self, idxs):
+        if not isinstance(idxs, tuple):
+            idxs = (idxs,)
+        offset = self._linear_offset(idxs)
+        if len(offset) == 1:
+            return self.load_impl(offset[0])
+        else:
+            return TensorView(
+                self.dtype,
+                offset[1],
+                offset[2],
+                offset[0],
+                self.load_impl,
+                self.store_impl,
+            )
+
+    def __setitem__(self, idxs, value):
+        if not isinstance(idxs, tuple):
+            idxs = (idxs,)
+        offset = self._linear_offset(idxs)
+        assert len(offset) == 1
+        self.store_impl(offset[0], value)
+
+    def vec_load(self, idxs, vec_size):
+        if not isinstance(idxs, tuple):
+            idxs = (idxs,)
+        offset = self._linear_offset(idxs)
+        assert len(offset) == 1
+        return self.load_impl(offset[0], vec_size=vec_size)
+
+    def vec_store(self, idxs, value, vec_size):
+        if not isinstance(idxs, tuple):
+            idxs = (idxs,)
+        offset = self._linear_offset(idxs)
+        assert len(offset) == 1
+        self.store_impl(offset[0], value, vec_size=vec_size)
+
+    def linear_offset(self, idxs):
+        if not isinstance(idxs, tuple):
+            idxs = (idxs,)
+        offset = self._linear_offset(idxs)
+        assert len(offset) == 1
+        return offset[0]
+
+    def local_tile(self, tile_shape, tile_idxs):
+        d_offset = self.base_offset
+        stride = []
+        for i in range_constexpr(len(tile_idxs)):
+            d_offset = d_offset + tile_idxs[i] * tile_shape[i] * self.stride[i]
+            stride.append(self.stride[i])
+        return TensorView(
+            self.dtype,
+            tile_shape,
+            tuple(stride),
+            d_offset,
+            self.load_impl,
+            self.store_impl,
+        )
+
+    def copy_(self, src_tensor, thread_layout, value_layout, thread_idxs, vec_size):
+        src_tensor._lazy_init()
+        ndim = len(thread_layout)
+        src_offset = src_tensor.base_offset
+        dst_offset = self.base_offset
+        for d in range_constexpr(ndim):
+            src_offset = src_offset + thread_idxs[d] * value_layout[d] * src_tensor.stride[d]
+            dst_offset = dst_offset + thread_idxs[d] * value_layout[d] * self.stride[d]
+        value_layout_v = value_layout[:-1] + (value_layout[-1] // vec_size,)
+        coords = tuple(product(*(range_constexpr(s) for s in value_layout_v)))
+        for coord in coords:
+            src_vec_offset = src_offset
+            dst_vec_offset = dst_offset
+            for d in range_constexpr(len(coord)):
+                if d == len(coord) - 1:
+                    src_vec_offset = src_vec_offset + coord[d] * src_tensor.stride[d] * vec_size
+                    dst_vec_offset = dst_vec_offset + coord[d] * self.stride[d] * vec_size
+                else:
+                    src_vec_offset = src_vec_offset + coord[d] * src_tensor.stride[d]
+                    dst_vec_offset = dst_vec_offset + coord[d] * self.stride[d]
+            value = src_tensor.load_impl(src_vec_offset, vec_size=vec_size)
+            self.store_impl(dst_vec_offset, value, vec_size=vec_size)
+
+
+class TensorBase(ABC):
+    def __init__(self, dtype, shape, stride=None, base_offset=0):
+        self.tensor_view = None
+        self.dtype = dtype
+        self.shape = shape
+        self.stride = stride
+        self.base_offset = base_offset
+
+    @abstractmethod
+    def load(self, offset):
+        return None
+
+    @abstractmethod
+    def store(self, offset, value):
+        pass
+
+    def _lazy_init(self):
+        if self.tensor_view is None:
+            self.tensor_view = TensorView(
+                self.dtype,
+                self.shape,
+                self.stride,
+                self.base_offset,
+                self.load,
+                self.store,
+            )
+            self.stride = self.tensor_view.stride
+            self.load_impl = self.tensor_view.load_impl
+            self.store_impl = self.tensor_view.store_impl
+
+    def __repr__(self):
+        self._lazy_init()
+        return self.tensor_view.__repr__()
+
+    def __getitem__(self, idxs):
+        self._lazy_init()
+        return self.tensor_view[idxs]
+
+    def __setitem__(self, idxs, value):
+        self._lazy_init()
+        self.tensor_view[idxs] = value
+
+    def vec_load(self, idxs, vec_size):
+        self._lazy_init()
+        return self.tensor_view.vec_load(idxs, vec_size)
+
+    def vec_store(self, idxs, value, vec_size):
+        self._lazy_init()
+        self.tensor_view.vec_store(idxs, value, vec_size)
+
+    def linear_offset(self, idxs):
+        self._lazy_init()
+        return self.tensor_view.linear_offset(idxs)
+
+    def local_tile(self, tile_shape, tile_idxs):
+        self._lazy_init()
+        return self.tensor_view.local_tile(tile_shape, tile_idxs)
+
+    def copy_(self, src_tensor, thread_layout, value_layout, thread_idxs, vec_size):
+        self._lazy_init()
+        self.tensor_view.copy_(src_tensor, thread_layout, value_layout, thread_idxs, vec_size)
+
+
+class TorchTensor(TensorBase):
+    def __init__(self, torch_tensor, dtype, shape, stride=None, base_offset=0):
+        super().__init__(dtype, shape, stride, base_offset)
+        self.torch_tensor = torch_tensor
+
+    def load(self, offset, vec_size=1):
+        return self.torch_tensor.view(-1)[offset : offset + vec_size]
+
+    def store(self, offset, value, vec_size=1):
+        self.torch_tensor.view(-1)[offset : offset + vec_size] = value
+
+
+class GTensor(TensorBase):
+    def __init__(
+        self,
+        memref,
+        dtype,
+        shape,
+        stride=None,
+        base_offset=0,
+        cache_modifier=0,
+        static_bytes_offset_i64=None,
+    ):
+        super().__init__(dtype, shape, stride, base_offset)
+        if static_bytes_offset_i64 is None:
+            self.rsrc = buffer_ops.create_buffer_resource(memref, max_size=True)
+        else:
+            array_base_i64 = self.get_llvm_ptr(memref, (static_bytes_offset_i64))
+            self.rsrc = buffer_ops.create_buffer_resource_from_addr(array_base_i64)
+        self.cache_modifier = cache_modifier
+
+    def load(self, offset, vec_size=1):
+        return buffer_ops.buffer_load(self.rsrc, offset, vec_width=vec_size, dtype=self.dtype)
+
+    def store(self, offset, value, vec_size=1):
+        buffer_ops.buffer_store(value, self.rsrc, offset, cache_modifier=self.cache_modifier)
+
+    def get_llvm_ptr(self, ptr, bytes_offset_i64, ptr_type="!llvm.ptr<1>"):
+        bytes_offset_i64 = arith.index_cast(T.i64, bytes_offset_i64)
+        _ptr_type = ir.Type.parse(ptr_type)
+        base_ptr = fly.extract_aligned_pointer_as_index(_ptr_type, extract_to_ir_values(ptr)[0])
+        base_ptr = llvm.PtrToIntOp(T.i64, base_ptr).result
+        llvm_ptr = llvm.AddOp(base_ptr, bytes_offset_i64, llvm.IntegerOverflowFlags(0)).result
+        return llvm_ptr
+
+
+class STensor(TensorBase):
+    def __init__(self, memptr, dtype, shape, stride=None, base_offset=0):
+        super().__init__(dtype, shape, stride, base_offset)
+        self.memptr = memptr.get()
+
+    def load(self, offset, vec_size=1):
+        vec_t = T.vec(vec_size, self.dtype)
+        x = vector.load_op(vec_t, self.memptr, [offset])
+        if vec_size > 1:
+            return x
+        else:
+            x = vector.extract(x, static_position=[0], dynamic_position=[])
+            return x
+
+    def store(self, offset, value, vec_size=1):
+        if vec_size > 1:
+            vector.store(value, self.memptr, [offset], alignment=16)
+        else:
+            vec_t = T.vec(1, self.dtype)
+            vec = vector.from_elements(vec_t, [value])
+            vector.store(vec, self.memptr, [offset], alignment=16)

--- a/torch/_inductor/template_heuristics/__init__.py
+++ b/torch/_inductor/template_heuristics/__init__.py
@@ -5,6 +5,7 @@ from . import (
     base,
     contiguous_mm,
     decompose_k,
+    flydsl_gemm,
     nv_universal_gemm,
     registry,
     tlx,

--- a/torch/_inductor/template_heuristics/flydsl_gemm.py
+++ b/torch/_inductor/template_heuristics/flydsl_gemm.py
@@ -1,0 +1,39 @@
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class FlyDSLHGemmConfig:
+    TILE_M: int
+    TILE_N: int = 128
+    TILE_K: int = 64
+    STAGES: int = 2
+    SPLIT_K: int = 1
+    BLOCK_M_WARPS: int = 1
+    BLOCK_N_WARPS: int = 4
+    BLOCK_K_WARPS: int = 1
+    B_TO_LDS: bool = True
+
+
+def get_default_hgemm_configs() -> list[FlyDSLHGemmConfig]:
+    return [
+        FlyDSLHGemmConfig(TILE_M=32),
+        FlyDSLHGemmConfig(TILE_M=64),
+        FlyDSLHGemmConfig(TILE_M=128),
+    ]
+
+
+def get_hgemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
+    configs: list[dict[str, object]] = []
+    for config in get_default_hgemm_configs():
+        if config.TILE_M > max(128, m):
+            continue
+        if k % config.SPLIT_K != 0:
+            continue
+        if (k // config.SPLIT_K) // config.TILE_K < config.STAGES:
+            continue
+        configs.append(
+            {
+                **asdict(config),
+            }
+        )
+    return configs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Add an experimental FlyDSL hgemm template backend for ROCm Inductor autotuning, including async compilation, scheduling, runtime gating, and focused tests.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo