### PR TITLE
[BE] Remove redundant tests from test_mps for glu, sigmoid and tanh

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3562,56 +3562,6 @@ class TestMPS(TestCaseMPS):
                         helper((N, C_out, H, W), (C_out, C_in, kH, kW), bias_shape=(C_in), stride=stride,
                                padding=padding, output_padding=output_padding, dilation=dilation)
 
-    # Test sigmoid
-    def test_sigmoid(self):
-        def helper(shape):
-
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)
-            x = cpu_x.detach().clone().to('mps').requires_grad_()
-
-            sigmoid_op = torch.nn.Sigmoid()
-
-            y = sigmoid_op(x)
-            ref_y = sigmoid_op(cpu_x)
-
-            cpu_grad = torch.ones_like(ref_y)
-            grad = cpu_grad.to('mps')
-
-            y.backward(gradient=grad)
-            ref_y.backward(gradient=cpu_grad)
-
-            self.assertEqual(y, ref_y)
-            self.assertEqual(x.grad, cpu_x.grad)
-
-        helper((2, 3, 4, 5))
-        helper((2, 3, 4))
-        helper((2, 8, 4, 5))
-
-    # Test tanh
-    def test_tanh(self):
-        def helper(shape):
-
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)
-            x = cpu_x.detach().clone().to('mps').requires_grad_()
-
-            tanh_op = torch.nn.Tanh()
-
-            y = tanh_op(x)
-            ref_y = tanh_op(cpu_x)
-
-            cpu_grad = torch.ones_like(ref_y)
-            grad = cpu_grad.to('mps')
-
-            y.backward(gradient=grad)
-            ref_y.backward(gradient=cpu_grad)
-
-            self.assertEqual(y, ref_y)
-            self.assertEqual(x.grad, cpu_x.grad)
-
-        helper((2, 3, 4, 5))
-        helper((2, 3, 4))
-        helper((2, 8, 4, 5))
-
     def test_threshold(self):
         def helper(threshold, value, num_elems, inplace=False, requires_grad=True):
             m = nn.Threshold(threshold=threshold, value=value, inplace=inplace)
@@ -8098,29 +8048,6 @@ class TestMPS(TestCaseMPS):
             F.elu(elu_input_noncontiguous.to('cpu'), alpha, inplace),
             F.elu(elu_input_noncontiguous.to('mps'), alpha, inplace)
         )
-
-    # Test glu
-    def test_glu(self):
-        def helper(shape, dim=0):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)
-            x = cpu_x.detach().clone().to('mps').requires_grad_()
-
-            for activation_func in [torch.nn.GLU(dim=dim)]:
-                glu_result = activation_func(x)
-                glu_result_cpu = activation_func(cpu_x)
-
-                cpu_grad = torch.randn(glu_result_cpu.shape)
-                grad = cpu_grad.to('mps')
-
-                glu_result.backward(gradient=grad)
-                glu_result_cpu.backward(gradient=cpu_grad)
-
-                self.assertEqual(glu_result, glu_result_cpu)
-                self.assertEqual(x.grad, cpu_x.grad)
-
-        for shape in [[4], (2, 4), (2, 8, 4, 6)]:
-            for dim in range(len(shape)):
-                helper(shape, dim)
 
     # Test softplus
     def test_softplus(self):


### PR DESCRIPTION
Remove redundant tests from test_mps.py for `glu`, `sigmoid` and `tanh` which are already tested by OpInfo tests:
- `test_glu`: `nn.functional.glu` OpInfo
- `test_sigmoid`: `sigmoid` OpInfo
- `test_tanh`: `tanh` OpInfo

You can run the tests with:
```bash
python test/test_mps.py -v \
  TestConsistencyMPS.test_output_match_nn_functional_glu_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_nn_functional_glu_mps_float32 \
  TestConsistencyMPS.test_output_match_sigmoid_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_sigmoid_mps_float32 \
  TestConsistencyMPS.test_output_match_tanh_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_tanh_mps_float32
```

To confirm that they actually exist.

P.S. Of course these are not the only ops that need to be yanked out of test_mps.py but this is a start. I'll try to batch them in batches of 3 so it's more easily reviewable