### PR TITLE
Don't retry job-id lookups when the GitHub API quota is already exhausted

### DIFF
--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -58,7 +58,11 @@ def fetch_url(
         with urlopen(Request(url, headers=headers)) as conn:
             return reader(conn)
     except urllib.error.HTTPError as err:
-        if isinstance(retries, (int, float)) and retries > 0:
+        # A depleted core quota resets on GitHub's schedule, up to an hour out, so
+        # retrying inside the backoff cannot succeed and only multiplies the burn
+        # against a limit every concurrent job in the repo shares.
+        quota_depleted = err.headers.get("X-RateLimit-Remaining") == "0"
+        if not quota_depleted and isinstance(retries, (int, float)) and retries > 0:
             time.sleep(backoff_timeout)
             return fetch_url(
                 url,

--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -18,6 +18,7 @@ from urllib.request import Request, urlopen
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from email.message import Message
 
 
 def parse_json_and_links(conn: Any) -> tuple[Any, dict[str, dict[str, str]]]:
@@ -44,6 +45,23 @@ def parse_json_and_links(conn: Any) -> tuple[Any, dict[str, dict[str, str]]]:
     return json.load(conn), links
 
 
+def retry_delay(
+    status_code: int, response_headers: Message, backoff_timeout: float
+) -> float:
+    # Secondary rate limits carry Retry-After, and asking again before it elapses
+    # is what escalates them, so never wait less than it asks. Only GitHub's own
+    # rate-limit statuses count: proxies attach the header to 503s that the short
+    # backoff can legitimately clear.
+    if status_code not in (403, 429):
+        return backoff_timeout
+    # isdecimal rather than isdigit: headers arrive latin-1 decoded, and the
+    # superscript digits in that range satisfy isdigit but raise in float.
+    retry_after = response_headers.get("Retry-After", "").strip()
+    if retry_after.isdecimal():
+        return max(backoff_timeout, float(retry_after))
+    return backoff_timeout
+
+
 def fetch_url(
     url: str,
     *,
@@ -61,14 +79,18 @@ def fetch_url(
         # A depleted core quota resets on GitHub's schedule, up to an hour out, so
         # retrying inside the backoff cannot succeed and only multiplies the burn
         # against a limit every concurrent job in the repo shares.
-        quota_depleted = err.headers.get("X-RateLimit-Remaining") == "0"
+        quota_depleted = err.headers.get("X-RateLimit-Remaining", "").strip() == "0"
         if not quota_depleted and isinstance(retries, (int, float)) and retries > 0:
-            time.sleep(backoff_timeout)
+            delay = retry_delay(err.code, err.headers, backoff_timeout)
+            time.sleep(delay)
             return fetch_url(
                 url,
                 headers=headers,
                 reader=reader,
-                retries=retries - 1,
+                # Waiting out a Retry-After already gave GitHub the pause it asked
+                # for; repeating it would multiply a minute-scale stall by the retry
+                # count inside a step that cannot time itself out.
+                retries=0 if delay > backoff_timeout else retries - 1,
                 backoff_timeout=backoff_timeout,
             )
         exception_message = (


### PR DESCRIPTION
**Impact:** CI `get-workflow-job-id` / `filter-test-configs`
**Risk:** low

## What
`fetch_url` in `get_workflow_job_id.py` now checks `X-RateLimit-Remaining` on an `HTTPError` and skips the retry loop when the quota is depleted, instead of burning three more requests against a limit that cannot recover within the backoff window.

## Why
When a pod exhausts the shared `GITHUB_TOKEN` core quota, the job-id lookup 403s. `main()` swallows that exception and sets no `job-name` output, so `filter-test-configs` looks up `unstable-jobs.json` under an empty job name, fails to match, and drops the unstable marker. A job that is red by design then reds main.

The core quota resets on GitHub's own schedule (up to an hour out), so the retries can never succeed — they just quadruple the request burn at exactly the moment the repo is already over budget, and every concurrent job is doing the same thing. Removing the amplification makes the exhaustion window shorter and less likely to cascade.

# Notes
This is the amplification half of the problem, not the whole thing. The silent-failure path in `main()` is still there: on any lookup failure it prints to stderr, sets no outputs, and exits 0, so the unstable marker still silently disappears. Making that path fail loudly (or having `filter-test-configs` treat an empty job name as an error rather than a miss) is the follow-up.

For now the idea of failing loudly is 'put in the shelve' as for now, tests would at least still run and hopefully AI advisor should help filter out those unstable redness and guide the author with the correct decision, if failing loudly is required we can iterate on this next.