### PR TITLE
[XPU] Keep host-side XPU activity types out of kCpuTypes

### DIFF
--- a/test/cpp/profiler/test_mtia_activity_filter.cpp
+++ b/test/cpp/profiler/test_mtia_activity_filter.cpp
@@ -98,8 +98,6 @@ TEST(MtiaActivityFilterTest, CollectiveSelectionUsesFiltersAndAvailability) {
       libkineto::ActivityType::CPU_INSTANT_EVENT,
       libkineto::ActivityType::USER_ANNOTATION,
       libkineto::ActivityType::EXTERNAL_CORRELATION,
-      libkineto::ActivityType::XPU_RUNTIME,
-      libkineto::ActivityType::XPU_DRIVER,
       libkineto::ActivityType::CUDA_RUNTIME,
       libkineto::ActivityType::CUDA_DRIVER,
       libkineto::ActivityType::PYTHON_FUNCTION,

--- a/test/profiler/test_xpu_profiler.py
+++ b/test/profiler/test_xpu_profiler.py
@@ -135,6 +135,46 @@ class XpuProfilerTest(TestCase):
         if Verbose:
             print(p.key_averages().table())
 
+    @unittest.skipIf(not TEST_XPU, "test requires XPU")
+    def test_profiler_xpu_filter_excludes_driver(self):
+        # A fine-grained XPU request must be able to leave XPU_DRIVER out even
+        # when ProfilerActivity.CPU is requested alongside it: the CPU group is
+        # inserted unfiltered, so it must not carry the host-side XPU activity
+        # types itself.
+        a = torch.rand([8, 16], device="xpu")
+        b = torch.rand([16, 32], device="xpu")
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                {
+                    torch.profiler.ProfilerActivity.XPU: [
+                        "CONCURRENT_KERNEL",
+                        "XPU_RUNTIME",
+                    ]
+                },
+            ],
+        ) as p:
+            result = torch.matmul(a, b)
+
+        self.assertTrue(result.numel() > 0)
+
+        with tempfile.NamedTemporaryFile(mode="w+", delete=True) as tmp:
+            p.export_chrome_trace(tmp.name)
+            with open(tmp.name) as f:
+                data = json.load(f)
+
+        count_cats = defaultdict(int)
+        for event in data["traceEvents"]:
+            if event.get("ph") == "X":
+                count_cats[event.get("cat")] += 1
+
+        if Verbose:
+            print(f"{count_cats=}")
+
+        self.assertIn("kernel", count_cats)
+        self.assertIn("xpu_runtime", count_cats)
+        self.assertNotIn("xpu_driver", count_cats)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -29,8 +29,6 @@ const ActivityTypeMap kCpuTypes{
     {libkineto::ActivityType::CPU_INSTANT_EVENT,     "CPU_INSTANT_EVENT"},
     {libkineto::ActivityType::USER_ANNOTATION,       "USER_ANNOTATION"},
     {libkineto::ActivityType::EXTERNAL_CORRELATION,  "EXTERNAL_CORRELATION"},
-    {libkineto::ActivityType::XPU_RUNTIME,           "XPU_RUNTIME"},
-    {libkineto::ActivityType::XPU_DRIVER,            "XPU_DRIVER"},
     {libkineto::ActivityType::CUDA_RUNTIME,          "CUDA_RUNTIME"},
     {libkineto::ActivityType::CUDA_DRIVER,           "CUDA_DRIVER"},
     {libkineto::ActivityType::PYTHON_FUNCTION,       "PYTHON_FUNCTION"},
@@ -54,7 +52,9 @@ const ActivityTypeMap kXpuTypes{
     {libkineto::ActivityType::GPU_MEMSET,            "GPU_MEMSET"},
     {libkineto::ActivityType::GPU_USER_ANNOTATION,   "GPU_USER_ANNOTATION"},
     {libkineto::ActivityType::CONCURRENT_KERNEL,     "CONCURRENT_KERNEL"},
-    // XPU_RUNTIME and XPU_DRIVER appear in both kCpuTypes and kXpuTypes.
+    // The host-side XPU activities belong here only, not in kCpuTypes: the CPU
+    // group is inserted unfiltered and would put them back into a filtered XPU
+    // request that deliberately left them out.
     {libkineto::ActivityType::XPU_RUNTIME,           "XPU_RUNTIME"},
     {libkineto::ActivityType::XPU_DRIVER,            "XPU_DRIVER"},
     {libkineto::ActivityType::OVERHEAD,              "OVERHEAD"},


### PR DESCRIPTION
Related: #176351 — this closes a gap in the fine-grained activity filter added there.

## Why

`XPU_RUNTIME` and `XPU_DRIVER` were listed in **both** `kCpuTypes` and `kXpuTypes` in
`torch/csrc/profiler/kineto_shim.cpp`. The CPU group is always inserted *unfiltered* —
`insertActivities(ActivityType::CPU, kCpuTypes)` inserts every entry of the map — so the two
host-side XPU views were switched on whenever `ProfilerActivity.CPU` was requested, including
behind a fine-grained XPU request that deliberately left them out.

The consequence is that the per-activity filter added in #176351 cannot subtract them:

```python
with torch.profiler.profile(
    activities=[
        ProfilerActivity.CPU,
        {ProfilerActivity.XPU: ["CONCURRENT_KERNEL", "XPU_RUNTIME"]},
    ]
) as p:
    ...
```

still traced the whole Level Zero driver layer, because the CPU group had already re-enabled
`XPU_DRIVER`. A user who wants kernels and the runtime view but not the (very numerous) driver
records had no way to express that.

Nothing depended on the entries being in `kCpuTypes`:

* Where the events land is decided by `deviceTypeFromActivity()`, which maps `XPU_RUNTIME` and
  `XPU_DRIVER` to `c10::DeviceType::CPU` independently of these maps. The records stay on the CPU
  tracks exactly as before.
* A CPU-only profile does not reach the XPU plugin at all: `libkineto_init(cpuOnly=true)` no
  longer registers XPUPTI (pytorch/kineto#1511), so the entries could not produce anything there
  either.

The `CUDA_RUNTIME` / `CUDA_DRIVER` duplication is left alone — this PR only claims the XPU entries
are unnecessary. If that duplication is deliberate for CUDA, I would be glad to hear why, since
the same argument seems to apply.

## How

Drop the two entries from `kCpuTypes`. `kXpuTypes` keeps them, which is what
`ProfilerActivity.XPU` relies on, so the default XPU profile is unaffected. The now-false
"appear in both" comment is replaced by the reason they live in one map only.

`test_profiler_xpu_filter_excludes_driver` is added: with `ProfilerActivity.CPU` requested
unfiltered next to `{ProfilerActivity.XPU: ["CONCURRENT_KERNEL", "XPU_RUNTIME"]}`, the exported
trace must contain `kernel` and `xpu_runtime` records but no `xpu_driver` records. It fails
without this change.

## Behaviour change

`{ProfilerActivity.CPU: ["XPU_RUNTIME"]}` (or `"XPU_DRIVER"`) now raises `Unknown or non-member
activity type name` instead of being accepted. Those are not CPU-group activity types, so the
rejection is the intended behaviour of the filter, but it is a visible difference for anyone who
spelled the request that way.

## Verification

Intel Data Center GPU Max Series, two repetitions per configuration, identical build except for
`kineto_shim.cpp`. Counts of `ph: "X"` events per category in the exported Chrome trace:

| `activities=` | before | after |
| --- | --- | --- |
| `[CPU, XPU]` | cpu_op 51, kernel 17, xpu_runtime 17, xpu_driver 192 | unchanged |
| `[XPU]` | kernel 17, xpu_runtime 17, xpu_driver 192 | unchanged |
| `[CPU, {XPU: [CONCURRENT_KERNEL, GPU_MEMCPY, GPU_MEMSET, XPU_RUNTIME]}]` | xpu_driver 192 | xpu_driver 0, rest unchanged |

`test/profiler/test_xpu_profiler.py` passes, including the pre-existing
`test_profiler_xpu_driver`, which asserts that `xpu_driver` *is* collected for `[CPU, XPU]`.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10