### PR TITLE
[Inductor] Add shape-dynamic FlyDSL GEMM cache reuse

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -252,7 +252,7 @@ def get_flydsl_mm_template_kwargs(
     if mat2.get_dtype() != dtype or layout.dtype != dtype:
         return []
 
-    if dtype != torch.bfloat16:
+    if dtype not in (torch.float16, torch.bfloat16):
         return []
 
     # FlyDSL GEMM consumes B as [N, K]. In aten.mm(A, B.T), Inductor sees
@@ -274,9 +274,17 @@ def get_flydsl_mm_template_kwargs(
     # The FlyDSL GEMM template consumes the RHS as contiguous [N, K].  The
     # aten.mm lowering sees B.T as a [K, N] ReinterpretView, so pass the
     # underlying B buffer and bake the static GEMM dimensions into the template.
+    from .vendored_templates.flydsl.kernels import (
+        GEMM_DTYPE_BF16,
+        GEMM_DTYPE_FP16,
+    )
+
     return [
         {
             **gemm_config,
+            "GEMM_DTYPE_ID": (
+                GEMM_DTYPE_FP16 if dtype == torch.float16 else GEMM_DTYPE_BF16
+            ),
             "MAT2_IS_NK": True,
             "GEMM_M": m_static,
             "GEMM_N": n_static,

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -15,11 +15,10 @@ from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
 _gemm_call_entry = None
 
 
-def _static_tensor_arg(tensor):
-    # Inductor only emits this template for static GEMM shapes with explicit
-    # size/stride guards, so FlyDSL can compile against static memref layouts and
-    # avoid per-launch dynamic-layout ABI slots.
-    return flydsl_jit_argument.from_torch_tensor(tensor)
+def _dynamic_tensor_arg(tensor):
+    # Keep concrete tensor shapes out of FlyDSL's JIT cache key so the same tile
+    # config can be reused across GEMM shapes.
+    return flydsl_jit_argument.TorchTensorJitArg(tensor)
 
 
 def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
@@ -28,11 +27,14 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
     entry = _gemm_call_entry
     if entry is None:
         has_k_tail = infer_has_k_tail(k, TILE_K, STAGES)
+        if USE_HALF_TILE_INTERLEAVED:
+            has_k_tail = has_k_tail or (((k + TILE_K - 1) // TILE_K) % 2 != 0)
         param = make_gemm_param_and_validate(
             m,
             n,
             k,
             {
+                "dtype_id": GEMM_DTYPE_ID,
                 "block_m": TILE_M,
                 "block_n": TILE_N,
                 "block_k": TILE_K,
@@ -40,6 +42,7 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
                 "m_waves": BLOCK_M_WARPS,
                 "n_waves": BLOCK_N_WARPS,
                 "group_m": GROUP_M,
+                "use_half_tile_interleaved": USE_HALF_TILE_INTERLEAVED,
                 "has_bias": False,
                 "has_k_tail": has_k_tail,
             },
@@ -54,9 +57,9 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
         ensure_flydsl_cache_dir()
         executor = flyc.compile(
             launch_gemm_gfx950,
-            _static_tensor_arg(output_mn),
-            _static_tensor_arg(mat1_mk),
-            _static_tensor_arg(mat2_nk),
+            _dynamic_tensor_arg(output_mn),
+            _dynamic_tensor_arg(mat1_mk),
+            _dynamic_tensor_arg(mat2_nk),
             m,
             n,
             k,

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -1,4 +1,6 @@
 from .gemm_gfx950 import (
+    GEMM_DTYPE_BF16,
+    GEMM_DTYPE_FP16,
     infer_has_k_tail,
     launch_gemm_gfx950,
     make_gemm_param_and_validate,
@@ -6,6 +8,8 @@ from .gemm_gfx950 import (
 )
 
 __all__ = [
+    "GEMM_DTYPE_BF16",
+    "GEMM_DTYPE_FP16",
     "infer_has_k_tail",
     "launch_gemm_gfx950",
     "make_gemm_gfx950_param",

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -5,15 +5,18 @@ import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
-from flydsl.expr import buffer_ops, const_expr, range_constexpr, rocdl
+from flydsl.expr import const_expr, range_constexpr, rocdl
 from flydsl.runtime.device import get_rocm_arch
 
 GFX950_DMA_BYTES = 16
 GFX950_WAVE_SIZE = 64
+GEMM_DTYPE_BF16 = 2
+GEMM_DTYPE_FP16 = 3
 
 
 @fx.struct
 class GemmGfx950Param:
+    dtype_id: fx.Constexpr[int]
     block_m: fx.Constexpr[int]
     block_n: fx.Constexpr[int]
     block_k: fx.Constexpr[int]
@@ -21,6 +24,7 @@ class GemmGfx950Param:
     m_waves: fx.Constexpr[int]
     n_waves: fx.Constexpr[int]
     group_m: fx.Constexpr[int]
+    use_half_tile_interleaved: fx.Constexpr[bool]
     has_bias: fx.Constexpr[bool]
     has_k_tail: fx.Constexpr[bool]
     async_load_bytes: fx.Constexpr[int]
@@ -36,6 +40,7 @@ class GemmGfx950Param:
 
 
 def make_gemm_gfx950_param(
+    dtype_id: int = GEMM_DTYPE_BF16,
     block_m: int = 256,
     block_n: int = 256,
     block_k: int = 64,
@@ -43,12 +48,15 @@ def make_gemm_gfx950_param(
     m_waves: int = 2,
     n_waves: int = 4,
     group_m: int = 0,
+    use_half_tile_interleaved: bool = False,
     has_bias: bool = False,
     has_k_tail: bool = False,
     mma_m: int = 16,
     mma_n: int = 16,
     mma_k: int = 32,
 ) -> GemmGfx950Param:
+    if dtype_id not in (GEMM_DTYPE_BF16, GEMM_DTYPE_FP16):
+        raise ValueError(f"unsupported dtype_id={dtype_id}")
     if block_m <= 0 or block_n <= 0 or block_k <= 0 or stages <= 0:
         raise ValueError("block_m, block_n, block_k, and stages must be positive")
     if (mma_m, mma_n, mma_k) != (16, 16, 32):
@@ -61,7 +69,36 @@ def make_gemm_gfx950_param(
         raise ValueError("group_m must be non-negative")
 
     in_dbytes = out_dbytes = 2
+    cshuffle_vec_size = GFX950_DMA_BYTES // out_dbytes
+    if use_half_tile_interleaved:
+        half_block_m = block_m // 2
+        half_block_n = block_n // 2
+        if stages != 2:
+            raise ValueError("half-tile interleaved kernel requires stages=2")
+        if m_waves != 2 or n_waves < 2:
+            raise ValueError(
+                "half-tile interleaved kernel requires m_waves=2 and n_waves>=2"
+            )
+        if half_block_m * 2 != block_m or half_block_n * 2 != block_n:
+            raise ValueError("half-tile interleaved kernel requires even block_m and block_n")
+        mma_m_half_repeat = half_block_m // m_waves // mma_m
+        mma_n_half_repeat = half_block_n // n_waves // mma_n
+        if mma_m_half_repeat * m_waves * mma_m != half_block_m:
+            raise ValueError("half block_m must be divisible by m_waves * mma_m")
+        if mma_n_half_repeat * n_waves * mma_n != half_block_n:
+            raise ValueError("half block_n must be divisible by n_waves * mma_n")
+        if mma_n_half_repeat != 2:
+            raise ValueError(
+                "half-tile interleaved kernel requires "
+                "half_block_n / n_waves / mma_n == 2"
+            )
+        if half_block_n % cshuffle_vec_size != 0:
+            raise ValueError("half block_n must be divisible by the c-shuffle vector size")
+    elif block_n % cshuffle_vec_size != 0:
+        raise ValueError("block_n must be divisible by the c-shuffle vector size")
+
     smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
+    smem_bytes = max(smem_bytes, block_m * block_n * out_dbytes)
     smem_capacity = {
         "gfx942": 65536,
         "gfx950": 163840,
@@ -97,6 +134,13 @@ def make_gemm_gfx950_param(
         )
     ldg_a_iters = (block_m * block_k) // load_elems_per_iter
     ldg_b_iters = (block_n * block_k) // load_elems_per_iter
+    if use_half_tile_interleaved:
+        half_ldg_a_iters = ((block_m // 2) * block_k) // load_elems_per_iter
+        half_ldg_b_iters = ((block_n // 2) * block_k) // load_elems_per_iter
+        if half_ldg_a_iters * load_elems_per_iter != (block_m // 2) * block_k:
+            raise ValueError("half-tile A load schedule must exactly cover the LDS tile")
+        if half_ldg_b_iters * load_elems_per_iter != (block_n // 2) * block_k:
+            raise ValueError("half-tile B load schedule must exactly cover the LDS tile")
     if (stages - 2) * (ldg_a_iters + ldg_b_iters) >= 63:
         raise ValueError("staged pipeline wait count exceeds supported range")
 
@@ -114,6 +158,7 @@ def make_gemm_gfx950_param(
         )
 
     return GemmGfx950Param(
+        dtype_id=dtype_id,
         block_m=block_m,
         block_n=block_n,
         block_k=block_k,
@@ -121,6 +166,7 @@ def make_gemm_gfx950_param(
         m_waves=m_waves,
         n_waves=n_waves,
         group_m=group_m,
+        use_half_tile_interleaved=use_half_tile_interleaved,
         has_bias=has_bias,
         has_k_tail=has_k_tail,
         async_load_bytes=GFX950_DMA_BYTES,
@@ -137,12 +183,14 @@ def make_gemm_gfx950_param(
 
 
 def make_gemm_gfx950_kernel_name(param: GemmGfx950Param) -> str:
-    name = f"gemm_t{param.block_m}x{param.block_n}x{param.block_k}x{param.stages}"
+    dtype_str = "fp16" if param.dtype_id == GEMM_DTYPE_FP16 else "bf16"
+    name = f"gemm_{dtype_str}_t{param.block_m}x{param.block_n}x{param.block_k}x{param.stages}"
     name += f"_w{param.m_waves}x{param.n_waves}"
     name += f"_gm{param.group_m}"
     name += f"_bias{int(param.has_bias)}"
     name += f"_ktail{int(param.has_k_tail)}"
     name += "_nt"
+    name += "_hti" if param.use_half_tile_interleaved else "_ft"
     return name
 
 
@@ -195,6 +243,10 @@ def __barrier(vmcnt=0):
     )
 
 
+def __waitcnt(vmcnt=0):
+    llvm.InlineAsmOp(None, [], f"s_waitcnt vmcnt({vmcnt})", "", has_side_effects=True)
+
+
 def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
     buffer_load_asm_dict = {
         16: "buffer_load_dwordx4",
@@ -217,15 +269,19 @@ def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
     )
 
 
+def _elem_dtype(param: GemmGfx950Param):
+    return fx.Float16 if const_expr(param.dtype_id == GEMM_DTYPE_FP16) else fx.BFloat16
+
+
 @flyc.kernel
 def gemm_gfx950_kernel(
     out: fx.Tensor,
     a: fx.Tensor,
     b: fx.Tensor,
     bias: fx.Tensor,
-    m: fx.Constexpr[int],
-    n: fx.Constexpr[int],
-    k: fx.Constexpr[int],
+    m: fx.Int32,
+    n: fx.Int32,
+    k: fx.Int32,
     tiled_mma: fx.TiledMma,
     param: GemmGfx950Param,
 ):
@@ -234,7 +290,6 @@ def gemm_gfx950_kernel(
     block_k = param.block_k
     stages = param.stages
     has_k_tail = param.has_k_tail
-    wave_size = GFX950_WAVE_SIZE
     async_load_bytes = param.async_load_bytes
     in_data_bytes = param.in_data_bytes
     async_load_vec_size = async_load_bytes // in_data_bytes
@@ -242,6 +297,8 @@ def gemm_gfx950_kernel(
     block_threads = param.block_threads
     ldg_a_iters = param.ldg_a_iters
     ldg_b_iters = param.ldg_b_iters
+    ldg_wait_count = ldg_a_iters + ldg_b_iters
+    elem_dtype = _elem_dtype(param)
 
     tid = fx.thread_idx.x
     num_pid_m = (m + block_m - 1) // block_m
@@ -253,42 +310,39 @@ def gemm_gfx950_kernel(
     k_tiles = (k + block_k - 1) // block_k
 
     @fx.struct
-    class LayoutGemmSharedStorage:
-        a: fx.Array[fx.BFloat16, stages * block_m * block_k, 16]
-        b: fx.Array[fx.BFloat16, stages * block_n * block_k, 16]
+    class SharedABStorage:
+        a: fx.Array[elem_dtype, stages * block_m * block_k, 16]
+        b: fx.Array[elem_dtype, stages * block_n * block_k, 16]
 
-    lds = fx.SharedAllocator().allocate(LayoutGemmSharedStorage).peek()
-    smem_a = lds.a.ptr
-    smem_b = lds.b.ptr
+    @fx.union
+    class SharedStorage:
+        ab: SharedABStorage
+        c: fx.Array[elem_dtype, block_m * block_n, 16]
 
-    wave_offset = rocdl.readfirstlane(
-        fx.Int64.ir_type,
-        fx.Int64(tid // wave_size * wave_size * async_load_bytes),
-    )
-
-    def make_wave_lds_ptr(ptr):
-        return fx.recast_iter(fx.Int8, ptr) + fx.Int32(wave_offset)
+    storage = fx.SharedAllocator().allocate(SharedStorage)
+    smem_a = storage.ab.a.peek().ptr
+    smem_b = storage.ab.b.peek().ptr
+    smem_c = storage.c.peek().ptr
 
     a_buf = fx.rocdl.make_buffer_tensor(a, max_size=True)
     b_buf = fx.rocdl.make_buffer_tensor(b, max_size=True)
-    a_rsrc = buffer_ops.create_buffer_resource(a, max_size=True)
-    b_rsrc = buffer_ops.create_buffer_resource(b, max_size=True)
+    out_buf = fx.rocdl.make_buffer_tensor(out, max_size=True)
     if const_expr(param.has_bias):
         bias_buf = fx.rocdl.make_buffer_tensor(bias, max_size=True)
     else:
         bias_buf = None
-    out = fx.rocdl.make_buffer_tensor(out, max_size=False)
-    gC = fx.flat_divide(out, (block_m, block_n))[None, None, bid_m, bid_n]
-    row_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (1, 0)))
-    col_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (0, 1)))
 
+    a_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(a_buf))
+    b_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(b_buf))
+
+    s2r_copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), elem_dtype)
+    g2r_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    r2g_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+
+    gC = fx.flat_divide(out_buf, (block_m, block_n))[None, None, bid_m, bid_n]
     thr_mma = tiled_mma.thr_slice(tid)
-    uni_copy = fx.make_copy_atom(fx.UniversalCopy128b(), fx.BFloat16)
-    copy_c = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), fx.BFloat16)
-    copy_ab = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.BFloat16)
-    thr_copy_s2r_A = fx.make_tiled_copy_A(copy_ab, tiled_mma).get_slice(tid)
-    thr_copy_s2r_B = fx.make_tiled_copy_B(copy_ab, tiled_mma).get_slice(tid)
-    thr_copy_C = fx.make_tiled_copy_C(copy_c, tiled_mma).get_slice(tid)
+    thr_copy_A = fx.make_tiled_copy_A(g2r_copy_atom, tiled_mma).get_slice(tid)
+    thr_copy_B = fx.make_tiled_copy_B(g2r_copy_atom, tiled_mma).get_slice(tid)
 
     swizzle = fx.static(fx.SwizzleType.get(3, 3, 3))
 
@@ -300,23 +354,46 @@ def gemm_gfx950_kernel(
 
     a_lds_layout = make_lds_layout(block_m)
     b_lds_layout = make_lds_layout(block_n)
+    c_lds_layout = fx.make_layout((block_m, block_n), (block_n, 1))
 
-    sA0 = fx.make_view(smem_a, a_lds_layout)
-    sB0 = fx.make_view(smem_b, b_lds_layout)
-    thr_gC = thr_copy_C.partition_D(gC)
-    thr_cRow = thr_copy_C.partition_S(row_coords)[(0, None), None, None]
-    thr_cCol = thr_copy_C.partition_S(col_coords)[(0, None), None, None]
+    sA = fx.make_view(smem_a, a_lds_layout)
+    sB = fx.make_view(smem_b, b_lds_layout)
+    sC = fx.make_view(smem_c, c_lds_layout)
+
+    frag_A = thr_mma.make_fragment_A(sA)
+    frag_B = thr_mma.make_fragment_B(sB)
+    frag_C = thr_mma.make_fragment_C(gC)
+    frag_A_retile = thr_copy_A.retile(frag_A)
+    frag_B_retile = thr_copy_B.retile(frag_B)
+
+    row_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (1, 0)))
+    col_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (0, 1)))
+    thr_mma_cRow = thr_mma.partition_C(row_coords)
     thr_mma_cCol = thr_mma.partition_C(col_coords)
 
-    frag_A = thr_mma.make_fragment_A(sA0)
-    frag_B = thr_mma.make_fragment_B(sB0)
-    frag_C = thr_mma.make_fragment_C(gC)
-    frag_C_bf16 = fx.make_fragment_like(frag_C, fx.BFloat16)
-    pred_C = fx.make_fragment_like(thr_gC, dtype=fx.Boolean)
-
-    frag_A_retile = thr_copy_s2r_A.retile(frag_A)
-    frag_B_retile = thr_copy_s2r_B.retile(frag_B)
-    frag_C_retile = thr_copy_C.retile(frag_C_bf16)
+    cshuffle_vec_size = GFX950_DMA_BYTES // param.out_data_bytes
+    cshuffle_x_threads = block_n // cshuffle_vec_size
+    cshuffle_thr_layout = fx.make_layout(
+        (block_threads // cshuffle_x_threads, cshuffle_x_threads),
+        (cshuffle_x_threads, 1),
+    )
+    cshuffle_val_layout = fx.make_layout((1, cshuffle_vec_size), (1, 1))
+    cshuffle_tile, cshuffle_tv_layout = fx.make_layout_tv(
+        cshuffle_thr_layout,
+        cshuffle_val_layout,
+    )
+    tiled_copy_cshuffle = fx.make_tiled_copy(
+        r2g_copy_atom,
+        cshuffle_tv_layout,
+        cshuffle_tile,
+    )
+    thr_copy_cshuffle = tiled_copy_cshuffle.get_slice(tid)
+    thr_sC = thr_copy_cshuffle.partition_S(sC)
+    thr_gC = thr_copy_cshuffle.partition_D(gC)
+    thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
+    thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
+    frag_C_cshuffle = fx.make_fragment_like(thr_sC)
+    pred_C = fx.make_fragment_like(thr_cRow, dtype=fx.Boolean)
 
     frag_C.fill(0.0)
     if const_expr(param.has_bias):
@@ -324,39 +401,34 @@ def gemm_gfx950_kernel(
             col_idx = fx.get_scalar(thr_mma_cCol[i])
             global_n_idx = bid_n * block_n + col_idx
             safe_global_n_idx = (global_n_idx < n).select(global_n_idx, 0)
-            bias_val = bias_buf[safe_global_n_idx].to(fx.Float32)
-            frag_C[i] = bias_val
+            frag_C[i] = bias_buf[safe_global_n_idx].to(fx.Float32)
+
     for i in range_constexpr(fx.size(pred_C.shape).unpack()):
-        row_idx = bid_m * block_m + fx.get_scalar(thr_cRow[i])
-        col_idx = bid_n * block_n + fx.get_scalar(thr_cCol[i])
-        pred_C[i] = (row_idx < m) & (col_idx < n)
+        local_row = fx.get_scalar(thr_cRow[i])
+        local_col = fx.get_scalar(thr_cCol[i])
+        row_idx = bid_m * block_m + local_row
+        col_idx = bid_n * block_n + local_col
+        pred_C[i] = (
+            (local_row < block_m)
+            & (local_col < block_n)
+            & (row_idx < m)
+            & (col_idx < n)
+        )
+
+    wave_offset = rocdl.readfirstlane(
+        fx.Int64.ir_type,
+        fx.Int64(tid // GFX950_WAVE_SIZE * GFX950_WAVE_SIZE * async_load_bytes),
+    )
+
+    def make_wave_lds_ptr(ptr):
+        return fx.recast_iter(fx.Int8, ptr) + fx.Int32(wave_offset)
 
     def swizzled_col_idx(row, col, layout):
-        elem_offset = fx.get_scalar(
-            fx.crd2idx(
-                (row, col),
-                layout,
-            )
-        )
+        elem_offset = fx.get_scalar(fx.crd2idx((row, col), layout))
         return elem_offset % block_k
 
-    def advance_lds_ptr(lds_ptr):
-        return lds_ptr + block_threads * async_load_bytes
-
-    def get_a_stage_ptr(stage):
-        return smem_a + stage * block_m * block_k
-
-    def get_b_stage_ptr(stage):
-        return smem_b + stage * block_n * block_k
-
-    def get_a_stage_view(stage):
-        return fx.make_view(get_a_stage_ptr(stage), a_lds_layout)
-
-    def get_b_stage_view(stage):
-        return fx.make_view(get_b_stage_ptr(stage), b_lds_layout)
-
     def async_load_a_to_lds(k_tile, stage):
-        lds_ptr = make_wave_lds_ptr(get_a_stage_ptr(stage))
+        lds_ptr = make_wave_lds_ptr(smem_a + stage * block_m * block_k)
         for i in range_constexpr(ldg_a_iters):
             global_tid = block_threads * i + tid
             m_local_idx = global_tid // ldg_x_threads
@@ -375,10 +447,10 @@ def gemm_gfx950_kernel(
             global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
             buffer_load_lds_inline(a_rsrc, lds_ptr, global_offset, async_load_bytes)
             if i < ldg_a_iters - 1:
-                lds_ptr = advance_lds_ptr(lds_ptr)
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
 
     def async_load_b_to_lds(k_tile, stage):
-        lds_ptr = make_wave_lds_ptr(get_b_stage_ptr(stage))
+        lds_ptr = make_wave_lds_ptr(smem_b + stage * block_n * block_k)
         for i in range_constexpr(ldg_b_iters):
             global_tid = block_threads * i + tid
             n_local_idx = global_tid // ldg_x_threads
@@ -397,20 +469,22 @@ def gemm_gfx950_kernel(
             global_offset = (safe_global_n_idx * k + safe_global_k_idx) * in_data_bytes
             buffer_load_lds_inline(b_rsrc, lds_ptr, global_offset, async_load_bytes)
             if i < ldg_b_iters - 1:
-                lds_ptr = advance_lds_ptr(lds_ptr)
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
 
     def compute_stage(read_stage, k_tile):
-        thr_sA_s2r = thr_copy_s2r_A.partition_S(get_a_stage_view(read_stage))
-        thr_sB_s2r = thr_copy_s2r_B.partition_S(get_b_stage_view(read_stage))
+        sA_stage = fx.make_view(smem_a + read_stage * block_m * block_k, a_lds_layout)
+        sB_stage = fx.make_view(smem_b + read_stage * block_n * block_k, b_lds_layout)
+        thr_sA_s2r = thr_copy_A.partition_S(sA_stage)
+        thr_sB_s2r = thr_copy_B.partition_S(sB_stage)
 
         def compute_k_chunk(block_k_iter):
             fx.copy(
-                uni_copy,
+                s2r_copy_atom,
                 thr_sB_s2r[None, None, block_k_iter],
                 frag_B_retile[None, None, block_k_iter],
             )
             fx.copy(
-                uni_copy,
+                s2r_copy_atom,
                 thr_sA_s2r[None, None, block_k_iter],
                 frag_A_retile[None, None, block_k_iter],
             )
@@ -431,37 +505,437 @@ def gemm_gfx950_kernel(
             else:
                 compute_k_chunk(block_k_iter)
 
-    LDG_WAIT_COUNT = ldg_a_iters + ldg_b_iters
-
     for stage in range_constexpr(stages - 1):
         async_load_b_to_lds(stage, stage)
         async_load_a_to_lds(stage, stage)
     rocdl.sched_barrier(0)
 
     if const_expr(has_k_tail):
-        has_main_loop = k_tiles > stages - 1
-        if const_expr(isinstance(has_main_loop, bool)):
-            main_loop_end = k_tiles - (stages - 1) if has_main_loop else 0
-        else:
-            main_loop_end = has_main_loop.select(k_tiles - (stages - 1), 0)
+        main_loop_end = (k_tiles > stages - 1).select(k_tiles - (stages - 1), 0)
     else:
         main_loop_end = k_tiles - (stages - 1)
     for k_tile in range(0, main_loop_end, 1):
         current_stage = k_tile % stages
         write_stage = (current_stage + stages - 1) % stages
-        __barrier((stages - 2) * LDG_WAIT_COUNT)
+        __barrier((stages - 2) * ldg_wait_count)
         async_load_b_to_lds(k_tile + (stages - 1), write_stage)
         async_load_a_to_lds(k_tile + (stages - 1), write_stage)
         compute_stage(current_stage, k_tile)
 
     current_stage = main_loop_end % stages
     for s in range_constexpr(0, stages - 1):
-        __barrier((stages - 2 - s) * LDG_WAIT_COUNT)
+        __barrier((stages - 2 - s) * ldg_wait_count)
         compute_stage(current_stage, main_loop_end + s)
         current_stage = (current_stage + 1) % stages
 
-    frag_C_bf16.store(frag_C.load().to(fx.BFloat16))
-    fx.copy(copy_c, frag_C_retile, thr_gC, pred=pred_C)
+    frag_C_out = fx.make_fragment_like(frag_C, elem_dtype)
+    frag_C_out.store(frag_C.load().to(elem_dtype))
+
+    fx.gpu.barrier()
+    for i in range_constexpr(fx.size(frag_C_out.shape).unpack()):
+        row = fx.get_scalar(thr_mma_cRow[i])
+        col = fx.get_scalar(thr_mma_cCol[i])
+        sC[row, col] = frag_C_out[i]
+
+    fx.gpu.barrier()
+    fx.copy(s2r_copy_atom, thr_sC, frag_C_cshuffle)
+    fx.copy(r2g_copy_atom, frag_C_cshuffle, thr_gC, pred=pred_C)
+
+
+@flyc.kernel
+def gemm_hti_gfx950_kernel(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    bias: fx.Tensor,
+    m: fx.Int32,
+    n: fx.Int32,
+    k: fx.Int32,
+    tiled_mma: fx.TiledMma,
+    param: GemmGfx950Param,
+):
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    half_block_m = block_m // 2
+    half_block_n = block_n // 2
+    stages = param.stages
+    has_k_tail = param.has_k_tail
+    async_load_bytes = param.async_load_bytes
+    in_data_bytes = param.in_data_bytes
+    async_load_vec_size = async_load_bytes // in_data_bytes
+    ldg_x_threads = param.ldg_x_threads
+    block_threads = param.block_threads
+    n_waves = param.n_waves
+    half_ldg_a_iters = param.ldg_a_iters // 2
+    half_ldg_b_iters = param.ldg_b_iters // 2
+    elem_dtype = _elem_dtype(param)
+
+    tid = fx.thread_idx.x
+    wid = tid // GFX950_WAVE_SIZE
+    num_pid_m = (m + block_m - 1) // block_m
+    num_pid_n = (n + block_n - 1) // block_n
+    block_swizzle = BlockSwizzle(
+        NUM_XCDS=8, NUM_PIDS_THRESHOLD=256, GROUP_M=param.group_m
+    )
+    bid_m, bid_n = block_swizzle.swizzle(num_pid_m, num_pid_n, fx.block_idx.x)
+    k_tiles = (k + block_k - 1) // block_k
+
+    @fx.struct
+    class SharedABStorage:
+        a: fx.Array[elem_dtype, stages * block_m * block_k, 16]
+        b: fx.Array[elem_dtype, stages * block_n * block_k, 16]
+
+    @fx.union
+    class SharedStorage:
+        ab: SharedABStorage
+        c: fx.Array[elem_dtype, block_m * block_n, 16]
+
+    storage = fx.SharedAllocator().allocate(SharedStorage)
+    smem_a = storage.ab.a.peek().ptr
+    smem_b = storage.ab.b.peek().ptr
+    smem_c = storage.c.peek().ptr
+
+    a_buf = fx.rocdl.make_buffer_tensor(a, max_size=True)
+    b_buf = fx.rocdl.make_buffer_tensor(b, max_size=True)
+    out = fx.rocdl.make_buffer_tensor(out, max_size=False)
+    if const_expr(param.has_bias):
+        bias_buf = fx.rocdl.make_buffer_tensor(bias, max_size=True)
+    else:
+        bias_buf = None
+
+    a_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(a_buf))
+    b_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(b_buf))
+
+    s2r_copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), elem_dtype)
+    g2r_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    r2g_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+
+    thr_mma = tiled_mma.thr_slice(tid)
+    thr_copy_A = fx.make_tiled_copy_A(g2r_copy_atom, tiled_mma).get_slice(tid)
+    thr_copy_B = fx.make_tiled_copy_B(g2r_copy_atom, tiled_mma).get_slice(tid)
+
+    swizzle = fx.static(fx.SwizzleType.get(3, 3, 3))
+
+    def make_lds_layout(rows):
+        return fx.make_composed_layout(
+            swizzle,
+            fx.make_ordered_layout((rows, block_k), (1, 0)),
+        )
+
+    a_lds_layout = make_lds_layout(half_block_m)
+    b_lds_layout = make_lds_layout(half_block_n)
+    c_lds_layout = fx.make_layout((half_block_m, half_block_n), (half_block_n, 1))
+
+    wave_offset = rocdl.readfirstlane(
+        fx.Int64.ir_type,
+        fx.Int64(tid // GFX950_WAVE_SIZE * GFX950_WAVE_SIZE * async_load_bytes),
+    )
+
+    def make_wave_lds_ptr(ptr):
+        return fx.recast_iter(fx.Int8, ptr) + fx.Int32(wave_offset)
+
+    def swizzled_col_idx(row, col, layout):
+        elem_offset = fx.get_scalar(fx.crd2idx((row, col), layout))
+        return elem_offset % block_k
+
+    def half_a_base(stage, m_part):
+        return smem_a + (stage * block_m + m_part * half_block_m) * block_k
+
+    def half_b_base(stage, n_part):
+        return smem_b + (stage * block_n + n_part * half_block_n) * block_k
+
+    def async_load_a_to_lds(m_part, k_tile, stage):
+        lds_ptr = make_wave_lds_ptr(half_a_base(stage, m_part))
+        for i in range_constexpr(half_ldg_a_iters):
+            global_tid = block_threads * i + tid
+            m_local_idx = global_tid // ldg_x_threads
+            k_local_idx = global_tid % ldg_x_threads * async_load_vec_size
+            global_m_idx = bid_m * block_m + m_part * half_block_m + m_local_idx
+            safe_global_m_idx = (global_m_idx < m).select(global_m_idx, 0)
+            global_k_idx = k_tile * block_k + swizzled_col_idx(
+                m_local_idx,
+                k_local_idx,
+                a_lds_layout,
+            )
+            if const_expr(has_k_tail):
+                safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            else:
+                safe_global_k_idx = global_k_idx
+            global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
+            buffer_load_lds_inline(a_rsrc, lds_ptr, global_offset, async_load_bytes)
+            if i < half_ldg_a_iters - 1:
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+    def async_load_b_to_lds(n_part, k_tile, stage):
+        lds_ptr = make_wave_lds_ptr(half_b_base(stage, n_part))
+        for i in range_constexpr(half_ldg_b_iters):
+            global_tid = block_threads * i + tid
+            n_local_idx = global_tid // ldg_x_threads
+            k_local_idx = global_tid % ldg_x_threads * async_load_vec_size
+            global_n_idx = bid_n * block_n + n_part * half_block_n + n_local_idx
+            safe_global_n_idx = (global_n_idx < n).select(global_n_idx, 0)
+            global_k_idx = k_tile * block_k + swizzled_col_idx(
+                n_local_idx,
+                k_local_idx,
+                b_lds_layout,
+            )
+            if const_expr(has_k_tail):
+                safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            else:
+                safe_global_k_idx = global_k_idx
+            global_offset = (safe_global_n_idx * k + safe_global_k_idx) * in_data_bytes
+            buffer_load_lds_inline(b_rsrc, lds_ptr, global_offset, async_load_bytes)
+            if i < half_ldg_b_iters - 1:
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+    def make_gC(m_part, n_part):
+        return fx.flat_divide(out, (half_block_m, half_block_n))[
+            None, None, bid_m * 2 + m_part, bid_n * 2 + n_part
+        ]
+
+    def make_c_fragment(m_part, n_part):
+        gC = make_gC(m_part, n_part)
+        frag_C = thr_mma.make_fragment_C(gC)
+        frag_C.fill(0.0)
+        return frag_C
+
+    def load_a_fragment(m_part, read_stage, k_tile):
+        sA = fx.make_view(half_a_base(read_stage, m_part), a_lds_layout)
+        frag_A = thr_mma.make_fragment_A(sA)
+        frag_A_retile = thr_copy_A.retile(frag_A)
+        thr_sA_s2r = thr_copy_A.partition_S(sA)
+
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.copy(
+                        s2r_copy_atom,
+                        thr_sA_s2r[None, None, block_k_iter],
+                        frag_A_retile[None, None, block_k_iter],
+                    )
+            else:
+                fx.copy(
+                    s2r_copy_atom,
+                    thr_sA_s2r[None, None, block_k_iter],
+                    frag_A_retile[None, None, block_k_iter],
+                )
+        return frag_A
+
+    def load_b_fragment(n_part, read_stage, k_tile):
+        sB = fx.make_view(half_b_base(read_stage, n_part), b_lds_layout)
+        frag_B = thr_mma.make_fragment_B(sB)
+        frag_B_retile = thr_copy_B.retile(frag_B)
+        thr_sB_s2r = thr_copy_B.partition_S(sB)
+
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.copy(
+                        s2r_copy_atom,
+                        thr_sB_s2r[None, None, block_k_iter],
+                        frag_B_retile[None, None, block_k_iter],
+                    )
+            else:
+                fx.copy(
+                    s2r_copy_atom,
+                    thr_sB_s2r[None, None, block_k_iter],
+                    frag_B_retile[None, None, block_k_iter],
+                )
+        return frag_B
+
+    def consume(k_tile, frag_C, frag_A, frag_B, emit_sched_barrier):
+        if const_expr(emit_sched_barrier):
+            rocdl.sched_barrier(0)
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.gemm(
+                        tiled_mma,
+                        frag_C,
+                        frag_A[None, None, block_k_iter],
+                        frag_B[None, None, block_k_iter],
+                        frag_C,
+                        traversal_order=fx.GemmTraversalOrder.KNM,
+                    )
+            else:
+                fx.gemm(
+                    tiled_mma,
+                    frag_C,
+                    frag_A[None, None, block_k_iter],
+                    frag_B[None, None, block_k_iter],
+                    frag_C,
+                    traversal_order=fx.GemmTraversalOrder.KNM,
+                )
+        if const_expr(emit_sched_barrier):
+            rocdl.sched_barrier(0)
+
+    def store_half_tile(m_part, n_part, frag_C):
+        gC = fx.flat_divide(out, (half_block_m, half_block_n))[
+            None, None, bid_m * 2 + m_part, bid_n * 2 + n_part
+        ]
+        sC = fx.make_view(smem_c, c_lds_layout)
+
+        row_coords = fx.make_view(
+            0, fx.make_layout((half_block_m, half_block_n), (1, 0))
+        )
+        col_coords = fx.make_view(
+            0, fx.make_layout((half_block_m, half_block_n), (0, 1))
+        )
+        thr_mma_cRow = thr_mma.partition_C(row_coords)
+        thr_mma_cCol = thr_mma.partition_C(col_coords)
+
+        cshuffle_vec_size = GFX950_DMA_BYTES // param.out_data_bytes
+        cshuffle_x_threads = half_block_n // cshuffle_vec_size
+        cshuffle_thr_layout = fx.make_layout(
+            (block_threads // cshuffle_x_threads, cshuffle_x_threads),
+            (cshuffle_x_threads, 1),
+        )
+        cshuffle_val_layout = fx.make_layout((1, cshuffle_vec_size), (1, 1))
+        cshuffle_tile, cshuffle_tv_layout = fx.make_layout_tv(
+            cshuffle_thr_layout,
+            cshuffle_val_layout,
+        )
+        tiled_copy_cshuffle = fx.make_tiled_copy(
+            r2g_copy_atom,
+            cshuffle_tv_layout,
+            cshuffle_tile,
+        )
+        thr_copy_cshuffle = tiled_copy_cshuffle.get_slice(tid)
+        thr_sC = thr_copy_cshuffle.partition_S(sC)
+        thr_gC = thr_copy_cshuffle.partition_D(gC)
+        thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
+        thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
+        frag_C_cshuffle = fx.make_fragment_like(thr_sC)
+        pred_C = fx.make_fragment_like(thr_cRow, dtype=fx.Boolean)
+
+        for i in range_constexpr(fx.size(pred_C.shape).unpack()):
+            local_row = fx.get_scalar(thr_cRow[i])
+            local_col = fx.get_scalar(thr_cCol[i])
+            row_idx = bid_m * block_m + m_part * half_block_m + local_row
+            col_idx = bid_n * block_n + n_part * half_block_n + local_col
+            pred_C[i] = (
+                (local_row < half_block_m)
+                & (local_col < half_block_n)
+                & (row_idx < m)
+                & (col_idx < n)
+            )
+
+        frag_C_out = fx.make_fragment_like(frag_C, elem_dtype)
+        for i in range_constexpr(fx.size(frag_C.shape).unpack()):
+            val = frag_C[i]
+            if const_expr(param.has_bias):
+                col = fx.get_scalar(thr_mma_cCol[i])
+                global_n_idx = bid_n * block_n + n_part * half_block_n + col
+                safe_global_n_idx = (global_n_idx < n).select(global_n_idx, 0)
+                val = val + bias_buf[safe_global_n_idx].to(fx.Float32)
+            frag_C_out[i] = val.to(elem_dtype)
+
+        fx.gpu.barrier()
+        for i in range_constexpr(fx.size(frag_C_out.shape).unpack()):
+            row = fx.get_scalar(thr_mma_cRow[i])
+            col = fx.get_scalar(thr_mma_cCol[i])
+            sC[row, col] = frag_C_out[i]
+
+        fx.gpu.barrier()
+        fx.copy(s2r_copy_atom, thr_sC, frag_C_cshuffle)
+        fx.copy(r2g_copy_atom, frag_C_cshuffle, thr_gC, pred=pred_C)
+        fx.gpu.barrier()
+
+    c00 = make_c_fragment(0, 0)
+    c01 = make_c_fragment(0, 1)
+    c10 = make_c_fragment(1, 0)
+    c11 = make_c_fragment(1, 1)
+
+    async_load_b_to_lds(0, 0, 0)
+    async_load_a_to_lds(0, 0, 0)
+    async_load_b_to_lds(1, 0, 0)
+    async_load_a_to_lds(1, 0, 0)
+    rocdl.sched_barrier(0)
+    if wid // n_waves == 1:
+        rocdl.s_barrier()
+    rocdl.sched_barrier(0)
+    rocdl.s_barrier()
+    rocdl.sched_barrier(0)
+    async_load_b_to_lds(0, 1, 1)
+    async_load_a_to_lds(0, 1, 1)
+    async_load_b_to_lds(1, 1, 1)
+    __barrier(half_ldg_b_iters + half_ldg_a_iters)
+
+    def compute_double_tile(k_tile, prefetch_next):
+        next_k_tile = k_tile + 2
+
+        b0 = load_b_fragment(0, 0, k_tile)
+        a0 = load_a_fragment(0, 0, k_tile)
+        async_load_a_to_lds(1, k_tile + 1, 1)
+        rocdl.s_barrier()
+        consume(k_tile, c00, a0, b0, True)
+        rocdl.s_barrier()
+
+        b1 = load_b_fragment(1, 0, k_tile)
+        if const_expr(prefetch_next):
+            async_load_b_to_lds(0, next_k_tile, 0)
+            rocdl.s_barrier()
+        consume(k_tile, c01, a0, b1, True)
+        rocdl.s_barrier()
+
+        a1 = load_a_fragment(1, 0, k_tile)
+        if const_expr(prefetch_next):
+            async_load_a_to_lds(0, next_k_tile, 0)
+            rocdl.s_barrier()
+        consume(k_tile, c10, a1, b0, True)
+        rocdl.s_barrier()
+
+        b0 = load_b_fragment(0, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            async_load_b_to_lds(1, next_k_tile, 0)
+            __barrier(2 * half_ldg_b_iters + half_ldg_a_iters)
+        consume(k_tile, c11, a1, b1, True)
+        if const_expr(not prefetch_next):
+            __waitcnt(0)
+        rocdl.s_barrier()
+
+        a0 = load_a_fragment(0, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            async_load_a_to_lds(1, next_k_tile, 0)
+            rocdl.s_barrier()
+        consume(k_tile + 1, c00, a0, b0, True)
+        rocdl.s_barrier()
+
+        b1 = load_b_fragment(1, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            async_load_b_to_lds(0, next_k_tile + 1, 1)
+            rocdl.s_barrier()
+        consume(k_tile + 1, c01, a0, b1, True)
+        rocdl.s_barrier()
+
+        a1 = load_a_fragment(1, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            async_load_a_to_lds(0, next_k_tile + 1, 1)
+            rocdl.s_barrier()
+        consume(k_tile + 1, c10, a1, b0, True)
+        rocdl.s_barrier()
+
+        if const_expr(prefetch_next):
+            async_load_b_to_lds(1, next_k_tile + 1, 1)
+            __barrier(half_ldg_b_iters + half_ldg_a_iters)
+        consume(k_tile + 1, c11, a1, b1, True)
+        rocdl.s_barrier()
+
+    final_double_tile = ((k_tiles % 2) == 0).select(k_tiles - 2, k_tiles - 1)
+    main_loop_end = (k_tiles > 2).select(final_double_tile, 0)
+    for k_tile in range(0, main_loop_end, 2):
+        compute_double_tile(k_tile, True)
+
+    compute_double_tile(main_loop_end, False)
+
+    store_half_tile(0, 0, c00)
+    store_half_tile(0, 1, c01)
+    store_half_tile(1, 0, c10)
+    store_half_tile(1, 1, c11)
 
 
 @flyc.jit
@@ -469,14 +943,15 @@ def launch_gemm_gfx950(
     out: fx.Tensor,
     a: fx.Tensor,
     b: fx.Tensor,
-    m: fx.Constexpr[int],
-    n: fx.Constexpr[int],
-    k: fx.Constexpr[int],
+    m: fx.Int32,
+    n: fx.Int32,
+    k: fx.Int32,
     param: GemmGfx950Param,
     stream: fx.Stream = fx.Stream(None),
 ):
+    elem_dtype = _elem_dtype(param)
     mma_atom = fx.make_mma_atom(
-        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, fx.BFloat16)
+        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, elem_dtype)
     )
     k_per_mfma_group = param.mma_k // 4
     tiled_mma = fx.make_tiled_mma(
@@ -496,11 +971,14 @@ def launch_gemm_gfx950(
     )
     num_pid_m = (m + param.block_m - 1) // param.block_m
     num_pid_n = (n + param.block_n - 1) // param.block_n
-    gemm_gfx950_kernel._known_block_size = [param.block_threads, 1, 1]
-    gemm_gfx950_kernel._func.__name__ = make_gemm_gfx950_kernel_name(param)
-    # The kernel ignores the bias operand when param.has_bias is false. Reuse
-    # out so the JIT host signature does not need a separate dummy bias tensor.
-    gemm_gfx950_kernel(out, a, b, out, m, n, k, tiled_mma, param).launch(
+    kernel_impl = (
+        gemm_hti_gfx950_kernel
+        if param.use_half_tile_interleaved
+        else gemm_gfx950_kernel
+    )
+    kernel_impl._known_block_size = [param.block_threads, 1, 1]
+    kernel_impl._func.__name__ = make_gemm_gfx950_kernel_name(param)
+    kernel_impl(out, a, b, out, m, n, k, tiled_mma, param).launch(
         grid=(num_pid_m * num_pid_n, 1, 1),
         block=(param.block_threads, 1, 1),
         stream=stream,
@@ -520,4 +998,8 @@ def make_gemm_param_and_validate(m, n, k, kwargs):
         return None
     if not ((n % 32 == 0) and (k % result.mma_k == 0)):
         return None
+    if result.use_half_tile_interleaved:
+        k_tiles = (k + result.block_k - 1) // result.block_k
+        if k_tiles < 2:
+            return None
     return result

--- a/torch/_inductor/template_heuristics/flydsl.py
+++ b/torch/_inductor/template_heuristics/flydsl.py
@@ -44,6 +44,7 @@ class FlyDSLGemmConfig:
     BLOCK_K_WARPS: int = 1
     GROUP_M: int = 0
     B_TO_LDS: bool = True
+    USE_HALF_TILE_INTERLEAVED: bool = False
 
 
 def _is_valid_gemm_config(gemm_config: dict[str, int | bool]) -> bool:
@@ -54,6 +55,9 @@ def _is_valid_gemm_config(gemm_config: dict[str, int | bool]) -> bool:
     m_waves = int(gemm_config["BLOCK_M_WARPS"])
     n_waves = int(gemm_config["BLOCK_N_WARPS"])
     group_m = int(gemm_config["GROUP_M"])
+    use_half_tile_interleaved = bool(
+        gemm_config.get("USE_HALF_TILE_INTERLEAVED", False)
+    )
     mma_m = 16
     mma_n = 16
     mma_k = 32
@@ -68,8 +72,33 @@ def _is_valid_gemm_config(gemm_config: dict[str, int | bool]) -> bool:
         return False
 
     in_dbytes = 2
+    out_dbytes = 2
+    cshuffle_vec_size = 16 // out_dbytes
+    if use_half_tile_interleaved:
+        half_block_m = block_m // 2
+        half_block_n = block_n // 2
+        if stages != 2:
+            return False
+        if m_waves != 2 or n_waves < 2:
+            return False
+        if half_block_m * 2 != block_m or half_block_n * 2 != block_n:
+            return False
+        mma_m_half_repeat = half_block_m // m_waves // mma_m
+        mma_n_half_repeat = half_block_n // n_waves // mma_n
+        if mma_m_half_repeat * m_waves * mma_m != half_block_m:
+            return False
+        if mma_n_half_repeat * n_waves * mma_n != half_block_n:
+            return False
+        if mma_n_half_repeat != 2:
+            return False
+        if half_block_n % cshuffle_vec_size != 0:
+            return False
+    elif block_n % cshuffle_vec_size != 0:
+        return False
+
     smem_capacity = _smem_capacity()
     smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
+    smem_bytes = max(smem_bytes, block_m * block_n * out_dbytes)
     if smem_bytes > smem_capacity:
         return False
 
@@ -86,6 +115,13 @@ def _is_valid_gemm_config(gemm_config: dict[str, int | bool]) -> bool:
         return False
     ldg_a_iters = (block_m * block_k) // load_elems_per_iter
     ldg_b_iters = (block_n * block_k) // load_elems_per_iter
+    if use_half_tile_interleaved:
+        half_ldg_a_iters = ((block_m // 2) * block_k) // load_elems_per_iter
+        half_ldg_b_iters = ((block_n // 2) * block_k) // load_elems_per_iter
+        if half_ldg_a_iters * load_elems_per_iter != (block_m // 2) * block_k:
+            return False
+        if half_ldg_b_iters * load_elems_per_iter != (block_n // 2) * block_k:
+            return False
     if ldg_a_iters <= 0 or ldg_b_iters <= 0:
         return False
     if (stages - 2) * (ldg_a_iters + ldg_b_iters) >= 63:
@@ -108,7 +144,7 @@ def get_exhaustive_gemm_configs() -> list[FlyDSLGemmConfig]:
     """
     selections = {
         "TILE_M": [16, 32, 48, 64, 96, 128, 256],
-        "TILE_N": [64, 96, 128, 256],
+        "TILE_N": [16, 32, 64, 96, 128, 256],
         "TILE_K": [64, 128, 256],
         "STAGES": [i for i in range(2, 10)],
         "BLOCK_M_WARPS": [1, 2, 4],
@@ -117,6 +153,7 @@ def get_exhaustive_gemm_configs() -> list[FlyDSLGemmConfig]:
         "BLOCK_K_WARPS": [1],
         "GROUP_M": [0, 4],
         "B_TO_LDS": [True],
+        "USE_HALF_TILE_INTERLEAVED": [False, True],
     }
     keys = selections.keys()
     values = selections.values()
@@ -160,6 +197,24 @@ def get_default_gemm_configs() -> list[FlyDSLGemmConfig]:
         (64, 64, 256, 2, 1, 2, 2, 1, 0, True),
         (128, 128, 64, 4, 1, 4, 4, 1, 4, True),
         (256, 256, 64, 2, 1, 4, 4, 1, 4, True),
+        # Small-N tiles help small-M decode GEMMs.
+        (16, 16, 128, 8, 1, 1, 1, 1, 4, True),
+        (16, 16, 64, 8, 1, 1, 1, 1, 0, True),
+        (32, 32, 64, 8, 1, 2, 2, 1, 4, True),
+        (64, 32, 128, 4, 1, 4, 2, 1, 4, True),
+        (64, 64, 64, 7, 1, 4, 2, 1, 4, True),
+        (64, 128, 64, 6, 1, 2, 4, 1, 4, True),
+        (128, 128, 64, 4, 1, 2, 4, 1, 4, True),
+        (128, 256, 64, 3, 1, 4, 4, 1, 4, True),
+        (32, 64, 64, 8, 1, 2, 2, 1, 0, True),
+        (16, 64, 128, 3, 1, 1, 4, 1, 4, True),
+        (64, 64, 64, 6, 1, 4, 2, 1, 4, True),
+        # Trailing True enables the half-tile interleaved kernel.
+        (128, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (128, 128, 64, 2, 1, 2, 2, 1, 4, True, True),
+        (128, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+        (256, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (256, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
     ]
     configs = [FlyDSLGemmConfig(*args) for args in config_tuples]
     return [

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2476,7 +2476,7 @@ def use_flydsl_template(layout: Layout) -> bool:
         return False
     if not (config.max_autotune or config.max_autotune_gemm):
         return False
-    if not _use_template_for_gpu(layout, [torch.bfloat16]):
+    if not _use_template_for_gpu(layout, [torch.float16, torch.bfloat16]):
         return False
     # The vendored FlyDSL GEMM kernel targets the gfx950 (MI350) layout; its LDS
     # capacity and MFMA assumptions do not hold on other archs, so gate strictly


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Use dynamic tensor layouts and runtime GEMM sizes so FlyDSL JIT artifacts are keyed by tile config instead of individual problem shapes, while syncing the latest gfx950 kernels and small-N tuning configs.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo