### PR TITLE
[OpenReg] Add IPC reference implementation

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.cpp
@@ -11,3 +11,53 @@ static bool register_hook_flag [[maybe_unused]] = []() {
 
 } // namespace c10::openreg
 // LITERALINCLUDE END: OPENREG HOOK REGISTER
+
+namespace {
+
+struct IpcCloseCtx {
+  void* ptr;
+  size_t size;
+};
+
+} // namespace
+
+namespace c10::openreg {
+
+at::IpcMemHandle OpenRegHooksInterface::getIpcMemHandle(void* ptr) const {
+#ifndef _WIN32
+  char name[OR_IPC_HANDLE_MAX_LEN];
+  ptrdiff_t offset = 0;
+  orError_t err = orGetIpcMemHandle(ptr, name, sizeof(name), &offset);
+  TORCH_CHECK(err == orSuccess, "orGetIpcMemHandle failed (err=", err, ")");
+  return at::IpcMemHandle{offset, std::string(name)};
+#else
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      false, "OpenReg IPC is not supported on Windows.");
+#endif
+}
+
+c10::DataPtr OpenRegHooksInterface::openIpcMemHandle(
+    const std::string& handle) const {
+#ifndef _WIN32
+  void* ptr = nullptr;
+  size_t size = 0;
+  orError_t err = orOpenIpcMemHandle(&ptr, handle.c_str(), &size);
+  TORCH_CHECK(err == orSuccess, "orOpenIpcMemHandle failed (err=", err, ")");
+
+  auto* ctx = new IpcCloseCtx{ptr, size};
+  return c10::DataPtr(
+      ptr,
+      ctx,
+      [](void* raw_ctx) {
+        auto* c = static_cast<IpcCloseCtx*>(raw_ctx);
+        orCloseIpcMemHandle(c->ptr, c->size);
+        delete c;
+      },
+      at::Device(at::DeviceType::PrivateUse1, current_device()));
+#else
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      false, "OpenReg IPC is not supported on Windows.");
+#endif
+}
+
+} // namespace c10::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegHooks.h
@@ -5,6 +5,7 @@
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
+#include <c10/core/Stream.h>
 
 #include <include/openreg.h>
 
@@ -90,6 +91,33 @@ struct OPENREG_EXPORT OpenRegHooksInterface : public at::PrivateUse1HooksInterfa
   at::Generator getNewGenerator(DeviceIndex device_index) const override {
     return at::make_generator<OpenRegGeneratorImpl>(device_index);
   }
