### PR TITLE
[inductor] Iterate the loop-reordering fusion round to a fixpoint

### DIFF
--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -2666,6 +2666,33 @@ class _NestedReductionBase:
         expected_kernels = 1 if self.force_persistent_outer_reduction is False else 2
         self.check_fusion(expected_kernels)
 
+    def test_standalone_flat_reshape_pack_fuses(self):
+        """A torchao-style FP4 quantizer fuses into one kernel.
+
+        The codes are built from the flat (M, K) view, so their block-scale
+        read carries a FloorDiv and only the loop-reordering fusion round joins
+        them to the reduction. The nibble pack can join only if that round is
+        repeated until nothing changes.
+        """
+        M, K, G = 2048, 3072, 32
+
+        def f(x):
+            blocks = x.view(M, K // G, G)
+            amax = blocks.abs().amax(dim=-1).unsqueeze(-1).float()
+            exponent = ((amax.view(torch.int32) >> 23) & 0xFF) - 127 - 2
+            biased = (exponent.clamp(-127, 128) + 127).to(torch.uint8)
+            biased = torch.where(torch.isnan(amax), 255, biased)
+            scale = ((biased.to(torch.int32) << 23).view(torch.float32)).clamp_min(
+                2.0**-126
+            )
+            codes = (blocks.float() / scale).reshape(M, K).clamp(0, 15).to(torch.uint8)
+            flat = codes.contiguous().view(-1)
+            return (flat[::2] | (flat[1::2] << 4)).view(M, K // 2), biased.squeeze(-1)
+
+        x = torch.randn(M, K, device=GPU_TYPE, dtype=torch.bfloat16)
+        self.check_nested_matches_unnested(f, (x,))
+        self.check_fusion()
+
 
 @inductor_config.patch("force_disable_caches", True)
 class NestedReductionTest(_NestedReductionBase, TestBase):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6888,7 +6888,13 @@ class Scheduler:
                 config.loop_ordering_after_fusion
                 or config.loop_index_inversion_in_fusion
             ):
-                nodes = self.fuse_nodes_once(nodes, is_reorder_round=True)
+                # A reordered fusion can expose a further fusion with the new
+                # fused node, so iterate like the plain rounds above.
+                for _ in range(10):
+                    old_len = len(nodes)
+                    nodes = self.fuse_nodes_once(nodes, is_reorder_round=True)
+                    if len(nodes) == old_len or len(nodes) == 1:
+                        break
             return nodes
 
     def process_grouped_nodes(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196335
* #196334
* #196333
* #196332

Scheduler.fuse_nodes runs the plain fusion round up to ten times until the
node count stops changing, then runs the loop-reordering round exactly
once. A fusion found by reordering can expose a further fusion with the
newly fused node, and nothing retries it.

The concrete case is the torchao-style FP4 quantizer that QuACK ships: the
FP4 codes are built from the flat (M, K) reshape, so the codes node reads
the per-block scale at 96*d0 + d1//32. The plain rounds cannot match that
against the reduction's write, see "no shared data", and leave reduction
and codes apart. The single reordering round joins them by re-splitting the
codes node's ranges, but the nibble pack can only fuse with the result of
that fusion through the standalone sub-parent planner, and there is no
further round to offer it. Iterating the reordering round like the plain
rounds lets the pack join: standalone to_mxfp4 goes from two kernels to
one, 27-31% faster at 2048x3072 / 8192x4096 / 65536x2048 bf16, byte-exact.

Formulations that build the pairs from the blocked view never hit this;
their first round already fuses everything, so this only matters for code
written the torchao way. The loop is bounded like the plain one.
test_torchinductor's failure set is byte-identical to a same-tree baseline.

Test Plan:

New test_standalone_flat_reshape_pack_fuses mirrors the torchao quantizer
(flat codes, e8m0 scale, flat-view nibble pack) and asserts one kernel; it
fails on main with two.

```
python test/inductor/test_nested_reduction.py
python test/inductor/test_loop_ordering.py
python test/inductor/test_torchinductor.py
```

Authored with an AI assistant.

(cherry picked from commit adb23a4d46408b1ac90ebd670ff4fe2675534cd8)