### PR TITLE
[BE][Ez]: Enable some optin cpp20 range features for AOT ArrayRef

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/mini_array_ref.h
+++ b/torch/csrc/inductor/aoti_runtime/mini_array_ref.h
@@ -158,3 +158,14 @@ class MiniArrayRef final {
 };
 
 } // namespace torch::aot_inductor
+
+#if __cplusplus >= 202002L
+#include <ranges>
+// MiniArrayRef is a non-owning view, so destroying it does not invalidate its
+// iterators.
+namespace std::ranges {
+template <typename T>
+inline constexpr bool
+    enable_borrowed_range<torch::aot_inductor::MiniArrayRef<T>> = true;
+} // namespace std::ranges
+#endif


### PR DESCRIPTION
This was missed earlier due to some non CPP20 AOT header users I think.