### PR TITLE
[Inductor] Document FlyDSL GEMM direct call path

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -637,6 +637,11 @@ class AsyncCompile:
         """Reload a kernel module from PyCodeCache and return its entry point."""
         mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
         main_func_name = f"{kernel_name}_{main_suffix}"
+        if not hasattr(mod, main_func_name):
+            available = [name for name in dir(mod) if callable(getattr(mod, name))]
+            raise RuntimeError(
+                f"Could not find kernel function '{main_func_name}'. Available callables: {available}"
+            )
         return getattr(mod, main_func_name)
 
     def cutedsl(self, kernel_name: str, source_code: str, precompile_metadata=None):
@@ -709,8 +714,8 @@ class AsyncCompile:
         Compile FlyDSL kernels.
 
         FlyDSL generated source is written through PyCodeCache so the module can
-        be imported and its `{kernel_name}_main` entry point can be wrapped for
-        Inductor's `.run(...)` call convention.
+        be imported and its `{kernel_name}_main` entry point can be called
+        directly from the Inductor wrapper.
         """
         from torch._inductor.codegen.flydsl.flydsl_kernel import MAIN_SUFFIX
 
@@ -747,16 +752,7 @@ class AsyncCompile:
             return LambdaFuture(get_result, future=subprocess_task)
         else:
             key, path = torch._inductor.codecache.PyCodeCache.write(source_code)
-            mod = torch._inductor.codecache.PyCodeCache.load_by_key_path(key, path)
-
-            main_func_name = f"{kernel_name}_{MAIN_SUFFIX}"
-            if not hasattr(mod, main_func_name):
-                available = [name for name in dir(mod) if callable(getattr(mod, name))]
-                raise RuntimeError(
-                    f"Could not find FlyDSL main kernel function '{main_func_name}'. Available callables: {available}"
-                )
-
-            return getattr(mod, main_func_name)
+            return self._load_kernel_fn(kernel_name, MAIN_SUFFIX, key, path)
 
     def pallas(self, kernel_name: str, source_code: str):
         """

--- a/torch/_inductor/codegen/flydsl/flydsl_kernel.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_kernel.py
@@ -16,7 +16,6 @@ from torch._inductor.virtualized import V
 MAIN_SUFFIX = "main"
 
 log = logging.getLogger(__name__)
-kernel_code_log = torch._logging.getArtifactLogger(__name__, "kernel_code")
 
 
 class FlyDSLTemplateKernel(Kernel):
@@ -171,6 +170,9 @@ class FlyDSLTemplateKernel(Kernel):
             call_args.append(call_arg)
             arg_types.append(arg_type)
 
+        # FlyDSL generated modules expose `{kernel_name}_main` as a normal
+        # Python callable.  Calling it directly avoids the Triton-specific
+        # `.run(..., stream=...)` adapter while preserving the same stream logic.
         device = V.graph.get_current_device_or_throw()
         call_args_str = ", ".join(wrapper.prepare_triton_kernel_call(call_args))
         current_stream_idx = V.graph.scheduler.current_stream_idx

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -271,6 +271,9 @@ def get_flydsl_mm_template_kwargs(
     if n_static % 32 != 0 or k_static % 32 != 0:
         return []
 
+    # The FlyDSL GEMM template consumes the RHS as contiguous [N, K].  The
+    # aten.mm lowering sees B.T as a [K, N] ReinterpretView, so pass the
+    # underlying B buffer and bake the static GEMM dimensions into the template.
     return [
         {
             **gemm_config,

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -16,6 +16,9 @@ _gemm_call_entry = None
 
 
 def _static_tensor_arg(tensor):
+    # Inductor only emits this template for static GEMM shapes with explicit
+    # size/stride guards, so FlyDSL can compile against static memref layouts and
+    # avoid per-launch dynamic-layout ABI slots.
     return flydsl_jit_argument.from_torch_tensor(tensor)
 
 
@@ -96,6 +99,7 @@ def _flydsl_mm(output, mat1, mat2, stream):
     n = GEMM_N
     k = GEMM_K
     if MAT2_IS_NK:
+        # The lowering passes the original contiguous B buffer for A @ B.T.
         mat2_nk = mat2
     else:
         mat2_nk = mat2.transpose(0, 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Clarify the generated FlyDSL GEMM call conventions and reuse the direct function loader for better diagnostics.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo