### PR TITLE
[dynamo] Guard object identity when constant-folding `is`/identity `==` (#196173)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -19383,6 +19383,98 @@ class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
                 self.assertEqual(got, expected)
 
 
+class IdentityComparisonTests(torch._inductor.test_case.TestCase):
+    def test_is_on_mutable_attr_toggles_branch_correctly(self):
+        # https://github.com/pytorch/pytorch/issues/196173
+        # Control flow based on the identity of mutable object attributes
+        # must not reuse a stale graph after an attribute is rebound to a
+        # different (same-typed) object.
+        class Holder:
+            def __init__(self):
+                self.left = object()
+                self.right = object()
+                self.current = self.left
+
+        def fn(x, holder):
+            is_left = holder.current is holder.left
+            holder.current = holder.right if is_left else holder.left
+            if is_left:
+                return x.square()
+            return -x
+
+        def run(callable_fn):
+            holder = Holder()
+            x = torch.tensor([2.0, 3.0])
+            outputs = []
+            for _ in range(6):
+                outputs.append(callable_fn(x, holder).clone())
+            return outputs, holder.current is holder.left
+
+        eager_outputs, eager_final = run(fn)
+        torch._dynamo.reset()
+        compiled_outputs, compiled_final = run(torch.compile(fn, backend="eager"))
+        self.assertEqual(eager_final, compiled_final)
+        for eager, compiled in zip(eager_outputs, compiled_outputs):
+            self.assertEqual(eager, compiled)
+
+    def test_is_on_local_args_recompiles_when_identity_changes(self):
+        # Passing two distinct objects to a compiled function that compares
+        # them with `is` must not reuse a graph compiled for identical args.
+        def fn(x, a, b):
+            if a is b:
+                return x.square()
+            return -x
+
+        o1, o2 = object(), object()
+        x = torch.tensor([2.0, 3.0])
+        opt = torch.compile(fn, backend="eager")
+        torch.testing.assert_close(opt(x, o1, o1), x.square())
+        torch.testing.assert_close(opt(x, o1, o2), -x)
+        torch.testing.assert_close(opt(x, o2, o1), -x)
+
+    def test_eq_identity_fallback_is_guarded(self):
+        # object.__eq__ defaults to identity, so == between objects without a
+        # custom __eq__ is an identity comparison and must be guarded the same
+        # way as `is`.
+        class Holder:
+            def __init__(self):
+                self.left = object()
+                self.right = object()
+                self.current = self.left
+
+        def fn(x, holder):
+            if holder.current == holder.left:
+                return x.square()
+            return -x
+
+        holder = Holder()
+        x = torch.tensor([2.0, 3.0])
+        opt = torch.compile(fn, backend="eager")
+        torch.testing.assert_close(opt(x, holder), x.square())
+        holder.current = holder.right
+        torch.testing.assert_close(opt(x, holder), -x)
+
+    def test_is_installs_identity_guards_on_sources(self):
+        class Holder:
+            def __init__(self):
+                self.a = object()
+                self.b = object()
+
+        def fn(x, holder):
+            return x.square() if holder.a is holder.b else -x
+
+        x = torch.tensor([2.0, 3.0])
+        holder = Holder()
+        opt = torch.compile(fn, backend="eager")
+        opt(x, holder)
+
+        cache_entries = _debug_get_cache_entry_list(fn.__code__)
+        self.assertEqual(len(cache_entries), 1)
+        guard_str = str(cache_entries[0].guard_manager)
+        self.assertIn("ID_MATCH: ___check_obj_id(L['holder'].a", guard_str)
+        self.assertIn("ID_MATCH: ___check_obj_id(L['holder'].b", guard_str)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -50,6 +50,27 @@ if TYPE_CHECKING:
     from ..symbolic_convert import InstructionTranslatorBase
 
 
+def _install_identity_guards(*operands: VariableTracker) -> None:
+    """Guard the identity of source-backed operands of an identity comparison.
+
+    When vt_identity_compare folds an ``is``/``is not``/identity-``==`` result
+    from the current Python objects behind the operands, the fold is only
+    valid while those objects keep their identity.  If an operand is read back
+    from a source that can change between calls (a local argument, an attribute
+    of a mutable object, ...), a rebinding to a different -- even same-typed --
+    object must invalidate the compiled code.  Without an ID_MATCH guard only
+    the operand's type is checked, so the stale graph is silently reused.
+    """
+    from ..guards import GuardBuilder, install_guard
+
+    for operand in operands:
+        source = operand.source
+        if source is not None and (
+            operand.get_real_python_backed_value() is not NO_SUCH_SUBOBJ
+        ):
+            install_guard(source.make_guard(GuardBuilder.ID_MATCH))
+
+
 def vt_identity_compare(
     left: VariableTracker,
     right: VariableTracker,
@@ -60,6 +81,7 @@ def vt_identity_compare(
     Mirrors the logic in BuiltinVariable's handle_is handler.
     """
     if left is right:
+        _install_identity_guards(left, right)
         return ConstantVariable.create(True)
 
     left_val = left.get_real_python_backed_value()
@@ -68,6 +90,7 @@ def vt_identity_compare(
     right_known = right_val is not NO_SUCH_SUBOBJ
 
     if left_known and right_known:
+        _install_identity_guards(left, right)
         return (
             ConstantVariable.create(True)
             if left_val is right_val


### PR DESCRIPTION
Fixes #196173

Silent-correctness bug in `torch.compile`: control flow based on identity comparisons of mutable Python objects (e.g. `holder.current is holder.left`) is constant-folded without guarding the *identity* of the objects at their sources, so rebinding an attribute (or passing a different object) reuses a stale compiled graph:

- guards on `L['holder'].current` / `L['holder'].left` were only `TYPE_MATCH`, so reassigning the attribute to a different, same-typed `object()` instance never invalidated the compiled code;
- the mutation inside the traced function is then never replayed, and the wrong branch is reused forever.

**Fix**: `vt_identity_compare` now installs `ID_MATCH` guards on any source-backed operand whose python-backed value the fold relies on, so an identity change triggers a recompile. Because the guard lives in `vt_identity_compare`, both `is`/`is not` and the identity fallback of `==`/`!=` on plain objects are covered.

**Test plan**: new dynamo tests cover attribute-rebinding branch toggling, local-arg identity changes, identity-based `==`, and ID_MATCH guard installation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98