### PR TITLE
Enable decomposed-K matmul in AOTInductor

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -34,12 +34,18 @@ from torch._inductor.codegen.wrapper import SymbolicCallArg
 from torch._inductor.cpp_builder import normalize_path_separator
 from torch._inductor.package import package_aoti
 from torch._inductor.runtime.runtime_utils import cache_dir
-from torch._inductor.select_algorithm import TritonTemplate
+from torch._inductor.select_algorithm import (
+    add_preprocessing_fn,
+    clear_preprocessing_fns,
+    TritonTemplate,
+)
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import (
+    get_k_splits,
     is_big_gpu,
     maybe_aoti_standalone_config,
     run_and_get_cpp_code,
+    use_decompose_k_choice,
 )
 from torch._library import capture_triton
 from torch._utils_internal import full_aoti_runtime_assert
@@ -324,6 +330,51 @@ def profiled_ivalue_kinds(code, kernel_name):
 
 
 class AOTInductorTestsTemplate:
+    def test_decompose_k(self):
+        if self.device != GPU_TYPE or not IS_BIG_GPU:
+            raise unittest.SkipTest("requires modern GPU to run max-autotune")
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.relu(a @ b)
+
+        inputs = (
+            torch.randn(16, 2048, device=self.device, dtype=torch.float16),
+            torch.randn(2048, 16, device=self.device, dtype=torch.float16),
+        )
+
+        def select_decompose_k(choices):
+            decompose_k_choices = [
+                choice for choice in choices if choice.name.startswith("decompose_k_mm")
+            ]
+            return decompose_k_choices or choices
+
+        get_k_splits.cache_clear()
+        use_decompose_k_choice.cache_clear()
+        add_preprocessing_fn(select_decompose_k)
+        try:
+            with config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "triton.decompose_k_threshold": 0,
+                    "triton.num_decompose_k_splits": 1,
+                }
+            ):
+                package_path, code = run_and_get_cpp_code(
+                    AOTIRunnerUtil.compile, Model(), inputs
+                )
+        finally:
+            clear_preprocessing_fns(clear_defaults=False)
+            get_k_splits.cache_clear()
+            use_decompose_k_choice.cache_clear()
+
+        optimized = torch._inductor.aoti_load_package(package_path)
+        self.assertEqual(optimized(*inputs), Model()(*inputs), atol=1e-2, rtol=1e-2)
+        FileCheck().check("// subgraph: decompose_k_mm").check("bmm_dtype_out").run(
+            code
+        )
+
     @common_utils.parametrize("embed_kernel_binary", [False, True])
     @common_utils.parametrize("max_autotune", [False, True])
     def test_simple(self, embed_kernel_binary, max_autotune):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3065,6 +3065,19 @@ class CppWrapperCpu(PythonWrapperCodegen):
         finally:
             self.pop_codegened_graph()
 
+    def codegen_subgraph_with_flattened_outputs(
+        self, subgraph, outer_inputs, outer_outputs
+    ):
+        for outer_output in outer_outputs:
+            self.writeline(f"RAIIAtenTensorHandle {outer_output};")
+
+        self.writeline("{")
+        with self._preserve_device_guard_state():
+            self.writeline(EnterSubgraphLine(self, subgraph.graph))
+            self.codegen_subgraph(subgraph, outer_inputs, outer_outputs)
+            self.writeline(ExitSubgraphLine(self))
+        self.writeline("}")
+
     def codegen_while_loop(self, while_loop, stack_output=False):
         """Emit ABI-compatible C++ for a higher-order while_loop.
 

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -137,7 +137,7 @@ def _bmm_shared_a_configs(dtype):
 aten_bmm = ExternKernelChoice(torch.bmm, "at::bmm_out", op_overload=aten.bmm.out)
 aten_bmm_dtype = ExternKernelChoice(
     torch.bmm,
-    "at::_bmm_out_dtype_xpu" if torch.xpu._is_compiled() else "at::_bmm_out_dtype_cuda",
+    "at::bmm_dtype_out",
     name="bmm_dtype",
     op_overload=aten.bmm.dtype_out,
 )

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2789,8 +2789,6 @@ def use_decompose_k_choice(
                 sympy.Ge(k, decompose_k_threshold * n),
             )
         )
-        and not V.graph.aot_mode  # TODO: Support AOTI for decomposeK
-        and not V.graph.cpp_wrapper
         and config.triton.num_decompose_k_splits > 0
     )
 

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_cuda.h
@@ -91,6 +91,9 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_avg_pool3d_backward(AtenTensorH
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_baddbmm_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle batch1, AtenTensorHandle batch2, double beta, double alpha);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_bernoulli__Tensor(AtenTensorHandle self, AtenTensorHandle p, AtenGeneratorHandle* generator);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_bernoulli__float(AtenTensorHandle self, double p, AtenGeneratorHandle* generator);
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_bmm_dtype_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle mat2, int32_t out_dtype);
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_bmm_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle mat2);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_bucketize_Tensor(AtenTensorHandle self, AtenTensorHandle boundaries, int32_t out_int32, int32_t right, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_cat(const AtenTensorHandle* tensors, int64_t tensors_len_, int64_t dim, AtenTensorHandle* ret0);

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_xpu.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_xpu.h
@@ -67,6 +67,9 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_avg_pool3d_backward(AtenTensorHa
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_baddbmm_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle batch1, AtenTensorHandle batch2, double beta, double alpha);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_bernoulli__Tensor(AtenTensorHandle self, AtenTensorHandle p, AtenGeneratorHandle* generator);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_bernoulli__float(AtenTensorHandle self, double p, AtenGeneratorHandle* generator);
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_bmm_dtype_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle mat2, int32_t out_dtype);
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_bmm_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle mat2);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_bucketize_Tensor(AtenTensorHandle self, AtenTensorHandle boundaries, int32_t out_int32, int32_t right, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_xpu_cat(const AtenTensorHandle* tensors, int64_t tensors_len_, int64_t dim, AtenTensorHandle* ret0);

--- a/torch/csrc/stable/c/shim_function_versions.txt
+++ b/torch/csrc/stable/c/shim_function_versions.txt
@@ -136,3 +136,5 @@ torch_has_storage: TORCH_VERSION_2_14_0
 torch_mps_set_arg_bytes: TORCH_VERSION_2_14_0
 torch_tensor_from_pyobject: TORCH_VERSION_2_14_0
 torch_tensor_to_pyobject: TORCH_VERSION_2_14_0
+aoti_torch_cuda_bmm_dtype_out: TORCH_VERSION_2_15_0
+aoti_torch_xpu_bmm_dtype_out: TORCH_VERSION_2_15_0

--- a/torch/csrc/stable/version.h
+++ b/torch/csrc/stable/version.h
@@ -39,3 +39,4 @@
 #define TORCH_VERSION_2_12_0 (((0ULL + 2) << 56) | ((0ULL + 12) << 48))
 #define TORCH_VERSION_2_13_0 (((0ULL + 2) << 56) | ((0ULL + 13) << 48))
 #define TORCH_VERSION_2_14_0 (((0ULL + 2) << 56) | ((0ULL + 14) << 48))
+#define TORCH_VERSION_2_15_0 (((0ULL + 2) << 56) | ((0ULL + 15) << 48))

--- a/torchgen/aoti/fallback_ops.py
+++ b/torchgen/aoti/fallback_ops.py
@@ -109,6 +109,7 @@ inductor_fallback_ops: dict[str, dict[str, str | dict[str, list[str] | str]]] = 
     "aten.baddbmm.out": {},
     "aten.bernoulli_.float": {},
     "aten.bernoulli_.Tensor": {},
+    "aten.bmm.dtype_out": {"since": "TORCH_VERSION_2_15_0"},
     "aten.bmm.out": {},
     "aten.bucketize.Tensor": {},
     "aten.cat.default": {},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #196357

Decomposed-K was disabled for AOTI because SubgraphBuffer only had a
Python-wrapper code generation path, and its FP32 batched matmul lacked a
stable C shim. Inline flattened subgraphs in the C++ wrapper with explicit
RAII output ownership, expose bmm.dtype_out through versioned CUDA and XPU
shims, and allow the autotuner to offer decomposed-K in AOT mode.

The AOTI regression test forces the decomposed-K choice and checks both the
generated wrapper code and loaded-package numerics.

Authored with assistance from Codex, an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

Differential Revision: [D119218413](https://our.internmc.facebook.com/intern/diff/D119218413)