### PR TITLE
[Inductor] Thin FlyDSL GEMM dispatch path

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -633,6 +633,12 @@ class AsyncCompile:
         main_func_name = f"{kernel_name}_{main_suffix}"
         return wrapper_cls(getattr(mod, main_func_name), kernel_path=path)
 
+    def _load_kernel_fn(self, kernel_name, main_suffix, key, path):
+        """Reload a kernel module from PyCodeCache and return its entry point."""
+        mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
+        main_func_name = f"{kernel_name}_{main_suffix}"
+        return getattr(mod, main_func_name)
+
     def cutedsl(self, kernel_name: str, source_code: str, precompile_metadata=None):
         """
         Compile CuteDSL (CUTLASS Python DSL) kernels.
@@ -706,10 +712,7 @@ class AsyncCompile:
         be imported and its `{kernel_name}_main` entry point can be wrapped for
         Inductor's `.run(...)` call convention.
         """
-        from torch._inductor.codegen.flydsl.flydsl_kernel import (
-            FlyDSLKernelWrapper,
-            MAIN_SUFFIX,
-        )
+        from torch._inductor.codegen.flydsl.flydsl_kernel import MAIN_SUFFIX
 
         kernel_code_log.info("FlyDSL Kernel:\n%s", source_code)
         _compile_start()
@@ -729,7 +732,7 @@ class AsyncCompile:
                 precompile_metadata,
             )
 
-            def get_result() -> FlyDSLKernelWrapper:
+            def get_result():
                 try:
                     key, path, elapsed_us = subprocess_task.result()
                 except SubprocException as e:
@@ -739,9 +742,7 @@ class AsyncCompile:
                     kernel_name,
                     elapsed_us,
                 )
-                return self._load_kernel_wrapper(
-                    kernel_name, MAIN_SUFFIX, FlyDSLKernelWrapper, key, path
-                )
+                return self._load_kernel_fn(kernel_name, MAIN_SUFFIX, key, path)
 
             return LambdaFuture(get_result, future=subprocess_task)
         else:
@@ -755,7 +756,7 @@ class AsyncCompile:
                     f"Could not find FlyDSL main kernel function '{main_func_name}'. Available callables: {available}"
                 )
 
