### PR TITLE
Use SLEEF u35 for Arm sin and cos

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -440,7 +440,7 @@ class Vectorized<float> {
   Vectorized<float> frac() const;
   Vectorized<float> sin() const {
     return USE_SLEEF(
-        Vectorized<float>(Sleef_sinfx_u10sve(values)), map(std::sin));
+        Vectorized<float>(Sleef_sinfx_u35sve(values)), map(std::sin));
   }
   // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
   // return finite results, because Sleef uses float-range intermediates
@@ -450,7 +450,7 @@ class Vectorized<float> {
   }
   Vectorized<float> cos() const {
     return USE_SLEEF(
-        Vectorized<float>(Sleef_cosfx_u10sve(values)), map(std::cos));
+        Vectorized<float>(Sleef_cosfx_u35sve(values)), map(std::cos));
   }
   Vectorized<float> cosh() const {
     return map(std::cosh);

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -492,14 +492,16 @@ class Vectorized<float> {
       nextafter,
       Sleef_nextafterf4)
   Vectorized<float> frac() const;
-  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(sin)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
+      sin, Sleef_sinf4_u35)
   // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
   // return finite results, because Sleef uses float-range intermediates
   // internally while the scalar C library uses double precision.
   Vectorized<float> sinh() const {
     return map(std::sinh);
   }
-  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(cos)
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
+      cos, Sleef_cosf4_u35)
   Vectorized<float> cosh() const {
     return map(std::cosh);
   }

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -493,7 +493,8 @@ class Vectorized<float> {
       Sleef_nextafterf4)
   Vectorized<float> frac() const;
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
-      sin, Sleef_sinf4_u35)
+      sin,
+      Sleef_sinf4_u35)
   // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
   // return finite results, because Sleef uses float-range intermediates
   // internally while the scalar C library uses double precision.
@@ -501,7 +502,8 @@ class Vectorized<float> {
     return map(std::sinh);
   }
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC_WITH_SLEEF_NAME(
-      cos, Sleef_cosf4_u35)
+      cos,
+      Sleef_cosf4_u35)
   Vectorized<float> cosh() const {
     return map(std::cosh);
   }


### PR DESCRIPTION
## Summary

Use the SLEEF u35 variants for float32 `sin` and `cos` in the Arm SVE128 and SVE256 vector paths. This aligns these paths with the 3.5-ULP accuracy class used by the x86 AVX2 implementation and improves throughput over the current u10 variants.

## Performance

Benchmarked on a single core using @malfet's script from #176256.

### Neoverse V2 (SVE128)

| op | SLEEF u10 (us) | SLEEF u35 (us) | Speedup |
| --- | ---: | ---: | ---: |
| sin | 243.7 | 141.3 | 1.72x |
| cos | 312.4 | 154.5 | 2.02x |

### Neoverse V1 (SVE256)

| op | SLEEF u10 (us) | SLEEF u35 (us) | Speedup |
| --- | ---: | ---: | ---: |
| sin | 205.0 | 94.4 | 2.17x |
| cos | 256.8 | 107.0 | 2.40x |

## Accuracy

All PyTorch-level checks used tensors large enough to enter the vectorized kernel. Random sweeps compare the u35 result with an FP64 result evaluated at the exact quantized input and rounded to the output dtype. The worst cases and selected special values were also checked against a 100-decimal-digit `mpmath` reference.

SLEEF's own `tester2simdsp.c` uses a [256-bit MPFR reference and targeted random inputs](https://github.com/shibatch/sleef/blob/5a1d179df9cf652951b59010a2d2075372d67f68/src/libm-tester/tester2simdsp.c#L330-L376). Its [`sinf` and `cosf` checks](https://github.com/shibatch/sleef/blob/5a1d179df9cf652951b59010a2d2075372d67f68/src/libm-tester/tester2simdsp.c#L448-L505) treat errors greater than 3.5 ULP as failures. The bounded SLEEF-style tests below use the same input classes: random float bit patterns and inputs close to multiples of `pi/4`.

### Random small- and large-range inputs

Each row contains 200,000 random inputs generated with seed `1234`. Small-range inputs were sampled from `|x| < 2^20`. Large-range inputs used random signs, mantissas in `[1, 2)`, and exponents from 20 through 100. FP16 has no large-range row because its maximum finite value is below `2^20`.

