### PR TITLE
[Inductor] Drop unrelated GPU wrapper diffs

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -678,7 +678,7 @@ class DeferredTritonCallWrapper:
             wrapper.device_codegen.cpp_kernel_type()
         )
 
-        # JIT-only: static hipFunction_t and embedded Triton source
+        # JIT-only: static CUfunction and embedded Triton source
         prefix.writeline_jit(f"static {kernel_type} {kernel_name} = nullptr;")
         kernel_source_str = self.kernel_name_to_body.get(kernel_name, "")
         kernel_body = f'R"TRITON(\n{kernel_source_str}\n)TRITON"'
@@ -853,7 +853,7 @@ class DeferredTritonCallWrapper:
                 ]
 
             # In AOTI mode on CUDA/HIP, pass the loaded_modules_ vector so
-            # hipModule_t handles are tracked and can be unloaded on destruction,
+            # CUmodule handles are tracked and can be unloaded on destruction,
             # preventing GPU code object leaks. XPU is excluded because its
             # loadKernel returns std::unique_ptr<sycl::kernel> and manages
             # cleanup via RAII.
@@ -1090,7 +1090,7 @@ class CppWrapperGpu(CppWrapperCpu):
         if self.device == "cuda":
             buffer.writeline(
                 maybe_hipify_code_wrapper(
-                    "AOTI_RUNTIME_CUDA_CHECK(hipDeviceSynchronize());"
+                    "AOTI_RUNTIME_CUDA_CHECK(cudaDeviceSynchronize());"
                 )
             )
             return
