### PR TITLE
[Inductor] Add FlyDSL GEMM accumulator epilogue fusion

### DIFF
--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -112,6 +112,37 @@ class TestFlyDSLTemplate(TestCase):
         self.assertIn("_flydsl_mm", code)
         self.assertTrue(torch.allclose(result, fn(a, b), atol=3e-2, rtol=3e-2))
 
+    @unittest.skipUnless(HAS_FLYDSL, "requires flydsl")
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        epilogue_fusion=True,
+    )
+    def test_flydsl_gemm_accumulator_epilogue_fusion(self):
+        from torch._inductor.codegen.flydsl import flydsl_utils
+        from torch._inductor.utils import run_and_get_code
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        def fn(a, b):
+            return torch.mm(a, b.t()) + 1.0
+
+        for dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                a = torch.randn(32, 128, device="cuda", dtype=dtype)
+                b = torch.randn(128, 128, device="cuda", dtype=dtype)
+                compiled_fn = torch.compile(fn, backend="inductor")
+                result, (code,) = run_and_get_code(compiled_fn, a, b)
+
+                self.assertIn("HAS_EPILOGUE: fx.Constexpr = True", code)
+                self.assertIn("EPILOGUE_FN", code)
+                self.assertTrue(
+                    torch.allclose(result, fn(a, b), atol=3e-2, rtol=3e-2)
+                )
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -92,7 +92,7 @@ class CUDACombinedScheduling(BaseScheduling):
         elif self._flydsl_scheduling.is_flydsl_template(
             node1
         ) or self._flydsl_scheduling.is_flydsl_template(node2):
-            return False
+            return self._flydsl_scheduling.can_fuse_vertical(node1, node2)
         # Only intercept when node1 is the NVGEMM template (epilogue direction).
         # Prologue direction (node1=pointwise, node2=template) must fall through to
         # Triton, or NVGEMM-winning MTBs silently lose Triton prologue fusion.
@@ -181,8 +181,6 @@ class CUDACombinedScheduling(BaseScheduling):
                 template_node, epilogue_nodes, prologue_nodes
             )
         elif self._flydsl_scheduling.is_flydsl_template(template_node):
-            if epilogue_nodes:
-                raise AssertionError("flydsl template does not support epilogue nodes")
             if prologue_nodes:
                 raise AssertionError("flydsl template does not support prologue nodes")
             return self._flydsl_scheduling.codegen_template(

--- a/torch/_inductor/codegen/flydsl/flydsl_kernel.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_kernel.py
@@ -77,6 +77,23 @@ class FlyDSLTemplateKernel(Kernel):
             params.writeline(f"{name}: fx.Constexpr = {val!r}")
         return params.getvalue()
 
+    def gen_epilogue(self) -> str:
+        epilogue_nodes = getattr(self, "epilogue_nodes", None)
+        if not epilogue_nodes:
+            return (
+                "HAS_EPILOGUE: fx.Constexpr = False\n"
+                "EPILOGUE_FN = lambda acc: acc\n"
+            )
+
+        from torch._inductor.kernel.flydsl.epilogue import (
+            materialize_flydsl_scheduler_epilogue,
+        )
+
+        _, code = materialize_flydsl_scheduler_epilogue(
+            self.original_output_name, list(epilogue_nodes)
+        )
+        return code
+
     def render(self, template, **kwargs):
         from torch._inductor.select_algorithm import PartialRender
 
@@ -84,6 +101,7 @@ class FlyDSLTemplateKernel(Kernel):
         template_env = {
             "def_kernel": self.def_kernel,
             "gen_defines": lambda: self.gen_defines(**kwargs),
+            "gen_epilogue": self.gen_epilogue,
             "get_output": self.get_output,
         }
 

--- a/torch/_inductor/codegen/flydsl/flydsl_scheduling.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_scheduling.py
@@ -10,7 +10,7 @@ from torch.utils._ordered_set import OrderedSet
 
 from ... import config
 from ...codecache import code_hash, get_path
-from ...ir import FlyDSLTemplateBuffer
+from ...ir import ComputedBuffer, FlyDSLTemplateBuffer, Pointwise
 from ...scheduler import (
     BaseSchedulerNode,
     BaseScheduling,
@@ -41,7 +41,43 @@ class FlyDSLScheduling(BaseScheduling):
     def can_fuse_vertical(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
-        return False
+        if not config.epilogue_fusion or not self.is_flydsl_template(node1):
+            return False
+        if node2.has_aliasing_or_mutation() or node2.is_reduction():
+            return False
+
+        template_node = cast(SchedulerNode, node1)
+        template = template_node.node
+        if not isinstance(template, FlyDSLTemplateBuffer):
+            return False
+
+        reads = OrderedSet()
+        for scheduler_node in node2.get_nodes():
+            node = scheduler_node.node
+            if not isinstance(node, ComputedBuffer) or not isinstance(
+                node.data, Pointwise
+            ):
+                return False
+            if not V.graph.sizevars.statically_known_list_equals(
+                node.get_size(), template.get_size()
+            ):
+                return False
+            reads |= OrderedSet(read.name for read in scheduler_node.read_writes.reads)
+
+        # The gfx950 epilogue ABI currently has no extra tensor arguments.
+        if reads != OrderedSet([template.get_name()]):
+            return False
+        try:
+            from torch._inductor.kernel.flydsl.epilogue import (
+                materialize_flydsl_scheduler_epilogue,
+            )
+
+            materialize_flydsl_scheduler_epilogue(
+                template.get_name(), list(node2.get_nodes())
+            )
+        except (AttributeError, NotImplementedError):
+            return False
+        return True
 
     def can_fuse_horizontal(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
@@ -103,15 +139,16 @@ class FlyDSLScheduling(BaseScheduling):
                 "Template node passed to FlyDSLScheduling.codegen_template must be a "
                 "SchedulerNode that wraps a FlyDSLTemplateBuffer"
             )
-        if epilogue_nodes:
-            raise AssertionError("FlyDSL doesn't support epilogue fusion yet")
         if prologue_nodes:
             raise AssertionError("FlyDSL doesn't support prologue fusion yet")
 
         template_node = cast(SchedulerNode, template_node)
         ftb: FlyDSLTemplateBuffer = cast(FlyDSLTemplateBuffer, template_node.node)
 
-        kernel, render = ftb.make_kernel_render(ftb)  # type: ignore[misc]
+        output_node = epilogue_nodes[-1].node if epilogue_nodes else ftb
+        kernel, render = ftb.make_kernel_render(output_node)  # type: ignore[misc]
+        kernel.original_output_name = ftb.get_name()
+        kernel.epilogue_nodes = epilogue_nodes
         template_node.mark_run()
         src_code = render()
         if isinstance(src_code, PartialRender):
@@ -122,12 +159,18 @@ class FlyDSLScheduling(BaseScheduling):
         precompile_metadata = self._build_precompile_metadata(kernel, ftb)
 
         with V.set_kernel_handler(kernel):
-            node_schedule = [template_node]
+            node_schedule = [template_node, *epilogue_nodes]
             kernel_name = self.define_kernel(
                 src_code_str, node_schedule, precompile_metadata
             )
         self.codegen_comment(node_schedule, kernel_name)
-        kernel.call_kernel(kernel_name, ftb)
+        if epilogue_nodes:
+            V.graph.removed_buffers.add(ftb.get_name())
+            for node in epilogue_nodes[:-1]:
+                V.graph.removed_buffers.add(node.get_name())
+            for node in epilogue_nodes:
+                node.mark_run()
+        kernel.call_kernel(kernel_name, output_node)
         V.graph.removed_buffers |= kernel.removed_buffers
         self.free_buffers_in_scheduler()
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6425,6 +6425,10 @@ class CuteDSLTemplateBuffer(TemplateBuffer):
         self.template = template
         self.mutated_inputs = mutated_inputs
         self.outputs: list[Buffer] = [self]
+        if self.name is None:
+            raise AssertionError("Expected FlyDSL template buffer name")
+        self.epilogue_fusable_outputs = {self.name: self.name}
+        self.allow_epilogue_fusion = True
 
         if mutated_inputs is not None:
             if not isinstance(self.inputs[0], IRNode):

--- a/torch/_inductor/kernel/flydsl/__init__.py
+++ b/torch/_inductor/kernel/flydsl/__init__.py
@@ -1,0 +1,3 @@
+from .epilogue import materialize_flydsl_scheduler_epilogue
+
+__all__ = ["materialize_flydsl_scheduler_epilogue"]

--- a/torch/_inductor/kernel/flydsl/epilogue.py
+++ b/torch/_inductor/kernel/flydsl/epilogue.py
@@ -1,0 +1,138 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import torch
+
+from torch._inductor.ir import ComputedBuffer, Pointwise
+from torch._inductor.scheduler import BaseSchedulerNode
+from torch._inductor.virtualized import V
+
+
+class _Expr:
+    def __init__(self, source: str):
+        self.source = source
+
+    def __str__(self) -> str:
+        return self.source
+
+
+class _EpilogueOps:
+    def __init__(self, accumulator_name: str):
+        self.accumulator_name = accumulator_name
+
+    def _binary(self, op: str, a: Any, b: Any) -> _Expr:
+        return _Expr(f"({a} {op} {b})")
+
+    def _unary(self, op: str, x: Any) -> _Expr:
+        return _Expr(f"{op}({x})")
+
+    def load(self, name: str, index: Any) -> _Expr:
+        if name != self.accumulator_name:
+            raise NotImplementedError(
+                "FlyDSL GEMM epilogues only support accumulator reads"
+            )
+        return _Expr("acc")
+
+    def constant(self, value: Any, dtype: torch.dtype) -> Any:
+        return repr(value)
+
+    def add(self, a: Any, b: Any, *, alpha: Any = 1) -> _Expr:
+        if alpha != 1:
+            b = self.mul(b, alpha)
+        return self._binary("+", a, b)
+
+    def sub(self, a: Any, b: Any, *, alpha: Any = 1) -> _Expr:
+        if alpha != 1:
+            b = self.mul(b, alpha)
+        return self._binary("-", a, b)
+
+    def mul(self, a: Any, b: Any) -> _Expr:
+        return self._binary("*", a, b)
+
+    def truediv(self, a: Any, b: Any) -> _Expr:
+        return self._binary("/", a, b)
+
+    def neg(self, x: Any) -> _Expr:
+        return self._unary("-", x)
+
+    def maximum(self, a: Any, b: Any) -> _Expr:
+        raise NotImplementedError("FlyDSL GEMM maximum epilogues are not supported yet")
+
+    def minimum(self, a: Any, b: Any) -> _Expr:
+        raise NotImplementedError("FlyDSL GEMM minimum epilogues are not supported yet")
+
+    def where(self, condition: Any, a: Any, b: Any) -> _Expr:
+        raise NotImplementedError("FlyDSL GEMM where epilogues are not supported yet")
+
+    def to_dtype(
+        self, x: Any, dtype: torch.dtype, *, use_compute_types: bool = False
+    ) -> _Expr:
+        dtype_name = {
+            torch.float16: "fx.Float16",
+            torch.bfloat16: "fx.BFloat16",
+            torch.float32: "fx.Float32",
+            torch.int32: "fx.Int32",
+            torch.bool: "fx.Boolean",
+        }.get(dtype)
+        if dtype_name is None:
+            raise NotImplementedError(f"unsupported FlyDSL epilogue dtype: {dtype}")
+        raise NotImplementedError("FlyDSL GEMM dtype casts are not supported yet")
+
+    convert_element_type = to_dtype
+
+    def __getattr__(self, name: str):
+        raise AttributeError(name)
+
+
+def _arg(value: Any, env: dict[str, Any]) -> Any:
+    if hasattr(value, "get_name"):
+        name = value.get_name()
+        if name in env:
+            return env[name]
+    if isinstance(value, (int, float, bool, torch.dtype)):
+        return value
+    if isinstance(value, (tuple, list)):
+        return type(value)(_arg(item, env) for item in value)
+    return value
+
+
+def materialize_flydsl_scheduler_epilogue(
+    original_buffer_name: str,
+    epilogue_nodes: list[BaseSchedulerNode],
+) -> tuple[str, str]:
+    if not epilogue_nodes:
+        return "", (
+            "HAS_EPILOGUE: fx.Constexpr = False\n"
+            "EPILOGUE_FN = None\n"
+        )
+
+    env: dict[str, Any] = {original_buffer_name: _Expr("acc")}
+    handler = _EpilogueOps(original_buffer_name)
+    for scheduler_node in epilogue_nodes:
+        if scheduler_node.is_reduction():
+            raise NotImplementedError("FlyDSL GEMM epilogue reductions unsupported")
+        for node in scheduler_node.get_nodes():
+            if not isinstance(node.node, ComputedBuffer) or not isinstance(
+                node.node.data, Pointwise
+            ):
+                raise NotImplementedError("FlyDSL GEMM epilogue must be pointwise")
+            with V.set_ops_handler(handler), V.set_current_node(node.node):
+                result = node.node.data.inner_fn(*node.node.data.inner_fn_args())
+            env[node.node.get_name()] = result
+            env[scheduler_node.get_name()] = result
+
+    final_name = epilogue_nodes[-1].get_name()
+    if final_name not in env:
+        raise AssertionError(f"missing final FlyDSL epilogue value {final_name}")
+
+    result = str(env[final_name])
+    key = hashlib.sha256(result.encode()).hexdigest()[:16]
+    name = f"flydsl_gemm_epilogue_{key}"
+    return (
+        name,
+        f"EPILOGUE_FN = lambda acc: {result}\n"
+        "HAS_EPILOGUE: fx.Constexpr = True\n"
+    )

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -11,6 +11,8 @@ from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
 
 {{gen_defines()}}
 
+{{gen_epilogue()}}
+
 
 _gemm_call_entry = None
 
@@ -44,6 +46,7 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
                 "group_m": GROUP_M,
                 "use_half_tile_interleaved": USE_HALF_TILE_INTERLEAVED,
                 "has_bias": False,
+                "has_epilogue": HAS_EPILOGUE,
                 "has_k_tail": has_k_tail,
             },
         )
@@ -64,6 +67,7 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
             n,
             k,
             param,
+            EPILOGUE_FN,
             stream,
         )
         if not os.environ.get("COMPILE_ONLY"):
@@ -77,6 +81,7 @@ def _run_gemm_gfx950(m, n, k, output_mn, mat1_mk, mat2_nk, stream):
             n,
             k,
             param,
+            EPILOGUE_FN,
             stream,
         )
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -26,6 +26,7 @@ class GemmGfx950Param:
     group_m: fx.Constexpr[int]
     use_half_tile_interleaved: fx.Constexpr[bool]
     has_bias: fx.Constexpr[bool]
+    has_epilogue: fx.Constexpr[bool]
     has_k_tail: fx.Constexpr[bool]
     async_load_bytes: fx.Constexpr[int]
     in_data_bytes: fx.Constexpr[int]
@@ -50,6 +51,7 @@ def make_gemm_gfx950_param(
     group_m: int = 0,
     use_half_tile_interleaved: bool = False,
     has_bias: bool = False,
+    has_epilogue: bool = False,
     has_k_tail: bool = False,
     mma_m: int = 16,
     mma_n: int = 16,
@@ -168,6 +170,7 @@ def make_gemm_gfx950_param(
         group_m=group_m,
         use_half_tile_interleaved=use_half_tile_interleaved,
         has_bias=has_bias,
+        has_epilogue=has_epilogue,
         has_k_tail=has_k_tail,
         async_load_bytes=GFX950_DMA_BYTES,
         in_data_bytes=in_dbytes,
@@ -284,6 +287,7 @@ def gemm_gfx950_kernel(
     k: fx.Int32,
     tiled_mma: fx.TiledMma,
     param: GemmGfx950Param,
+    epilogue_fn: fx.Constexpr,
 ):
     block_m = param.block_m
     block_n = param.block_n
@@ -529,7 +533,11 @@ def gemm_gfx950_kernel(
         current_stage = (current_stage + 1) % stages
 
     frag_C_out = fx.make_fragment_like(frag_C, elem_dtype)
-    frag_C_out.store(frag_C.load().to(elem_dtype))
+    for i in range_constexpr(fx.size(frag_C.shape).unpack()):
+        val = frag_C[i]
+        if const_expr(param.has_epilogue):
+            val = epilogue_fn(val.to(elem_dtype))
+        frag_C_out[i] = val.to(elem_dtype)
 
     fx.gpu.barrier()
     for i in range_constexpr(fx.size(frag_C_out.shape).unpack()):
@@ -553,6 +561,7 @@ def gemm_hti_gfx950_kernel(
     k: fx.Int32,
     tiled_mma: fx.TiledMma,
     param: GemmGfx950Param,
+    epilogue_fn: fx.Constexpr,
 ):
     block_m = param.block_m
     block_n = param.block_n
@@ -832,6 +841,8 @@ def gemm_hti_gfx950_kernel(
                 global_n_idx = bid_n * block_n + n_part * half_block_n + col
                 safe_global_n_idx = (global_n_idx < n).select(global_n_idx, 0)
                 val = val + bias_buf[safe_global_n_idx].to(fx.Float32)
+            if const_expr(param.has_epilogue):
+                val = epilogue_fn(val.to(elem_dtype))
             frag_C_out[i] = val.to(elem_dtype)
 
         fx.gpu.barrier()
@@ -947,6 +958,7 @@ def launch_gemm_gfx950(
     n: fx.Int32,
     k: fx.Int32,
     param: GemmGfx950Param,
+    epilogue_fn: fx.Constexpr,
     stream: fx.Stream = fx.Stream(None),
 ):
     elem_dtype = _elem_dtype(param)
@@ -978,7 +990,7 @@ def launch_gemm_gfx950(
     )
     kernel_impl._known_block_size = [param.block_threads, 1, 1]
     kernel_impl._func.__name__ = make_gemm_gfx950_kernel_name(param)
-    kernel_impl(out, a, b, out, m, n, k, tiled_mma, param).launch(
+    kernel_impl(out, a, b, out, m, n, k, tiled_mma, param, epilogue_fn).launch(
         grid=(num_pid_m * num_pid_n, 1, 1),
         block=(param.block_threads, 1, 1),
         stream=stream,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196276

Enable vertical fusion for accumulator-only pointwise epilogues in the gfx950 FlyDSL GEMM path. Route fused output through the existing gfx950 and half-tile-interleaved stores while rejecting unsupported epilogues and extra tensor reads.

Validation: GPU7 ROCm 7.2 / FlyDSL atom-dev container; FP16 and BF16 correctness passed. Static BF16 4096x4096 benchmarks (TFLOP/s, 50 timed iterations): ATen plain 32/128/512 = 32.04/141.21/568.35, Triton plain = 51.48/191.79/549.53, FlyDSL plain = 29.03/112.45/428.39; ATen fused = 30.12/115.36/502.75, Triton fused = 52.90/200.68/536.90, FlyDSL fused = 28.94/111.71/309.68.
Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo