### PR TITLE
Remove redundant _device_t alias in torch.accelerator (#152952)

### DIFF
--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -7,9 +7,10 @@ from typing import Any
 from typing_extensions import deprecated
 
 import torch
+from torch.types import Device
 
 from . import random
-from ._utils import _device_t, _get_device_index
+from ._utils import _get_device_index
 from .graphs import Graph
 from .memory import (
     empty_cache,
@@ -160,7 +161,7 @@ current_device_idx.__doc__ = r"""
 
 
 @cache
-def get_device_capability(device: _device_t = None, /) -> dict[str, Any]:
+def get_device_capability(device: Device = None, /) -> dict[str, Any]:
     r"""Return the capability of the currently selected device.
 
     Args:
@@ -186,7 +187,7 @@ def get_device_capability(device: _device_t = None, /) -> dict[str, Any]:
     return torch._C._accelerator_getDeviceCapability(device_index)
 
 
-def set_device_index(device: _device_t, /) -> None:
+def set_device_index(device: Device, /) -> None:
     r"""Set the current device index to a given device.
 
     Args:
@@ -218,7 +219,7 @@ set_device_idx.__doc__ = r"""
     """
 
 
-def current_stream(device: _device_t = None, /) -> torch.Stream:
+def current_stream(device: Device = None, /) -> torch.Stream:
     r"""Return the currently selected stream for a given device.
 
     Args:
@@ -244,7 +245,7 @@ def set_stream(stream: torch.Stream) -> None:
     torch._C._accelerator_setStream(stream)
 
 
-def synchronize(device: _device_t = None, /) -> None:
+def synchronize(device: Device = None, /) -> None:
     r"""Wait for all kernels in all streams on the given device to complete.
 
     Args:

--- a/torch/accelerator/_utils.py
+++ b/torch/accelerator/_utils.py
@@ -1,10 +1,10 @@
 from collections.abc import Callable
 
 import torch
-from torch.types import Device as _device_t
+from torch.types import Device
 
 
-def _get_device_index(device: _device_t, optional: bool = False) -> int:
+def _get_device_index(device: Device, optional: bool = False) -> int:
     if isinstance(device, int):
         return device
     if isinstance(device, str):

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -2,8 +2,9 @@ from collections import OrderedDict
 from typing import Any
 
 import torch
+from torch.types import Device
 
-from ._utils import _device_t, _get_device_index
+from ._utils import _get_device_index
 
 
 __all__ = [
@@ -51,7 +52,7 @@ def _flatten_stats(result: list[tuple[str, Any]], prefix: str, value: Any) -> No
         result.append((prefix, value))
 
 
-def memory_stats(device_index: _device_t = None, /) -> OrderedDict[str, Any]:
+def memory_stats(device_index: Device = None, /) -> OrderedDict[str, Any]:
     r"""Return a dictionary of accelerator device memory allocator statistics for a given device index.
 
     The return value of this function is a dictionary of statistics, each of
@@ -124,7 +125,7 @@ def memory_stats(device_index: _device_t = None, /) -> OrderedDict[str, Any]:
     return OrderedDict(flat_stats)
 
 
-def memory_allocated(device_index: _device_t = None, /) -> int:
+def memory_allocated(device_index: Device = None, /) -> int:
     r"""Return the current :ref:`accelerator<accelerators>` device memory occupied by tensors
     in bytes for a given device index.
 
@@ -140,7 +141,7 @@ def memory_allocated(device_index: _device_t = None, /) -> int:
     return memory_stats(device_index).get("allocated_bytes.all.current", 0)
 
 
-def max_memory_allocated(device_index: _device_t = None, /) -> int:
+def max_memory_allocated(device_index: Device = None, /) -> int:
     r"""Return the current :ref:`accelerator<accelerators>` maximum device memory occupied by tensors
     in bytes for a given device index.
 
@@ -160,7 +161,7 @@ def max_memory_allocated(device_index: _device_t = None, /) -> int:
     return memory_stats(device_index).get("allocated_bytes.all.peak", 0)
 
 
-def memory_reserved(device_index: _device_t = None, /) -> int:
+def memory_reserved(device_index: Device = None, /) -> int:
     r"""Return the current :ref:`accelerator<accelerators>` device memory managed by the caching allocator
     in bytes for a given device index.
 
@@ -176,7 +177,7 @@ def memory_reserved(device_index: _device_t = None, /) -> int:
     return memory_stats(device_index).get("reserved_bytes.all.current", 0)
 
 
-def max_memory_reserved(device_index: _device_t = None, /) -> int:
+def max_memory_reserved(device_index: Device = None, /) -> int:
     r"""Return the current :ref:`accelerator<accelerators>` maximum device memory managed by the caching allocator
     in bytes for a given device index.
 
@@ -196,7 +197,7 @@ def max_memory_reserved(device_index: _device_t = None, /) -> int:
     return memory_stats(device_index).get("reserved_bytes.all.peak", 0)
 
 
-def reset_accumulated_memory_stats(device_index: _device_t = None, /) -> None:
+def reset_accumulated_memory_stats(device_index: Device = None, /) -> None:
     r"""Reset the "accumulated" (historical) stats tracked by the current :ref:`accelerator<accelerators>`
     memory allocator for a given device index.
 
@@ -215,7 +216,7 @@ def reset_accumulated_memory_stats(device_index: _device_t = None, /) -> None:
     return torch._C._accelerator_resetAccumulatedStats(device_index)
 
 
-def reset_peak_memory_stats(device_index: _device_t = None, /) -> None:
+def reset_peak_memory_stats(device_index: Device = None, /) -> None:
     r"""Reset the "peak" stats tracked by the current :ref:`accelerator<accelerators>`
     memory allocator for a given device index.
 
@@ -234,7 +235,7 @@ def reset_peak_memory_stats(device_index: _device_t = None, /) -> None:
     return torch._C._accelerator_resetPeakStats(device_index)
 
 
-def get_memory_info(device_index: _device_t = None, /) -> tuple[int, int]:
+def get_memory_info(device_index: Device = None, /) -> tuple[int, int]:
     r"""Return the current device memory information for a given device index.
 
     Args:

--- a/torch/accelerator/random.py
+++ b/torch/accelerator/random.py
@@ -1,10 +1,11 @@
 import torch
 from torch import Tensor
+from torch.types import Device
 
-from ._utils import _device_t, _get_device_index
+from ._utils import _get_device_index
 
 
-def initial_seed(device: _device_t = None, /) -> int:
+def initial_seed(device: Device = None, /) -> int:
     r"""Return the initial seed of the default :class:`torch.Generator` for the current :ref:`accelerator<accelerators>`
     on the specified device.
 
@@ -23,7 +24,7 @@ def initial_seed(device: _device_t = None, /) -> int:
     return default_generator.initial_seed()
 
 
-def get_rng_state(device: _device_t = None, /) -> Tensor:
+def get_rng_state(device: Device = None, /) -> Tensor:
     r"""Return the RNG state of the default :class:`torch.Generator` for the current :ref:`accelerator<accelerators>`
     as a `torch.Tensor` of dtype `torch.uint8` for the specified accelerator device.
 

--- a/torch/accelerator/random.py
+++ b/torch/accelerator/random.py
@@ -1,11 +1,11 @@
 import torch
 from torch import Tensor
-from torch.types import Device
+from torch.types import Device as _device_t
 
 from ._utils import _get_device_index
 
 
-def initial_seed(device: Device = None, /) -> int:
+def initial_seed(device: _device_t = None, /) -> int:
     r"""Return the initial seed of the default :class:`torch.Generator` for the current :ref:`accelerator<accelerators>`
     on the specified device.
 
@@ -24,7 +24,7 @@ def initial_seed(device: Device = None, /) -> int:
     return default_generator.initial_seed()
 
 
-def get_rng_state(device: Device = None, /) -> Tensor:
+def get_rng_state(device: _device_t = None, /) -> Tensor:
     r"""Return the RNG state of the default :class:`torch.Generator` for the current :ref:`accelerator<accelerators>`
     as a `torch.Tensor` of dtype `torch.uint8` for the specified accelerator device.
 


### PR DESCRIPTION
_device_t in torch/accelerator/_utils.py was just `Device` from torch.types re-exported under a different name. This continues the cleanup started by #161031 (which did the same for torch/cpu), moving on to the last remaining module still using the alias: torch.accelerator.

- torch/accelerator/_utils.py: drop the `as _device_t` re-export, import Device directly.
- torch/accelerator/__init__.py, memory.py, random.py: replace all _device_t annotations with Device, update imports accordingly.

No behavior change -- Device and _device_t were always the same type. torch.xpu, torch.mtia, and torch.cpu were already migrated by other contributors; this covers the one module (torch.accelerator) still using the old alias.

Fixes #152952