### PR TITLE
[Inductor] Harden FlyDSL GEMM backend gating and cache handling

### DIFF
--- a/torch/_inductor/codegen/flydsl/flydsl_kernel.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_kernel.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import logging
-from typing import Any
+from collections.abc import Callable
 from unittest.mock import patch
 
 import torch
@@ -20,7 +20,7 @@ kernel_code_log = torch._logging.getArtifactLogger(__name__, "kernel_code")
 
 
 class FlyDSLTemplateKernel(Kernel):
-    """Minimal template kernel implementation for FlyDSL Inductor demos."""
+    """Minimal template kernel implementation for FlyDSL Inductor integration."""
 
     def __init__(
         self,

--- a/torch/_inductor/runtime/flydsl_cache.py
+++ b/torch/_inductor/runtime/flydsl_cache.py
@@ -13,12 +13,16 @@ def _cache_dir() -> Path:
 
 
 def ensure_flydsl_cache_dir() -> str:
-    """Ensure FlyDSL uses TorchInductor's cache root by default.
+    """Route FlyDSL's disk cache through TorchInductor's cache root by default.
 
     FlyDSL has its own disk cache controlled by ``FLYDSL_RUNTIME_CACHE_DIR``.
     Inductor-generated kernels should participate in Inductor cache cleanup and
-    subprocess warming, so force FlyDSL to use an Inductor-owned subdirectory.
+    subprocess warming, so default FlyDSL to an Inductor-owned subdirectory --
+    but respect an explicit ``FLYDSL_RUNTIME_CACHE_DIR`` the user already set.
     """
+    existing = os.environ.get("FLYDSL_RUNTIME_CACHE_DIR")
+    if existing:
+        return existing
     cache_dir = str(_cache_dir())
     os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = cache_dir
     return cache_dir

--- a/torch/_inductor/template_heuristics/flydsl.py
+++ b/torch/_inductor/template_heuristics/flydsl.py
@@ -4,6 +4,34 @@ from itertools import product
 import torch._inductor.config as config
 
 
+# Keep in sync with make_gemm_gfx950_param in
+# torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+_SMEM_CAPACITY_BY_ARCH = {
+    "gfx942": 65536,
+    "gfx950": 163840,
+}
+_DEFAULT_SMEM_CAPACITY = 65536
+
+
+def _smem_capacity() -> int:
+    """Best-effort per-arch LDS capacity, matching the vendored gfx950 kernel.
+
+    Falls back to the conservative gfx942 value so configs that only fit the
+    larger gfx950 LDS are never proposed on an unknown/smaller device.
+    """
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            gcn_arch = (
+                torch.cuda.get_device_properties(0).gcnArchName or ""
+            ).split(":", 1)[0]
+            return _SMEM_CAPACITY_BY_ARCH.get(gcn_arch, _DEFAULT_SMEM_CAPACITY)
+    except Exception:
+        pass
+    return _DEFAULT_SMEM_CAPACITY
+
+
 @dataclass(frozen=True)
 class FlyDSLGemmConfig:
     TILE_M: int = 128
@@ -40,7 +68,7 @@ def _is_valid_gemm_config(gemm_config: dict[str, int | bool]) -> bool:
         return False
 
     in_dbytes = 2
-    smem_capacity = 163840
+    smem_capacity = _smem_capacity()
     smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
     if smem_bytes > smem_capacity:
         return False

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2478,6 +2478,17 @@ def use_flydsl_template(layout: Layout) -> bool:
         return False
     if not _use_template_for_gpu(layout, [torch.bfloat16]):
         return False
+    # The vendored FlyDSL GEMM kernel targets the gfx950 (MI350) layout; its LDS
+    # capacity and MFMA assumptions do not hold on other archs, so gate strictly
+    # on gfx950 to avoid emitting kernels that fail to compile or run there.
+    try:
+        device_index = layout.device.index if layout.device.index is not None else 0
+        gcn_arch = torch.cuda.get_device_properties(device_index).gcnArchName or ""
+    except Exception:
+        log.debug("Could not determine ROCm arch for FlyDSL gate", exc_info=True)
+        return False
+    if gcn_arch.split(":", 1)[0] != "gfx950":
+        return False
     try:
         from .codegen.flydsl import flydsl_utils
     except Exception:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Address review feedback on the FlyDSL GEMM template integration:

- Gate use_flydsl_template strictly on gfx950; the vendored kernel is
  written for the gfx950 (MI350) LDS/MFMA layout and would fail to
  compile or run on other ROCm archs (e.g. gfx942).
- Make the config heuristic LDS capacity arch-aware instead of a
  hardcoded gfx950 value, keeping it in sync with make_gemm_gfx950_param
  and falling back to the conservative gfx942 capacity on unknown archs.
- Respect a user-set FLYDSL_RUNTIME_CACHE_DIR instead of overwriting it.
- Import Callable (fixes undefined name) and drop the unused Any import.
- Reword a docstring ("demos" -> "integration").

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo