### PR TITLE
[Inductor] Rename FlyDSL GEMM integration and tighten configs

### DIFF
--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -42,7 +42,7 @@ class TestFlyDSLTemplate(TestCase):
         max_autotune_gemm=True,
         max_autotune_gemm_backends="FLYDSL",
     )
-    def test_flydsl_hgemm_transposed_rhs_e2e(self):
+    def test_flydsl_gemm_transposed_rhs_e2e(self):
         from torch._inductor.utils import run_and_get_code
 
         if not flydsl_utils.runtime_available():

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -255,7 +255,7 @@ def get_flydsl_mm_template_kwargs(
     if dtype != torch.bfloat16:
         return []
 
-    # FlyDSL hgemm consumes B as [N, K]. In aten.mm(A, B.T), Inductor sees
+    # FlyDSL GEMM consumes B as [N, K]. In aten.mm(A, B.T), Inductor sees
     # the RHS as a [K, N] transpose view with stride[0] == 1.
     if not sizevars.statically_known_equals(mat2_stride[0], 1):
         return []

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -3,18 +3,18 @@ import os
 
 from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
     infer_has_k_tail,
-    launch_hgemm_gfx950,
-    make_hgemm_param_and_validate,
+    launch_gemm_gfx950,
+    make_gemm_param_and_validate,
 )
 from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
 
 {{gen_defines()}}
 
 
-_hgemm_fn_cache = {}
+_gemm_fn_cache = {}
 
 
-def _hgemm_param_cache_key(param):
+def _gemm_param_cache_key(param):
     return (
         param.block_m,
         param.block_n,
@@ -38,16 +38,16 @@ def _hgemm_param_cache_key(param):
     )
 
 
-def _run_hgemm_gfx950(param, *runtime_args):
+def _run_gemm_gfx950(param, *runtime_args):
     """First call compiles and executes; subsequent calls dispatch the cached executor."""
-    cache_key = _hgemm_param_cache_key(param)
+    cache_key = _gemm_param_cache_key(param)
     args = runtime_args[:-1] + (param, runtime_args[-1])
-    executor = _hgemm_fn_cache.get(cache_key)
+    executor = _gemm_fn_cache.get(cache_key)
     if executor is None:
         ensure_flydsl_cache_dir()
-        executor = flyc.compile(launch_hgemm_gfx950, *args)
+        executor = flyc.compile(launch_gemm_gfx950, *args)
         if not os.environ.get("COMPILE_ONLY"):
-            _hgemm_fn_cache[cache_key] = executor
+            _gemm_fn_cache[cache_key] = executor
     else:
         executor(*args)
 
@@ -80,7 +80,7 @@ def _flydsl_mm(output, mat1, mat2, stream):
 
     has_k_tail = infer_has_k_tail(k, TILE_K, STAGES)
 
-    param = make_hgemm_param_and_validate(
+    param = make_gemm_param_and_validate(
         m,
         n,
         k,
@@ -96,7 +96,7 @@ def _flydsl_mm(output, mat1, mat2, stream):
             "has_k_tail": has_k_tail,
         },
     )
-    _run_hgemm_gfx950(
+    _run_gemm_gfx950(
         param,
         output_mn,
         mat1_mk,
@@ -138,7 +138,7 @@ def {{kernel_name}}_precompile(
 
     env_updates = {"COMPILE_ONLY": "1"}
     if flydsl_gpu_arch is not None:
-        # FlyDSL's hgemm factory and backend read different arch env names.
+        # FlyDSL's GEMM factory and backend read different arch env names.
         env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
         env_updates["ARCH"] = flydsl_gpu_arch
 
@@ -157,4 +157,4 @@ def {{kernel_name}}_precompile(
             try:
                 _flydsl_mm(output, mat1, mat2, stream=0)
             finally:
-                _hgemm_fn_cache.clear()
+                _gemm_fn_cache.clear()

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -1,13 +1,13 @@
-from .hgemm_gfx950 import (
+from .gemm_gfx950 import (
     infer_has_k_tail,
-    launch_hgemm_gfx950,
-    make_hgemm_param_and_validate,
-    make_hgemm_gfx950_param,
+    launch_gemm_gfx950,
+    make_gemm_param_and_validate,
+    make_gemm_gfx950_param,
 )
 
 __all__ = [
     "infer_has_k_tail",
-    "launch_hgemm_gfx950",
-    "make_hgemm_gfx950_param",
-    "make_hgemm_param_and_validate",
+    "launch_gemm_gfx950",
+    "make_gemm_gfx950_param",
+    "make_gemm_param_and_validate",
 ]

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -13,7 +13,7 @@ GFX950_WAVE_SIZE = 64
 
 
 @fx.struct
-class HGemmGfx950Param:
+class GemmGfx950Param:
     block_m: fx.Constexpr[int]
     block_n: fx.Constexpr[int]
     block_k: fx.Constexpr[int]
@@ -35,7 +35,7 @@ class HGemmGfx950Param:
     mma_k: fx.Constexpr[int]
 
 
-def make_hgemm_gfx950_param(
+def make_gemm_gfx950_param(
     block_m: int = 256,
     block_n: int = 256,
     block_k: int = 64,
@@ -48,7 +48,7 @@ def make_hgemm_gfx950_param(
     mma_m: int = 16,
     mma_n: int = 16,
     mma_k: int = 32,
-) -> HGemmGfx950Param:
+) -> GemmGfx950Param:
     if block_m <= 0 or block_n <= 0 or block_k <= 0 or stages <= 0:
         raise ValueError("block_m, block_n, block_k, and stages must be positive")
     if (mma_m, mma_n, mma_k) != (16, 16, 32):
@@ -82,8 +82,21 @@ def make_hgemm_gfx950_param(
         )
 
     block_threads = m_waves * n_waves * GFX950_WAVE_SIZE
-    ldg_a_iters = (block_m * block_k) // (block_threads * async_load_vec_size)
-    ldg_b_iters = (block_n * block_k) // (block_threads * async_load_vec_size)
+    load_elems_per_iter = block_threads * async_load_vec_size
+    if (block_m * block_k) % load_elems_per_iter != 0:
+        raise ValueError(
+            "A tile load schedule must exactly cover the LDS tile: "
+            f"block_m={block_m}, block_k={block_k}, "
+            f"block_threads={block_threads}, async_load_vec_size={async_load_vec_size}"
+        )
+    if (block_n * block_k) % load_elems_per_iter != 0:
+        raise ValueError(
+            "B tile load schedule must exactly cover the LDS tile: "
+            f"block_n={block_n}, block_k={block_k}, "
+            f"block_threads={block_threads}, async_load_vec_size={async_load_vec_size}"
+        )
+    ldg_a_iters = (block_m * block_k) // load_elems_per_iter
+    ldg_b_iters = (block_n * block_k) // load_elems_per_iter
     if (stages - 2) * (ldg_a_iters + ldg_b_iters) >= 63:
         raise ValueError("staged pipeline wait count exceeds supported range")
 
@@ -100,7 +113,7 @@ def make_hgemm_gfx950_param(
             f"block_n={block_n}, n_waves={n_waves}, mma_n={mma_n}"
         )
 
-    return HGemmGfx950Param(
+    return GemmGfx950Param(
         block_m=block_m,
         block_n=block_n,
         block_k=block_k,
@@ -123,8 +136,8 @@ def make_hgemm_gfx950_param(
     )
 
 
-def make_hgemm_gfx950_kernel_name(param: HGemmGfx950Param) -> str:
-    name = f"hgemm_t{param.block_m}x{param.block_n}x{param.block_k}x{param.stages}"
+def make_gemm_gfx950_kernel_name(param: GemmGfx950Param) -> str:
+    name = f"gemm_t{param.block_m}x{param.block_n}x{param.block_k}x{param.stages}"
     name += f"_w{param.m_waves}x{param.n_waves}"
     name += f"_gm{param.group_m}"
     name += f"_bias{int(param.has_bias)}"
@@ -201,7 +214,7 @@ def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
 
 
 @flyc.kernel
-def hgemm_gfx950_kernel(
+def gemm_gfx950_kernel(
     out: fx.Tensor,
     a: fx.Tensor,
     b: fx.Tensor,
@@ -210,7 +223,7 @@ def hgemm_gfx950_kernel(
     n: fx.Int32,
     k: fx.Int32,
     tiled_mma: fx.TiledMma,
-    param: HGemmGfx950Param,
+    param: GemmGfx950Param,
 ):
     block_m = param.block_m
     block_n = param.block_n
@@ -444,7 +457,7 @@ def hgemm_gfx950_kernel(
 
 
 @flyc.jit
-def launch_hgemm_gfx950(
+def launch_gemm_gfx950(
     out: fx.Tensor,
     a: fx.Tensor,
     b: fx.Tensor,
@@ -452,7 +465,7 @@ def launch_hgemm_gfx950(
     m: fx.Int32,
     n: fx.Int32,
     k: fx.Int32,
-    param: HGemmGfx950Param,
+    param: GemmGfx950Param,
     stream: fx.Stream = fx.Stream(None),
 ):
     mma_atom = fx.make_mma_atom(
@@ -476,9 +489,9 @@ def launch_hgemm_gfx950(
     )
     num_pid_m = (m + param.block_m - 1) // param.block_m
     num_pid_n = (n + param.block_n - 1) // param.block_n
-    hgemm_gfx950_kernel._known_block_size = [param.block_threads, 1, 1]
-    hgemm_gfx950_kernel._func.__name__ = make_hgemm_gfx950_kernel_name(param)
-    hgemm_gfx950_kernel(out, a, b, bias, m, n, k, tiled_mma, param).launch(
+    gemm_gfx950_kernel._known_block_size = [param.block_threads, 1, 1]
+    gemm_gfx950_kernel._func.__name__ = make_gemm_gfx950_kernel_name(param)
+    gemm_gfx950_kernel(out, a, b, bias, m, n, k, tiled_mma, param).launch(
         grid=(num_pid_m * num_pid_n, 1, 1),
         block=(param.block_threads, 1, 1),
         stream=stream,
@@ -490,10 +503,10 @@ def infer_has_k_tail(k: int, block_k: int, stages: int):
     return (k % block_k != 0) or (k_tiles < stages - 1)
 
 
-def make_hgemm_param_and_validate(m, n, k, kwargs):
+def make_gemm_param_and_validate(m, n, k, kwargs):
     result = None
     try:
-        result = make_hgemm_gfx950_param(**kwargs)
+        result = make_gemm_gfx950_param(**kwargs)
     except Exception:
         return None
     if not ((n % 32 == 0) and (k % result.mma_k == 0)):

--- a/torch/_inductor/template_heuristics/flydsl.py
+++ b/torch/_inductor/template_heuristics/flydsl.py
@@ -18,14 +18,14 @@ class FlyDSLGemmConfig:
     B_TO_LDS: bool = True
 
 
-def _is_valid_hgemm_config(hgemm_config: dict[str, int | bool]) -> bool:
-    block_m = int(hgemm_config["TILE_M"])
-    block_n = int(hgemm_config["TILE_N"])
-    block_k = int(hgemm_config["TILE_K"])
-    stages = int(hgemm_config["STAGES"])
-    m_waves = int(hgemm_config["BLOCK_M_WARPS"])
-    n_waves = int(hgemm_config["BLOCK_N_WARPS"])
-    group_m = int(hgemm_config["GROUP_M"])
+def _is_valid_gemm_config(gemm_config: dict[str, int | bool]) -> bool:
+    block_m = int(gemm_config["TILE_M"])
+    block_n = int(gemm_config["TILE_N"])
+    block_k = int(gemm_config["TILE_K"])
+    stages = int(gemm_config["STAGES"])
+    m_waves = int(gemm_config["BLOCK_M_WARPS"])
+    n_waves = int(gemm_config["BLOCK_N_WARPS"])
+    group_m = int(gemm_config["GROUP_M"])
     mma_m = 16
     mma_n = 16
     mma_k = 32
@@ -51,8 +51,13 @@ def _is_valid_hgemm_config(hgemm_config: dict[str, int | bool]) -> bool:
         return False
 
     block_threads = m_waves * n_waves * 64
-    ldg_a_iters = (block_m * block_k) // (block_threads * async_load_vec_size)
-    ldg_b_iters = (block_n * block_k) // (block_threads * async_load_vec_size)
+    load_elems_per_iter = block_threads * async_load_vec_size
+    if (block_m * block_k) % load_elems_per_iter != 0:
+        return False
+    if (block_n * block_k) % load_elems_per_iter != 0:
+        return False
+    ldg_a_iters = (block_m * block_k) // load_elems_per_iter
+    ldg_b_iters = (block_n * block_k) // load_elems_per_iter
     if ldg_a_iters <= 0 or ldg_b_iters <= 0:
         return False
     if (stages - 2) * (ldg_a_iters + ldg_b_iters) >= 63:
@@ -89,15 +94,15 @@ def get_exhaustive_gemm_configs() -> list[FlyDSLGemmConfig]:
     values = selections.values()
     configs = [dict(zip(keys, combo)) for combo in product(*values)]
     valid_configs: list[FlyDSLGemmConfig] = []
-    for hgemm_config in configs:
-        mma_m_iters = hgemm_config["TILE_M"] // hgemm_config["BLOCK_M_WARPS"] // 16
-        mma_n_iters = hgemm_config["TILE_N"] // hgemm_config["BLOCK_N_WARPS"] // 16
+    for gemm_config in configs:
+        mma_m_iters = gemm_config["TILE_M"] // gemm_config["BLOCK_M_WARPS"] // 16
+        mma_n_iters = gemm_config["TILE_N"] // gemm_config["BLOCK_N_WARPS"] // 16
         if mma_m_iters > 4 or mma_n_iters > 4:
             continue
-        if not _is_valid_hgemm_config(hgemm_config):
+        if not _is_valid_gemm_config(gemm_config):
             continue
         try:
-            valid_configs.append(FlyDSLGemmConfig(**hgemm_config))
+            valid_configs.append(FlyDSLGemmConfig(**gemm_config))
         except Exception:
             pass
     return valid_configs
@@ -130,9 +135,9 @@ def get_default_gemm_configs() -> list[FlyDSLGemmConfig]:
     ]
     configs = [FlyDSLGemmConfig(*args) for args in config_tuples]
     return [
-        hgemm_config
-        for hgemm_config in configs
-        if _is_valid_hgemm_config(asdict(hgemm_config))
+        gemm_config
+        for gemm_config in configs
+        if _is_valid_gemm_config(asdict(gemm_config))
     ]
 
 
@@ -152,4 +157,4 @@ def get_gemm_configs() -> list[dict[str, object]]:
         configs = get_default_gemm_configs()
     else:
         configs = [get_default_gemm_configs()[0]]
-    return [asdict(hgemm_config) for hgemm_config in configs]
+    return [asdict(gemm_config) for gemm_config in configs]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Use GEMM-neutral names for the FlyDSL Inductor glue and keep the vendored gfx950 kernel on exact LDS load schedules selected by the config validator.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo