### PR TITLE
Document how adaptive max pooling computes its pooling regions

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1320,6 +1320,21 @@ class AdaptiveMaxPool1d(_AdaptiveMaxPoolNd):
     The output size is :math:`L_{out}`, for any input size.
     The number of output features is equal to the number of input planes.
 
+    Each output element is the maximum over a region of the input whose bounds are
+    derived from the input and output sizes:
+
+    .. math::
+        \text{start}(k) = \left\lfloor \frac{k \times L_{in}}{L_{out}} \right\rfloor
+        \qquad
+        \text{end}(k) = \left\lceil \frac{(k + 1) \times L_{in}}{L_{out}} \right\rceil
+
+    .. math::
+        out(N_i, C_j, k) = \max_{\text{start}(k) \le l < \text{end}(k)} input(N_i, C_j, l)
+
+    When :math:`L_{in}` is not divisible by :math:`L_{out}`, these regions may have
+    different sizes and may overlap. For example, an input of size 5 pooled to size 3
+    uses the regions :math:`[0, 2)`, :math:`[1, 4)` and :math:`[3, 5)`.
+
     Args:
         output_size: the target output size :math:`L_{out}`.
         return_indices: if ``True``, will return the indices along with the outputs.
@@ -1350,6 +1365,28 @@ class AdaptiveMaxPool2d(_AdaptiveMaxPoolNd):
 
     The output is of size :math:`H_{out} \times W_{out}`, for any input size.
     The number of output features is equal to the number of input planes.
+
+    Each output element is the maximum over a rectangular region of the input. The
+    bounds are computed independently for each spatial dimension, from an output index
+    :math:`k`, an input size :math:`I` and an output size :math:`O`:
+
+    .. math::
+        \text{start}(k, I, O) = \left\lfloor \frac{k \times I}{O} \right\rfloor
+        \qquad
+        \text{end}(k, I, O) = \left\lceil \frac{(k + 1) \times I}{O} \right\rceil
+
+    Writing :math:`h_0 = \text{start}(h, H_{in}, H_{out})` and
+    :math:`h_1 = \text{end}(h, H_{in}, H_{out})`, and likewise :math:`w_0` and
+    :math:`w_1` from :math:`(W_{in}, W_{out})`, the output is
+
+    .. math::
+        out(N_i, C_j, h, w) = \max_{h_0 \le m < h_1} \max_{w_0 \le n < w_1}
+                input(N_i, C_j, m, n)
+
+    When an input size is not divisible by the corresponding output size, these regions
+    may have different sizes and may overlap. For example, a :math:`3 \times 3` input
+    pooled to :math:`2 \times 2` takes the maximum over four overlapping
+    :math:`2 \times 2` regions.
 
     Args:
         output_size: the target output size of the image of the form :math:`H_{out} \times W_{out}`.
@@ -1393,6 +1430,23 @@ class AdaptiveMaxPool3d(_AdaptiveMaxPoolNd):
 
     The output is of size :math:`D_{out} \times H_{out} \times W_{out}`, for any input size.
     The number of output features is equal to the number of input planes.
+
+    Each output element is the maximum over a cuboidal region of the input. The bounds
+    are computed independently for each spatial dimension, from an output index
+    :math:`k`, an input size :math:`I` and an output size :math:`O`:
+
+    .. math::
+        \text{start}(k, I, O) = \left\lfloor \frac{k \times I}{O} \right\rfloor
+        \qquad
+        \text{end}(k, I, O) = \left\lceil \frac{(k + 1) \times I}{O} \right\rceil
+
+    The region for output element :math:`(d, h, w)` spans
+    :math:`[\text{start}(d, D_{in}, D_{out}), \text{end}(d, D_{in}, D_{out}))` along the
+    depth dimension, and likewise with :math:`(H_{in}, H_{out})` and
+    :math:`(W_{in}, W_{out})` along height and width.
+
+    When an input size is not divisible by the corresponding output size, these regions
+    may have different sizes and may overlap.
 
     Args:
         output_size: the target output size of the image of the form :math:`D_{out} \times H_{out} \times W_{out}`.


### PR DESCRIPTION
Fixes #108197

## Problem

`AdaptiveMaxPool1d/2d/3d` document *what shape* they produce but never *how* an output element is computed. That is fine when the input size divides the output size, and ambiguous exactly when adaptive pooling is actually interesting: for a 3×3 input pooled to 2×2, the docs give no way to tell whether each output is the maximum over a 2×2 region, or over regions of size 2×2, 2×1, 1×2 and 1×1.

There is also a long-standing in-repo `FIXME (by @ssnl)` just above these classes asking for exactly this ("specify what the input and output shapes are, and how the operation computes output"). I've left it in place, since `AdaptiveAvgPool*` still needs the same treatment — see the follow-up note below.

## What this documents

The bounds come from `aten/src/ATen/native/AdaptivePooling.h`:

```cpp
inline int64_t start_index(int64_t a, int64_t b, int64_t c) {
  return (a / b) * c + ((a % b) * c) / b;
}
inline int64_t end_index(int64_t a, int64_t b, int64_t c) {
  return 1 + ((a + 1) * c - 1) / b;
}
```

With `a` the output index, `b` the output size and `c` the input size, and integer division, these are exactly `floor(a·c/b)` and `ceil((a+1)·c/b)`. The docstrings state that closed form, note that the region is half-open `[start, end)`, and add the part that actually trips people up: **when the input size is not divisible by the output size the regions may have different sizes and may overlap**.

## Verification

I did not want to transcribe a formula from a header and hope, so I checked it against the shipped implementation:

1. **Algebraic equivalence.** The C++ integer expressions and the documented `floor`/`ceil` forms agree on every `(input size, output size, output index)` triple for sizes 1–59 — 3,481 size pairs, no mismatches.
2. **Against real behaviour.** For `AdaptiveMaxPool1d/2d/3d` I compared every output element against `max()` over the predicted window. On the `output_size <= input_size` subset I additionally used `return_indices=True` to confirm the returned argmax index falls inside that same window:

   | case | output elements checked | mismatches |
   | --- | --- | --- |
   | `AdaptiveMaxPool1d` | 1,300 | 0 |
   | `AdaptiveMaxPool2d` | 22,932 | 0 |
   | `AdaptiveMaxPool3d` | 1,200 | 0 |

   This includes `output_size > input_size`, since the docs claim these layers work "for any input size".
3. **The issue's own example.** A 3×3 input pooled to 2×2 gives regions `[0,2)×[0,2)`, `[0,2)×[1,3)`, `[1,3)×[0,2)`, `[1,3)×[1,3)` — four overlapping 2×2 windows, which is what the reporter expected and what the new text says.
4. **Overlap / differing sizes are both real**, so neither claim is overstated: input 5 → output 3 gives regions `[0,2)`, `[1,4)`, `[3,5)` (sizes 2, 3, 2, overlapping); input 4 → output 2 gives `[0,2)`, `[2,4)` (equal, non-overlapping).

Run against `torch 2.14.0+cpu`.

## Rendering

Docs-only change, so I checked it renders rather than relying on eyeballing:

- Parsed each of the three docstrings with `docutils` and diffed the messages against the `main` baseline: **no new reStructuredText errors**. (`AdaptiveMaxPool1d` has one pre-existing "Unexpected indentation" from the Google-style `Args:` block, which Sphinx's napoleon handles; it is present before and after this change.)
- The `.. math::` directives resolve to real `math_block` nodes in the doctree.
- Only LaTeX constructs already used elsewhere in PyTorch docstrings are used here — `\lfloor`/`\rfloor` and `\max_{...}` appear in this same file, `\lceil`/`\rceil` in `torch/_torch_docs.py`. I deliberately avoided `\substack`, which is not used anywhere in the codebase.
- `ruff` and `flake8` (with the repo's `.flake8` config) are clean on the changed file.

## Scope

`AdaptiveAvgPool1d/2d/3d` use the same `start_index`/`end_index` helpers and deserve the same paragraph, but I kept this PR to the classes named in #108197. Happy to send that as a follow-up, or fold it in here if you would rather review it once.

---

Written with AI assistance; I reviewed and verified the change myself.