-            return FlyDSLKernelWrapper(getattr(mod, main_func_name), kernel_path=path)
+            return getattr(mod, main_func_name)
 
     def pallas(self, kernel_name: str, source_code: str):
         """

--- a/torch/_inductor/codegen/flydsl/flydsl_kernel.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_kernel.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import contextlib
 import logging
-from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 
@@ -9,6 +8,7 @@ import torch
 
 from torch._inductor.codegen.common import IndentedBuffer, Kernel
 from torch._inductor.ir import BaseView, Buffer, ExternKernel, MutableBox, ReinterpretView
+from torch._inductor.stream_constants import DEFAULT_STREAM_IDX
 from torch._inductor.utils import OrderedSet
 from torch._inductor.virtualized import V
 
@@ -17,18 +17,6 @@ MAIN_SUFFIX = "main"
 
 log = logging.getLogger(__name__)
 kernel_code_log = torch._logging.getArtifactLogger(__name__, "kernel_code")
-
-
-class FlyDSLKernelWrapper:
-    """Wrapper to provide the `.run()` interface expected by Inductor."""
-
-    def __init__(self, kernel_fn: Callable[..., Any], kernel_path: str | None = None):
-        self.kernel_fn = kernel_fn
-        self.kernel_path = kernel_path
-        kernel_code_log.info("FlyDSL kernel path: %s", kernel_path)
-
-    def run(self, *args, stream=None, **kwargs):
-        return self.kernel_fn(*args, stream=stream, **kwargs)
 
 
 class FlyDSLTemplateKernel(Kernel):
@@ -183,4 +171,14 @@ class FlyDSLTemplateKernel(Kernel):
             call_args.append(call_arg)
             arg_types.append(arg_type)
 
-        wrapper.generate_kernel_call(name, call_args, triton=True, arg_types=arg_types)
+        device = V.graph.get_current_device_or_throw()
+        call_args_str = ", ".join(wrapper.prepare_triton_kernel_call(call_args))
+        current_stream_idx = V.graph.scheduler.current_stream_idx
+        if current_stream_idx is not None and current_stream_idx != DEFAULT_STREAM_IDX:
+            wrapper.write_get_raw_stream_header()
+            stream_name = "raw_stream"
+            wrapper.writeline(f"{stream_name} = get_raw_stream({device.index})")
+        else:
+            stream_name = wrapper.write_get_raw_stream(device.index, V.graph.name)
+
+        wrapper.writeline(f"{name}({call_args_str}, {stream_name})")

--- a/torch/_inductor/codegen/flydsl/flydsl_template.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_template.py
@@ -10,7 +10,15 @@ from torch._inductor.virtualized import V
 from torch._logging import getArtifactLogger
 
 from ...autotune_process import FlyDSLBenchmarkRequest, TensorMeta
-from ...ir import Buffer, ChoiceCaller, FlyDSLTemplateBuffer, IRNode, Layout, TensorBox
+from ...ir import (
+    Buffer,
+    ChoiceCaller,
+    FlyDSLTemplateBuffer,
+    IRNode,
+    Layout,
+    ReinterpretView,
+    TensorBox,
+)
 from ..common import KernelTemplate
 from .flydsl_kernel import FlyDSLTemplateKernel
 
@@ -57,6 +65,11 @@ class FlyDSLTemplate(KernelTemplate):
         input_nodes = kwargs.pop("input_nodes")
         layout = kwargs.pop("layout")
         mutated_inputs = kwargs.pop("mutated_inputs", None)
+        if kwargs.get("MAT2_IS_NK") and len(input_nodes) >= 2:
+            mat2 = input_nodes[1]
+            if isinstance(mat2, ReinterpretView):
+                input_nodes = [*input_nodes]
+                input_nodes[1] = mat2.data
         template_kwargs = dict(kwargs)
         kernel_name = f"flydsl_{self.name}_{next(self.index_counter)}"
 

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -271,7 +271,16 @@ def get_flydsl_mm_template_kwargs(
     if n_static % 32 != 0 or k_static % 32 != 0:
         return []
 
-    return get_gemm_configs()
+    return [
+        {
+            **gemm_config,
+            "MAT2_IS_NK": True,
+            "GEMM_M": m_static,
+            "GEMM_N": n_static,
+            "GEMM_K": k_static,
+        }
+        for gemm_config in get_gemm_configs()
+    ]
 
 
 aten_bias_addmm = ExternKernelChoice(bias_addmm, None)

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -1,9 +1,10 @@
 import contextlib
 import os
 
+from flydsl.compiler import jit_argument as flydsl_jit_argument
 from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
     infer_has_k_tail,
-    launch_gemm_gfx950,
+    launch_gemm_gfx950_no_bias,
     make_gemm_param_and_validate,
 )
 from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
@@ -11,15 +12,19 @@ from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
 {{gen_defines()}}
 
 
-_gemm_call_cache = {}
+_gemm_call_entry = None
 
 
-def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, bias_tensor, stream):
+def _static_tensor_arg(tensor):
+    return flydsl_jit_argument.from_torch_tensor(tensor)
+
+
+def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
     """First call compiles and executes; subsequent calls dispatch the cached executor."""
-    has_k_tail = infer_has_k_tail(k, TILE_K, STAGES)
-    cache_key = (int(has_k_tail),)
-    entry = _gemm_call_cache.get(cache_key)
+    global _gemm_call_entry
+    entry = _gemm_call_entry
     if entry is None:
+        has_k_tail = infer_has_k_tail(k, TILE_K, STAGES)
         param = make_gemm_param_and_validate(
             m,
             n,
@@ -38,18 +43,17 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, bias_tensor, stream):
         )
         assert param is not None, "unsupported FlyDSL GEMM shape/config"
         entry = [param, None]
-        _gemm_call_cache[cache_key] = entry
+        _gemm_call_entry = entry
     else:
         param = entry[0]
     executor = entry[1]
     if executor is None:
         ensure_flydsl_cache_dir()
         executor = flyc.compile(
-            launch_gemm_gfx950,
-            output_mn,
-            mat1_mk,
-            mat2_nk,
-            bias_tensor,
+            launch_gemm_gfx950_no_bias,
+            _static_tensor_arg(output_mn),
+            _static_tensor_arg(mat1_mk),
+            _static_tensor_arg(mat2_nk),
             m,
             n,
             k,
@@ -63,7 +67,6 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, bias_tensor, stream):
             output_mn,
             mat1_mk,
             mat2_nk,
-            bias_tensor,
             m,
             n,
             k,
@@ -89,16 +92,18 @@ def _temporary_env(updates):
 
 
 def _flydsl_mm(output, mat1, mat2, stream):
-    k = mat1.shape[-1]
-    mat2_nk = mat2.transpose(0, 1)
+    m = GEMM_M
+    n = GEMM_N
+    k = GEMM_K
+    if MAT2_IS_NK:
+        mat2_nk = mat2
+    else:
+        mat2_nk = mat2.transpose(0, 1)
 
-    mat1_mk = mat1.view(-1, k)
-    m = mat1_mk.shape[0]
-    n = mat2_nk.shape[0]
-    output_mn = output.view(-1, n)
-    bias_tensor = mat1_mk
+    mat1_mk = mat1
+    output_mn = output
 
-    _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, bias_tensor, stream)
+    _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream)
     return output
 
 
@@ -149,4 +154,5 @@ def {{kernel_name}}_precompile(
             try:
                 _flydsl_mm(output, mat1, mat2, stream=0)
             finally:
-                _gemm_call_cache.clear()
+                global _gemm_call_entry
+                _gemm_call_entry = None

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -1,6 +1,7 @@
 from .gemm_gfx950 import (
     infer_has_k_tail,
     launch_gemm_gfx950,
+    launch_gemm_gfx950_no_bias,
     make_gemm_param_and_validate,
     make_gemm_gfx950_param,
 )
@@ -8,6 +9,7 @@ from .gemm_gfx950 import (
 __all__ = [
     "infer_has_k_tail",
     "launch_gemm_gfx950",
+    "launch_gemm_gfx950_no_bias",
     "make_gemm_gfx950_param",
     "make_gemm_param_and_validate",
 ]

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -175,6 +175,10 @@ class BlockSwizzle:
         swizzled_n = intra_group // group_size_m
         swizzled_m = first_pid_m + (intra_group % group_size_m)
         use_simple = (num_wg < swizzle_threshold) | ((num_wg % num_xcds) != 0)
+        if const_expr(isinstance(use_simple, bool)):
+            if const_expr(use_simple):
+                return simple_m, simple_n
+            return swizzled_m, swizzled_n
         return (
             use_simple.select(simple_m, swizzled_m),
             use_simple.select(simple_n, swizzled_n),
@@ -219,9 +223,9 @@ def gemm_gfx950_kernel(
     a: fx.Tensor,
     b: fx.Tensor,
     bias: fx.Tensor,
-    m: fx.Int32,
-    n: fx.Int32,
-    k: fx.Int32,
+    m: fx.Constexpr[int],
+    n: fx.Constexpr[int],
+    k: fx.Constexpr[int],
     tiled_mma: fx.TiledMma,
     param: GemmGfx950Param,
 ):
@@ -435,7 +439,11 @@ def gemm_gfx950_kernel(
     rocdl.sched_barrier(0)
 
     if const_expr(has_k_tail):
-        main_loop_end = (k_tiles > stages - 1).select(k_tiles - (stages - 1), 0)
+        has_main_loop = k_tiles > stages - 1
+        if const_expr(isinstance(has_main_loop, bool)):
+            main_loop_end = k_tiles - (stages - 1) if has_main_loop else 0
+        else:
+            main_loop_end = has_main_loop.select(k_tiles - (stages - 1), 0)
     else:
         main_loop_end = k_tiles - (stages - 1)
     for k_tile in range(0, main_loop_end, 1):
@@ -462,9 +470,9 @@ def launch_gemm_gfx950(
     a: fx.Tensor,
     b: fx.Tensor,
     bias: fx.Tensor,
-    m: fx.Int32,
-    n: fx.Int32,
-    k: fx.Int32,
+    m: fx.Constexpr[int],
+    n: fx.Constexpr[int],
+    k: fx.Constexpr[int],
     param: GemmGfx950Param,
     stream: fx.Stream = fx.Stream(None),
 ):
@@ -492,6 +500,49 @@ def launch_gemm_gfx950(
     gemm_gfx950_kernel._known_block_size = [param.block_threads, 1, 1]
     gemm_gfx950_kernel._func.__name__ = make_gemm_gfx950_kernel_name(param)
     gemm_gfx950_kernel(out, a, b, bias, m, n, k, tiled_mma, param).launch(
+        grid=(num_pid_m * num_pid_n, 1, 1),
+        block=(param.block_threads, 1, 1),
+        stream=stream,
+    )
+
+
+@flyc.jit
+def launch_gemm_gfx950_no_bias(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    m: fx.Constexpr[int],
+    n: fx.Constexpr[int],
+    k: fx.Constexpr[int],
+    param: GemmGfx950Param,
+    stream: fx.Stream = fx.Stream(None),
+):
+    mma_atom = fx.make_mma_atom(
+        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, fx.BFloat16)
+    )
+    k_per_mfma_group = param.mma_k // 4
+    tiled_mma = fx.make_tiled_mma(
+        mma_atom,
+        fx.make_layout(
+            (param.m_waves, param.n_waves, 1),
+            (param.n_waves, 1, 0),
+        ),
+        fx.make_tile(
+            None,
+            None,
+            fx.make_layout(
+                (k_per_mfma_group, 4),
+                (1, k_per_mfma_group),
+            ),
+        ),
+    )
+    num_pid_m = (m + param.block_m - 1) // param.block_m
+    num_pid_n = (n + param.block_n - 1) // param.block_n
+    gemm_gfx950_kernel._known_block_size = [param.block_threads, 1, 1]
+    gemm_gfx950_kernel._func.__name__ = make_gemm_gfx950_kernel_name(param)
+    # The kernel ignores the bias operand when param.has_bias is false. Reuse
+    # out so the JIT host signature does not need a separate dummy bias tensor.
+    gemm_gfx950_kernel(out, a, b, out, m, n, k, tiled_mma, param).launch(
         grid=(num_pid_m * num_pid_n, 1, 1),
         block=(param.block_threads, 1, 1),
         stream=stream,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Route FlyDSL GEMM templates through a direct callable path and static launch state so wrapper overhead is comparable to Triton for small GEMMs.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo