### PR TITLE
[profiler] Fix unlinked runtime/driver events be counted in device time

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -20,7 +20,7 @@ import types
 import unittest
 import warnings
 from typing import TYPE_CHECKING
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 
 # Suppress libkineto USDT profiler_start/profiler_stop logs in this verbose
@@ -2002,66 +2002,62 @@ class TestProfiler(TestCase):
             validate_json(prof, gc_flag)
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
-    @parametrize("device_type", [DeviceType.CUDA, DeviceType.XPU])
-    @parametrize("backend_type", ["runtime", "driver", "overhead"])
-    @parametrize("owner_type", ["cpu_op", "user_annotation"])
-    def test_parse_kineto_results_correlation_id_collision(
-        self, device_type, backend_type, owner_type
-    ):
-        with _profile(use_kineto=True) as p:
-            with record_function("frontend"):
-                pass
+    @unittest.skipIf(not torch.accelerator.is_available(), "Accelerator is required")
+    def test_region_device_time(self):
+        if not supported_activities() - {ProfilerActivity.CPU, ProfilerActivity.HPU}:
+            self.skipTest("Device kernel attribution is unavailable")
 
-        # Preserve real Kineto defaults, but force a collision independent of the
-        # backend's ID allocation and of any earlier profiling sessions.
-        template = next(e for e in p.kineto_results.events() if e.name() == "frontend")
-        owner = Mock(wraps=template)
-        owner.correlation_id.return_value = 7
-        owner.linked_correlation_id.return_value = 0
-        owner.external_id.return_value = 7
-        owner.activity_type.return_value = owner_type
-        owner.is_user_annotation.return_value = owner_type == "user_annotation"
+        # Isolate backend/operator ID allocation from earlier profiler tests.
+        script = """
+import json
+import sys
 
-        backend = Mock(wraps=template)
-        backend.name.return_value = "backend"
-        backend.correlation_id.return_value = 7
-        backend.linked_correlation_id.return_value = 0
-        backend.external_id.return_value = 0
-        prefix = "cuda" if device_type == DeviceType.CUDA else "xpu"
-        activity = (
-            "overhead" if backend_type == "overhead" else f"{prefix}_{backend_type}"
-        )
-        backend.activity_type.return_value = activity
-        backend.is_user_annotation.return_value = False
+import torch
+from torch.profiler import DeviceType, profile, record_function
 
-        device = Mock(wraps=template)
-        device.name.return_value = "device_activity"
-        device.correlation_id.return_value = 99
-        device.linked_correlation_id.return_value = 7
-        device.external_id.return_value = 7
-        device.device_type.return_value = device_type
-        device.device_index.return_value = 0
-        device.activity_type.return_value = (
-            "gpu_user_annotation" if owner_type == "user_annotation" else "kernel"
-        )
-        device.end_ns.return_value = template.start_ns() + 100_000
+device = torch.accelerator.current_accelerator(check_available=True)
+x = torch.randn(128, 128, device=device)
+torch.accelerator.synchronize()
+with profile() as prof:
+    for _ in range(4):
+        with record_function("workload"):
+            torch.accelerator.synchronize()
+            output = torch.empty_like(x)
+            torch.mm(x, x, out=output)
+    torch.accelerator.synchronize()
 
-        result = Mock(wraps=p.kineto_results)
-        result.events.return_value = [backend, device, owner]
-        events = p._parse_kineto_results(result)
-        self.assertEqual(len(events), 3)
-        by_name = {e.name: e for e in events}
-        self.assertEqual(by_name["backend"].kernels, [])
-        self.assertEqual(by_name["device_activity"].kernels, [])
-        self.assertEqual(len(by_name["frontend"].kernels), 1)
-        kernel = by_name["frontend"].kernels[0]
-        self.assertEqual(
-            (kernel.name, kernel.device, kernel.duration), ("device_activity", 0, 100)
-        )
-        self.assertEqual(
-            by_name["backend"].cpu_time_total,
-            (template.end_ns() - template.start_ns()) / 1000,
-        )
+raw = prof.profiler.kineto_results.events()
+raw_device_us = sum(
+    (e.end_ns() - e.start_ns()) / 1000 for e in raw
+    if e.activity_type() in ("kernel", "gpu_memcpy", "gpu_memset")
+)
+cpu_scopes = [e for e in prof.events() if e.name == "workload" and e.device_type == DeviceType.CPU]
+# CPU scopes select the workload; their host durations are never summed.
+# Match benchmarks by collecting descendants' attached device durations, not
+# the scopes' own synthetic device annotation spans.
+children = [child for scope in cpu_scopes for child in scope.cpu_children]
+benchmark_device_us = 0
+while children:
+    event = children.pop()
+    benchmark_device_us += sum(k.duration for k in event.kernels)
+    children.extend(event.cpu_children)
+with open(sys.argv[1], "w") as f:
+    json.dump([len(cpu_scopes), raw_device_us, benchmark_device_us], f)
+"""
+        with TemporaryFileName() as filename:
+            result = subprocess.run(
+                [sys.executable, "-c", script, filename],
+                capture_output=True,
+                text=True,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+                timeout=120,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            with open(filename) as f:
+                scope_count, raw_device_us, benchmark_device_us = json.load(f)
+        self.assertEqual(scope_count, 4)
+        self.assertGreater(raw_device_us, 0, "Expected real device activity")
+        self.assertEqual(benchmark_device_us, raw_device_us, atol=1e-6, rtol=0)
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_parse_kineto_results_timeout_none(self):

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2001,8 +2001,8 @@ class TestProfiler(TestCase):
                 payload()
             validate_json(prof, gc_flag)
 
+    @onlyAccelerator
     @unittest.skipIf(not kineto_available(), "Kineto is required")
-    @unittest.skipIf(not torch.accelerator.is_available(), "Accelerator is required")
     def test_region_device_time(self):
         if not supported_activities() - {ProfilerActivity.CPU, ProfilerActivity.HPU}:
             self.skipTest("Device kernel attribution is unavailable")

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -20,7 +20,7 @@ import types
 import unittest
 import warnings
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 # Suppress libkineto USDT profiler_start/profiler_stop logs in this verbose
@@ -2000,6 +2000,68 @@ class TestProfiler(TestCase):
             ) as prof:
                 payload()
             validate_json(prof, gc_flag)
+
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    @parametrize("device_type", [DeviceType.CUDA, DeviceType.XPU])
+    @parametrize("backend_type", ["runtime", "driver", "overhead"])
+    @parametrize("owner_type", ["cpu_op", "user_annotation"])
+    def test_parse_kineto_results_correlation_id_collision(
+        self, device_type, backend_type, owner_type
+    ):
+        with _profile(use_kineto=True) as p:
+            with record_function("frontend"):
+                pass
+
+        # Preserve real Kineto defaults, but force a collision independent of the
+        # backend's ID allocation and of any earlier profiling sessions.
+        template = next(e for e in p.kineto_results.events() if e.name() == "frontend")
+        owner = Mock(wraps=template)
+        owner.correlation_id.return_value = 7
+        owner.linked_correlation_id.return_value = 0
+        owner.external_id.return_value = 7
+        owner.activity_type.return_value = owner_type
+        owner.is_user_annotation.return_value = owner_type == "user_annotation"
+
+        backend = Mock(wraps=template)
+        backend.name.return_value = "backend"
+        backend.correlation_id.return_value = 7
+        backend.linked_correlation_id.return_value = 0
+        backend.external_id.return_value = 0
+        prefix = "cuda" if device_type == DeviceType.CUDA else "xpu"
+        activity = (
+            "overhead" if backend_type == "overhead" else f"{prefix}_{backend_type}"
+        )
+        backend.activity_type.return_value = activity
+        backend.is_user_annotation.return_value = False
+
+        device = Mock(wraps=template)
+        device.name.return_value = "device_activity"
+        device.correlation_id.return_value = 99
+        device.linked_correlation_id.return_value = 7
+        device.external_id.return_value = 7
+        device.device_type.return_value = device_type
+        device.device_index.return_value = 0
+        device.activity_type.return_value = (
+            "gpu_user_annotation" if owner_type == "user_annotation" else "kernel"
+        )
+        device.end_ns.return_value = template.start_ns() + 100_000
+
+        result = Mock(wraps=p.kineto_results)
+        result.events.return_value = [backend, device, owner]
+        events = p._parse_kineto_results(result)
+        self.assertEqual(len(events), 3)
+        by_name = {e.name: e for e in events}
+        self.assertEqual(by_name["backend"].kernels, [])
+        self.assertEqual(by_name["device_activity"].kernels, [])
+        self.assertEqual(len(by_name["frontend"].kernels), 1)
+        kernel = by_name["frontend"].kernels[0]
+        self.assertEqual(
+            (kernel.name, kernel.device, kernel.duration), ("device_activity", 0, 100)
+        )
+        self.assertEqual(
+            by_name["backend"].cpu_time_total,
+            (template.end_ns() - template.start_ns()) / 1000,
+        )
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_parse_kineto_results_timeout_none(self):

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -2001,8 +2001,8 @@ class TestProfiler(TestCase):
                 payload()
             validate_json(prof, gc_flag)
 
-    @onlyAccelerator
     @unittest.skipIf(not kineto_available(), "Kineto is required")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Accelerator is required")
     def test_region_device_time(self):
         if not supported_activities() - {ProfilerActivity.CPU, ProfilerActivity.HPU}:
             self.skipTest("Device kernel attribution is unavailable")

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -789,9 +789,10 @@ class profile:
                     device_corr_map[corr_id] = []
                 device_corr_map[corr_id].append(fe)
             elif corr_id == 0:
-                # Skip OVERHEAD events (profiler-internal host cost):
-                # they do no device work and would otherwise inflate reported device time.
-                if fe.activity_type != "overhead":
+                # Unlinked runtime/driver records and overhead have external_id=0.
+                # Their correlation ids can alias PyTorch operator ids, so do not
+                # use them to look up device work. See KinetoEvent::externalId().
+                if fe.external_id != 0:
                     frontend_function_events.append(fe)
             else:
                 raise RuntimeError(


### PR DESCRIPTION
# Description
The `torch/autograd/profiler.py` has the following logic:

https://github.com/pytorch/pytorch/blob/a7014b42fb76e762dfd99653ab70a3f109373764/torch/autograd/profiler.py#L786-L795

Then append the kernel like:

```python
for fe in frontend_function_events:
    for f_evt in device_corr_map[fe.id]:
          fe.append_kernel(...)
```

However, there are cases when a non-PyTorch event id shares the same `linked_correlation_id`, so the event is wrongly counted, making the total time can't add up.  This change filters out the events when `fe.external_id == 0` to avoid duplication count.

Basically, this follows previous change on https://github.com/pytorch/pytorch/pull/193924

# BackGrounds
The `external_id` in kineto is defined in [output_json.cpp](https://github.com/pytorch/kineto/blob/eeaa4244e5f8e5f2690212c7c24e8b08061382d8/libkineto/src/output_json.cpp#L887-L907) as follows:

```cpp
  int external_id = 0;
  if (op.linkedActivity()) {
    external_id = op.linkedActivity()->correlationId();
  } else {
    // Some runtime events and kernels may not have a linked activity,
    // should not set an "External id" for them. Otherwise, these events
    // may be incorrectly linked to the other external events.
    static const std::set<libkineto::ActivityType> excludedTypes = {
        libkineto::ActivityType::GPU_MEMCPY,
        libkineto::ActivityType::GPU_MEMSET,
        libkineto::ActivityType::CONCURRENT_KERNEL,
        libkineto::ActivityType::CUDA_RUNTIME,
        libkineto::ActivityType::CUDA_DRIVER,
        libkineto::ActivityType::XPU_RUNTIME,
        libkineto::ActivityType::XPU_DRIVER,
        libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
        libkineto::ActivityType::PRIVATEUSE1_DRIVER};
    if (!excludedTypes.contains(op.type())) {
      external_id = op.correlationId();
    }
  }
```

So from this side, we exclude activities that has `external_id!=0` should work.


# Testing
Test Cases
```python
import torch

x = torch.randn(1024, 1024, device=torch.accelerator.current_accelerator())
with torch.profiler.profile() as prof:
    for _ in range(4):
         torch.accelerator.synchronize()
         torch.mm(x, x)
    torch.accelerator.synchronize()
print(torch.__version__)
print(prof.key_averages().table(sort_by="self_device_time_total", row_limit=8))
```
Before
```text
                                             Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls
                                         aten::mm        72.08%      75.845ms        96.55%     101.596ms      25.399ms     823.714us       100.00%     823.714us     205.928us             4
                           ampere_sgemm_128x64_nn         0.00%       0.000us         0.00%       0.000us       0.000us     816.418us        99.11%     816.418us     204.104us             4
                            cudaDeviceSynchronize         0.65%     685.797us         0.65%     685.797us     114.300us     205.632us        24.96%     205.632us      34.272us             6
                                  Memset (Device)         0.00%       0.000us         0.00%       0.000us       0.000us       7.296us         0.89%       7.296us       1.824us             4
Self CPU time total: 105.229ms
Self CUDA time total: 823.714us
```
After
```text
                                             Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls
                                         aten::mm        72.20%      76.429ms        96.53%     102.194ms      25.549ms     868.577us       100.00%     868.577us     217.144us             4
                           ampere_sgemm_128x64_nn         0.00%       0.000us         0.00%       0.000us       0.000us     860.801us        99.10%     860.801us     215.200us             4
                                  Memset (Device)         0.00%       0.000us         0.00%       0.000us       0.000us       7.776us         0.90%       7.776us       1.944us             4
                            cudaDeviceSynchronize         0.70%     736.210us         0.70%     736.210us     122.702us       0.000us         0.00%       0.000us       0.000us             6
Self CPU time total: 105.864ms
Self CUDA time total: 868.577us
```

The `Self CUDA time` is 823.714us, which should be the summary of all `aten::mm` , and the  `cudaDeviceSynchronize` is supposed to not be counted in.

AI Assisted by GPT-6 Astra

cc: @guangyey 