### PR TITLE
[Inductor] Simplify FlyDSL GEMM launcher API

### DIFF
--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -4,7 +4,7 @@ import os
 from flydsl.compiler import jit_argument as flydsl_jit_argument
 from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
     infer_has_k_tail,
-    launch_gemm_gfx950_no_bias,
+    launch_gemm_gfx950,
     make_gemm_param_and_validate,
 )
 from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
@@ -53,7 +53,7 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
     if executor is None:
         ensure_flydsl_cache_dir()
         executor = flyc.compile(
-            launch_gemm_gfx950_no_bias,
+            launch_gemm_gfx950,
             _static_tensor_arg(output_mn),
             _static_tensor_arg(mat1_mk),
             _static_tensor_arg(mat2_nk),

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -1,7 +1,6 @@
 from .gemm_gfx950 import (
     infer_has_k_tail,
     launch_gemm_gfx950,
-    launch_gemm_gfx950_no_bias,
     make_gemm_param_and_validate,
     make_gemm_gfx950_param,
 )
@@ -9,7 +8,6 @@ from .gemm_gfx950 import (
 __all__ = [
     "infer_has_k_tail",
     "launch_gemm_gfx950",
-    "launch_gemm_gfx950_no_bias",
     "make_gemm_gfx950_param",
     "make_gemm_param_and_validate",
 ]

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -469,48 +469,6 @@ def launch_gemm_gfx950(
     out: fx.Tensor,
     a: fx.Tensor,
     b: fx.Tensor,
-    bias: fx.Tensor,
-    m: fx.Constexpr[int],
-    n: fx.Constexpr[int],
-    k: fx.Constexpr[int],
-    param: GemmGfx950Param,
-    stream: fx.Stream = fx.Stream(None),
-):
-    mma_atom = fx.make_mma_atom(
-        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, fx.BFloat16)
-    )
-    k_per_mfma_group = param.mma_k // 4
-    tiled_mma = fx.make_tiled_mma(
-        mma_atom,
-        fx.make_layout(
-            (param.m_waves, param.n_waves, 1),
-            (param.n_waves, 1, 0),
-        ),
-        fx.make_tile(
-            None,
-            None,
-            fx.make_layout(
-                (k_per_mfma_group, 4),
-                (1, k_per_mfma_group),
-            ),
-        ),
-    )
-    num_pid_m = (m + param.block_m - 1) // param.block_m
-    num_pid_n = (n + param.block_n - 1) // param.block_n
-    gemm_gfx950_kernel._known_block_size = [param.block_threads, 1, 1]
-    gemm_gfx950_kernel._func.__name__ = make_gemm_gfx950_kernel_name(param)
-    gemm_gfx950_kernel(out, a, b, bias, m, n, k, tiled_mma, param).launch(
-        grid=(num_pid_m * num_pid_n, 1, 1),
-        block=(param.block_threads, 1, 1),
-        stream=stream,
-    )
-
-
-@flyc.jit
-def launch_gemm_gfx950_no_bias(
-    out: fx.Tensor,
-    a: fx.Tensor,
-    b: fx.Tensor,
     m: fx.Constexpr[int],
     n: fx.Constexpr[int],
     k: fx.Constexpr[int],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Keep the gfx950 kernel bias-capable internally while exposing only the bias-free launcher used by the current Inductor MM template.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo