### PR TITLE
[FakeTensor] Fix the dead accelerator guard in init_gpu_context

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -684,6 +684,100 @@ class FakeTensorTest(TestCase):
             fake_tensor.fake_device = torch.device("cuda")
             self.assertEqual(fake_tensor.fake_device, torch.device("cuda:0"))
 
+    def test_init_gpu_context_only_for_current_accelerator(self):
+        """The warmup allocation targets the accelerator device, only when it
+        matches the current accelerator, and stays REAL under the dispatch
+        states FakeTensor construction can hold (FakeTensorMode pushed and
+        in_kernel_invocation_manager's meta TLS include set)."""
+        from torch._subclasses import fake_tensor as ft
+
+        def attempts_for(accel, device, ctx=None):
+            attempts = []
+            results = []
+            meta_tls = []
+            real_empty = torch.empty
+            real_zeros = torch.zeros
+
+            def spy(*args, **kwargs):
+                attempts.append(kwargs.get("device"))
+                meta_tls.append(torch._C._meta_in_tls_dispatch_include())
+                if torch.version.hip is None:
+                    out = real_empty(*args, **kwargs)
+                else:
+                    out = real_zeros(*args, **kwargs)
+                results.append(out)
+                return out
+
+            ft.init_gpu_context.cache_clear()
+            with (
+                patch(
+                    "torch.accelerator.current_accelerator",
+                    lambda check_available=False: accel,
+                ),
+                patch.object(torch, "empty", spy),
+                patch.object(torch, "zeros", spy),
+            ):
+                if ctx is None:
+                    FakeTensor._normalize_fake_device(device)
+                else:
+                    with ctx:
+                        FakeTensor._normalize_fake_device(device)
+            return attempts, results, meta_tls
+
+        def assert_real_warmup(accel, device, ctx=None):
+            attempts, results, meta_tls = attempts_for(accel, device, ctx=ctx)
+            self.assertEqual(attempts, [torch.device(device)])
+            # The allocation must be a real tensor, not a FakeTensor: a meta
+            # kernel or mode interception would leave the accelerator context
+            # uninitialized while functools.cache records it as warmed up.
+            self.assertEqual(len(results), 1)
+            self.assertNotIsInstance(results[0], FakeTensor)
+            self.assertEqual(results[0].device.type, torch.device(device).type)
+            # The meta TLS include set must be cleared at allocation time: with
+            # a non-meta accelerator held under in_kernel_invocation_manager,
+            # leaving it set diverts torch.empty to the meta kernel.
+            self.assertEqual(meta_tls, [False])
+
+        meta = torch.device("meta")
+        # Accelerator matches: allocation requested on that device, real.
+        assert_real_warmup(meta, meta)
+        # Under an avoid_device_init mode, FakeTensorMode.__enter__ sets
+        # only_lift_cpu_tensors, whose contract forbids materializing on
+        # device, so the warmup is skipped even though the accelerator
+        # matches. avoid_device_init is True on cpu-only builds and Apple
+        # silicon (which it does not consult mps for), False when an
+        # accelerator it consults is available: branch the expectation on the
+        # mode's own property so the case is deterministic on every build.
+        with FakeTensorMode() as mode:
+            expected_in_mode = [] if mode.avoid_device_init else [torch.device(meta)]
+            self.assertEqual(attempts_for(meta, meta)[0], expected_in_mode)
+        # Outside the mode the warmup runs again (the TLS gate is restored).
+        assert_real_warmup(meta, meta)
+        # With the meta TLS include set held (as in_kernel_invocation_manager
+        # does) but the only-lift gate off (as on a cuda build), the warmup
+        # still runs and clears the include around the real allocation.
+        prev_lift = torch._C._only_lift_cpu_tensors()
+        prev_include = torch._C._meta_in_tls_dispatch_include()
+        torch._C._set_only_lift_cpu_tensors(False)
+        try:
+            torch._C._set_meta_in_tls_dispatch_include(True)
+            assert_real_warmup(meta, meta)
+            # The include must be restored after _normalize_fake_device: a
+            # leaked False would divert later in-kernel ops to the wrong
+            # kernel.
+            include_still_set = torch._C._meta_in_tls_dispatch_include()
+        finally:
+            torch._C._set_only_lift_cpu_tensors(prev_lift)
+            torch._C._set_meta_in_tls_dispatch_include(prev_include)
+        self.assertTrue(include_still_set)
+        # Non-matching accelerator: no allocation at all.
+        self.assertEqual(
+            attempts_for(torch.device("meta"), torch.device("cpu"))[0],
+            [],
+        )
+        # No accelerator (CPU-only build): no allocation at all.
+        self.assertEqual(attempts_for(None, torch.device("meta"))[0], [])
+
     def test_convert_fake_to_real(self):
         x = torch.ones([20])
         with FakeTensorMode(allow_non_fake_inputs=True) as m:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -704,13 +704,32 @@ class FakeTensorConverter:
 
 @functools.cache
 def init_gpu_context(device: torch.device) -> None:
-    # Backward will error with cuda Fake Tensors if no cuda tensors have been initialized first
-    if torch.accelerator.current_accelerator(True) == device.type:
-        (
-            torch.empty(1, device=device)
-            if torch.version.hip is None
-            else torch.zeros(1, device=device)
-        )
+    # Backward will error with FakeTensors on an accelerator if no real tensors
+    # have been initialized on it first. Self-guards on the current accelerator,
+    # so any other device type (cpu and meta included) is a no-op. The
+    # allocation must be REAL: callers may hold the meta TLS include set
+    # (in_kernel_invocation_manager), under which a plain torch.empty would
+    # hit the meta kernel instead of the real device, and no_dispatch() alone
+    # does not clear that include set, so clear it explicitly around the
+    # allocation, keeping the key guard state intact.
+    # NB: only the *current* accelerator warms up. getAccelerator() prefers a
+    # registered PrivateUse1 backend and runtime MTIA over compile-time
+    # backends, so on builds where a higher-precedence accelerator is present,
+    # cuda/xpu FakeTensors do not warm up here.
+    # Cached contract: the warmup decision is derived from the current
+    # accelerator at first call and is NOT invalidated by later backend
+    # registration. Registering (without renaming) a PrivateUse1 backend after
+    # a generic-name privateuse1 FakeTensor was already built keeps a stale
+    # no-warmup entry for that device; late registration is unsupported here.
+    acc = torch.accelerator.current_accelerator(True)
+    if acc is not None and acc.type == device.type:
+        with no_dispatch(), torch._C._PreserveDispatchKeyGuard():
+            torch._C._set_meta_in_tls_dispatch_include(False)
+            (
+                torch.empty(1, device=device)
+                if torch.version.hip is None
+                else torch.zeros(1, device=device)
+            )
 
 
 @contextlib.contextmanager
@@ -931,8 +950,16 @@ class FakeTensor(Tensor):
 
     @staticmethod
     def _normalize_fake_device(device: torch.device) -> torch.device:
-        """Normalize device by initializing GPU context and setting device index."""
-        if device.type in ("cuda", "xpu"):
+        """Normalize device by initializing the accelerator context and index."""
+        # Self-guards on the current accelerator, so no device-type whitelist is
+        # needed here and PrivateUse1 backends are covered. The
+        # only_lift_cpu_tensors TLS gate (set by FakeTensorMode.__enter__ when
+        # avoid_device_init is True: cpu-only machines, and Apple silicon,
+        # whose avoid_device_init does not consult mps) forbids materializing
+        # on device, so the warmup is skipped there. The gate is checked at
+        # this call site, NOT inside init_gpu_context, so a gate-driven skip
+        # is never cached: later calls with the gate off still warm up.
+        if not torch._C._only_lift_cpu_tensors():
             init_gpu_context(device)
 
         if _is_indexed_device_type(device.type) and device.index is None:


### PR DESCRIPTION
## Motivation

`init_gpu_context()` allocates one real tensor on the accelerator a FakeTensor is about to stand in for, because backward errors on an accelerator FakeTensor if no real tensor was created on that device first. #176409 replaced the old `is_available()`-style probe with `torch.accelerator.current_accelerator(True) == device.type` — but the left side is a `torch.device` (or `None`) and the right side is a `str`, so the comparison is **always False**: the guard has silently disabled the warmup for every backend, including cuda and xpu, since March. The comment's promised protection ("backward will error") has not actually been in effect since then. Reported as #191293; independently confirmed on a CUDA box in the review of #191296.

