### PR TITLE
fix `OptimizedModule.__bool__` for truth value testing

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -522,6 +522,11 @@ class OptimizedModule(torch.nn.Module):
         self._initialize()
         self.training = self._orig_mod.training
 
+    def __bool__(self) -> bool:
+        # Proxy the bool call to the original module
+        # pyrefly: ignore [unsafe-overlap]
+        return bool(self._orig_mod)
+
     def __len__(self) -> int:
         # Proxy the len call to the original module
         # pyrefly: ignore [unsafe-overlap]


### PR DESCRIPTION
fix #196253 

**The bug**

After `torch.compile`, the model is wrapped by `OptimizedModule`. Calling `bool(compiled_model)` fullback to `OptimizedModul.__len__`, which further calls `original_model.__len__` (#159208). When there is no such method implementation, the program fails. The expected behavior should be calling `bool(original_model)`.

Minimal example:
```python
import torch
from torch import nn

class Model(nn.Module):
    def forward(self, x):
        return x + 1

model = Model()
compiled_model = torch.compile(model)

print(f"bool before compile: {bool(model)}")           # True
print(f"bool of _orig_mod after compile: {bool(compiled_model._orig_mod)}") # True
print(f"bool after compile: {bool(compiled_model)}")  # Affected versions: TypeError
```
Output:
```
bool before compile: True
bool of _orig_mod after compile: True
TypeError: Model does not support len()
```

**The fix**
Add `__bool__` to `OptimizedModule` and calls `bool(_orig_mod)`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98