### PR TITLE
[ROCm][UT] Fix runOnRocmArch used in boolean context in test_cublas_baddbmm_large_input

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -752,7 +752,7 @@ class TestMatmulCuda(InductorTestCase):
         if N == M and M == P:
             M2_eye = torch.eye(N, device=device, dtype=dtype)
             out1_eye_gpu = torch.nn.functional.linear(M1, M2_eye.t(), torch.zeros_like(A))
-            if runOnRocmArch(MI200_ARCH) and dtype == torch.float16:
+            if TEST_WITH_ROCM and isRocmArchAnyOf(MI200_ARCH) and dtype == torch.float16:
                 self.assertEqual(M1_cpu.to(dtype=dtype), out1_eye_gpu.cpu(), atol=1e-4, rtol=0.001)
             else:
                 self.assertEqual(M1_cpu.to(dtype=dtype), out1_eye_gpu.cpu())
@@ -770,7 +770,7 @@ class TestMatmulCuda(InductorTestCase):
         if N == M and M == P:
             M2_eye = torch.eye(N, device=device, dtype=dtype).expand(batch_size, N, N)
             out2_eye_gpu = torch.baddbmm(torch.zeros_like(A), M1, M2_eye, beta=beta, alpha=alpha)
-            if runOnRocmArch(MI200_ARCH) and dtype == torch.float16:
+            if TEST_WITH_ROCM and isRocmArchAnyOf(MI200_ARCH) and dtype == torch.float16:
                 self.assertEqual(M1_cpu.to(dtype=dtype), out2_eye_gpu.cpu(), atol=1e-4, rtol=0.001)
             else:
                 self.assertEqual(M1_cpu.to(dtype=dtype), out2_eye_gpu.cpu())


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/196572

## Summary

`runOnRocmArch()` is a decorator factory. It returns a function, which is
always truthy. In `test_cublas_baddbmm_large_input`:

```python
if runOnRocmArch(MI200_ARCH) and dtype == torch.float16:
```

The arch check is discarded and the condition reduces to
`dtype == torch.float16`. The relaxed MI200 tolerance was therefore applied on
every platform, including CUDA, and the strict `else` branch was unreachable
for fp16.

Use `TEST_WITH_ROCM` and `isRocmArchAnyOf(MI200_ARCH)`, the form already used in
this file for the Navi guard in `test_cublas_addmm`.

Scope of the behaviour change is narrow: `_DTYPE_PRECISIONS[torch.float16]` is
`(0.001, 1e-5)`, so both code paths use `rtol=1e-3` and the only difference is
atol, `1e-4` -> `1e-5`. MI200 is unaffected: it takes the relaxed path before
and after. Non-MI200 ROCm and NVIDIA fp16 move to the default atol.

## Validation

The identity matmul under test (linear and baddbmm) is bitwise
exact, `max_abs = max_rel = 0.0`, on gfx1100 and gfx1200 for
`N in {100, 1000, 10000}` across fp16/bf16/fp32, so the tightened atol has
ample headroom on RDNA. `test_matmul_cuda` passes 12/12 on both GPUs.

MI200, MI300, MI350 and NVIDIA hardware were not available locally; please run
`ciflow/rocm-mi200` and `ciflow/trunk` jobs.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang