### PR TITLE
Skip fully-masked-out slices in masked softmax OpInfo samples

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -951,11 +951,6 @@ class TestOperators(TestCase):
                 decorate(
                     "linalg.householder_product", decorator=runOnRocm
                 ),  # works on ROCm
-                xfail(
-                    # nans
-                    "masked.softmax",
-                    device_type="cpu",
-                ),
                 xfail("native_layer_norm"),  # vmap: inplace into a regular tensor
                 # got a batched tensor as input while the running_mean or running_var,
                 # which will be updated in place, were not batched.

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -354,9 +354,22 @@ def sample_inputs_masked_softmax(
     for sample_input in sample_inputs_softmax_variant(
         op_info, device, dtype, requires_grad, with_dtype=with_dtype, **kwargs
     ):
+        dim = sample_input.args[0]
         for mask in _generate_masked_op_mask(
             sample_input.input.shape, device, **kwargs
         ):
+            if mask is not None:
+                # A softmax/softmin/log_softmax slice whose elements are all
+                # masked out has an undefined result (see torch/masked/_ops.py),
+                # which makes gradient checks compare against nan. Skip masks
+                # that leave any slice along ``dim`` fully masked out.
+                expanded = torch.broadcast_to(mask, sample_input.input.shape)
+                if expanded.ndim == 0:
+                    unmasked_per_slice = expanded
+                else:
+                    unmasked_per_slice = expanded.any(dim=dim, keepdim=True)
+                if not unmasked_per_slice.all():
+                    continue
             yield SampleInput(
                 sample_input.input.clone().requires_grad_(requires_grad),
                 *sample_input.args,


### PR DESCRIPTION
### Summary

`test/functorch/test_ops.py::TestOperators::test_vmapvjpvjp_masked_softmax_*`
(and `..._masked_softmin_*`) can fail with a `nan` vs `0` mismatch,
depending on the RNG stream of the device under test.

The failing sample is the 0-d case from `sample_inputs_masked_softmax`: a
scalar input with `dim=0` and a mask drawn by `_generate_masked_op_mask`
via `make_tensor(shape, dtype=torch.bool)`. For a 0-d input that mask is a
single random bool; when it is `False` the input is *fully masked out*,
which `torch/masked/_ops.py` explicitly documents as undefined:

> If all elements of `input` along the given `dim` are ignored
> (fully masked-out), the corresponding element of the output tensor will
> have undefined value

The eager path yields `nan` and the vmap path yields `0`, so the
gradient check compares values the op makes no promise about. CPU has
carried an `xfail("masked.softmax", device_type="cpu")` for this;
#193412 renamed the test class, which reshuffled the RNG draw and made
CUDA / ROCm / XPU start hitting the fully-masked mask too.

### Changes

- `torch/testing/_internal/opinfo/definitions/_masked.py`:
  `sample_inputs_masked_softmax` now skips a mask that leaves any slice
  along the softmax `dim` fully masked out (covers `masked.softmax`,
  `masked.softmin`, `masked.log_softmax`).
- `test/functorch/test_ops.py`: remove the now-unnecessary
  `xfail("masked.softmax", device_type="cpu")` in `test_vmapvjpvjp`.

The change only drops the degenerate samples — with a fixed seed, the
generator went from 24 samples (2 with a fully-masked slice) to 22 (0),
and all non-degenerate samples are unchanged.

### Testing

Verified on CPU (`torch==2.14.0` runtime with the patched
`_masked.py` / `test_ops.py` overlaid):

```
# before: xfail (was masking a real nan-vs-0 failure)
$ python -m pytest test/functorch/test_ops.py \
    -k "test_vmapvjpvjp_masked_softmax and cpu and float32"
# with the xfail removed and the sample-generator fix NOT applied -> FAILS:
#   Greatest absolute difference: nan at index (0,)
#   Caused by sample input at index 23: SampleInput(input=Tensor[size=()],
#     args=(0), kwargs={'mask': Tensor[size=()] bool})

# after (fix applied, xfail removed):
$ python -m pytest test/functorch/test_ops.py \
    -k "masked_softmax or masked_softmin or masked_log_softmax"
41 passed, 1 skipped
```

### Issue

Fixes #196289
