### PR TITLE
[BE] Remove redundant tests from test_mps for abs, sign and neg

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7826,19 +7826,6 @@ class TestMPS(TestCaseMPS):
         # Empty test - Currently failing! Empty tensor not handled!
         # helper([0, 2, 4, 5])
 
-    # Test abs
-    def test_abs(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            x = cpu_x.detach().clone().to('mps')
-
-            abs_result = torch.abs(x)
-            abs_result_cpu = torch.abs(cpu_x)
-
-            self.assertEqual(abs_result, abs_result_cpu)
-
-        helper((2, 8, 4, 5))
-
     def test_angle(self):
         def helper(shape, dtype):
             cpu_x = torch.randn(shape, device='cpu', dtype=dtype, requires_grad=False)
@@ -8656,25 +8643,6 @@ class TestMPS(TestCaseMPS):
         mps_transpose6 = torch.transpose(mps_x, 1, 2).to('cpu')
         self.assertEqual(cpu_transpose6, mps_transpose6)
 
-    # Test sign
-    def test_sign(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)
-            x = cpu_x.detach().clone().to('mps').requires_grad_()
-
-            sign_result = torch.sign(x)
-            sign_result_cpu = torch.sign(cpu_x)
-
-            cpu_grad = torch.ones_like(sign_result_cpu)
-            grad = cpu_grad.to('mps')
-
-            sign_result.backward(gradient=grad)
-            sign_result_cpu.backward(gradient=cpu_grad)
-
-            self.assertEqual(sign_result, sign_result_cpu)
-
-        helper((2, 8, 4, 5))
-
     def test_signbit(self):
         def helper(shape, dtype):
             cpu_x = torch.randn(shape, device='cpu').to(dtype)
@@ -8688,25 +8656,6 @@ class TestMPS(TestCaseMPS):
         helper((2, 8, 4, 5), torch.int)
         helper((2, 8, 4, 5), torch.float)
         helper((2, 8, 4, 5), torch.int64)
-
-    # Test neg
-    def test_neg(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)
-            x = cpu_x.detach().clone().to('mps').requires_grad_()
-
-            neg_result = torch.neg(x)
-            neg_result_cpu = torch.neg(cpu_x)
-
-            cpu_grad = torch.ones_like(neg_result_cpu)
-            grad = cpu_grad.to('mps')
-
-            neg_result.backward(gradient=grad)
-            neg_result_cpu.backward(gradient=cpu_grad)
-
-            self.assertEqual(neg_result, neg_result_cpu)
-
-        helper((2, 8, 4, 5))
 
     def test_neg_strided_input(self):
         # See https://github.com/pytorch/pytorch/issues/98074#issuecomment-1496088337


### PR DESCRIPTION
pr removes `test_abs`, `test_neg` and `test_sign` from `test/test_mps.py`. These ops are already covered by the MPS OpInfo consistency tests.

Shape coverage for the removed float32 cases:

| Deleted test | Removed input | MPS OpInfo inputs |
| --- | --- | --- |
| `test_abs` | Contiguous `(2, 8, 4, 5)` |  contiguous `(20, 20)` |
| `test_neg` | Contiguous `(2, 8, 4, 5)` |  contiguous `(20, 20)` |
| `test_sign` | Contiguous `(2, 8, 4, 5)` |  contiguous `(20, 20)` |

Since these are elementwise ops, replacing them with 2D tensor is fine, all of those ops run metal kernels already so 4d mps graph regressions are not expected.

Run the existing MPS OpInfo checks with:

```bash
python test/test_mps.py -v \
  TestConsistencyMPS.test_output_match_abs_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_abs_mps_float32 \
  TestConsistencyMPS.test_output_match_neg_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_neg_mps_float32 \
  TestConsistencyMPS.test_output_match_sign_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_sign_mps_float32
```
