### PR TITLE
Fix OptimizedModule truthiness for modules that are not Sized

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1035,6 +1035,12 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         compiled_filled = torch.compile(original_filled, backend="eager")
         self.assertEqual(bool(original_filled), bool(compiled_filled))
         self.assertTrue(bool(compiled_filled))
+        # Test with a plain nn.Module that is not Sized: bool() must not fall
+        # back to __len__ and raise (https://github.com/pytorch/pytorch/issues/196253)
+        original_plain = nn.Linear(10, 5)
+        compiled_plain = torch.compile(original_plain, backend="eager")
+        self.assertEqual(bool(original_plain), bool(compiled_plain))
+        self.assertTrue(bool(compiled_plain))
 
     def guard_manager_clone_hook_fn(self, guard_manager_wrapper, f_locals, builder):
         root = guard_manager_wrapper.root

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -530,6 +530,13 @@ class OptimizedModule(torch.nn.Module):
         # Mimic python's default behavior for objects without a length
         raise TypeError(f"{type(self._orig_mod).__name__} does not support len()")
 
+    def __bool__(self) -> bool:
+        # Mirror the truthiness of the wrapped module. Without this, ``bool()``
+        # falls back to ``__len__`` (added to proxy ``len()``), which raises
+        # ``TypeError`` for modules that are not ``Sized`` such as a plain
+        # ``nn.Module``.
+        return bool(self._orig_mod)
+
     def _initialize(self) -> None:
         # Do this stuff in constructor to lower overhead slightly
         if isinstance(self.dynamo_ctx, DisableContext):


### PR DESCRIPTION
### Summary

`torch.compile` returns an `OptimizedModule` wrapping the original module.
`OptimizedModule.__len__` proxies `len()` to the wrapped module and raises
`TypeError` when it is not `Sized`. Python evaluates `bool(obj)` via `__len__`
when `__bool__` is absent, so `bool(compiled_model)` raised
`TypeError: <Model> does not support len()` for any plain `nn.Module`.

```python
import torch
from torch import nn

class Model(nn.Module):
    def forward(self, x):
        return x + 1

compiled = torch.compile(Model())
bool(compiled)   # TypeError: Model does not support len()  -> should be True
```

This adds `OptimizedModule.__bool__`, delegating to the wrapped module so
`bool(compiled_model) == bool(model)`.

### Root Cause

`OptimizedModule` originally defined neither `__bool__` nor `__len__`, so
`bool()` used default object truthiness (always `True`). #159208 added
`__len__` so that `bool(torch.compile(nn.ModuleList()))` matches
`bool(nn.ModuleList())` for `Sized` containers. As a side effect, for a
non-`Sized` module `bool()` now reaches the `raise TypeError` branch of
`__len__` instead of falling back to default truthiness.

### Changes

- `torch/_dynamo/eval_frame.py`: add `OptimizedModule.__bool__` returning
  `bool(self._orig_mod)`.
- `test/dynamo/test_repros.py`: extend `test_compiled_module_truthiness` with a
  non-`Sized` module (`nn.Linear`) case.

Behavior after the fix:

| case | before | after |
|---|---|---|
| plain `nn.Module` | `TypeError` | truthy |
| empty `nn.ModuleList()` / `nn.ModuleDict()` | falsy | falsy (unchanged, #159208) |
| non-empty container | truthy | truthy (unchanged) |
| wrapped module defines its own `__bool__`/`__len__` | &mdash; | honored |
| `len(compiled_model)` on a non-`Sized` module | `TypeError` | `TypeError` (unchanged) |

### Testing

Pure-Python change; verified by overlaying `torch/_dynamo/eval_frame.py` on an
installed CPU build (`torch==2.14.0`) and running the dynamo suites on CPU.

```
# new assertion in test_compiled_module_truthiness, before the fix -> fails:
#   TypeError: Linear does not support len()   (eval_frame.py __len__)

$ python -m pytest test/dynamo/test_repros.py -k test_compiled_module_truthiness
1 passed

$ python -m pytest test/dynamo/test_modules.py
147 passed, 8 subtests passed

$ python -m pytest test/dynamo/test_repros.py
363 passed, 20 skipped, 4 xfailed
```

The full `test_repros.py` run has 2 failures
(`test_grad_attr_does_not_poison_the_interned_none`,
`test_record_runtime_overhead_gated_on_profiler`) that also reproduce on a
clean checkout without this change (test file is newer than the 2.14.0 runtime
used locally); they are unrelated to `OptimizedModule`.

### Issue

Fixes #196253


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98