### PR TITLE
[native_aot] emit the AOT stubs header only where something declares

### DIFF
--- a/tools/test/test_native_aot.py
+++ b/tools/test/test_native_aot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import glob
 import os
 import tempfile
 import textwrap
@@ -10,13 +11,14 @@ import yaml
 from torchgen import native_aot
 from torchgen.dest.register_dispatch_key import RegisterDispatchKey
 from torchgen.gen import (
+    gen_source_files,
     get_grouped_native_functions,
     LineLoader,
     parse_native_yaml_struct,
 )
 from torchgen.model import DispatchKey, NativeFunctionsGroup
 from torchgen.selective_build.selector import SelectiveBuilder
-from torchgen.utils import Target
+from torchgen.utils import FileManager, Target
 
 
 # A minimal structured group (out declares the kernel), an unstructured op for
@@ -297,6 +299,64 @@ REGISTER_NO_CPU_DISPATCH(embfoo_aot_stub)
     # assertExpectedInline without pulling in torch's expecttest plumbing.
     def assertExpectedInline(self, actual: str, expected: str) -> None:
         self.assertEqual(actual, textwrap.dedent(expected))
+
+
+class TestRegistrationTranslationUnit(unittest.TestCase):
+    """What a declaration adds to RegisterCUDA, and what it must not add without one."""
+
+    TEMPLATES = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "aten/src/ATen/templates",
+    )
+
+    def _register_cuda(self, manifests: dict) -> str:
+        """Every RegisterCUDA shard the fixture generates, concatenated."""
+        parsed = _parse_fixture()
+        grouped = get_grouped_native_functions(parsed.native_functions)
+        with tempfile.TemporaryDirectory() as d:
+            fm = FileManager(install_dir=d, template_dir=self.TEMPLATES, dry_run=False)
+            gen_source_files(
+                native_functions=parsed.native_functions,
+                grouped_native_functions=grouped,
+                structured_native_functions=[
+                    g
+                    for g in grouped
+                    if isinstance(g, NativeFunctionsGroup) and g.structured
+                ],
+                view_groups=[],
+                selector=SelectiveBuilder.get_nop_selector(),
+                static_dispatch_idx=[],
+                backend_indices=parsed.backend_indices,
+                aoti_fm=fm,
+                core_fm=fm,
+                cpu_vec_fm=fm,
+                cpu_fm=fm,
+                device_fms={"cuda": fm},
+                dispatch_keys=[DispatchKey.CUDA],
+                functions_keys={DispatchKey.CUDA},
+                rocm=False,
+                force_schema_registration=False,
+                per_operator_headers=False,
+                skip_dispatcher_op_registration=False,
+                update_aoti_c_shim=False,
+                aoti_backends=set(),
+                extend_aoti_c_shim=False,
+                native_aot_manifests=manifests,
+            )
+            shards = sorted(glob.glob(os.path.join(d, "RegisterCUDA_*.cpp")))
+            if not shards:
+                raise AssertionError(f"no RegisterCUDA shards in {sorted(os.listdir(d))}")
+            return "\n".join(open(s).read() for s in shards)
+
+    def test_stubs_header_included_only_where_a_declaration_exists(self) -> None:
+        # A tree declaring nothing builds the registration TU it had pre-native-AOT.
+        m = native_aot.NativeAotManifest(op="embfoo", dispatch_key=DispatchKey.CUDA)
+        self.assertIn(
+            "#include <ATen/NativeAotStubs.h>",
+            self._register_cuda({(DispatchKey.CUDA, "embfoo"): m}),
+        )
+        self.assertNotIn("#include <ATen/NativeAotStubs.h>", self._register_cuda({}))
+
 
 
 if __name__ == "__main__":

--- a/tools/test/test_native_aot.py
+++ b/tools/test/test_native_aot.py
@@ -345,7 +345,9 @@ class TestRegistrationTranslationUnit(unittest.TestCase):
             )
             shards = sorted(glob.glob(os.path.join(d, "RegisterCUDA_*.cpp")))
             if not shards:
-                raise AssertionError(f"no RegisterCUDA shards in {sorted(os.listdir(d))}")
+                raise AssertionError(
+                    f"no RegisterCUDA shards in {sorted(os.listdir(d))}"
+                )
             return "\n".join(open(s).read() for s in shards)
 
     def test_stubs_header_included_only_where_a_declaration_exists(self) -> None:
@@ -356,7 +358,6 @@ class TestRegistrationTranslationUnit(unittest.TestCase):
             self._register_cuda({(DispatchKey.CUDA, "embfoo"): m}),
         )
         self.assertNotIn("#include <ATen/NativeAotStubs.h>", self._register_cuda({}))
-
 
 
 if __name__ == "__main__":

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -49,6 +49,7 @@ def gen_registration_headers(
     backend_index: BackendIndex,
     per_operator_headers: bool,
     rocm: bool,
+    has_native_aot: bool = False,
 ) -> list[str]:
     if per_operator_headers:
         headers = ["#include <ATen/ops/as_strided_native.h>"]
@@ -62,7 +63,11 @@ def gen_registration_headers(
             headers.append("#include <ATen/hip/EmptyTensor.h>")
         else:
             headers.append("#include <ATen/cuda/EmptyTensor.h>")
-        headers.append("#include <ATen/NativeAotStubs.h>")
+        # Only when a declaration targets this key: a tree (or a build that
+        # opts out with --native-aot-ops-dir=) that declares nothing produces
+        # the same registration TU it did before native-AOT existed.
+        if has_native_aot:
+            headers.append("#include <ATen/NativeAotStubs.h>")
     elif backend_index.dispatch_key == DispatchKey.MPS:
         headers.append("#include <ATen/mps/EmptyTensor.h>")
     elif backend_index.dispatch_key == DispatchKey.XPU:

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2444,13 +2444,22 @@ def gen_source_files(
             dispatch_key != DispatchKey.CompositeImplicitAutogradNestedTensor
         )
 
+        native_aot_manifests_for_key = {
+            op: m
+            for (key, op), m in native_aot_manifests.items()
+            if key == dispatch_key
+        }
+
         register_dispatch_key_base_env = {
             "extra_cuda_headers": extra_cuda_headers
             if is_cuda_dispatch_key(dispatch_key)
             else "",
             "external_backend_headers": "",
             "dispatch_headers": dest.gen_registration_headers(
-                backend_index, per_operator_headers, rocm
+                backend_index,
+                per_operator_headers,
+                rocm,
+                has_native_aot=bool(native_aot_manifests_for_key),
             ),
             # ops_headers *could* be sharded, but doesn't seem necessary?
             "ops_headers": operator_headers(),
@@ -2459,12 +2468,6 @@ def gen_source_files(
                 if gen_dispatch_helpers
                 else []
             ),
-        }
-
-        native_aot_manifests_for_key = {
-            op: m
-            for (key, op), m in native_aot_manifests.items()
-            if key == dispatch_key
         }
 
         def register_dispatch_key_env_callable(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191669
* #190899
* #196070
* #190898
* __->__ #196310

Human Notes:

Fix an internal build issue due to `NativeAotStubs.h` being unconditionally included,
but not actually generated in the build. Guard against that.

Claude:

The CUDA/HIP arm of gen_registration_headers appended
`#include <ATen/NativeAotStubs.h>` unconditionally, so every RegisterCUDA shard
carried it even in a tree with no declarations at all -- including a build that
opts out with --native-aot-ops-dir=. The manifests are already grouped per
dispatch key a few lines below, so the flag is free: hoist that dict above
register_dispatch_key_base_env and pass has_native_aot to the header helper. A
declaration-free build now produces the registration TU it produced before
native-AOT existed. gen_backend_stubs.py, the other caller, keeps the default
and stays without the include, which is right for an external backend that emits
no stubs.

Below the runtime and topk commits deliberately: it fixes codegen that has
already landed, so if that lands-and-reverts it goes with it.

The test asserts the generated RegisterCUDA text rather than the helper's return
value, because a unit test of the helper alone passes with
`has_native_aot=True` hardcoded at the call site -- verified by mutating it.

NativeAotStubs.h and .cpp are still written unconditionally (they are empty
without declarations); only the include is gated here.

Authored with an AI assistant (Claude Code).

Test Plan:

```
pytest tools/test/test_native_aot.py -k RegistrationTranslationUnit
```