### PR TITLE
[typing] Tighten Triton HOP value annotations

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3633,7 +3633,7 @@ class DynamoTritonHOPifier(TritonHOPifier):
             hints=[],
         )
 
-    def is_callable(self, maybe_callable: VariableTracker) -> bool:
+    def is_callable(self, maybe_callable: object) -> bool:
         return isinstance(
             maybe_callable, (NestedUserFunctionVariable, UserFunctionVariable)
         )

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -11,7 +11,7 @@ import threading
 import typing
 from collections import defaultdict
 from collections.abc import Callable, Sequence
-from typing import Any, Optional, Protocol, TYPE_CHECKING, TypeVar, Union
+from typing import Any, Optional, Protocol, TYPE_CHECKING, Union
 from typing_extensions import Never
 
 import sympy
@@ -73,8 +73,6 @@ if TYPE_CHECKING:
     TritonAutotunerType = Union[Autotuner]  # noqa: UP007
 
 log = logging.getLogger("torch._dynamo")
-
-_T = TypeVar("_T")
 
 # e.g. for a host-side Triton TMA API call ``create_2d_tma_descriptor(ptr, 50, 60, 32, 15, 4)``,
 # the metadata will look like ``("experimental", ([50, 60], [32, 15], 4))``
@@ -151,7 +149,7 @@ def maybe_unpack_host_tma_descriptor(
 
     from torch.fx.experimental.symbolic_shapes import statically_known_true
 
-    def matches(actual: Sequence[object], expected: Sequence[object]) -> bool:
+    def matches(actual: Sequence[IntLikeType], expected: Sequence[IntLikeType]) -> bool:
         # Sizes may be symbolic, so compare without installing guards.
         return len(actual) == len(expected) and all(
             a is b or statically_known_true(a == b) for a, b in zip(actual, expected)
@@ -2644,7 +2642,7 @@ class TracingTritonHOPifier(TritonHOPifier):
     def is_callable(self, maybe_callable: object) -> bool:
         return callable(maybe_callable)
 
-    def get_value(self, val: _T) -> _T:
+    def get_value(self, val: Any) -> Any:
         return val
 
     def call_grid(
@@ -2663,11 +2661,11 @@ class TracingTritonHOPifier(TritonHOPifier):
 
     def wrap_user_defined_obj(
         self,
-        user_obj: _T,
+        user_obj: Any,
         tx: Optional["InstructionTranslatorBase"],
         variable: Union["TritonKernelVariable", "TraceableTritonKernelWrapper"] | None,
         name: str,
-    ) -> _T:
+    ) -> Any:
         if tx is not None:
             raise AssertionError("tx must be None for TracingTritonHOPifier")
         return user_obj
@@ -2695,7 +2693,7 @@ class TracingTritonHOPifier(TritonHOPifier):
             raise AssertionError(f"configs must be a list, got {type(configs)}")
         return configs
 
-    def maybe_unpack_heuristic_result(self, result: _T) -> _T:
+    def maybe_unpack_heuristic_result(self, result: Any) -> Any:
         return result
 
     def check_grid(

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -11,7 +11,7 @@ import threading
 import typing
 from collections import defaultdict
 from collections.abc import Callable, Sequence
-from typing import Any, Optional, Protocol, TYPE_CHECKING, Union
+from typing import Any, Optional, Protocol, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import Never
 
 import sympy
@@ -74,6 +74,8 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("torch._dynamo")
 
+_T = TypeVar("_T")
+
 # e.g. for a host-side Triton TMA API call ``create_2d_tma_descriptor(ptr, 50, 60, 32, 15, 4)``,
 # the metadata will look like ``("experimental", ([50, 60], [32, 15], 4))``
 TMAExperimentalMetadata = tuple[
@@ -127,7 +129,9 @@ def maybe_unpack_tma_stable_metadata(
     return None
 
 
-def maybe_unpack_host_tma_descriptor(arg: Any) -> tuple[Any, TMAStableMetadata] | None:
+def maybe_unpack_host_tma_descriptor(
+    arg: object,
+) -> tuple[Tensor, TMAStableMetadata] | None:
     """Split a host-side (stable API) TMA descriptor into its base tensor and the
     metadata needed to rebuild it downstream. Returns None for non-descriptor args.
 
@@ -147,7 +151,7 @@ def maybe_unpack_host_tma_descriptor(arg: Any) -> tuple[Any, TMAStableMetadata] 
 
     from torch.fx.experimental.symbolic_shapes import statically_known_true
 
-    def matches(actual: Sequence[Any], expected: Sequence[Any]) -> bool:
+    def matches(actual: Sequence[object], expected: Sequence[object]) -> bool:
         # Sizes may be symbolic, so compare without installing guards.
         return len(actual) == len(expected) and all(
             a is b or statically_known_true(a == b) for a, b in zip(actual, expected)
@@ -197,7 +201,7 @@ TMADescriptorMetadata = dict[
 class KernelSideTable:
     id_to_kernel: dict[int, "TritonKernelType"] = {}
     kernel_to_id: dict["TritonKernelType", int] = {}
-    constant_args: dict[int, dict[str, Any]] = {}
+    constant_args: dict[int, dict[str, object]] = {}
     lock = threading.Lock()
 
     # Returns index on the table
@@ -220,14 +224,14 @@ class KernelSideTable:
 
     # Not every constant arg can be added to the graph. Use this side table
     # for constant args.
-    def add_constant_args(self, args: dict[str, Any]) -> int:
+    def add_constant_args(self, args: dict[str, object]) -> int:
         with self.lock:
             idx = len(self.constant_args)
             self.constant_args[idx] = args
             return idx
 
     # Returns the constant args
-    def get_constant_args(self, idx: int) -> dict[str, Any]:
+    def get_constant_args(self, idx: int) -> dict[str, object]:
         # No need to lock here as fetching from dict is atomic
         if idx not in self.constant_args:
             raise AssertionError(
@@ -372,7 +376,7 @@ def generate_ttir(
         else:
             ordered_args[name] = a
 
-    def is_stable_tensor_descriptor_arg(arg: Any) -> bool:
+    def is_stable_tensor_descriptor_arg(arg: object) -> bool:
         if has_triton_tensor_descriptor_host_tma():
             from triton.tools.tensor_descriptor import TensorDescriptor
 
@@ -380,7 +384,7 @@ def generate_ttir(
                 return True
         return False
 
-    def _is_constexpr_or_none(name: str, arg: Any) -> bool:
+    def _is_constexpr_or_none(name: str, arg: object) -> bool:
         param_idx = kernel.arg_names.index(name)
         return kernel.params[param_idx].is_constexpr or arg is None
 
@@ -397,7 +401,7 @@ def generate_ttir(
     # whereas `constexpr` are inlined, and None are excluded. We both preserve
     # scalars and tensors as this matters for "odd" ordering,
     # eg. [tensor, scalar, tensor].
-    def get_arg_names(name: str, arg: Any) -> list[str]:
+    def get_arg_names(name: str, arg: object) -> list[str]:
         if _is_constexpr_or_none(name, arg):
             return []
 
@@ -2008,7 +2012,7 @@ class TritonHOPifier:
     def raise_unsupported(self, msg: str) -> Never:
         raise NotImplementedError("abstract method")
 
-    def is_callable(self, maybe_callable: Any) -> bool:
+    def is_callable(self, maybe_callable: object) -> bool:
         raise NotImplementedError("abstract method")
 
     def get_value(self, val: Any) -> Any:
@@ -2144,7 +2148,7 @@ class TritonHOPifier:
             # The call to get_first_attr is to maintain backward-compatibility.
 
             def defaults_ok(
-                attr: str, alternates: tuple[str, ...], values: tuple[Any, ...]
+                attr: str, alternates: tuple[str, ...], values: tuple[object, ...]
             ) -> bool:
                 if attr not in defaults:
                     return True
@@ -2637,10 +2641,10 @@ class TracingTritonHOPifier(TritonHOPifier):
     def raise_unsupported(self, msg: str) -> Never:
         raise RuntimeError(msg)
 
-    def is_callable(self, maybe_callable: Any) -> bool:
+    def is_callable(self, maybe_callable: object) -> bool:
         return callable(maybe_callable)
 
-    def get_value(self, val: Any) -> Any:
+    def get_value(self, val: _T) -> _T:
         return val
 
     def call_grid(
@@ -2659,11 +2663,11 @@ class TracingTritonHOPifier(TritonHOPifier):
 
     def wrap_user_defined_obj(
         self,
-        user_obj: Any,
+        user_obj: _T,
         tx: Optional["InstructionTranslatorBase"],
         variable: Union["TritonKernelVariable", "TraceableTritonKernelWrapper"] | None,
         name: str,
-    ) -> Any:
+    ) -> _T:
         if tx is not None:
             raise AssertionError("tx must be None for TracingTritonHOPifier")
         return user_obj
@@ -2691,7 +2695,7 @@ class TracingTritonHOPifier(TritonHOPifier):
             raise AssertionError(f"configs must be a list, got {type(configs)}")
         return configs
 
-    def maybe_unpack_heuristic_result(self, result: Any) -> Any:
+    def maybe_unpack_heuristic_result(self, result: _T) -> _T:
         return result
 
     def check_grid(
@@ -2714,7 +2718,7 @@ class TracingTritonHOPifier(TritonHOPifier):
         Put them in the side table.
         """
 
-        def is_graphable(val: Any) -> bool:
+        def is_graphable(val: object) -> bool:
             return isinstance(val, (fx.node.base_types, fx.Node))
 
         non_graphable_args = {
@@ -2726,7 +2730,7 @@ class TracingTritonHOPifier(TritonHOPifier):
 
         return graphable_args, constant_args_idx
 
-    def is_dynamic_backend_option(self, value: Any) -> bool:
+    def is_dynamic_backend_option(self, value: object) -> bool:
         # Backend options are compile-time values. In proxy tracing, a value can
         # be a Proxy/Node directly or be nested inside a tuple/list option such
         # as backend_option=(sym_size,). Reject those unless the name is later


### PR DESCRIPTION
## Summary

- type Triton HOP constant side-table values as `object` instead of `Any`
- accept `object` in pure value classifiers while retaining concrete transform-method inputs
- keep host TMA descriptor unpacking typed as `Tensor` on the successful path
- preserve `IntLikeType` precision for symbolic descriptor size and stride comparisons

## Test plan

- `python -m py_compile torch/_higher_order_ops/triton_kernel_wrap.py torch/_dynamo/variables/functions.py`
- `lintrunner -a --skip PYREFLY torch/_higher_order_ops/triton_kernel_wrap.py torch/_dynamo/variables/functions.py`
- focused `pyrefly check` comparison: the same 55 pre-existing diagnostics before and after this change
- focused CUDA tests for constant arguments, tracing, dynamic backend options, heuristics, export serialization, and the Triton HOP path
- direct host-TMA descriptor check confirming base tensor identity and metadata are preserved

This PR was authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98