### PR TITLE
[FSDP2] Avoid division-by-one allocation for singleton shards

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -80,6 +80,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     TransformerBlock,
 )
 from torch.testing._internal.inductor_utils import skipCUDAIf
+from torch.utils._python_dispatch import TorchDispatchMode
 
 
 c10d_ops = torch.ops.c10d
@@ -2046,10 +2047,33 @@ class TestFullyShardForceSumReduction(FSDPTest):
         self.assertRegex(logs, all_reduce_sum_re)
 
 
+@instantiate_parametrized_tests
 class TestFullyShardReduceOpWorldSize1(FSDPTest):
     @property
     def world_size(self) -> int:
         return 1
+
+    @parametrize("divide_factor", [None, 1.0, 2.0])
+    def test_singleton_copy_division(self, divide_factor):
+        divisions = []
+
+        class RecordDivisions(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                if func == torch.ops.aten.div.Tensor:
+                    divisions.append(func)
+                return func(*args, **(kwargs or {}))
+
+        model = nn.Linear(8, 4, bias=False, device=device_type)
+        fully_shard(model, mesh=init_device_mesh(device_type.type, (1,)))
+        if divide_factor is not None:
+            model.set_gradient_divide_factor(divide_factor)
+        inp = torch.ones(3, 8, device=device_type)
+        loss = model(inp).sum()
+        with RecordDivisions():
+            loss.backward()
+        self.assertEqual(len(divisions), int(divide_factor not in (None, 1)))
+        expected = torch.full_like(inp[:1].expand(4, -1), 3 / (divide_factor or 1))
+        self.assertEqual(model.weight.grad.to_local(), expected)
 
     def test_size1_reduceop(self):
         from torch.distributed.distributed_c10d import ReduceOp

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -625,7 +625,7 @@ def foreach_reduce(
         else:
             # For single GPU, just copy the input to output (no actual reduce-scatter needed), and
             # account for a possible gradient_divide_factor.
-            if gradient_divide_factor is not None:
+            if gradient_divide_factor is not None and gradient_divide_factor != 1:
                 reduce_output.copy_(reduce_scatter_input / gradient_divide_factor)
             else:
                 reduce_output.copy_(reduce_scatter_input)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -625,7 +625,7 @@ def foreach_reduce(
         else:
             # For single GPU, just copy the input to output (no actual reduce-scatter needed), and
             # account for a possible gradient_divide_factor.
-            if gradient_divide_factor is not None and gradient_divide_factor != 1:
+            if gradient_divide_factor is not None and gradient_divide_factor != 1.0:
                 reduce_output.copy_(reduce_scatter_input / gradient_divide_factor)
             else:
                 reduce_output.copy_(reduce_scatter_input)


### PR DESCRIPTION
Since we counter OOM in hsdp, with replication degree = 2 and sharding degree = 1. Therefore we are trying to fix the bug

@ppl-ai


> AI-assisted description:
>
> We encountered CUDA OOM with **DP2: drep=2, FSDP=1, CP=1**, using a `(d_rep=2, d_fsdp_cp=1)` mesh and FP32 gradient reduction.
>
> Although the shard group has size one, `foreach_reduce` computes `input / 1` before copying to the output. In our run, this requested an additional **36.76 GiB** with only **3.48 GiB** free.
>
> **Proposed change — pseudocode:**
> ```python
> if shard_world_size == 1:
>     if divide_factor is None or divide_factor == 1:
>         output.copy_(input)
>     else:
>         output.copy_(input / divide_factor)
> ```
>
> **Validation on GB200, PyTorch 2.13.0+cu130:**
>
> - Four isolated unit tests passed, covering numerical equivalence, unchanged inputs, division counts, and CUDA peak allocation.
> - For a 64 MiB FP32 buffer, additional peak allocation decreased from **64 MiB to 0**.
> - DP2 FSDP backward matched the original implementation and analytic gradients exactly for FP32/BF16 with divide factors `None`, `1`, and `2`.
>
> Tests used a process-local patch. The upstream-format regression test and full-model OOM reproduction have not yet been rerun against the patched checkout.