The `device.type in ("cuda", "xpu")` whitelist in `FakeTensor._normalize_fake_device()` is a second layer: even with a working guard, PrivateUse1 backends (registered via `rename_privateuse1_backend`, e.g. npu) never enter the warmup path.

## Changes

- Fix the guard: `acc = current_accelerator(True); if acc is not None and acc.type == device.type` — the warmup actually happens for the current accelerator again. `@functools.cache` and the signature are untouched; the allocation expression is unchanged but now runs inside `no_dispatch() + torch._C._PreserveDispatchKeyGuard()` with the meta TLS include cleared, so it stays a *real* device allocation when `_normalize_fake_device` is reached from inside `in_kernel_invocation_manager` (op outputs via `from_meta_and_device`).
- Drop the whitelist: `_normalize_fake_device` now calls `init_gpu_context(device)` for every device type, gated only by the `torch._C._only_lift_cpu_tensors()` TLS flag that `FakeTensorMode.__enter__` sets when `avoid_device_init` is true (checked at the call site so a gate-driven skip is never cached); the guard itself decides, which covers PrivateUse1 backends (they become the current accelerator once registered) and keeps this file from growing a third device-name list next to `_is_indexed_device_type` and `avoid_device_init`.

Behavior delta, stated plainly: relative to today (guard dead), any FakeTensor on the **current available accelerator** now warms up — that is the behavior #176409 intended. It covers cuda/xpu as a restoration and adds hpu as a deliberate extension; mps/mtia warm up only outside FakeTensorMode, because `avoid_device_init` (and hence the call-site gate) does not consult them. On machines where a registered PrivateUse1 backend or MTIA is the current accelerator, cuda/xpu FakeTensors deliberately do *not* warm up (precedence in `at::getAccelerator`); this matches #176409's intent. cpu and meta never warm up (`getAccelerator()` never returns them; CPU-only builds return `None`). The failure mode is unchanged: `torch.empty` errors still propagate out of `init_gpu_context` (`functools.cache` does not cache exceptions).

Supersedes #191296, which adds the PrivateUse1 backend name to the whitelist but leaves the dead guard in place. Its review (aorenste) asked for exactly this shape: fix the guard, then make the call unconditional so hpu/mps/mtia are covered for free. Fixes #191293.

## Test Plan

Added `test_init_gpu_context_only_for_current_accelerator` to `FakeTensorTest`: it patches `torch.accelerator.current_accelerator` and spies on `torch.empty`, asserting the **allocation request and its device** (not merely that `init_gpu_context` was called — a call-spy stays green while the guard is broken, which is how this bug survived). `meta` is the stand-in device: constructible on every build and truly allocatable, so the positive case proves the branch is reached. Three equivalence classes: accelerator matches → allocation requested on that device; non-matching accelerator → no allocation; no accelerator (CPU-only build) → no allocation. `init_gpu_context.cache_clear()` runs per case so the `functools.cache` does not swallow later cases.

```
cd /tmp && unset PYTHONPATH
python -m pytest <repo>/test/test_fake_tensor.py -q -k init_gpu_context_only
# base wheel: 2 failed (AssertionError: 0 != 1 — the warmup never happens, i.e. the test
#   protects the fix: reverting the source change turns it red)
# patched (hunks overlaid onto the wheel): 2 passed
python -m pytest <repo>/test/test_fake_tensor.py -q
# 12 failed, 336 passed, 112 skipped, 7 xfailed
# the 12 failures are identical to the base wheel's (ragged tensor-constructor error
#   messages and dispatch-cache signature drift between the 08-19 wheel and trunk
#   tests; all pre-existing, none touch this diff's hunks)
lintrunner --take PYFMT,RUFF torch/_subclasses/fake_tensor.py test/test_fake_tensor.py
# ok No lint issues.
```

Draft while CI is pending maintainer approval (first-time-contributor workflow approval has not happened yet, so no GPU shard has run); the effect assertion (registered PrivateUse1 backend `is_initialized()` flipping False→True, per the review of #191296) needs an accelerator CI backend and is tracked as the follow-up the reviewer asked for.