| platform | op | dtype | range | max ULP | results > 1 ULP | results > 3 ULP | max absolute error |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: |
| SVE128 | sin | float16 | small | 0 | 0 | 0 | `2.441e-04` |
| SVE128 | sin | bfloat16 | small | 0 | 0 | 0 | `1.949e-03` |
| SVE128 | sin | bfloat16 | large | 0 | 0 | 0 | `1.953e-03` |
| SVE128 | sin | float32 | small | 1 | 0 | 0 | `4.804e-08` |
| SVE128 | sin | float32 | large | 1 | 0 | 0 | `4.504e-08` |
| SVE128 | cos | float16 | small | 0 | 0 | 0 | `2.440e-04` |
| SVE128 | cos | bfloat16 | small | 0 | 0 | 0 | `1.951e-03` |
| SVE128 | cos | bfloat16 | large | 0 | 0 | 0 | `1.953e-03` |
| SVE128 | cos | float32 | small | 1 | 0 | 0 | `4.619e-08` |
| SVE128 | cos | float32 | large | 1 | 0 | 0 | `4.632e-08` |
| SVE256 | sin | float16 | small | 0 | 0 | 0 | `2.441e-04` |
| SVE256 | sin | bfloat16 | small | 0 | 0 | 0 | `1.949e-03` |
| SVE256 | sin | bfloat16 | large | 0 | 0 | 0 | `1.953e-03` |
| SVE256 | sin | float32 | small | 2 | 22 | 0 | `1.026e-07` |
| SVE256 | sin | float32 | large | 2 | 29 | 0 | `1.002e-07` |
| SVE256 | cos | float16 | small | 0 | 0 | 0 | `2.440e-04` |
| SVE256 | cos | bfloat16 | small | 0 | 0 | 0 | `1.951e-03` |
| SVE256 | cos | bfloat16 | large | 0 | 0 | 0 | `1.953e-03` |
| SVE256 | cos | float32 | small | 2 | 29 | 0 | `1.072e-07` |
| SVE256 | cos | float32 | large | 2 | 32 | 0 | `1.009e-07` |

### SLEEF-style float32 stress inputs

For each operation and platform, this covers 996,155 finite random float32 bit patterns, 250,000 values near integer multiples of `pi/4`, and 248,968 values near `random_float * pi/4` (seed `20260908`). The table gives the worst input from each class. No result exceeded 3 ULP.

| platform | op | input class | max ULP | input | u35 result | high-precision reference |
| --- | --- | --- | ---: | --- | --- | --- |
| SVE128 | sin | random bits | 1 | `0x1.3c1078p+92` | `0x1.fdfddep-1` | `0x1.fdfdep-1` |
| SVE128 | sin | near integer `pi/4` multiples | 1 | `-0x1.9afd1ep+32` | `0x1.e4ece6p-1` | `0x1.e4ece4p-1` |
| SVE128 | sin | near `random_float*pi/4` | 1 | `0x1.4951a6p+73` | `-0x1.9d935ap-3` | `-0x1.9d9358p-3` |
| SVE128 | cos | random bits | 1 | `0x1.9ad816p+67` | `0x1.9c7d1ep-1` | `0x1.9c7d2p-1` |
| SVE128 | cos | near integer `pi/4` multiples | 1 | `-0x1.974a6p+32` | `-0x1.fcbdbep-1` | `-0x1.fcbdcp-1` |
| SVE128 | cos | near `random_float*pi/4` | 1 | `-0x1.12b7a2p+126` | `0x1.9d1b4cp-1` | `0x1.9d1b4ep-1` |
| SVE256 | sin | random bits | 2 | `0x1.9f498p+12` | `-0x1.ffd638p-4` | `-0x1.ffd634p-4` |
| SVE256 | sin | near integer `pi/4` multiples | 2 | `-0x1.28da44p+30` | `0x1.fd5354p-1` | `0x1.fd535p-1` |
| SVE256 | sin | near `random_float*pi/4` | 2 | `-0x1.4c95aap+19` | `0x1.fd47ccp-1` | `0x1.fd47dp-1` |
| SVE256 | cos | random bits | 2 | `0x1.ce59b4p-11` | `0x1.fffff6p-1` | `0x1.fffff2p-1` |
| SVE256 | cos | near integer `pi/4` multiples | 2 | `-0x1.ae9204p+31` | `-0x1.fd25bp-1` | `-0x1.fd25acp-1` |
| SVE256 | cos | near `random_float*pi/4` | 2 | `0x1.a4d40ep+105` | `-0x1.fd11c8p-1` | `-0x1.fd11ccp-1` |

### Values around `+/-2^20`

| op | input | SVE128 result | SVE256 result | reference | SVE128 ULP | SVE256 ULP |
| --- | --- | --- | --- | --- | ---: | ---: |
| sin | `0x1.fffffep+19` | `0x1.156658p-2` | `0x1.156658p-2` | `0x1.156658p-2` | 0 | 0 |
| sin | `0x1p+20` | `0x1.526cccp-2` | `0x1.526cccp-2` | `0x1.526cccp-2` | 0 | 0 |
| sin | `0x1.000002p+20` | `0x1.c8471p-2` | `0x1.c8471p-2` | `0x1.c8471p-2` | 0 | 0 |
| sin | `-0x1.000002p+20` | `-0x1.c8471p-2` | `-0x1.c8471p-2` | `-0x1.c8471p-2` | 0 | 0 |
| sin | `-0x1p+20` | `-0x1.526cccp-2` | `-0x1.526cccp-2` | `-0x1.526cccp-2` | 0 | 0 |
| sin | `-0x1.fffffep+19` | `-0x1.156658p-2` | `-0x1.156658p-2` | `-0x1.156658p-2` | 0 | 0 |
| cos | `0x1.fffffep+19` | `0x1.ecdaf4p-1` | `0x1.ecdaf4p-1` | `0x1.ecdaf4p-1` | 0 | 0 |
| cos | `0x1p+20` | `0x1.e33adap-1` | `0x1.e33adcp-1` | `0x1.e33adap-1` | 0 | 1 |
| cos | `0x1.000002p+20` | `0x1.ca5cf2p-1` | `0x1.ca5cfp-1` | `0x1.ca5cf2p-1` | 0 | 1 |
| cos | `-0x1.000002p+20` | `0x1.ca5cf2p-1` | `0x1.ca5cfp-1` | `0x1.ca5cf2p-1` | 0 | 1 |
| cos | `-0x1p+20` | `0x1.e33adap-1` | `0x1.e33adcp-1` | `0x1.e33adap-1` | 0 | 1 |
| cos | `-0x1.fffffep+19` | `0x1.ecdaf4p-1` | `0x1.ecdaf4p-1` | `0x1.ecdaf4p-1` | 0 | 0 |

### Vectorized special values

Each value was repeated 256 times so that the check exercises vector lanes. The exact float32 inputs and high-precision rounded references are shown below.

| op | case | input | SVE128 result | SVE256 result | reference | SVE128 ULP | SVE256 ULP |
| --- | --- | --- | --- | --- | --- | ---: | ---: |
| sin | `+0.0` | `0x0p+0` | `0x0p+0` | `0x0p+0` | `0x0p+0` | 0 | 0 |
| sin | `-0.0` | `-0x0p+0` | `-0x0p+0` | `-0x0p+0` | `-0x0p+0` | 0 | 0 |
| sin | minimum subnormal | `0x1p-149` | `0x1p-149` | `0x1p-149` | `0x1p-149` | 0 | 0 |
| sin | minimum normal | `0x1p-126` | `0x1p-126` | `0x1p-126` | `0x1p-126` | 0 | 0 |
| sin | `pi/6` | `0x1.0c1524p-1` | `0x1p-1` | `0x1p-1` | `0x1p-1` | 0 | 0 |
| sin | `pi/2` | `0x1.921fb6p+0` | `0x1p+0` | `0x1p+0` | `0x1p+0` | 0 | 0 |
| sin | `pi` | `0x1.921fb6p+1` | `-0x1.777a5cp-24` | `-0x1.777a5cp-24` | `-0x1.777a5cp-24` | 0 | 0 |
| sin | `-pi` | `-0x1.921fb6p+1` | `0x1.777a5cp-24` | `0x1.777a5cp-24` | `0x1.777a5cp-24` | 0 | 0 |
| sin | maximum finite | `0x1.fffffep+127` | `-0x1.0b3366p-1` | `-0x1.0b3366p-1` | `-0x1.0b3366p-1` | 0 | 0 |
| sin | negative maximum finite | `-0x1.fffffep+127` | `0x1.0b3366p-1` | `0x1.0b3366p-1` | `0x1.0b3366p-1` | 0 | 0 |
| cos | `+0.0` | `0x0p+0` | `0x1p+0` | `0x1p+0` | `0x1p+0` | 0 | 0 |
| cos | `-0.0` | `-0x0p+0` | `0x1p+0` | `0x1p+0` | `0x1p+0` | 0 | 0 |
| cos | minimum subnormal | `0x1p-149` | `0x1p+0` | `0x1p+0` | `0x1p+0` | 0 | 0 |
| cos | minimum normal | `0x1p-126` | `0x1p+0` | `0x1p+0` | `0x1p+0` | 0 | 0 |
| cos | `pi/6` | `0x1.0c1524p-1` | `0x1.bb67aep-1` | `0x1.bb67bp-1` | `0x1.bb67aep-1` | 0 | 1 |
| cos | `pi/2` | `0x1.921fb6p+0` | `-0x1.777a5cp-25` | `-0x1.777a5cp-25` | `-0x1.777a5cp-25` | 0 | 0 |
| cos | `pi` | `0x1.921fb6p+1` | `-0x1p+0` | `-0x1p+0` | `-0x1p+0` | 0 | 0 |
| cos | `-pi` | `-0x1.921fb6p+1` | `-0x1p+0` | `-0x1p+0` | `-0x1p+0` | 0 | 0 |
| cos | maximum finite | `0x1.fffffep+127` | `0x1.b4bf2cp-1` | `0x1.b4bf2cp-1` | `0x1.b4bf2cp-1` | 0 | 0 |
| cos | negative maximum finite | `-0x1.fffffep+127` | `0x1.b4bf2cp-1` | `0x1.b4bf2cp-1` | `0x1.b4bf2cp-1` | 0 | 0 |

## Test plan

- Built PyTorch from source on SVE128 and SVE256
- Ran the existing vector `sin` and `cos` tests on both targets
- Ran random and special-value accuracy tests
- Ran single-core performance benchmarks

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01
