### PR TITLE
[Inductor] Cache FlyDSL GEMM launch state

### DIFF
--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -11,45 +11,65 @@ from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
 {{gen_defines()}}
 
 
-_gemm_fn_cache = {}
+_gemm_call_cache = {}
 
 
-def _gemm_param_cache_key(param):
-    return (
-        param.block_m,
-        param.block_n,
-        param.block_k,
-        param.stages,
-        param.m_waves,
-        param.n_waves,
-        param.group_m,
-        int(param.has_bias),
-        int(param.has_k_tail),
-        param.async_load_bytes,
-        param.in_data_bytes,
-        param.out_data_bytes,
-        param.ldg_x_threads,
-        param.block_threads,
-        param.ldg_a_iters,
-        param.ldg_b_iters,
-        param.mma_m,
-        param.mma_n,
-        param.mma_k,
-    )
-
-
-def _run_gemm_gfx950(param, *runtime_args):
+def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, bias_tensor, stream):
     """First call compiles and executes; subsequent calls dispatch the cached executor."""
-    cache_key = _gemm_param_cache_key(param)
-    args = runtime_args[:-1] + (param, runtime_args[-1])
-    executor = _gemm_fn_cache.get(cache_key)
+    has_k_tail = infer_has_k_tail(k, TILE_K, STAGES)
+    cache_key = (int(has_k_tail),)
+    entry = _gemm_call_cache.get(cache_key)
+    if entry is None:
+        param = make_gemm_param_and_validate(
+            m,
+            n,
+            k,
+            {
+                "block_m": TILE_M,
+                "block_n": TILE_N,
+                "block_k": TILE_K,
+                "stages": STAGES,
+                "m_waves": BLOCK_M_WARPS,
+                "n_waves": BLOCK_N_WARPS,
+                "group_m": GROUP_M,
+                "has_bias": False,
+                "has_k_tail": has_k_tail,
+            },
+        )
+        assert param is not None, "unsupported FlyDSL GEMM shape/config"
+        entry = [param, None]
+        _gemm_call_cache[cache_key] = entry
+    else:
+        param = entry[0]
+    executor = entry[1]
     if executor is None:
         ensure_flydsl_cache_dir()
-        executor = flyc.compile(launch_gemm_gfx950, *args)
+        executor = flyc.compile(
+            launch_gemm_gfx950,
+            output_mn,
+            mat1_mk,
+            mat2_nk,
+            bias_tensor,
+            m,
+            n,
+            k,
+            param,
+            stream,
+        )
         if not os.environ.get("COMPILE_ONLY"):
-            _gemm_fn_cache[cache_key] = executor
+            entry[1] = executor
     else:
-        executor(*args)
+        executor(
+            output_mn,
+            mat1_mk,
+            mat2_nk,
+            bias_tensor,
+            m,
+            n,
+            k,
+            param,
+            stream,
+        )
 
 
 @contextlib.contextmanager
@@ -78,35 +98,7 @@ def _flydsl_mm(output, mat1, mat2, stream):
     output_mn = output.view(-1, n)
     bias_tensor = mat1_mk
 
-    has_k_tail = infer_has_k_tail(k, TILE_K, STAGES)
-
-    param = make_gemm_param_and_validate(
-        m,
-        n,
-        k,
-        {
-            "block_m": TILE_M,
-            "block_n": TILE_N,
-            "block_k": TILE_K,
-            "stages": STAGES,
-            "m_waves": BLOCK_M_WARPS,
-            "n_waves": BLOCK_N_WARPS,
-            "group_m": GROUP_M,
-            "has_bias": False,
-            "has_k_tail": has_k_tail,
-        },
-    )
-    _run_gemm_gfx950(
-        param,
-        output_mn,
-        mat1_mk,
-        mat2_nk,
-        bias_tensor,
-        m,
-        n,
-        k,
-        stream,
-    )
+    _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, bias_tensor, stream)
     return output
 
 
@@ -157,4 +149,4 @@ def {{kernel_name}}_precompile(
             try:
                 _flydsl_mm(output, mat1, mat2, stream=0)
             finally:
-                _gemm_fn_cache.clear()
+                _gemm_call_cache.clear()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Avoid rebuilding FlyDSL GEMM params on every generated-template invocation so small GEMM dispatch time reflects the cached executor path.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo