### PR TITLE
[inductor] Disambiguate nested graph stream variables

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -1408,6 +1408,22 @@ class WhileLoopTests(TestCase):
         self.assertEqual(cnt.frame_count, 1, "only one compilation expected")
 
     @requires_gpu
+    def test_while_loop_cpp_wrapper(self):
+        def fn(x):
+            def cond_fn(a):
+                return a.sum() > 100
+
+            def body_fn(a):
+                return (a * 0.5,)
+
+            return torch.while_loop(cond_fn, body_fn, (x,))
+
+        x = torch.full((4,), 26.0, device=GPU_TYPE, dtype=torch.float32)
+        expected = fn(x)
+        actual = torch.compile(fn, fullgraph=True, options={"cpp_wrapper": True})(x)
+        self.assertEqual(actual, expected)
+
+    @requires_gpu
     @parametrize("device", ["cpu", GPU_TYPE])
     @parametrize("dynamic", [False, True])
     @parametrize("autograd", [False, True])

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1371,6 +1371,9 @@ class CppWrapperGpu(CppWrapperCpu):
         if V.graph.is_dual_wrapper_mode:
             return name
 
+        if graph_name:
+            name = f"{graph_name}_{name}"
+
         self.writeline(
             maybe_hipify_code_wrapper(
                 f"{self.device_codegen.cpp_stream_type()} {name};"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196224
* __->__ #196324

Fixes https://github.com/pytorch/pytorch/issues/193806

The C++ wrapper caches stream lookups by device and graph, but emitted every
graph-specific lookup with the same stream variable name. When both a while
loop condition and body launched GPU kernels, the generated function declared
stream0 twice in the same scope and failed to compile.

Include the nested graph name in JIT C++ stream variables so the declarations
match the existing cache scope. Keep pure AOTI and dual-wrapper stream names
unchanged, and cover a while loop whose condition and body both launch kernels.

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo