### PR TITLE
[inductor] Support multi-kernel for nested reductions

### DIFF
--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -2626,6 +2626,27 @@ class _NestedReductionBase:
 
         self._check_rejected(f, (torch.randn(4, 2048, device=GPU_TYPE),))
 
+    @inductor_config.patch("triton.multi_kernel", True)
+    @parametrize("staged", [False, True])
+    def test_multi_kernel(self, staged):
+        B, D, G = 32, 1024, 16
+
+        def f(x, weight):
+            y = F.rms_norm(x, (D,), weight)
+            yg = y.view(B, D // G, G)
+            scale = (yg.abs().amax(dim=-1) / 6.0).clamp(min=1e-12, max=448.0)
+            if not staged:
+                return scale
+            pairs = yg.view(B, D // G, G // 2, 2)
+            scale_f = scale.unsqueeze(-1)
+            return scale, pairs[..., 0] / scale_f, pairs[..., 1] / scale_f
+
+        args = (torch.randn(B, D, device=GPU_TYPE), torch.randn(D, device=GPU_TYPE))
+        self.check_nested_matches_unnested(f, args)
+        # A looped kernel has no persistent alternative to offer.
+        expected_kernels = 1 if self.force_persistent_outer_reduction is False else 2
+        self.check_fusion(expected_kernels)
+
 
 @inductor_config.patch("force_disable_caches", True)
 class NestedReductionTest(_NestedReductionBase, TestBase):
@@ -2692,10 +2713,12 @@ def _run_and_capture_source_bundle(
     kernel_signatures = (
         (kernel_signature,) if isinstance(kernel_signature, str) else kernel_signature
     )
+    # Match on the kernel's own name: a chunk runs up to the next decorator, so
+    # it trails the following kernel's definition header.
     kernel_codes = [
         kernel_code
         for kernel_code in TRITON_KERNEL_RE.findall(combined_code)
-        if any(signature in kernel_code for signature in kernel_signatures)
+        if _kernel_name(kernel_code).startswith(kernel_signatures)
         and _is_wrapper_launched_kernel(wrapper_code, kernel_code)
     ]
     return wrapper_code, kernel_codes
@@ -3232,6 +3255,20 @@ class _InternalsBase:
                 kernel_code
             )
 
+    def multi_kernel_wrapper_checks(self, min_rblock: int) -> FileCheck:
+        """Both reduction forms carry the nested metadata and share a dispatcher."""
+        if self.force_persistent_outer_reduction is False:
+            # A looped base kernel has no persistent alternative to offer.
+            return FileCheck().check_not("async_compile.multi_kernel(")
+        return (
+            FileCheck()
+            .check_count(f"'min_rblock': {min_rblock}", 2, exactly=True)
+            .check("async_compile.multi_kernel(")
+            .check("triton_red_fused")
+            .check("triton_per_fused")
+            .check("multi_kernel_0.run(")
+        )
+
     def assert_single_kernel_form(
         self,
         capture,
@@ -3245,6 +3282,7 @@ class _InternalsBase:
         min_xblock: int | None = None,
         min_rblock: int | None = None,
         extra_checks: FileCheck | None = None,
+        wrapper_checks: FileCheck | None = None,
     ) -> str:
         wrapper_code, kernel_code = capture(
             *capture_args,
@@ -3285,6 +3323,8 @@ class _InternalsBase:
         )
         if extra_checks is not None:
             extra_checks.run(kernel_code)
+        if wrapper_checks is not None:
+            wrapper_checks.run(wrapper_code)
         return kernel_code
 
     def test_layernorm_block_amax_kernel_form(self):
@@ -3358,6 +3398,7 @@ class _InternalsBase:
             meta_num_load=self.looped_or_persistent(3, 2),
             min_rblock=16,
             extra_checks=FileCheck().check_not("tl.split("),
+            wrapper_checks=self.multi_kernel_wrapper_checks(16),
         )
 
     def test_producer_consumer_scale_kernel_form(self):
@@ -3607,6 +3648,7 @@ class _InternalsBase:
                 if self.force_persistent_outer_reduction is False
                 else FileCheck().check_count("tl.split(", 1, exactly=True)
             ),
+            wrapper_checks=self.multi_kernel_wrapper_checks(2),
         )
 
     @inductor_config.patch(benchmark_kernel=True)
@@ -3710,6 +3752,37 @@ class NestedReductionAOTITest(TestCase):
                 inductor_configs={
                     "loop_ordering_after_fusion": True,
                     "triton.nested_reduction": True,
+                },
+            )
+            compiled = torch._inductor.aoti_load_package(package_path)
+            actual = compiled(x)
+
+        self.assertEqual(actual, expected, atol=1e-2, rtol=1e-2)
+        self.assertEqual(metrics.codegen_nested_reduction, 1)
+
+    def test_rmsnorm_block_amax_multi_kernel(self):
+        """cpp-wrapper resolves the multi-kernel choice at compile time."""
+        B, D, G = 8, 1024, 32
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                normalized = _rmsnorm(x)
+                block_amax = normalized.reshape(B, D // G, G).abs().amax(dim=-1)
+                return normalized, block_amax
+
+        model = Model()
+        x = torch.randn(B, D, device=GPU_TYPE)
+        expected = model(x)
+        metrics.reset()
+        with fresh_inductor_cache():
+            exported = torch.export.export(model, (x,))
+            package_path = torch._inductor.aoti_compile_and_package(
+                exported,
+                inductor_configs={
+                    "loop_ordering_after_fusion": True,
+                    "triton.nested_reduction": True,
+                    "triton.multi_kernel": True,
+                    "triton.autotune_at_compile_time": True,
                 },
             )
             compiled = torch._inductor.aoti_load_package(package_path)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -3687,140 +3687,145 @@ class SIMDScheduling(BaseScheduling):
             "features": kernel_features,
             "override_cooperative_reduction": False,
             "tiling_scores": tiling_score,
-            "disable_multi_kernel": True,
         }
-        kernel = cast(
-            "TritonKernel",
+        kernels = cast(
+            "list[TritonKernel]",
             self.create_kernel_choices(
                 kernel_features,
                 [tiling],
                 kernel_kwargs,
-            )[0],
+            ),
         )
 
-        if local_reduction_in_r:
-            kernel.min_rblock = local_reduction_size_hint
-        else:
-            kernel.min_xblock = local_reduction_size_hint
+        for kernel in kernels:
+            if local_reduction_in_r:
+                kernel.min_rblock = local_reduction_size_hint
+            else:
+                kernel.min_xblock = local_reduction_size_hint
 
-        with kernel:
-            layout: _GroupedReductionLayout = _GroupedReductionLayout.from_kernel(
-                kernel,
-                local_reduction_size,
-                local_reduction_in_r,
-            )
-            sub_parent_family: _DerivedIterationFamily | None = None
-            value_resolver: _SubParentValueResolver | None = None
-            if sub_parent_stage is not None:
-                sub_parent_family = layout.make_sub_parent_family(
-                    sub_parent_stage.factor
-                )
-                value_resolver = _SubParentValueResolver(
-                    V.get_ops_handler(),
+            with kernel:
+                layout: _GroupedReductionLayout = _GroupedReductionLayout.from_kernel(
                     kernel,
-                    layout,
-                    sub_parent_family,
-                    access_relations=sub_parent_stage.access_relations,
-                    sub_parent_factor=sub_parent_stage.factor,
+                    local_reduction_size,
+                    local_reduction_in_r,
                 )
-            with V.set_ops_handler(value_resolver or V.get_ops_handler()):
-                self._codegen_node_schedule_body(combined_schedule, kernel)
-            # Flush the outer reduction code:
-            # - Persistent: one pass, no loops
-            # - Looped: disable_reduction already flushed loop 1
-            #   and post-loop code, but pending buffers may still have the next
-            #   pass. Flush it now so later nested stages can consume it.
-            kernel.codegen_body()
+                sub_parent_family: _DerivedIterationFamily | None = None
+                value_resolver: _SubParentValueResolver | None = None
+                if sub_parent_stage is not None:
+                    sub_parent_family = layout.make_sub_parent_family(
+                        sub_parent_stage.factor
+                    )
+                    value_resolver = _SubParentValueResolver(
+                        V.get_ops_handler(),
+                        kernel,
+                        layout,
+                        sub_parent_family,
+                        access_relations=sub_parent_stage.access_relations,
+                        sub_parent_factor=sub_parent_stage.factor,
+                    )
+                with V.set_ops_handler(value_resolver or V.get_ops_handler()):
+                    self._codegen_node_schedule_body(combined_schedule, kernel)
+                # Flush the outer reduction code:
+                # - Persistent: one pass, no loops
+                # - Looped: disable_reduction already flushed loop 1
+                #   and post-loop code, but pending buffers may still have the next
+                #   pass. Flush it now so later nested stages can consume it.
+                kernel.codegen_body()
 
-            group_reduction_vars = layout.construct_group_reduction_vars(
-                grouped_reduction_body
-            )
-            reduced_output_family = layout.make_reduced_output_family(
-                group_reduction_vars
-            )
-            parent_full_family = layout.make_parent_full_family()
-            local_reduction_source: _IterationSpace = (
-                self._local_reduction_iteration_values(
-                    grouped_reduction_body,
-                    group_reduction_vars.iter_remapped,
-                    group_reduction_vars.reduce_remapped,
+                group_reduction_vars = layout.construct_group_reduction_vars(
+                    grouped_reduction_body
                 )
-            )
-            parent_full_source: _IterationSpace = layout.parent_full_iteration_values(
-                group_reduction_vars
-            )
-            with V.set_ops_handler(value_resolver or V.get_ops_handler()):
-                self._codegen_remapped_pointwise(
-                    kernel,
-                    outer_local_reduction_pointwise,
-                    parent_full_family,
-                    local_reduction_source,
-                    load_transform=_ParentFullLoadTransform(kernel, layout),
+                reduced_output_family = layout.make_reduced_output_family(
+                    group_reduction_vars
                 )
-                self._codegen_nested_grouped_schedule(
-                    kernel,
-                    grouped_schedule,
-                    grouped_reduction,
-                    layout,
-                    group_reduction_vars,
-                    local_reduction_source,
-                    parent_full_source,
-                    pointwise_domain_by_node,
-                    reduced_output_family,
-                    parent_full_family,
+                parent_full_family = layout.make_parent_full_family()
+                local_reduction_source: _IterationSpace = (
+                    self._local_reduction_iteration_values(
+                        grouped_reduction_body,
+                        group_reduction_vars.iter_remapped,
+                        group_reduction_vars.reduce_remapped,
+                    )
                 )
-            if sub_parent_stage is not None:
-                if sub_parent_family is None or value_resolver is None:
-                    raise AssertionError("sub-parent stage requires its codegen state")
-                value_resolver.materialize_sources(
-                    relation
-                    for relation in sub_parent_stage.access_relations
-                    if relation.parent_lane is not None
+                parent_full_source: _IterationSpace = (
+                    layout.parent_full_iteration_values(group_reduction_vars)
                 )
-                self._codegen_sub_parent_output_groups(
-                    kernel,
-                    sub_parent_stage,
-                    layout,
-                    sub_parent_family,
-                    value_resolver,
-                )
+                with V.set_ops_handler(value_resolver or V.get_ops_handler()):
+                    self._codegen_remapped_pointwise(
+                        kernel,
+                        outer_local_reduction_pointwise,
+                        parent_full_family,
+                        local_reduction_source,
+                        load_transform=_ParentFullLoadTransform(kernel, layout),
+                    )
+                    self._codegen_nested_grouped_schedule(
+                        kernel,
+                        grouped_schedule,
+                        grouped_reduction,
+                        layout,
+                        group_reduction_vars,
+                        local_reduction_source,
+                        parent_full_source,
+                        pointwise_domain_by_node,
+                        reduced_output_family,
+                        parent_full_family,
+                    )
+                if sub_parent_stage is not None:
+                    if sub_parent_family is None or value_resolver is None:
+                        raise AssertionError("sub-parent stage requires codegen state")
+                    value_resolver.materialize_sources(
+                        relation
+                        for relation in sub_parent_stage.access_relations
+                        if relation.parent_lane is not None
+                    )
+                    self._codegen_sub_parent_output_groups(
+                        kernel,
+                        sub_parent_stage,
+                        layout,
+                        sub_parent_family,
+                        value_resolver,
+                    )
 
-            kernel.codegen_body()
+                kernel.codegen_body()
 
-        self._finalize_nested_reduction_kernel(
-            kernel,
+        self._finalize_nested_reduction_kernels(
+            kernels,
             combined_schedule,
             node.get_nodes(),
             indexing_schedule,
         )
 
-    def _finalize_nested_reduction_kernel(
+    def _finalize_nested_reduction_kernels(
         self,
-        kernel,
+        kernels,
         combined_schedule,
         nodes_to_mark,
         config_patch_schedule=None,
     ) -> None:
+        MultiKernel.merge_workspaces_inplace(kernels)
         config_patches = self._collect_config_patches(
             config_patch_schedule or combined_schedule
         )
-        with V.set_kernel_handler(kernel), config.patch(**config_patches):
-            src_code = kernel.codegen_kernel()
-        kernel.kernel_name = self.define_kernel(
-            src_code,
-            combined_schedule,
-            kernel,
-        )
-        kernel.code_hash = code_hash(src_code)
+        for kernel in kernels:
+            with V.set_kernel_handler(kernel), config.patch(**config_patches):
+                src_code = kernel.codegen_kernel()
+            kernel.kernel_name = self.define_kernel(
+                src_code,
+                combined_schedule,
+                kernel,
+            )
+            kernel.code_hash = code_hash(src_code)
 
-        with V.set_kernel_handler(kernel):
+        final_kernel: SIMDKernel | MultiKernel = (
+            MultiKernel(kernels) if len(kernels) > 1 else kernels[0]
+        )
+        with V.set_kernel_handler(final_kernel):
             for sn in nodes_to_mark:
                 sn.mark_run()
 
         base_scheduler_nodes = [
             node for node in combined_schedule if isinstance(node, BaseSchedulerNode)
         ]
-        self._launch_kernel_and_cleanup(kernel, base_scheduler_nodes)
+        self._launch_kernel_and_cleanup(final_kernel, base_scheduler_nodes)
 
     def _codegen_nested_grouped_schedule(
         self,
@@ -4138,49 +4143,49 @@ class SIMDScheduling(BaseScheduling):
             "features": kernel_features,
             "tiling_scores": tiling_score,
             "override_cooperative_reduction": False,
-            "disable_multi_kernel": True,
         }
-        kernel = cast(
-            "TritonKernel",
-            self.create_kernel_choices(kernel_features, [tiling], kernel_kwargs)[0],
+        kernels = cast(
+            "list[TritonKernel]",
+            self.create_kernel_choices(kernel_features, [tiling], kernel_kwargs),
         )
         metrics.codegen_nested_reduction += 1
         sub_parent_factor = stage.factor
         parent_rnumel = plan.parent_rnumel
-        kernel.min_rblock = sub_parent_factor
-        if len(kernel.range_trees) != 2:
-            raise AssertionError("sub-parent codegen requires a 2D kernel")
-        layout = _GroupedReductionLayout.from_kernel(
-            kernel,
-            parent_rnumel,
-            local_reduction_in_r=True,
-        )
-        sub_parent_family = layout.make_sub_parent_family(sub_parent_factor)
-        with kernel:
-            value_resolver = _SubParentValueResolver(
-                V.get_ops_handler(),
+        for kernel in kernels:
+            kernel.min_rblock = sub_parent_factor
+            if len(kernel.range_trees) != 2:
+                raise AssertionError("sub-parent codegen requires a 2D kernel")
+            layout = _GroupedReductionLayout.from_kernel(
                 kernel,
-                layout,
-                sub_parent_family,
-                access_relations=stage.access_relations,
-                sub_parent_factor=sub_parent_factor,
+                parent_rnumel,
+                local_reduction_in_r=True,
             )
-            with V.set_ops_handler(value_resolver):
-                self._codegen_node_schedule_body(parent_schedule, kernel)
-            if not required_lane_relations:
+            sub_parent_family = layout.make_sub_parent_family(sub_parent_factor)
+            with kernel:
+                value_resolver = _SubParentValueResolver(
+                    V.get_ops_handler(),
+                    kernel,
+                    layout,
+                    sub_parent_family,
+                    access_relations=stage.access_relations,
+                    sub_parent_factor=sub_parent_factor,
+                )
+                with V.set_ops_handler(value_resolver):
+                    self._codegen_node_schedule_body(parent_schedule, kernel)
+                if not required_lane_relations:
+                    kernel.codegen_body()
+                else:
+                    value_resolver.materialize_sources(required_lane_relations)
+                self._codegen_sub_parent_output_groups(
+                    kernel,
+                    stage,
+                    layout,
+                    sub_parent_family,
+                    value_resolver,
+                )
                 kernel.codegen_body()
-            else:
-                value_resolver.materialize_sources(required_lane_relations)
-            self._codegen_sub_parent_output_groups(
-                kernel,
-                stage,
-                layout,
-                sub_parent_family,
-                value_resolver,
-            )
-            kernel.codegen_body()
 
-        self._finalize_nested_reduction_kernel(kernel, combined_schedule, nodes)
+        self._finalize_nested_reduction_kernels(kernels, combined_schedule, nodes)
 
     def codegen_node(
         self, node: scheduler.FusedSchedulerNode | scheduler.SchedulerNode

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -8662,15 +8662,12 @@ class TritonScheduling(SIMDScheduling):
             # TODO(jansel): scan does not yet work with cooperative reductions
             kernel_kwargs["override_cooperative_reduction"] = False
 
-        disable_multi_kernel = kernel_kwargs.pop("disable_multi_kernel", False)
         kernel_type.apply_feature_required_overrides(kernel_features, kernel_kwargs)
 
         kernel_kwargs = V.choices.triton_kernel_kwargs(
             kernel_type, kernel_features, kernel_args, kernel_kwargs
         )
         kernel = kernel_type(*kernel_args, **kernel_kwargs)
-        if disable_multi_kernel:
-            return [kernel]
         return self.add_multi_kernel_choices(kernel, kernel_args, kernel_kwargs)
 
     def add_multi_kernel_choices(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196334
* __->__ #196333
* #196332

Nested reduction codegen pinned itself to the first kernel choice
(disable_multi_kernel at both the grouped and standalone sub-parent
sites), so a shape that lands over the persistent threshold could only
get the looped form. For RMSNorm -> MXFP8 at widths 2048-4096 the looped
form is 7-16% slower than not fusing, while the persistent form is 8-20%
faster.

Both sites now iterate create_kernel_choices like codegen_node_schedule,
rebuilding per-kernel state (min_rblock/min_xblock, grouped layout, value
resolver) for each choice; the finalizer merges workspaces and wraps
multiple kernels in MultiKernel, which benchmarks and picks at runtime.
Only looped and persistent forms are produced, and only from a persistent
base. The disable_multi_kernel kwarg had no other user and is removed.

Test Plan: python test/inductor/test_nested_reduction.py,
test_multi_kernel.py, test_loop_ordering.py. The *_multi_kernel_form
tests now check both forms and the dispatcher. Also fixes the test
harness's TRITON_KERNEL_RE chunk filter, which matched the looped kernel
against the persistent signature once two forms existed.

Authored with an AI assistant.

(cherry picked from commit a30f04c119db0d7e6db6049fc8d37e3aab9b6793)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo