### PR TITLE
[inductor] Hoist sub-parent epilogues through single-owner mutations

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -151,6 +151,15 @@ class TestScheduler(TestCase):
         node.ancestors = OrderedSet(ancestors)
         node.get_operation_names.return_value = OrderedSet([name])
         node.get_buffer_names.return_value = OrderedSet(writes)
+
+        def make_output(buf_name):
+            buf = Mock()
+            buf.get_name.return_value = buf_name
+            buf.get_aliases.return_value = ()
+            buf.get_mutations.return_value = ()
+            return buf
+
+        node.get_outputs.return_value = tuple(make_output(w) for w in writes)
         node.is_reduction.return_value = is_reduction
         if is_reduction:
             node.__class__ = SchedulerNode
@@ -1372,8 +1381,6 @@ class TestScheduler(TestCase):
             writes=("packed",),
             ancestors=("writer", "grouped"),
         )
-        for node in (outer_reduction, writer, grouped, epilogue):
-            node.has_aliasing_or_mutation.return_value = False
         outer = Mock()
         outer.get_nodes.return_value = (outer_reduction, writer)
         outer.group = (None, (8, 16))

--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -1194,7 +1194,7 @@ class _NestedReductionBase:
         self.assertEqual(metrics.codegen_nested_reduction, 1)
         self.assertGreater(metrics.generated_kernel_count, 1)
 
-    def test_producer_consumer_rejects_sub_parent_mutation(self):
+    def test_producer_consumer_sub_parent_mutation(self):
         B, D, G = 32, 1024, 16
 
         def f(x, weight, out):
@@ -1213,8 +1213,7 @@ class _NestedReductionBase:
         actual = torch.compile(f, fullgraph=True)(x, weight, out)
         self.assertEqual(actual, expected)
         self.assertEqual(out, ref_out)
-        self.assertEqual(metrics.codegen_nested_reduction, 1)
-        self.assertEqual(metrics.generated_kernel_count, 2)
+        self.check_fusion()
 
     def test_producer_consumer_sub_parent_source_mutated_later(self):
         B, D, G = 8, 1024, 16
@@ -2395,7 +2394,7 @@ class _NestedReductionBase:
         self.check_nested_matches_unnested(f, (x,))
         self.check_fusion()
 
-    def test_standalone_sub_parent_rejects_mutation(self):
+    def test_standalone_sub_parent_mutation(self):
         B, D, G = 32, 1024, 16
 
         def f(x, out):
@@ -2412,8 +2411,28 @@ class _NestedReductionBase:
         act_scale = torch.compile(f, fullgraph=True)(x, out)
         self.assertEqual(act_scale, ref_scale, atol=1e-2, rtol=1e-2)
         self.assertEqual(out, ref_out, atol=1e-2, rtol=1e-2)
+        self.check_fusion()
+
+    def test_standalone_sub_parent_rejects_shared_mutation_target(self):
+        """Two epilogues storing into one destination cannot both be hoisted."""
+        B, D, G = 32, 1024, 16
+
+        def f(x, out):
+            xg = x.view(B, D // G, G)
+            scale = (xg.float().abs().amax(dim=-1) / 6.0).clamp(min=1e-12, max=448.0)
+            pairs = xg.view(B, D // G, G // 2, 2)
+            out[..., :4].copy_(pairs[..., 0].float()[..., :4] / scale.unsqueeze(-1))
+            out[..., 4:].copy_(pairs[..., 1].float()[..., 4:] / scale.unsqueeze(-1))
+            return scale
+
+        x = torch.randn(B, D, device=GPU_TYPE, dtype=torch.bfloat16)
+        out = torch.randn(B, D // G, G // 2, device=GPU_TYPE)
+        ref_out = out.clone()
+        ref_scale = f(x, ref_out)
+        act_scale = torch.compile(f, fullgraph=True)(x, out)
+        self.assertEqual(act_scale, ref_scale, atol=1e-2, rtol=1e-2)
+        self.assertEqual(out, ref_out, atol=1e-2, rtol=1e-2)
         self.check_no_fusion()
-        self.assertGreater(metrics.generated_kernel_count, 1)
 
     def test_fullres_x_epilogue_rejects_intermediate_dependency(self):
         """Do not fuse a full-res consumer before its extra producer."""

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -655,6 +655,51 @@ class NestedReduction:
         )
 
     @classmethod
+    def _mutations_survive_hoisting(
+        cls,
+        nodes: Sequence[BaseSchedulerNode],
+        group: Sequence[BaseSchedulerNode] | None = None,
+    ) -> bool:
+        """Whether ``nodes``' aliasing and mutation survive sub-parent hoisting.
+
+        Hoisting an epilogue into the parent kernel moves its stores relative to
+        the rest of the group, so a mutation is only safe when no other node
+        there touches that storage. ``group`` defaults to ``nodes`` and must
+        cover everything sharing the fused kernel, since a node outside the
+        hoisted set observes the reordering just the same; ordering against
+        nodes outside the kernel is already carried by dependency edges.
+
+        Both names for the storage are claimed. The mutator keeps the
+        pre-mutation one -- its own StarDep self-edge and any read-modify-write
+        hoist along with it, so only another node reading that name is a
+        hazard -- while later nodes see the post-mutation name via
+        Scheduler.mutation_renames. In practice functionalization leaves one
+        mutator per buffer and no post-mutation reader, so only the
+        pre-mutation read rejects today; the rest keep this conservative rather
+        than wrong if that ever changes. Aliasing stays rejected outright: the
+        lane index math assumes each store owns its destination.
+        """
+        owners: dict[str, BaseSchedulerNode] = {}
+        for node in nodes:
+            for buf in node.get_outputs():
+                if buf.get_aliases():
+                    return False
+                if not buf.get_mutations():
+                    continue
+                for name in (*buf.get_mutations(), buf.get_name()):
+                    # A second node on the same storage makes their relative
+                    # order load-bearing, which hoisting does not preserve.
+                    if owners.setdefault(name, node) is not node:
+                        return False
+        if not owners:
+            return True
+        return all(
+            owners.get(dep.name, node) is node
+            for node in (nodes if group is None else group)
+            for dep in node.read_writes.reads_and_writes()
+        )
+
+    @classmethod
     def sub_parent_epilogue_plan(
         cls,
         nodes: Sequence[BaseSchedulerNode],
@@ -668,8 +713,7 @@ class NestedReduction:
         [Sub-parent reduction epilogues].
         """
         parent_rnumel = V.graph.sizevars.simplify(rnumel)
-        # TODO: No fundamental limitation; track aliases and mutation versions here.
-        if any(node.has_aliasing_or_mutation() for node in nodes):
+        if not cls._mutations_survive_hoisting(nodes):
             return None
         if not all(isinstance(node, SchedulerNode) for node in nodes):
             return None
@@ -1804,8 +1848,8 @@ class NestedReduction:
         )
         if not sub_parent_nodes:
             return None
-        # TODO: No fundamental limitation; track aliases and mutation versions here.
-        if any(node.has_aliasing_or_mutation() for node in sub_parent_nodes):
+        kernel_nodes = (outer_node, *grouped_nodes)
+        if not cls._mutations_survive_hoisting(sub_parent_nodes, kernel_nodes):
             return None
 
         candidates: list[SubParentEpilogueCandidate] = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196334
* #196333
* #196332

Sub-parent epilogue planning bailed on any node with aliasing or
mutation. A quantize tail scatters its packed payload into a preallocated
destination, so it mutates by construction, and the fusion this pass
exists for was always discarded: the reduction ran, then the payload ran
again as its own kernel.

Hoisting only reorders stores within the fused kernel, so the real
requirement is narrower than "no mutation": no other node in the kernel
may touch the mutated storage. _mutations_survive_hoisting checks exactly
that. It claims both of the buffer's names (the mutator still sees the
pre-rename name while later nodes see the post-rename one) and ignores
the mutator's StarDep self-edge, which is bookkeeping rather than a read.
Aliasing stays rejected: the lane index math assumes each store owns its
destination. The second bail site now scans the whole kernel group, not
just the hoisted nodes. Mutation-version tracking (the removed TODO) is
unnecessary because functionalization leaves one mutator per buffer and
no post-mutation reader.

Perf (208-cell padded-blocked-scale matrix, CUDA graphs): 32 cells drop a
kernel, none rise.

  dcn_mxfp6     2048x3072    9.52us -> 8.58us
  mxfp6_quant   95x3072      3.23us -> 2.53us
  rmsnorm_mxfp6 2048x3072    13.66us -> 12.70us

Test Plan: python test/inductor/test_nested_reduction.py. New
test_standalone_sub_parent_rejects_shared_mutation_target covers the one
rejection reachable through a real graph: two slice-copy_ epilogues into
one destination.

Authored with assistance from Claude Code.

(cherry picked from commit e5196889c55fc409b6878ba13f35ad714f97a0e9)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo