### PR TITLE
[inductor] Type AOTI eager metadata as object

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8,6 +8,7 @@ import functools
 import gc
 import importlib
 import itertools
+import json
 import logging
 import math
 import operator
@@ -1737,6 +1738,43 @@ class CommonTemplate:
             kernel_libs_abs_path.append(kernel_path.as_posix())
 
         self.assertTrue(kernel_lib_path in kernel_libs_abs_path)
+
+    @parametrize(
+        "json_data",
+        [
+            subtest({}, name="non_list"),
+            subtest([{"meta_info": []}], name="missing_kernel_path"),
+            subtest(
+                [
+                    {
+                        "kernel_path": "kernel.so",
+                        "meta_info": [{"dtype": 1}],
+                    }
+                ],
+                name="non_string_dtype",
+            ),
+            subtest(
+                [
+                    {
+                        "kernel_path": "kernel.so",
+                        "meta_info": [{"dtype": "torch.nn"}],
+                    }
+                ],
+                name="invalid_dtype",
+            ),
+        ],
+    )
+    def test_aoti_eager_malformed_cache(self, json_data):
+        namespace = "test"
+        op_name = "malformed"
+        device = "test"
+        device_kernel_cache = aoti_eager_cache_dir(namespace, device)
+        device_kernel_cache.mkdir(parents=True)
+        (device_kernel_cache / "kernel.so").touch()
+        with open(device_kernel_cache / f"{op_name}.json", "w") as f:
+            json.dump(json_data, f)
+
+        self.assertEqual(load_aoti_eager_cache(namespace, op_name, device), [])
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
     @skip_if_halide  # aoti

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1478,6 +1478,57 @@ def target_assert_alignment_regex(
 
 
 @instantiate_parametrized_tests
+class AOTIEagerCacheTests(TestCase):
+    @parametrize(
+        "json_data,expected_count",
+        [
+            subtest(
+                ([{"kernel_path": "kernel.so", "meta_info": []}], 1),
+                name="valid",
+            ),
+            subtest(({}, 0), name="non_list"),
+            subtest(([{"meta_info": []}], 0), name="missing_kernel_path"),
+            subtest(
+                (
+                    [
+                        {
+                            "kernel_path": "kernel.so",
+                            "meta_info": [{"dtype": 1}],
+                        }
+                    ],
+                    0,
+                ),
+                name="non_string_dtype",
+            ),
+            subtest(
+                (
+                    [
+                        {
+                            "kernel_path": "kernel.so",
+                            "meta_info": [{"dtype": "torch.nn"}],
+                        }
+                    ],
+                    0,
+                ),
+                name="invalid_dtype",
+            ),
+        ],
+    )
+    def test_aoti_eager_cache_validation(self, json_data, expected_count):
+        namespace = "test"
+        op_name = "validation"
+        device = "test"
+        device_kernel_cache = aoti_eager_cache_dir(namespace, device)
+        device_kernel_cache.mkdir(parents=True, exist_ok=True)
+        (device_kernel_cache / "kernel.so").touch()
+        with open(device_kernel_cache / f"{op_name}.json", "w") as f:
+            json.dump(json_data, f)
+
+        cache = load_aoti_eager_cache(namespace, op_name, device)
+        self.assertEqual(len(cache), expected_count)
+
+
+@instantiate_parametrized_tests
 class CommonTemplate:
     def is_dtype_supported(self, dtype: torch.dtype) -> bool:
         device_interface = get_interface_for_device(self.device)
@@ -1738,43 +1789,6 @@ class CommonTemplate:
             kernel_libs_abs_path.append(kernel_path.as_posix())
 
         self.assertTrue(kernel_lib_path in kernel_libs_abs_path)
-
-    @parametrize(
-        "json_data",
-        [
-            subtest({}, name="non_list"),
-            subtest([{"meta_info": []}], name="missing_kernel_path"),
-            subtest(
-                [
-                    {
-                        "kernel_path": "kernel.so",
-                        "meta_info": [{"dtype": 1}],
-                    }
-                ],
-                name="non_string_dtype",
-            ),
-            subtest(
-                [
-                    {
-                        "kernel_path": "kernel.so",
-                        "meta_info": [{"dtype": "torch.nn"}],
-                    }
-                ],
-                name="invalid_dtype",
-            ),
-        ],
-    )
-    def test_aoti_eager_malformed_cache(self, json_data):
-        namespace = "test"
-        op_name = "malformed"
-        device = "test"
-        device_kernel_cache = aoti_eager_cache_dir(namespace, device)
-        device_kernel_cache.mkdir(parents=True)
-        (device_kernel_cache / "kernel.so").touch()
-        with open(device_kernel_cache / f"{op_name}.json", "w") as f:
-            json.dump(json_data, f)
-
-        self.assertEqual(load_aoti_eager_cache(namespace, op_name, device), [])
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
     @skip_if_halide  # aoti

--- a/torch/_inductor/aoti_eager.py
+++ b/torch/_inductor/aoti_eager.py
@@ -73,7 +73,7 @@ def load_aoti_eager_cache(
                         f"expected loaded_data to be list, got {type(loaded_data)}"
                     )
 
-                json_data: list[dict[str, object] | None] = []
+                json_data: list[dict[str, object]] = []
                 for loaded_item in loaded_data:
                     if not isinstance(loaded_item, dict):
                         raise AssertionError(
@@ -115,11 +115,11 @@ def load_aoti_eager_cache(
                             and metadata["device_type"] == "cpu"
                         ):
                             metadata["device_index"] = -1
-                        for torch_value_key in [
-                            "dtype",
-                            "dtype_value",
-                            "layout_value",
-                            "memory_format_value",
+                        for torch_value_key, expected_type in [
+                            ("dtype", torch.dtype),
+                            ("dtype_value", torch.dtype),
+                            ("layout_value", torch.layout),
+                            ("memory_format_value", torch.memory_format),
                         ]:
                             if torch_value_key not in metadata:
                                 continue
@@ -129,13 +129,17 @@ def load_aoti_eager_cache(
                                     f"expected {torch_value_key} to be str, got "
                                     f"{type(torch_value)}"
                                 )
-                            metadata[torch_value_key] = getattr(
-                                torch, torch_value.split(".")[-1]
-                            )
+                            resolved_value = getattr(torch, torch_value.split(".")[-1])
+                            if not isinstance(resolved_value, expected_type):
+                                raise AssertionError(
+                                    f"expected {torch_value_key} to resolve to "
+                                    f"{expected_type}, got {type(resolved_value)}"
+                                )
+                            metadata[torch_value_key] = resolved_value
 
                     json_data.append(item)
 
-                return json_data
+                return cast(list[dict[str, Any] | None], json_data)
     except Exception as e:
         err_msg = f"Failed to load aoti eager cache: {e}"
         log.exception(err_msg)
@@ -386,7 +390,6 @@ def aoti_compile_with_persistent_cache(
                 Path(kernel_lib_path).relative_to(persistent_cache).as_posix()
             )
 
-            json_data: list[object] = []
             update_json = True
             op_conf = persistent_cache / f"{op_func_name_with_overload}.json"
             mode = "r" if op_conf.exists() else "w"
@@ -401,15 +404,15 @@ def aoti_compile_with_persistent_cache(
                         raise AssertionError(
                             f"expected loaded_data to be list, got {type(loaded_data)}"
                         )
-                    json_data = cast(list[object], loaded_data)
+                    json_data: list[object] = cast(list[object], loaded_data)
                     for item in json_data:
                         if not isinstance(item, dict):
                             raise AssertionError(
                                 f"expected item to be dict, got {type(item)}"
                             )
-                        item = cast(dict[str, object], item)
                         # Same kernel meta info already exists in the json file
-                        if item["meta_info"] == kernel_metadata_items:
+                        cached_meta_info: object = item["meta_info"]
+                        if cached_meta_info == kernel_metadata_items:
                             update_json = False
                             break
 

--- a/torch/_inductor/aoti_eager.py
+++ b/torch/_inductor/aoti_eager.py
@@ -404,15 +404,14 @@ def aoti_compile_with_persistent_cache(
                         raise AssertionError(
                             f"expected loaded_data to be list, got {type(loaded_data)}"
                         )
-                    json_data: list[object] = cast(list[object], loaded_data)
+                    json_data = cast(list[object], loaded_data)
                     for item in json_data:
                         if not isinstance(item, dict):
                             raise AssertionError(
                                 f"expected item to be dict, got {type(item)}"
                             )
                         # Same kernel meta info already exists in the json file
-                        cached_meta_info: object = item["meta_info"]
-                        if cached_meta_info == kernel_metadata_items:
+                        if item["meta_info"] == kernel_metadata_items:
                             update_json = False
                             break
 

--- a/torch/_inductor/aoti_eager.py
+++ b/torch/_inductor/aoti_eager.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest import mock
 
 import torch
@@ -54,6 +54,7 @@ def aoti_eager_op_conf_lock(op_func_name_with_overload: str) -> Any:
 def load_aoti_eager_cache(
     ns: str, op_func_name_with_overload: str, device_type: str
 ) -> list[dict[str, Any] | None]:
+    """Load and deserialize persistent AOTI eager kernel metadata."""
     backend = _aoti_compile_backends.get(device_type)
     if backend:
         return backend.load_fn(ns, op_func_name_with_overload, device_type)
@@ -66,17 +67,45 @@ def load_aoti_eager_cache(
     try:
         with aoti_eager_op_conf_lock(op_func_name_with_overload):
             with open(op_conf) as f:
-                json_data = json.load(f)
-                for item in json_data:
+                loaded_data: object = json.load(f)
+                if not isinstance(loaded_data, list):
+                    raise AssertionError(
+                        f"expected loaded_data to be list, got {type(loaded_data)}"
+                    )
+
+                json_data: list[dict[str, object] | None] = []
+                for loaded_item in loaded_data:
+                    if not isinstance(loaded_item, dict):
+                        raise AssertionError(
+                            f"expected loaded_item to be dict, got {type(loaded_item)}"
+                        )
+                    item = cast(dict[str, object], loaded_item)
+
                     # Get absolute path for kernel library
-                    kernel_lib_abs_path = device_kernel_cache / item["kernel_path"]
+                    kernel_path = item.get("kernel_path")
+                    if not isinstance(kernel_path, str):
+                        raise AssertionError(
+                            f"expected kernel_path to be str, got {type(kernel_path)}"
+                        )
+                    kernel_lib_abs_path = device_kernel_cache / kernel_path
                     item["kernel_path"] = kernel_lib_abs_path.as_posix()
 
                     # Check if the kernel library exists
                     if not kernel_lib_abs_path.exists():
                         return []
 
-                    for metadata in item["meta_info"]:
+                    meta_info = item.get("meta_info")
+                    if not isinstance(meta_info, list):
+                        raise AssertionError(
+                            f"expected meta_info to be list, got {type(meta_info)}"
+                        )
+                    for loaded_metadata in meta_info:
+                        if not isinstance(loaded_metadata, dict):
+                            raise AssertionError(
+                                "expected metadata to be dict, got "
+                                f"{type(loaded_metadata)}"
+                            )
+                        metadata = cast(dict[str, object], loaded_metadata)
                         if metadata.get("is_dynamic"):
                             raise NotImplementedError(
                                 "Only support static shape for now"
@@ -86,19 +115,25 @@ def load_aoti_eager_cache(
                             and metadata["device_type"] == "cpu"
                         ):
                             metadata["device_index"] = -1
-                        for dtype_key in ["dtype", "dtype_value"]:
-                            if dtype_key in metadata:
-                                metadata[dtype_key] = getattr(
-                                    torch, metadata[dtype_key].split(".")[-1]
+                        for torch_value_key in [
+                            "dtype",
+                            "dtype_value",
+                            "layout_value",
+                            "memory_format_value",
+                        ]:
+                            if torch_value_key not in metadata:
+                                continue
+                            torch_value = metadata[torch_value_key]
+                            if not isinstance(torch_value, str):
+                                raise AssertionError(
+                                    f"expected {torch_value_key} to be str, got "
+                                    f"{type(torch_value)}"
                                 )
-                        if "layout_value" in metadata:
-                            metadata["layout_value"] = getattr(
-                                torch, metadata["layout_value"].split(".")[-1]
+                            metadata[torch_value_key] = getattr(
+                                torch, torch_value.split(".")[-1]
                             )
-                        if "memory_format_value" in metadata:
-                            metadata["memory_format_value"] = getattr(
-                                torch, metadata["memory_format_value"].split(".")[-1]
-                            )
+
+                    json_data.append(item)
 
                 return json_data
     except Exception as e:
@@ -116,8 +151,8 @@ def supported_scalar_types() -> tuple[type, ...]:
     return tuple(type_to_torch_dtype.keys())
 
 
-def extract_tensor_metadata(dynamic: bool, input: torch.Tensor) -> dict[str, Any]:
-    metadata: dict[str, Any] = {}
+def extract_tensor_metadata(dynamic: bool, input: torch.Tensor) -> dict[str, object]:
+    metadata: dict[str, object] = {}
     metadata["is_dynamic"] = dynamic
 
     if not isinstance(input, torch.Tensor):
@@ -138,22 +173,22 @@ def extract_tensor_metadata(dynamic: bool, input: torch.Tensor) -> dict[str, Any
 def extract_tensor_list_metadata(
     dynamic: bool,
     input: list[torch.Tensor],
-) -> dict[str, Any]:
+) -> dict[str, object]:
     metadata_list = []
     for item in input:
         if not isinstance(item, torch.Tensor):
             raise AssertionError(f"expected torch.Tensor, got {type(item)}")
         metadata_list.append(extract_tensor_metadata(dynamic, item))
 
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, object] = {}
     metadata["tensor_list"] = metadata_list
     return metadata
 
 
-def extract_scalar_metadata(device_type: str, input: Any) -> dict[str, Any]:
+def extract_scalar_metadata(device_type: str, input: object) -> dict[str, object]:
     if not isinstance(input, supported_scalar_types()):
         raise AssertionError(f"expected a supported scalar type, got {type(input)}")
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, object] = {}
     metadata["is_dynamic"] = False
     # Scalar tensor
     metadata["device_type"] = device_type
@@ -164,46 +199,46 @@ def extract_scalar_metadata(device_type: str, input: Any) -> dict[str, Any]:
     return metadata
 
 
-def extract_string_metadata(input: str) -> dict[str, Any]:
+def extract_string_metadata(input: str) -> dict[str, object]:
     if not isinstance(input, str):
         raise AssertionError(f"expected str, got {type(input)}")
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, object] = {}
     metadata["string_value"] = input
     return metadata
 
 
-def extract_dtype_metadata(input: torch.dtype) -> dict[str, Any]:
+def extract_dtype_metadata(input: torch.dtype) -> dict[str, object]:
     if not isinstance(input, torch.dtype):
         raise AssertionError(f"expected torch.dtype, got {type(input)}")
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, object] = {}
     metadata["dtype_value"] = f"{input}"
     return metadata
 
 
-def extract_device_metadata(input: torch.device) -> dict[str, Any]:
+def extract_device_metadata(input: torch.device) -> dict[str, object]:
     if not isinstance(input, torch.device):
         raise AssertionError(f"expected torch.device, got {type(input)}")
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, object] = {}
     metadata["device_type_value"] = f"{input.type}"
     metadata["device_index_value"] = input.index
     return metadata
 
 
-def extract_layout_metadata(input: torch.layout) -> dict[str, Any]:
+def extract_layout_metadata(input: torch.layout) -> dict[str, object]:
     if not isinstance(input, torch.layout):
         raise AssertionError(f"expected torch.layout, got {type(input)}")
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, object] = {}
     metadata["layout_value"] = f"{input}"
     return metadata
 
 
-def extract_int_list_metadata(input: list[int]) -> dict[str, Any]:
+def extract_int_list_metadata(input: list[int]) -> dict[str, object]:
     if not (
         isinstance(input, (list, tuple))
         and all(isinstance(item, int) and not isinstance(item, bool) for item in input)
     ):
         raise AssertionError(f"expected a list/tuple of int, got {input!r}")
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, object] = {}
     metadata["int_list_value"] = list(input)
     return metadata
 
@@ -345,32 +380,34 @@ def aoti_compile_with_persistent_cache(
                 metadata["arg_order"] = idx
                 kernel_metadata_items.append(metadata)
 
-            kernel_meta_info: dict[str, Any] = {}
+            kernel_meta_info: dict[str, object] = {}
             kernel_meta_info["meta_info"] = kernel_metadata_items
             kernel_meta_info["kernel_path"] = (
                 Path(kernel_lib_path).relative_to(persistent_cache).as_posix()
             )
 
-            json_data = []
+            json_data: list[object] = []
             update_json = True
             op_conf = persistent_cache / f"{op_func_name_with_overload}.json"
             mode = "r" if op_conf.exists() else "w"
             with aoti_eager_op_conf_lock(op_func_name_with_overload):
                 with open(op_conf, mode) as op_conf_file:
                     try:
-                        json_data = json.load(op_conf_file)
+                        loaded_data: object = json.load(op_conf_file)
                     except Exception:
-                        json_data = []
+                        loaded_data = []
 
-                    if not isinstance(json_data, list):
+                    if not isinstance(loaded_data, list):
                         raise AssertionError(
-                            f"expected json_data to be list, got {type(json_data)}"
+                            f"expected loaded_data to be list, got {type(loaded_data)}"
                         )
+                    json_data = cast(list[object], loaded_data)
                     for item in json_data:
                         if not isinstance(item, dict):
                             raise AssertionError(
                                 f"expected item to be dict, got {type(item)}"
                             )
+                        item = cast(dict[str, object], item)
                         # Same kernel meta info already exists in the json file
                         if item["meta_info"] == kernel_metadata_items:
                             update_json = False


### PR DESCRIPTION
## Summary

AOTI eager's private metadata builders used `Any` for dictionaries containing
heterogeneous JSON and Torch values. This tightens those dictionaries and the
scalar classification input to `object`, and narrows values read from JSON
before using list, dictionary, string, or path operations.

The registered backend callback signatures and the cache loader's return
contract remain unchanged for compatibility with out-of-tree backends.
Although the extractor names are not underscore-prefixed, they live in the
private `torch._inductor` package and have no callers outside this module in
the repository. `TypedDict` schemas would be a larger cache-format redesign;
this change is intentionally limited to stopping `Any` propagation while
preserving the existing heterogeneous dictionaries.
The pre-existing `memory_format_value` reader is left unchanged even though it
has no current in-tree writer or consumer; removing legacy cache handling is
outside this focused typing change.

## Test Plan

```bash
PATH=/home/bobren/local/b/pytorch-env/bin:$PATH pyrefly check torch/_inductor/aoti_eager.py
```

```bash
PATH=/home/bobren/local/b/pytorch-env/bin:$PATH PYTHONPATH=/home/bobren/local/b/pytorch/agent_space:/home/bobren/local/b/pytorch UV_NO_CONFIG=1 UV_OFFLINE=1 spin quicklint
```

```bash
PATH=/home/bobren/local/b/pytorch-env/bin:$PATH PYTHONPYCACHEPREFIX=/home/bobren/local/b/pytorch/agent_space/aoti-eager-pycache PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu python agent_space/run_local_aoti_eager_tests.py
```

The targeted test command ran all twelve AOTI eager CPU cases successfully,
including one positive-control and four malformed-cache variants.

Authored with AI assistance.