+
+  bool supportsIpc() const override {
+    return true;
+  }
+
+  // OpenReg syncs inside getIpcMemHandle; no separate event wait needed.
+  bool requiresEventSync() const override {
+    return false;
+  }
+
+  // Copies the allocation containing ptr into a POSIX shm object and
+  // returns the shm name and byte offset (see OpenRegHooks.cpp).
+  at::IpcMemHandle getIpcMemHandle(void* ptr) const override;
+
+  // Not invoked by the framework when requiresEventSync() returns false.
+  std::string getIpcEventHandle() const override {
+    return {};
+  }
+
+  // Opens the POSIX shm named by handle, mmaps it, and returns a DataPtr
+  // whose deleter calls orCloseIpcMemHandle (munmap) when storage is freed.
+  c10::DataPtr openIpcMemHandle(const std::string& handle) const override;
+
+  // No-op: requiresEventSync() == false, so this is never called.
+  void waitIpcEvent(
+      [[maybe_unused]] const std::string& event_bytes,
+      [[maybe_unused]] const c10::Stream& stream) const override {}
 };
 
 } // namespace c10::openreg

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/CMakeLists.txt
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/CMakeLists.txt
@@ -15,6 +15,12 @@ add_library(${LIBRARY_NAME} SHARED ${SOURCE_FILES})
 
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+# shm_open/shm_unlink live in librt on older glibc (< 2.17).
+# Modern glibc and macOS include them in libc; linking rt is harmless there.
+if(UNIX AND NOT APPLE)
+  target_link_libraries(${LIBRARY_NAME} PRIVATE rt)
+endif()
+
 install(TARGETS ${LIBRARY_NAME}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/memory.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/csrc/memory.cpp
@@ -2,8 +2,15 @@
 
 #include <include/openreg.h>
 
+#include <cstdio>
 #include <map>
 #include <mutex>
+
+#ifndef _WIN32
+#include <cinttypes>
+#include <fcntl.h>
+#include <sys/stat.h>
+#endif
 
 namespace {
 
@@ -124,7 +131,7 @@ class MemoryManager {
     if (!attributes || !ptr)
       return orErrorUnknown;
 
-    std ::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     Block* info = getBlockInfoNoLock(ptr);
 
     if (!info) {
@@ -149,6 +156,105 @@ class MemoryManager {
     std::lock_guard<std::mutex> lock(m_mutex);
     return protectNoLock(getBlockInfoNoLock(ptr));
   }
+
+#ifndef _WIN32
+  orError_t getIpcMemHandle(
+      void* ptr,
+      char* name_out,
+      size_t name_buf_len,
+      ptrdiff_t* offset_out) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    Block* info = getBlockInfoNoLock(ptr);
+    if (!info || info->type != orMemoryType::orMemoryTypeDevice) {
+      return orErrorUnknown;
+    }
+
+    // Byte delta from the allocation base to the requested pointer.
+    ptrdiff_t offset =
+        static_cast<const char*>(ptr) -
+        static_cast<const char*>(info->pointer);
+
+    // Build a unique shm name: /or_<pid>_<base_hex>_<seq>.
+    // m_ipc_seq is protected by m_mutex; no extra atomics are needed.
+    char name[OR_IPC_HANDLE_MAX_LEN];
+    snprintf(
+        name,
+        sizeof(name),
+        "/or_%d_%" PRIxPTR "_%" PRIu64,
+        static_cast<int>(getpid()),
+        reinterpret_cast<uintptr_t>(info->pointer),
+        static_cast<uint64_t>(m_ipc_seq));
+
+    if (name_buf_len < strlen(name) + 1) {
+      return orErrorUnknown;
+    }
+    ++m_ipc_seq;
+
+    int fd = shm_open(name, O_CREAT | O_RDWR | O_EXCL, 0600);
+    if (fd < 0) {
+      return orErrorUnknown;
+    }
+    if (ftruncate(fd, static_cast<off_t>(info->size)) != 0) {
+      close(fd);
+      shm_unlink(name);
+      return orErrorUnknown;
+    }
+    void* shm = ::mmap(
+        nullptr, info->size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (shm == MAP_FAILED) {
+      shm_unlink(name);
+      return orErrorUnknown;
+    }
+
+    // Temporarily unprotect source block, copy into shm, re-protect.
+    unprotectNoLock(info);
+    ::memcpy(shm, info->pointer, info->size);
+    protectNoLock(info);
+    ::munmap(shm, info->size);
+
+    // Leave the shm name live; the consumer calls shm_unlink after
+    // shm_open so the kernel reclaims the name slot automatically.
+    snprintf(name_out, name_buf_len, "%s", name);
+    *offset_out = offset;
+    return orSuccess;
+  }
+
+  orError_t openIpcMemHandle(
+      void** ptr_out,
+      const char* name,
+      size_t* size_out) {
+    int fd = shm_open(name, O_RDWR, 0);
+    if (fd < 0) {
+      return orErrorUnknown;
+    }
+    struct stat st{};
+    if (fstat(fd, &st) != 0) {
+      close(fd);
+      return orErrorUnknown;
+    }
+    auto size = static_cast<size_t>(st.st_size);
+    void* ptr =
+        ::mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (ptr == MAP_FAILED) {
+      return orErrorUnknown;
+    }
+    // Unlink now: the mapping survives until munmap; the name is reclaimed.
+    shm_unlink(name);
+
+    *ptr_out = ptr;
+    *size_out = size;
+    return orSuccess;
+  }
+
+  orError_t closeIpcMemHandle(void* ptr, size_t size) {
+    if (::munmap(ptr, size) != 0) {
+      return orErrorUnknown;
+    }
+    return orSuccess;
+  }
+#endif // !_WIN32
 
  private:
   MemoryManager() = default;
@@ -198,6 +304,8 @@ class MemoryManager {
 
   std::map<void*, Block> m_registry;
   std::mutex m_mutex;
+  // Sequence counter for unique shm names. Incremented under m_mutex.
+  uint64_t m_ipc_seq{0};
 };
 
 } // namespace
@@ -257,3 +365,28 @@ orError_t orMemoryUnprotect(void* devPtr) {
 orError_t orMemoryProtect(void* devPtr) {
   return MemoryManager::getInstance().protect(devPtr);
 }
+
+#ifndef _WIN32
+orError_t orGetIpcMemHandle(
+    void* devPtr,
+    char* name_out,
+    size_t name_buf_len,
+    ptrdiff_t* offset_out) {
+  // Sync before snapshotting so all device writes are visible in the shm copy.
+  orDeviceSynchronize();
+  return MemoryManager::getInstance().getIpcMemHandle(
+      devPtr, name_out, name_buf_len, offset_out);
+}
+
+orError_t orOpenIpcMemHandle(
+    void** ptr_out,
+    const char* name,
+    size_t* size_out) {
+  return MemoryManager::getInstance().openIpcMemHandle(
+      ptr_out, name, size_out);
+}
+
+orError_t orCloseIpcMemHandle(void* ptr, size_t size) {
+  return MemoryManager::getInstance().closeIpcMemHandle(ptr, size);
+}
+#endif // !_WIN32

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/include/openreg.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/include/openreg.h
@@ -66,6 +66,31 @@ orPointerGetAttributes(orPointerAttributes* attributes, const void* ptr);
 OPENREG_EXPORT orError_t orMemoryUnprotect(void* devPtr);
 OPENREG_EXPORT orError_t orMemoryProtect(void* devPtr);
 
+// IPC via POSIX shared memory (not available on Windows)
+#ifndef _WIN32
+// Max byte length of the shm name string (including null terminator).
+#define OR_IPC_HANDLE_MAX_LEN 64
+
+// Snapshot devPtr's allocation into a POSIX shm object; write its name into
+// name_out (name_buf_len >= OR_IPC_HANDLE_MAX_LEN required) and the byte
+// delta from the allocation base to devPtr into *offset_out.
+OPENREG_EXPORT orError_t orGetIpcMemHandle(
+    void* devPtr,
+    char* name_out,
+    size_t name_buf_len,
+    ptrdiff_t* offset_out);
+
+// Open the shm, mmap it, and unlink the name. *ptr_out is the mapped base;
+// *size_out is the page-aligned block size. Call orCloseIpcMemHandle to unmap.
+OPENREG_EXPORT orError_t orOpenIpcMemHandle(
+    void** ptr_out,
+    const char* name,
+    size_t* size_out);
+
+// Unmap the region. size must equal *size_out from orOpenIpcMemHandle.
+OPENREG_EXPORT orError_t orCloseIpcMemHandle(void* ptr, size_t size);
+#endif // !_WIN32
+
 // Device
 OPENREG_EXPORT orError_t orGetDeviceCount(int* count);
 OPENREG_EXPORT orError_t orSetDevice(int device);

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/memory_tests.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/third_party/openreg/tests/memory_tests.cpp
@@ -188,4 +188,130 @@ TEST_F(MemoryTest, DoubleFreeFails) {
   EXPECT_EQ(orFree(dev_ptr), orErrorUnknown);
 }
 
+// ---------------------------------------------------------------------------
+// IPC tests
+// ---------------------------------------------------------------------------
+#ifndef _WIN32
+
+TEST_F(MemoryTest, IpcRoundTripSameProcess) {
+  // Allocate, write a pattern, get an IPC handle, open it, verify the data
+  // matches, then clean up.  All within a single process — fork-based tests
+  // are in test_ipc.py.
+  void* dev_ptr = nullptr;
+  ASSERT_EQ(orMalloc(&dev_ptr, 16), orSuccess);
+
+  const char src[16] = "ipc_test_data!!";
+  ASSERT_EQ(orMemcpy(dev_ptr, src, 16, orMemcpyHostToDevice), orSuccess);
+
+  char name[OR_IPC_HANDLE_MAX_LEN];
+  ptrdiff_t offset = 0;
+  ASSERT_EQ(
+      orGetIpcMemHandle(dev_ptr, name, sizeof(name), &offset), orSuccess);
+  EXPECT_EQ(offset, ptrdiff_t{0}); // dev_ptr is the allocation base
+  EXPECT_GT(strlen(name), 0u);
+
+  void* mapped = nullptr;
+  size_t size = 0;
+  ASSERT_EQ(orOpenIpcMemHandle(&mapped, name, &size), orSuccess);
+  // orMalloc page-aligns: actual block size >= requested size.
+  EXPECT_GE(size, 16u);
+  EXPECT_EQ(memcmp(mapped, src, 16), 0);
+
+  EXPECT_EQ(orCloseIpcMemHandle(mapped, size), orSuccess);
+  EXPECT_EQ(orFree(dev_ptr), orSuccess);
+}
+
+TEST_F(MemoryTest, IpcHandleNullDevPtr) {
+  // A null pointer is not a registered device allocation.
+  char name[OR_IPC_HANDLE_MAX_LEN];
+  ptrdiff_t offset = 0;
+  EXPECT_EQ(
+      orGetIpcMemHandle(nullptr, name, sizeof(name), &offset),
+      orErrorUnknown);
+}
+
+TEST_F(MemoryTest, IpcHandleNameBufferTooSmall) {
+  void* dev_ptr = nullptr;
+  ASSERT_EQ(orMalloc(&dev_ptr, 8), orSuccess);
+
+  char tiny[4]; // deliberately undersized
+  ptrdiff_t offset = 0;
+  EXPECT_EQ(
+      orGetIpcMemHandle(dev_ptr, tiny, sizeof(tiny), &offset),
+      orErrorUnknown);
+
+  EXPECT_EQ(orFree(dev_ptr), orSuccess);
+}
+
+TEST_F(MemoryTest, IpcOpenNonExistentHandle) {
+  // Opening a name that was never created must fail.
+  void* mapped = nullptr;
+  size_t size = 0;
+  EXPECT_EQ(
+      orOpenIpcMemHandle(&mapped, "/or_no_such_shm", &size),
+      orErrorUnknown);
+}
+
+TEST_F(MemoryTest, IpcSequenceNumberProducesUniqueNames) {
+  // Two consecutive handles for the same allocation must have different
+  // names so a re-share never collides with the previous shm object.
+  void* dev_ptr = nullptr;
+  ASSERT_EQ(orMalloc(&dev_ptr, 8), orSuccess);
+
+  char name1[OR_IPC_HANDLE_MAX_LEN];
+  char name2[OR_IPC_HANDLE_MAX_LEN];
+  ptrdiff_t off = 0;
+
+  ASSERT_EQ(
+      orGetIpcMemHandle(dev_ptr, name1, sizeof(name1), &off), orSuccess);
+  void* m1 = nullptr;
+  size_t sz1 = 0;
+  ASSERT_EQ(orOpenIpcMemHandle(&m1, name1, &sz1), orSuccess); // also unlinks
+  ASSERT_EQ(orCloseIpcMemHandle(m1, sz1), orSuccess);
+
+  ASSERT_EQ(
+      orGetIpcMemHandle(dev_ptr, name2, sizeof(name2), &off), orSuccess);
+  EXPECT_STRNE(name1, name2);
+
+  void* m2 = nullptr;
+  size_t sz2 = 0;
+  ASSERT_EQ(orOpenIpcMemHandle(&m2, name2, &sz2), orSuccess);
+  ASSERT_EQ(orCloseIpcMemHandle(m2, sz2), orSuccess);
+
+  EXPECT_EQ(orFree(dev_ptr), orSuccess);
+}
+
+TEST_F(MemoryTest, IpcOffsetForSuballocatedPointer) {
+  // When ptr points into the interior of an allocation the returned offset
+  // must equal the byte delta from the block base to ptr.
+  void* dev_ptr = nullptr;
+  ASSERT_EQ(orMalloc(&dev_ptr, 64), orSuccess);
+
+  // Write a recognisable pattern at byte 16 via a full-block host copy.
+  char host_src[64] = {};
+  const char pattern[4] = {0x11, 0x22, 0x33, 0x44};
+  memcpy(host_src + 16, pattern, 4);
+  ASSERT_EQ(
+      orMemcpy(dev_ptr, host_src, 64, orMemcpyHostToDevice), orSuccess);
+
+  char* inner_ptr = static_cast<char*>(dev_ptr) + 16;
+  char name[OR_IPC_HANDLE_MAX_LEN];
+  ptrdiff_t offset = 0;
+  ASSERT_EQ(
+      orGetIpcMemHandle(inner_ptr, name, sizeof(name), &offset), orSuccess);
+  EXPECT_EQ(offset, ptrdiff_t{16});
+
+  void* mapped = nullptr;
+  size_t size = 0;
+  ASSERT_EQ(orOpenIpcMemHandle(&mapped, name, &size), orSuccess);
+  // Apply the reported offset to reach the inner data.
+  const char* consumer_ptr = static_cast<const char*>(mapped) + offset;
+  EXPECT_EQ(memcmp(consumer_ptr, pattern, 4), 0);
+
+  EXPECT_EQ(orCloseIpcMemHandle(mapped, size), orSuccess);
+  EXPECT_EQ(orFree(dev_ptr), orSuccess);
+}
+
+#endif // !_WIN32
+
 } // namespace


### PR DESCRIPTION
### Summary

Adds the OpenReg IPC reference implementation: the concrete `PrivateUse1HooksInterface`
overrides and the C runtime backing them. OpenReg uses `requiresEventSync() == false`,
making it the simplest valid reference for vendors with no event mechanism.

**What is added:**

- `openreg.h`: `orGetIpcMemHandle`, `orOpenIpcMemHandle`, `orCloseIpcMemHandle` C APIs
  and `OR_IPC_HANDLE_MAX_LEN`, guarded by `#ifndef _WIN32`.
- `memory.cpp`: POSIX shared memory implementation; `MemoryManager` gains `m_ipc_seq`
  for unique shm names.
- `OpenRegHooks.h/.cpp`: implements all six IPC hook overrides.
- `memory_tests.cpp`: six gtests covering the IPC C API round-trip, error paths,
  unique names, and sub-allocated pointer offset.
- `tests/test_ipc.py`: End-to-end Python tests covering the full
  two-process producer → queue → consumer path using the `spawn` start
  method: basic round-trip, non-zero storage offset, non-contiguous
  stride, `received_via_ipc_` re-share guard, and
  producer-exits-with-tensor-in-limbo (clean exit with warning).


This is **PR 5 of 5** for [RFC #192099](https://github.com/pytorch/pytorch/issues/192099) (Adding IPC Support for Third-Party Devices).

cc @mansiag05 @fffrog @albanD @cyyever