@@ -1322,7 +1322,7 @@ static inline void ensure_triton_kernel_compiles_started() {{
         self.writeline(f"alignas(64) CUtensorMap {desc_name};")
 
         # `source` is in the form of `&var_x`, where `var_x` is the data pointer
-        # (hipDeviceptr_t); we dereference `source` and cast to `void*` to pass to
+        # (CUdeviceptr); we dereference `source` and cast to `void*` to pass to
         # the data pointer of the source tensor to the helper function
         # `init{1,2}DTMADescriptor`
         ptr = f"reinterpret_cast<void*>(*({source}))"

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -47,9 +47,9 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
 
     def kernel_header(self) -> str:
         source_codes = """
-        #include <c10/hip/HIPGuard.h>
-        #include <c10/hip/HIPStream.h>
-        #include <ATen/hip/EmptyTensor.h>
+        #include <c10/cuda/CUDAGuard.h>
+        #include <c10/cuda/CUDAStream.h>
+        #include <ATen/cuda/EmptyTensor.h>
         """
         return source_codes
 
@@ -61,66 +61,66 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         source_codes = """
             #define CUDA_DRIVER_CHECK(EXPR)                    \\
             do {                                               \\
-                hipError_t code = EXPR;                          \\
+                CUresult code = EXPR;                          \\
                 const char *msg;                               \\
-                hipError_t code_get_error = hipDrvGetErrorString(code, &msg); \\
-                if (code_get_error != hipSuccess) {          \\
+                CUresult code_get_error = cuGetErrorString(code, &msg); \\
+                if (code_get_error != CUDA_SUCCESS) {          \\
                     throw std::runtime_error(                  \\
                         std::string("CUDA driver error: ") +   \\
                         std::string("invalid error code!"));   \\
                 }                                              \\
-                if (code != hipSuccess) {                    \\
+                if (code != CUDA_SUCCESS) {                    \\
                     throw std::runtime_error(                  \\
                         std::string("CUDA driver error: ") +   \\
                         std::string(msg));                     \\
                 }                                              \\
             } while (0);
 
-            static inline hipFunction_t loadKernel(
+            static inline CUfunction loadKernel(
                     std::string filePath,
                     const std::string &funcName,
                     uint32_t sharedMemBytes,
                     const std::optional<std::string> &cubinDir = std::nullopt,
-                    std::vector<hipModule_t>* loaded_modules = nullptr) {
+                    std::vector<CUmodule>* loaded_modules = nullptr) {
                 if (cubinDir) {
                     std::filesystem::path p1{*cubinDir};
                     std::filesystem::path p2{filePath};
                     filePath = (p1 / p2.filename()).string();
                 }
 
-                hipModule_t mod;
-                hipFunction_t func;
-                CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
+                CUmodule mod;
+                CUfunction func;
+                CUDA_DRIVER_CHECK(cuModuleLoad(&mod, filePath.c_str()));
                 if (loaded_modules) {
                     loaded_modules->push_back(mod);
                 }
-                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
+                CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
-                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
+                    CUDA_DRIVER_CHECK(cuFuncSetAttribute(
                         func,
-                        hipFuncAttributeMaxDynamicSharedMemorySize,
+                        CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                         sharedMemBytes
                     ))
                 }
                 return func;
             }
 
-            static inline hipFunction_t loadKernel(
+            static inline CUfunction loadKernel(
                     const void* start,
                     const std::string &funcName,
                     uint32_t sharedMemBytes,
-                    std::vector<hipModule_t>* loaded_modules = nullptr) {
-                hipModule_t mod;
-                hipFunction_t func;
-                CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, start));
+                    std::vector<CUmodule>* loaded_modules = nullptr) {
+                CUmodule mod;
+                CUfunction func;
+                CUDA_DRIVER_CHECK(cuModuleLoadData(&mod, start));
                 if (loaded_modules) {
                     loaded_modules->push_back(mod);
                 }
-                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
+                CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
                 if (sharedMemBytes > 0) {
-                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
+                    CUDA_DRIVER_CHECK(cuFuncSetAttribute(
                         func,
-                        hipFuncAttributeMaxDynamicSharedMemorySize,
+                        CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                         sharedMemBytes
                     ))
                 }
@@ -128,15 +128,15 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
             }
 
             static inline void launchKernel(
-                    hipFunction_t func,
+                    CUfunction func,
                     uint32_t gridX,
                     uint32_t gridY,
                     uint32_t gridZ,
                     uint32_t numWarps,
                     uint32_t sharedMemBytes,
                     void* args[],
-                    hipStream_t stream) {
-                CUDA_DRIVER_CHECK(hipModuleLaunchKernel(
+                    cudaStream_t stream) {
+                CUDA_DRIVER_CHECK(cuLaunchKernel(
                     func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
                 ));
             }
@@ -161,7 +161,7 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         # New APIs (fillTMADescriptor):
         # https://github.com/triton-lang/triton/blob/main/third_party/nvidia/backend/driver.c#L283
         return """
-            #if !defined(USE_ROCM) && defined(TORCH_HIP_VERSION) && TORCH_HIP_VERSION >= 12000
+            #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12000
             [[maybe_unused]] static void init1DTMADescriptor(
                     CUtensorMap* m,
                     void* globalAddress,
@@ -337,16 +337,16 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         """
 
     def cpp_stream_type(self) -> str:
-        return "hipStream_t"
+        return "cudaStream_t"
 
     def aoti_get_stream(self) -> str:
         return "aoti_torch_get_current_cuda_stream"
 
     def cpp_kernel_type(self) -> str:
-        return "hipFunction_t"
+        return "CUfunction"
 
     def cpp_device_ptr(self) -> str:
-        return "hipDeviceptr_t"
+        return "CUdeviceptr"
 
     def cpp_scratch(
         self, idx: int, workspace: TritonScratchWorkspace, prefix: str | None = None
@@ -372,12 +372,12 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                         f"{workspace.generate_dtype_str()}, {device_type}, {device_idx}, &{var_name}_handle));"
                     ),
                     f"RAIIAtenTensorHandle {var_name}_tensor({var_name}_handle);",
-                    f"hipDeviceptr_t {var_name} = reinterpret_cast<hipDeviceptr_t>({var_name}_tensor.data_ptr());",
+                    f"CUdeviceptr {var_name} = reinterpret_cast<CUdeviceptr>({var_name}_tensor.data_ptr());",
                 ],
                 var_name,
             )
         else:
-            return [f"hipDeviceptr_t {var_name} = 0;"], var_name
+            return [f"CUdeviceptr {var_name} = 0;"], var_name
 
 
 register_device_op_overrides("cuda", CUDADeviceOpOverrides())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Keep the FlyDSL hgemm branch focused on the Inductor template path by removing unrelated HIP wrapper changes.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo