### PR TITLE
[MPS] Sort the sparse intersection matches so the result is really coalesced

### DIFF
--- a/aten/src/ATen/native/sparse/mps/SparseMPSTensorMath.mm
+++ b/aten/src/ATen/native/sparse/mps/SparseMPSTensorMath.mm
@@ -482,6 +482,22 @@ static std::tuple<Tensor, Tensor, int64_t> mps_intersect_binary_search(
   });
 
   const auto match_count = static_cast<int64_t>(counter.item<int32_t>());
+
+  // The kernel takes its output slot from an atomic counter, so the pairs land in
+  // thread arrival order rather than key order. Both operands are coalesced, so
+  // the matches are a common subsequence of two sorted key lists and sorting them
+  // by their lhs position puts them back in key order. Callers rely on that:
+  // the result indices are gathered with these positions and the tensor is then
+  // marked coalesced.
+  if (match_count > 1) {
+    auto matchA = outA_idx.narrow(0, 0, match_count);
+    auto matchB = outB_idx.narrow(0, 0, match_count);
+    auto [sortedA, perm] = matchA.sort();
+    auto sortedB = matchB.index_select(0, perm);
+    matchA.copy_(sortedA);
+    matchB.copy_(sortedB);
+  }
+
   return std::make_tuple(std::move(outA_idx), std::move(outB_idx), match_count);
 }
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1864,6 +1864,28 @@ class TestSparse(TestSparseBase):
         test_shape(7, 8, 9, 20, False)
         test_shape(7, 8, 9, 20, True)
 
+    @dtypes(torch.double)
+    @dtypesIfMPS(torch.float32)
+    def test_sparse_mul_result_is_coalesced(self, device, dtype):
+        # The result of multiplying two coalesced tensors is flagged coalesced,
+        # so its indices have to be sorted. On MPS the intersection kernel used
+        # to take its output slot from an atomic counter, which put the matches
+        # in thread arrival order; the flag then lied and everything relying on
+        # it, `to_sparse_csr` in particular, produced a malformed tensor. The
+        # ordering depended on scheduling, hence the loop.
+        i = torch.arange(64, device=device).unsqueeze(0).repeat(2, 1)
+        i[1] = i[1].flip(0)
+        a = torch.sparse_coo_tensor(i, torch.ones(64, dtype=dtype, device=device),
+                                    (64, 64)).coalesce()
+        b = torch.sparse_coo_tensor(i, torch.full((64,), 2, dtype=dtype, device=device),
+                                    (64, 64)).coalesce()
+        for _ in range(50):
+            r = a * b
+            self.assertTrue(r.is_coalesced())
+            flat = r._indices()[0] * r.size(1) + r._indices()[1]
+            self.assertTrue(bool((flat[1:] > flat[:-1]).all()),
+                            f"indices of a coalesced result are not sorted: {flat.tolist()}")
+
     @unittest.skipIf(IS_LINUX or IS_MACOS or TEST_WITH_ROCM or IS_WINDOWS, "https://github.com/pytorch/pytorch/issues/174389")
     @coalescedonoff
     @dtypes(torch.double)


### PR DESCRIPTION
`intersect_binary_search` takes its output slot from an atomic counter:

```metal
uint pos = atomic_fetch_add_explicit(counter, 1u, memory_order_relaxed);
outA_idx[pos] = (long)gid;
outB_idx[pos] = (long)lo;
```

so the pairs land in thread arrival order, not key order. `mul_out_sparse_mps`
gathers the result indices with those positions and then asserts
`r_._coalesced_(true)`, so multiplying two coalesced operands can return a tensor
that is flagged coalesced while its indices are an arbitrary permutation:

```
operand a: coalesced=True  sorted=True
operand b: coalesced=True  sorted=True
result   : coalesced=True  sorted=False
rows = [3,3,3,3,3,3,3,3, 4,4,4,4,4,4,4,4,4,4, 0,0,...]
```

Anything relying on the contract then breaks. `coo_to_sparse_csr` feeds
`coalesce().indices()[0]` to `_convert_indices_from_coo_to_csr`, which assumes
sorted rows, and the compressed indices come out malformed. Because the
permutation follows GPU scheduling it is intermittent and does not reproduce from
the same operands in isolation, which is what made it hard to pin down.

The matches are a common subsequence of two sorted key lists, so ordering them by
their lhs position restores key order. Done once on the host after the kernel, at
the cost of sorting M elements.

Fixes #196190.

Test Plan:

```
python test/test_sparse.py -k mps -q
```

1371 tests pass. The new `test_sparse_mul_result_is_coalesced` multiplies two
coalesced tensors fifty times and checks the indices are sorted each time; the
loop is needed because the ordering depends on scheduling. Before the change the
reproducer in #196190 failed in five runs out of six, after it three runs out of
three are clean.

This PR was authored with the help of an AI assistant (Claude).
