### PR TITLE
[inductor-perf] Reuse r_numel from args inputs in indexing to remove redundant kernel arguments

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -6,6 +6,7 @@ import unittest
 from types import SimpleNamespace
 
 import sympy
+
 import torch
 from torch._dynamo.source import ConstantSource
 from torch._inductor import config
@@ -1277,6 +1278,57 @@ class ReductionInvariantIndexingTests(InductorTestCase):
             )
 
         self.assertEqual(expected, actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check("r0_1 + r0_numel*x0").check_not("ks0").run(kernels[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_reuse_second_reduction_numel_for_indexing(self):
+        def fn(x):
+            return x.sum()
+
+        x = torch.randn(295, device=GPU_TYPE).as_strided((7, 37), (37, 2))
+        expected = fn(x)
+
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.prefer_nd_tiling": True,
+                "triton.tile_reductions": True,
+            }
+        ):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True, dynamic=True),
+                x,
+                remove_quote=True,
+            )
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check("ks0*r1_1 + r0_0*r1_numel").check_not("ks1").run(kernels[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_reuse_reduction_numel_for_cooperative_reduction(self):
+        def fn(x):
+            return x.sum(dim=1)
+
+        x = torch.randn(64, 8193, device=GPU_TYPE)
+        expected = fn(x)
+
+        with config.patch(
+            {
+                "force_disable_caches": True,
+                "triton.cooperative_reductions": True,
+                "triton.force_cooperative_reductions": True,
+            }
+        ):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True, dynamic=True),
+                x,
+                remove_quote=True,
+            )
+
+        # Cooperative reductions can accumulate in a different order than eager.
+        self.assertEqual(expected, actual, rtol=1e-3, atol=1e-6)
         self.assertEqual(1, len(kernels))
         FileCheck().check("r0_1 + r0_numel*x0").check_not("ks0").run(kernels[0])
 

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -6,7 +6,6 @@ import unittest
 from types import SimpleNamespace
 
 import sympy
-
 import torch
 from torch._dynamo.source import ConstantSource
 from torch._inductor import config
@@ -1262,6 +1261,25 @@ class TestOptimizationHintWideUnbackedSubstitution(InductorTestCase):
 
 @instantiate_parametrized_tests
 class ReductionInvariantIndexingTests(InductorTestCase):
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_reuse_reduction_numel_for_indexing(self):
+        def fn(x):
+            return x.sum(dim=1)
+
+        x = torch.randn(7, 37, device=GPU_TYPE)
+        expected = fn(x)
+
+        with config.patch({"force_disable_caches": True}):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True, dynamic=True),
+                x,
+                remove_quote=True,
+            )
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(1, len(kernels))
+        FileCheck().check("r0_1 + r0_numel*x0").check_not("ks0").run(kernels[0])
+
     @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
     @parametrize("persistent_reductions", [False, True])
     def test_reduction_invariant_masked_index_load(self, persistent_reductions):

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -9,7 +9,7 @@ import sympy
 
 import torch
 from torch._dynamo.source import ConstantSource
-from torch._inductor import config
+from torch._inductor import config, metrics
 from torch._inductor.codegen.cpp import cexpr
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import texpr
@@ -1279,7 +1279,9 @@ class ReductionInvariantIndexingTests(InductorTestCase):
 
         self.assertEqual(expected, actual)
         self.assertEqual(1, len(kernels))
-        FileCheck().check("r0_1 + r0_numel*x0").check_not("ks0").run(kernels[0])
+        kernel = metrics._parse_proper_kernel_fn_code(kernels[0])
+        self.assertEqual(6, metrics._count_args(kernel))
+        FileCheck().check("r0_1 + r0_numel*x0").check_not("ks0").run(kernel)
 
     @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
     def test_reuse_second_reduction_numel_for_indexing(self):

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -118,7 +118,7 @@ class TestSIMDRangeTrees(TestCase):
                 self.assertEqual(kernel.range_trees, [x_tree, r_tree])
                 self.assertFalse(indexing.has_rmask())
 
-    def test_reduction_numel_reuse_uses_parent_tree_extent(self):
+    def test_derived_reduction_extent_reuses_r_numel(self):
         graph = self._make_graph()
         with V.set_graph_handler(graph):
             reduction_numel = graph.sizevars.shape_env.create_symbol(
@@ -136,17 +136,25 @@ class TestSIMDRangeTrees(TestCase):
             )
             x_tree, r_tree = kernel.range_trees
             derived = self._make_derived_root(r_tree, group_size=sympy.Integer(2))
-            expected = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+            r_numel_symbol = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
 
             kernel.finalize_indexing([reduction_numel])
+            self.assertEqual(
+                kernel._r_numel_reuse_replacements,
+                {r_numel_symbol: reduction_numel},
+            )
+            self.assertEqual(
+                kernel._r_numel_reuse_eliminated_symbols,
+                OrderedSet([reduction_numel]),
+            )
             with kernel.use_range_trees([x_tree, derived]):
                 self.assertEqual(
                     kernel._replace_reduction_numel_in_index(reduction_numel),
-                    expected,
+                    r_numel_symbol,
                 )
                 self.assertEqual(
                     kernel._replace_reduction_numel_in_index(derived.numel),
-                    FloorDiv(expected, 2),
+                    FloorDiv(r_numel_symbol, 2),
                 )
 
     def test_reduction_numel_reuse_supports_multiple_reduction_trees(self):

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -3,17 +3,19 @@
 import sys
 import typing
 import unittest
+from types import SimpleNamespace
 
 import sympy
-
+from torch._dynamo.source import ConstantSource
 from torch._inductor.codegen.simd import DerivedIterationRangesRoot, IterationRangesRoot
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import IndexingOptions, TritonKernel, TritonSymbols
 from torch._inductor.virtualized import V
+from torch.fx.experimental.symbolic_shapes import DimDynamic
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.inductor_utils import MockGraphHandler
 from torch.utils._ordered_set import OrderedSet
-from torch.utils._sympy.functions import FloorDiv
+from torch.utils._sympy.functions import CeilDiv, FloorDiv
 
 
 try:
@@ -114,6 +116,135 @@ class TestSIMDRangeTrees(TestCase):
 
                 self.assertEqual(kernel.range_trees, [x_tree, r_tree])
                 self.assertFalse(indexing.has_rmask())
+
+    def test_reduction_numel_reuse_uses_parent_tree_extent(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            reduction_numel = graph.sizevars.shape_env.create_symbol(
+                512,
+                source=ConstantSource("__test_reduction_numel"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            features = SIMDKernelFeatures([], sympy.Integer(4), reduction_numel)
+            kernel = TritonKernel(
+                {"x": sympy.Integer(4), "r0_": reduction_numel},
+                features=features,
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+            x_tree, r_tree = kernel.range_trees
+            derived = self._make_derived_root(r_tree, group_size=sympy.Integer(2))
+            expected = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+
+            kernel.finalize_indexing([reduction_numel])
+            with kernel.use_range_trees([x_tree, derived]):
+                self.assertEqual(
+                    kernel._replace_reduction_numel_in_index(reduction_numel),
+                    expected,
+                )
+                self.assertEqual(
+                    kernel._replace_reduction_numel_in_index(derived.numel),
+                    FloorDiv(expected, 2),
+                )
+
+    def test_reduction_numel_reuse_requires_dead_size_argument(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            dynamic_size = graph.sizevars.shape_env.create_symbol(
+                1023,
+                source=ConstantSource("__test_dynamic_size"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            reduction_numel = CeilDiv(dynamic_size, 2)
+            features = SIMDKernelFeatures([], sympy.Integer(4), reduction_numel)
+            kernel = TritonKernel(
+                {"x": sympy.Integer(4), "r0_": reduction_numel},
+                features=features,
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+            expected = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+
+            kernel.finalize_indexing([reduction_numel])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(reduction_numel),
+                expected,
+            )
+
+            kernel.finalize_indexing([reduction_numel, dynamic_size])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(reduction_numel),
+                reduction_numel,
+            )
+
+            kernel.range_tree_nodes[sympy.Symbol("__test_range")] = SimpleNamespace(
+                expr=dynamic_size
+            )
+            kernel.finalize_indexing([reduction_numel])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(reduction_numel),
+                reduction_numel,
+            )
+
+    def test_reduction_numel_reuse_skips_ineligible_extents(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            no_reduction = TritonKernel(
+                {"x": sympy.Integer(4)},
+                features=SIMDKernelFeatures([], sympy.Integer(4)),
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+            static_reduction = TritonKernel(
+                {"x": sympy.Integer(4), "r0_": sympy.Integer(512)},
+                features=SIMDKernelFeatures([], sympy.Integer(4), sympy.Integer(512)),
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+
+            self.assertEqual(
+                no_reduction._replace_reduction_numel_in_index(
+                    sympy.Symbol("s0"), force=True
+                ),
+                sympy.Symbol("s0"),
+            )
+            self.assertEqual(
+                static_reduction._replace_reduction_numel_in_index(
+                    sympy.Integer(512), force=True
+                ),
+                sympy.Integer(512),
+            )
+
+    def test_reduction_numel_reuse_skips_staged_indexing_schedule(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            dynamic_size = graph.sizevars.shape_env.create_symbol(
+                1023,
+                source=ConstantSource("__test_staged_dynamic_size"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            reduction_numel = CeilDiv(dynamic_size, 2)
+            features = SIMDKernelFeatures(
+                [],
+                sympy.Integer(4),
+                reduction_numel,
+                indexing_node_schedule=[],
+            )
+            kernel = TritonKernel(
+                {"x": sympy.Integer(4), "r0_": reduction_numel},
+                features=features,
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+
+            kernel.finalize_indexing([reduction_numel])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(reduction_numel),
+                reduction_numel,
+            )
 
     def test_use_range_trees_clears_simplify_indexing_cache(self):
         graph = self._make_graph()

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -121,15 +121,15 @@ class TestSIMDRangeTrees(TestCase):
     def test_derived_reduction_extent_reuses_r_numel(self):
         graph = self._make_graph()
         with V.set_graph_handler(graph):
-            reduction_numel = graph.sizevars.shape_env.create_symbol(
+            reduction_extent = graph.sizevars.shape_env.create_symbol(
                 512,
                 source=ConstantSource("__test_reduction_numel"),
                 dynamic_dim=DimDynamic.DYNAMIC,
                 constraint_dim=None,
             )
-            features = SIMDKernelFeatures([], sympy.Integer(4), reduction_numel)
+            features = SIMDKernelFeatures([], sympy.Integer(4), reduction_extent)
             kernel = TritonKernel(
-                {"x": sympy.Integer(4), "r0_": reduction_numel},
+                {"x": sympy.Integer(4), "r0_": reduction_extent},
                 features=features,
                 override_persistent_reduction=False,
                 override_cooperative_reduction=False,
@@ -138,23 +138,28 @@ class TestSIMDRangeTrees(TestCase):
             derived = self._make_derived_root(r_tree, group_size=sympy.Integer(2))
             r_numel_symbol = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
 
-            kernel.finalize_indexing([reduction_numel])
+            index_before = reduction_extent
+            expected_index = r_numel_symbol
+            derived_index_before = derived.numel
+            expected_derived_index = FloorDiv(r_numel_symbol, 2)
+
+            kernel.finalize_indexing([index_before])
             self.assertEqual(
                 kernel._r_numel_reuse_replacements,
-                {r_numel_symbol: reduction_numel},
+                {r_numel_symbol: reduction_extent},
             )
             self.assertEqual(
                 kernel._r_numel_reuse_eliminated_symbols,
-                OrderedSet([reduction_numel]),
+                OrderedSet([reduction_extent]),
             )
             with kernel.use_range_trees([x_tree, derived]):
                 self.assertEqual(
-                    kernel._replace_reduction_numel_in_index(reduction_numel),
-                    r_numel_symbol,
+                    kernel._replace_reduction_numel_in_index(index_before),
+                    expected_index,
                 )
                 self.assertEqual(
-                    kernel._replace_reduction_numel_in_index(derived.numel),
-                    FloorDiv(r_numel_symbol, 2),
+                    kernel._replace_reduction_numel_in_index(derived_index_before),
+                    expected_derived_index,
                 )
 
     def test_reduction_numel_reuse_supports_joint_elimination(self):
@@ -166,28 +171,34 @@ class TestSIMDRangeTrees(TestCase):
                 dynamic_dim=DimDynamic.DYNAMIC,
                 constraint_dim=None,
             )
-            r0_numel = CeilDiv(source, 2)
-            r1_numel = CeilDiv(source, 3)
+            r0_extent = CeilDiv(source, 2)
+            r1_extent = CeilDiv(source, 3)
             kernel = TritonKernel(
                 {
                     "x": sympy.Integer(1),
-                    "r0_": r0_numel,
-                    "r1_": r1_numel,
+                    "r0_": r0_extent,
+                    "r1_": r1_extent,
                 },
-                features=SIMDKernelFeatures([], sympy.Integer(1), r0_numel * r1_numel),
+                features=SIMDKernelFeatures(
+                    [], sympy.Integer(1), r0_extent * r1_extent
+                ),
                 override_persistent_reduction=False,
                 override_cooperative_reduction=False,
             )
 
-            kernel.finalize_indexing([r0_numel, r1_numel])
+            index_before = r0_extent + r1_extent
+            expected_index = sympy.Symbol(
+                "r0_numel", integer=True, nonnegative=True
+            ) + sympy.Symbol("r1_numel", integer=True, nonnegative=True)
+
+            kernel.finalize_indexing([r0_extent, r1_extent])
             self.assertEqual(
                 kernel._r_numel_reuse_eliminated_symbols,
                 OrderedSet([source]),
             )
             self.assertEqual(
-                kernel._replace_reduction_numel_in_index(r0_numel + r1_numel),
-                sympy.Symbol("r0_numel", integer=True, nonnegative=True)
-                + sympy.Symbol("r1_numel", integer=True, nonnegative=True),
+                kernel._replace_reduction_numel_in_index(index_before),
+                expected_index,
             )
 
     def test_reduction_numel_reuse_requires_dead_size_argument(self):
@@ -199,35 +210,37 @@ class TestSIMDRangeTrees(TestCase):
                 dynamic_dim=DimDynamic.DYNAMIC,
                 constraint_dim=None,
             )
-            reduction_numel = CeilDiv(dynamic_size, 2)
-            features = SIMDKernelFeatures([], sympy.Integer(4), reduction_numel)
+            reduction_extent = CeilDiv(dynamic_size, 2)
+            features = SIMDKernelFeatures([], sympy.Integer(4), reduction_extent)
             kernel = TritonKernel(
-                {"x": sympy.Integer(4), "r0_": reduction_numel},
+                {"x": sympy.Integer(4), "r0_": reduction_extent},
                 features=features,
                 override_persistent_reduction=False,
                 override_cooperative_reduction=False,
             )
             r_numel_symbol = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+            index_before = reduction_extent
+            expected_index = r_numel_symbol
 
-            kernel.finalize_indexing([reduction_numel])
+            kernel.finalize_indexing([index_before])
             self.assertEqual(
-                kernel._replace_reduction_numel_in_index(reduction_numel),
-                r_numel_symbol,
+                kernel._replace_reduction_numel_in_index(index_before),
+                expected_index,
             )
 
-            kernel.finalize_indexing([reduction_numel, dynamic_size])
+            kernel.finalize_indexing([index_before, dynamic_size])
             self.assertEqual(
-                kernel._replace_reduction_numel_in_index(reduction_numel),
-                reduction_numel,
+                kernel._replace_reduction_numel_in_index(index_before),
+                index_before,
             )
 
             kernel.range_tree_nodes[sympy.Symbol("__test_range")] = SimpleNamespace(
                 expr=dynamic_size
             )
-            kernel.finalize_indexing([reduction_numel])
+            kernel.finalize_indexing([index_before])
             self.assertEqual(
-                kernel._replace_reduction_numel_in_index(reduction_numel),
-                reduction_numel,
+                kernel._replace_reduction_numel_in_index(index_before),
+                index_before,
             )
 
     def test_reduction_numel_reuse_skips_staged_indexing_schedule(self):
@@ -239,24 +252,26 @@ class TestSIMDRangeTrees(TestCase):
                 dynamic_dim=DimDynamic.DYNAMIC,
                 constraint_dim=None,
             )
-            reduction_numel = CeilDiv(dynamic_size, 2)
+            reduction_extent = CeilDiv(dynamic_size, 2)
             features = SIMDKernelFeatures(
                 [],
                 sympy.Integer(4),
-                reduction_numel,
+                reduction_extent,
                 indexing_node_schedule=[],
             )
             kernel = TritonKernel(
-                {"x": sympy.Integer(4), "r0_": reduction_numel},
+                {"x": sympy.Integer(4), "r0_": reduction_extent},
                 features=features,
                 override_persistent_reduction=False,
                 override_cooperative_reduction=False,
             )
 
-            kernel.finalize_indexing([reduction_numel])
+            index_before = reduction_extent
+
+            kernel.finalize_indexing([index_before])
             self.assertEqual(
-                kernel._replace_reduction_numel_in_index(reduction_numel),
-                reduction_numel,
+                kernel._replace_reduction_numel_in_index(index_before),
+                index_before,
             )
 
     def test_use_range_trees_clears_simplify_indexing_cache(self):

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -6,6 +6,7 @@ import unittest
 from types import SimpleNamespace
 
 import sympy
+
 from torch._dynamo.source import ConstantSource
 from torch._inductor.codegen.simd import DerivedIterationRangesRoot, IterationRangesRoot
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
@@ -147,6 +148,177 @@ class TestSIMDRangeTrees(TestCase):
                     kernel._replace_reduction_numel_in_index(derived.numel),
                     FloorDiv(expected, 2),
                 )
+
+    def test_reduction_numel_reuse_supports_multiple_reduction_trees(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            r0_numel = graph.sizevars.shape_env.create_symbol(
+                7,
+                source=ConstantSource("__test_r0_numel"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            r1_numel = graph.sizevars.shape_env.create_symbol(
+                37,
+                source=ConstantSource("__test_r1_numel"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            features = SIMDKernelFeatures([], sympy.Integer(1), r0_numel * r1_numel)
+            kernel = TritonKernel(
+                {
+                    "x": sympy.Integer(1),
+                    "r0_": r0_numel,
+                    "r1_": r1_numel,
+                },
+                features=features,
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+            expected = sympy.Symbol("r1_numel", integer=True, nonnegative=True)
+
+            kernel.finalize_indexing([r1_numel])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(r1_numel),
+                expected,
+            )
+
+    def test_reduction_numel_reuse_is_profitable_per_expression(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            r0_source = graph.sizevars.shape_env.create_symbol(
+                13,
+                source=ConstantSource("__test_profitable_r0_source"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            r1_source = graph.sizevars.shape_env.create_symbol(
+                109,
+                source=ConstantSource("__test_unprofitable_r1_source"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            r0_numel = CeilDiv(r0_source, 2)
+            r1_numel = CeilDiv(r1_source, 3)
+            features = SIMDKernelFeatures([], sympy.Integer(1), r0_numel * r1_numel)
+            kernel = TritonKernel(
+                {
+                    "x": sympy.Integer(1),
+                    "r0_": r0_numel,
+                    "r1_": r1_numel,
+                },
+                features=features,
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+
+            kernel.finalize_indexing([r0_numel, r1_numel, r1_source])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(r0_numel),
+                sympy.Symbol("r0_numel", integer=True, nonnegative=True),
+            )
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(r1_numel),
+                r1_numel,
+            )
+
+    def test_reduction_numel_reuse_supports_joint_elimination(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            r0_source = graph.sizevars.shape_env.create_symbol(
+                13,
+                source=ConstantSource("__test_joint_r0_source"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            r1_source = graph.sizevars.shape_env.create_symbol(
+                109,
+                source=ConstantSource("__test_joint_r1_source"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            r0_numel = CeilDiv(r0_source, 2)
+            r1_numel = CeilDiv(r1_source, 3)
+            kernel = TritonKernel(
+                {
+                    "x": sympy.Integer(1),
+                    "r0_": r0_numel,
+                    "r1_": r1_numel,
+                },
+                features=SIMDKernelFeatures([], sympy.Integer(1), r0_numel * r1_numel),
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+
+            kernel.finalize_indexing([r0_numel, r1_numel])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(r0_numel + r1_numel),
+                sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+                + sympy.Symbol("r1_numel", integer=True, nonnegative=True),
+            )
+
+    def test_reduction_numel_reuse_prefers_enclosing_extent(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            inner_numel = graph.sizevars.shape_env.create_symbol(
+                37,
+                source=ConstantSource("__test_inner_reduction_numel"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            outer_factor = graph.sizevars.shape_env.create_symbol(
+                7,
+                source=ConstantSource("__test_outer_reduction_factor"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            outer_numel = inner_numel * outer_factor
+            kernel = TritonKernel(
+                {
+                    "x": sympy.Integer(1),
+                    "r0_": outer_numel,
+                    "r1_": inner_numel,
+                },
+                features=SIMDKernelFeatures(
+                    [], sympy.Integer(1), outer_numel * inner_numel
+                ),
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+
+            kernel.finalize_indexing([outer_numel])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(outer_numel),
+                sympy.Symbol("r0_numel", integer=True, nonnegative=True),
+            )
+
+    def test_reduction_numel_reuse_uses_first_equal_tree(self):
+        graph = self._make_graph()
+        with V.set_graph_handler(graph):
+            reduction_numel = graph.sizevars.shape_env.create_symbol(
+                37,
+                source=ConstantSource("__test_equal_reduction_numel"),
+                dynamic_dim=DimDynamic.DYNAMIC,
+                constraint_dim=None,
+            )
+            kernel = TritonKernel(
+                {
+                    "x": sympy.Integer(1),
+                    "r0_": reduction_numel,
+                    "r1_": reduction_numel,
+                },
+                features=SIMDKernelFeatures(
+                    [], sympy.Integer(1), reduction_numel * reduction_numel
+                ),
+                override_persistent_reduction=False,
+                override_cooperative_reduction=False,
+            )
+
+            kernel.finalize_indexing([reduction_numel])
+            self.assertEqual(
+                kernel._replace_reduction_numel_in_index(reduction_numel),
+                sympy.Symbol("r0_numel", integer=True, nonnegative=True),
+            )
 
     def test_reduction_numel_reuse_requires_dead_size_argument(self):
         graph = self._make_graph()

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -157,96 +157,17 @@ class TestSIMDRangeTrees(TestCase):
                     FloorDiv(r_numel_symbol, 2),
                 )
 
-    def test_reduction_numel_reuse_supports_multiple_reduction_trees(self):
-        graph = self._make_graph()
-        with V.set_graph_handler(graph):
-            r0_numel = graph.sizevars.shape_env.create_symbol(
-                7,
-                source=ConstantSource("__test_r0_numel"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            r1_numel = graph.sizevars.shape_env.create_symbol(
-                37,
-                source=ConstantSource("__test_r1_numel"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            features = SIMDKernelFeatures([], sympy.Integer(1), r0_numel * r1_numel)
-            kernel = TritonKernel(
-                {
-                    "x": sympy.Integer(1),
-                    "r0_": r0_numel,
-                    "r1_": r1_numel,
-                },
-                features=features,
-                override_persistent_reduction=False,
-                override_cooperative_reduction=False,
-            )
-            expected = sympy.Symbol("r1_numel", integer=True, nonnegative=True)
-
-            kernel.finalize_indexing([r1_numel])
-            self.assertEqual(
-                kernel._replace_reduction_numel_in_index(r1_numel),
-                expected,
-            )
-
-    def test_reduction_numel_reuse_is_profitable_per_expression(self):
-        graph = self._make_graph()
-        with V.set_graph_handler(graph):
-            r0_source = graph.sizevars.shape_env.create_symbol(
-                13,
-                source=ConstantSource("__test_profitable_r0_source"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            r1_source = graph.sizevars.shape_env.create_symbol(
-                109,
-                source=ConstantSource("__test_unprofitable_r1_source"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            r0_numel = CeilDiv(r0_source, 2)
-            r1_numel = CeilDiv(r1_source, 3)
-            features = SIMDKernelFeatures([], sympy.Integer(1), r0_numel * r1_numel)
-            kernel = TritonKernel(
-                {
-                    "x": sympy.Integer(1),
-                    "r0_": r0_numel,
-                    "r1_": r1_numel,
-                },
-                features=features,
-                override_persistent_reduction=False,
-                override_cooperative_reduction=False,
-            )
-
-            kernel.finalize_indexing([r0_numel, r1_numel, r1_source])
-            self.assertEqual(
-                kernel._replace_reduction_numel_in_index(r0_numel),
-                sympy.Symbol("r0_numel", integer=True, nonnegative=True),
-            )
-            self.assertEqual(
-                kernel._replace_reduction_numel_in_index(r1_numel),
-                r1_numel,
-            )
-
     def test_reduction_numel_reuse_supports_joint_elimination(self):
         graph = self._make_graph()
         with V.set_graph_handler(graph):
-            r0_source = graph.sizevars.shape_env.create_symbol(
-                13,
-                source=ConstantSource("__test_joint_r0_source"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            r1_source = graph.sizevars.shape_env.create_symbol(
+            source = graph.sizevars.shape_env.create_symbol(
                 109,
-                source=ConstantSource("__test_joint_r1_source"),
+                source=ConstantSource("__test_joint_source"),
                 dynamic_dim=DimDynamic.DYNAMIC,
                 constraint_dim=None,
             )
-            r0_numel = CeilDiv(r0_source, 2)
-            r1_numel = CeilDiv(r1_source, 3)
+            r0_numel = CeilDiv(source, 2)
+            r1_numel = CeilDiv(source, 3)
             kernel = TritonKernel(
                 {
                     "x": sympy.Integer(1),
@@ -260,72 +181,13 @@ class TestSIMDRangeTrees(TestCase):
 
             kernel.finalize_indexing([r0_numel, r1_numel])
             self.assertEqual(
+                kernel._r_numel_reuse_eliminated_symbols,
+                OrderedSet([source]),
+            )
+            self.assertEqual(
                 kernel._replace_reduction_numel_in_index(r0_numel + r1_numel),
                 sympy.Symbol("r0_numel", integer=True, nonnegative=True)
                 + sympy.Symbol("r1_numel", integer=True, nonnegative=True),
-            )
-
-    def test_reduction_numel_reuse_prefers_enclosing_extent(self):
-        graph = self._make_graph()
-        with V.set_graph_handler(graph):
-            inner_numel = graph.sizevars.shape_env.create_symbol(
-                37,
-                source=ConstantSource("__test_inner_reduction_numel"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            outer_factor = graph.sizevars.shape_env.create_symbol(
-                7,
-                source=ConstantSource("__test_outer_reduction_factor"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            outer_numel = inner_numel * outer_factor
-            kernel = TritonKernel(
-                {
-                    "x": sympy.Integer(1),
-                    "r0_": outer_numel,
-                    "r1_": inner_numel,
-                },
-                features=SIMDKernelFeatures(
-                    [], sympy.Integer(1), outer_numel * inner_numel
-                ),
-                override_persistent_reduction=False,
-                override_cooperative_reduction=False,
-            )
-
-            kernel.finalize_indexing([outer_numel])
-            self.assertEqual(
-                kernel._replace_reduction_numel_in_index(outer_numel),
-                sympy.Symbol("r0_numel", integer=True, nonnegative=True),
-            )
-
-    def test_reduction_numel_reuse_uses_first_equal_tree(self):
-        graph = self._make_graph()
-        with V.set_graph_handler(graph):
-            reduction_numel = graph.sizevars.shape_env.create_symbol(
-                37,
-                source=ConstantSource("__test_equal_reduction_numel"),
-                dynamic_dim=DimDynamic.DYNAMIC,
-                constraint_dim=None,
-            )
-            kernel = TritonKernel(
-                {
-                    "x": sympy.Integer(1),
-                    "r0_": reduction_numel,
-                    "r1_": reduction_numel,
-                },
-                features=SIMDKernelFeatures(
-                    [], sympy.Integer(1), reduction_numel * reduction_numel
-                ),
-                override_persistent_reduction=False,
-                override_cooperative_reduction=False,
-            )
-
-            kernel.finalize_indexing([reduction_numel])
-            self.assertEqual(
-                kernel._replace_reduction_numel_in_index(reduction_numel),
-                sympy.Symbol("r0_numel", integer=True, nonnegative=True),
             )
 
     def test_reduction_numel_reuse_requires_dead_size_argument(self):
@@ -345,12 +207,12 @@ class TestSIMDRangeTrees(TestCase):
                 override_persistent_reduction=False,
                 override_cooperative_reduction=False,
             )
-            expected = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+            r_numel_symbol = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
 
             kernel.finalize_indexing([reduction_numel])
             self.assertEqual(
                 kernel._replace_reduction_numel_in_index(reduction_numel),
-                expected,
+                r_numel_symbol,
             )
 
             kernel.finalize_indexing([reduction_numel, dynamic_size])
@@ -366,35 +228,6 @@ class TestSIMDRangeTrees(TestCase):
             self.assertEqual(
                 kernel._replace_reduction_numel_in_index(reduction_numel),
                 reduction_numel,
-            )
-
-    def test_reduction_numel_reuse_skips_ineligible_extents(self):
-        graph = self._make_graph()
-        with V.set_graph_handler(graph):
-            no_reduction = TritonKernel(
-                {"x": sympy.Integer(4)},
-                features=SIMDKernelFeatures([], sympy.Integer(4)),
-                override_persistent_reduction=False,
-                override_cooperative_reduction=False,
-            )
-            static_reduction = TritonKernel(
-                {"x": sympy.Integer(4), "r0_": sympy.Integer(512)},
-                features=SIMDKernelFeatures([], sympy.Integer(4), sympy.Integer(512)),
-                override_persistent_reduction=False,
-                override_cooperative_reduction=False,
-            )
-
-            self.assertEqual(
-                no_reduction._replace_reduction_numel_in_index(
-                    sympy.Symbol("s0"), simulate=True
-                ),
-                sympy.Symbol("s0"),
-            )
-            self.assertEqual(
-                static_reduction._replace_reduction_numel_in_index(
-                    sympy.Integer(512), simulate=True
-                ),
-                sympy.Integer(512),
             )
 
     def test_reduction_numel_reuse_skips_staged_indexing_schedule(self):

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -234,6 +234,9 @@ class TestSIMDRangeTrees(TestCase):
                 index_before,
             )
 
+            # A range-tree expression still uses dynamic_size, deliberately
+            # preventing removal of its scalar argument and making the
+            # replacement unprofitable.
             kernel.range_tree_nodes[sympy.Symbol("__test_range")] = SimpleNamespace(
                 expr=dynamic_size
             )

--- a/test/inductor/test_simd_range_trees.py
+++ b/test/inductor/test_simd_range_trees.py
@@ -378,13 +378,13 @@ class TestSIMDRangeTrees(TestCase):
 
             self.assertEqual(
                 no_reduction._replace_reduction_numel_in_index(
-                    sympy.Symbol("s0"), force=True
+                    sympy.Symbol("s0"), simulate=True
                 ),
                 sympy.Symbol("s0"),
             )
             self.assertEqual(
                 static_reduction._replace_reduction_numel_in_index(
-                    sympy.Integer(512), force=True
+                    sympy.Integer(512), simulate=True
                 ),
                 sympy.Integer(512),
             )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -27,6 +27,7 @@ import torch.utils._pytree as pytree
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype, type_to_dtype
+from torch.fx.experimental.symbolic_shapes import has_free_symbols
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import (
     CeilDiv,
@@ -3316,11 +3317,41 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
     def finalize_indexing(self, indices: Sequence[sympy.Expr]) -> None:
         super().finalize_indexing(indices)
-        self._eliminated_reduction_numel_symbols_for_indexing.clear()
-        # Staged reductions emit some indexing outside this prepass, so their
-        # complete scalar-argument liveness is not available here.
+        self._finalize_r_numel_reuse(indices)
+
+    def _finalize_r_numel_reuse(self, indices: Sequence[sympy.Expr]) -> None:
+        """Select profitable indexing expressions to rewrite with ``rN_numel``.
+        The goal is to reuse an existing ``rN_numel`` kernel argument when
+        doing so eliminates an ordinary scalar size argument from the kernel.
+
+        1. Collect size symbols from all ordinary indexing and range-tree
+           expressions.
+        2. Simulate every statically valid replacement with the corresponding
+           existing ``rN_numel`` argument. Simulating them together detects
+           arguments that become unused only after multiple replacements.
+        3. Record the size symbols absent from the fully rewritten expressions.
+        4. During source emission, keep only replacements involving one of
+           these eliminated symbols, avoiding neutral indexing rewrites.
+        """
+        self._r_numel_reuse_eliminated_symbols.clear()
+        self._r_numel_reuse_replacements.clear()
+        # Staged reductions emit some symbolic indexing expressions after
+        # this prepass, so we cannot prove that a size argument is unused.
         if self.features.indexing_node_schedule is not self.features.node_schedule:
             return
+
+        sizevars = V.graph.sizevars
+        replacements = {}
+        for prefix, numel in self.numels.items():
+            if not prefix_is_reduction(prefix):
+                continue
+            numel = sizevars.simplify(sizevars.remove_precomputed_replacements(numel))
+            if has_free_symbols(numel):
+                r_numel_symbol = sympy.Symbol(
+                    f"{prefix}numel", integer=True, nonnegative=True
+                )
+                replacements[r_numel_symbol] = numel
+        self._r_numel_reuse_replacements.update(replacements)
 
         allowed_symbol_types = (
             SymT.SIZE,
@@ -3328,6 +3359,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             SymT.PRECOMPUTED_SIZE,
         )
 
+        # Only these symbols become ordinary ks* size arguments, which are the
+        # kernel arguments this profitability check is intended to eliminate.
         def size_symbols(exprs: Iterable[sympy.Expr]) -> OrderedSet[sympy.Symbol]:
             return OrderedSet(
                 symbol
@@ -3336,43 +3369,29 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if symbol_is_type(symbol, allowed_symbol_types)
             )
 
-        all_indices = [
+        all_indexing_exprs = [
             *indices,
             *(entry.expr for entry in self.range_tree_nodes.values()),
         ]
-        original_symbols = size_symbols(all_indices)
+        original_symbols = size_symbols(all_indexing_exprs)
         rewritten_symbols = size_symbols(
-            self._replace_reduction_numel_in_index(index, force=True)
-            for index in all_indices
+            self._replace_reduction_numel_in_index(index, simulate=True)
+            for index in all_indexing_exprs
         )
-        self._eliminated_reduction_numel_symbols_for_indexing.update(
+        self._r_numel_reuse_eliminated_symbols.update(
             original_symbols - rewritten_symbols
         )
 
     def _replace_reduction_numel_in_index(
-        self, index: sympy.Expr, *, force: bool = False
+        self, index: sympy.Expr, *, simulate: bool = False
     ) -> sympy.Expr:
-        if not force and not self._eliminated_reduction_numel_symbols_for_indexing:
+        if not simulate and not self._r_numel_reuse_eliminated_symbols:
+            return index
+
+        if not self._r_numel_reuse_replacements:
             return index
 
         sizevars = V.graph.sizevars
-        reduction_numels = []
-        for prefix, numel in self.numels.items():
-            if not prefix_is_reduction(prefix):
-                continue
-            numel = sizevars.simplify(sizevars.remove_precomputed_replacements(numel))
-            if numel.free_symbols:
-                reduction_numels.append(
-                    (
-                        numel,
-                        sympy.Symbol(f"{prefix}numel", integer=True, nonnegative=True),
-                    )
-                )
-
-        if not reduction_numels:
-            return index
-
-        reduction_numel_symbols = OrderedSet(symbol for _, symbol in reduction_numels)
         allowed_symbol_types = (
             SymT.SIZE,
             SymT.UNBACKED_INT,
@@ -3382,29 +3401,35 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         def replacement(candidate: sympy.Basic) -> sympy.Symbol | None:
             if not isinstance(candidate, sympy.Expr):
                 return None
-            if candidate in reduction_numel_symbols or not candidate.free_symbols:
+            if (
+                candidate in self._r_numel_reuse_replacements
+                or not candidate.free_symbols
+            ):
                 return None
             if any(
                 not symbol_is_type(symbol, allowed_symbol_types)
                 for symbol in candidate.free_symbols
             ):
                 return None
-            if not force and not candidate.free_symbols.intersection(
-                self._eliminated_reduction_numel_symbols_for_indexing
+            if not simulate and not candidate.free_symbols.intersection(
+                self._r_numel_reuse_eliminated_symbols
             ):
                 return None
 
             normalized_candidate = sizevars.simplify(
                 sizevars.remove_precomputed_replacements(candidate)
             )
-            for reduction_numel, reduction_numel_symbol in reduction_numels:
+            for (
+                r_numel_symbol,
+                equivalent_extent_expr,
+            ) in self._r_numel_reuse_replacements.items():
                 if (
-                    normalized_candidate == reduction_numel
+                    normalized_candidate == equivalent_extent_expr
                     or sizevars.statically_known_equals(
-                        normalized_candidate, reduction_numel
+                        normalized_candidate, equivalent_extent_expr
                     )
                 ):
-                    return reduction_numel_symbol
+                    return r_numel_symbol
             return None
 
         # Prefer an enclosing match over nested matches: replacing the whole
@@ -3434,9 +3459,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     ) -> None:
         self.optimize_mask: bool = optimize_mask
         self.fixed_config = fixed_config
-        self._eliminated_reduction_numel_symbols_for_indexing: OrderedSet[
-            sympy.Symbol
-        ] = OrderedSet()
+        self._r_numel_reuse_eliminated_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
+        self._r_numel_reuse_replacements: dict[sympy.Symbol, sympy.Expr] = {}
         self.is_combo_kernel: bool = is_combo_kernel
         self.per_subkernel_blocks: bool = per_subkernel_blocks
         super().__init__(tiling, **kwargs)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -19,11 +19,10 @@ from functools import lru_cache
 from typing import Any, cast, TYPE_CHECKING, TypeVar
 
 import sympy
-from sympy.printing.precedence import PRECEDENCE
-
 import torch
 import torch._logging
 import torch.utils._pytree as pytree
+from sympy.printing.precedence import PRECEDENCE
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype, type_to_dtype
@@ -3314,6 +3313,90 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     )
     transpose_discontiguous_tensor_descriptors_override: bool | None = None
 
+    def finalize_indexing(self, indices: Sequence[sympy.Expr]) -> None:
+        super().finalize_indexing(indices)
+        self._reuse_reduction_numel_for_indexing = False
+        # Staged reductions emit some indexing outside this prepass, so their
+        # complete scalar-argument liveness is not available here.
+        if self.features.indexing_node_schedule is not self.features.node_schedule:
+            return
+
+        allowed_symbol_types = (
+            SymT.SIZE,
+            SymT.UNBACKED_INT,
+            SymT.PRECOMPUTED_SIZE,
+        )
+
+        def size_symbols(exprs: Iterable[sympy.Expr]) -> OrderedSet[sympy.Symbol]:
+            return OrderedSet(
+                symbol
+                for expr in exprs
+                for symbol in expr.free_symbols
+                if symbol_is_type(symbol, allowed_symbol_types)
+            )
+
+        all_indices = [
+            *indices,
+            *(entry.expr for entry in self.range_tree_nodes.values()),
+        ]
+        original_symbols = size_symbols(all_indices)
+        rewritten_symbols = size_symbols(
+            self._replace_reduction_numel_in_index(index, force=True)
+            for index in all_indices
+        )
+        self._reuse_reduction_numel_for_indexing = bool(
+            original_symbols - rewritten_symbols
+        )
+
+    def _replace_reduction_numel_in_index(
+        self, index: sympy.Expr, *, force: bool = False
+    ) -> sympy.Expr:
+        if not force and not self._reuse_reduction_numel_for_indexing:
+            return index
+
+        reduction_numel = self.numels.get("r0_")
+        if reduction_numel is None:
+            return index
+
+        sizevars = V.graph.sizevars
+        reduction_numel = sizevars.simplify(
+            sizevars.remove_precomputed_replacements(reduction_numel)
+        )
+        if not reduction_numel.free_symbols:
+            return index
+
+        r0_numel = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+        allowed_symbol_types = (
+            SymT.SIZE,
+            SymT.UNBACKED_INT,
+            SymT.PRECOMPUTED_SIZE,
+        )
+
+        def matches(candidate: sympy.Basic) -> bool:
+            if not isinstance(candidate, sympy.Expr):
+                return False
+            if candidate == r0_numel or not candidate.free_symbols:
+                return False
+            if any(
+                not symbol_is_type(symbol, allowed_symbol_types)
+                for symbol in candidate.free_symbols
+            ):
+                return False
+
+            candidate = sizevars.simplify(
+                sizevars.remove_precomputed_replacements(candidate)
+            )
+            return candidate == reduction_numel or sizevars.statically_known_equals(
+                candidate, reduction_numel
+            )
+
+        return index.replace(matches, lambda _: r0_numel)
+
+    def index_to_str(self, index: sympy.Expr) -> str:
+        if not isinstance(index, list):
+            index = self._replace_reduction_numel_in_index(index)
+        return super().index_to_str(index)
+
     def __init__(
         self,
         tiling: dict[str, sympy.Expr],
@@ -3327,6 +3410,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     ) -> None:
         self.optimize_mask: bool = optimize_mask
         self.fixed_config = fixed_config
+        self._reuse_reduction_numel_for_indexing = False
         self.is_combo_kernel: bool = is_combo_kernel
         self.per_subkernel_blocks: bool = per_subkernel_blocks
         super().__init__(tiling, **kwargs)
@@ -7855,7 +7939,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return TritonCSEVariable(*args, **kwargs)
 
     def codegen_iteration_ranges_entry(self, entry: IterationRangesEntry):
-        line = f"{entry.name} = {self.kexpr(self.rename_indexing(entry.expr))}"
+        line = f"{entry.name} = {self.index_to_str(entry.expr)}"
 
         # mix order reduction introduces an extra loop across the x
         # dimension

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -19,10 +19,11 @@ from functools import lru_cache
 from typing import Any, cast, TYPE_CHECKING, TypeVar
 
 import sympy
+from sympy.printing.precedence import PRECEDENCE
+
 import torch
 import torch._logging
 import torch.utils._pytree as pytree
-from sympy.printing.precedence import PRECEDENCE
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import identity, preserve_rng_state
 from torch._prims_common import is_integer_dtype, type_to_dtype
@@ -3315,7 +3316,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
     def finalize_indexing(self, indices: Sequence[sympy.Expr]) -> None:
         super().finalize_indexing(indices)
-        self._reuse_reduction_numel_for_indexing = False
+        self._eliminated_reduction_numel_symbols_for_indexing.clear()
         # Staged reductions emit some indexing outside this prepass, so their
         # complete scalar-argument liveness is not available here.
         if self.features.indexing_node_schedule is not self.features.node_schedule:
@@ -3344,56 +3345,79 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self._replace_reduction_numel_in_index(index, force=True)
             for index in all_indices
         )
-        self._reuse_reduction_numel_for_indexing = bool(
+        self._eliminated_reduction_numel_symbols_for_indexing.update(
             original_symbols - rewritten_symbols
         )
 
     def _replace_reduction_numel_in_index(
         self, index: sympy.Expr, *, force: bool = False
     ) -> sympy.Expr:
-        if not force and not self._reuse_reduction_numel_for_indexing:
-            return index
-
-        reduction_numel = self.numels.get("r0_")
-        if reduction_numel is None:
+        if not force and not self._eliminated_reduction_numel_symbols_for_indexing:
             return index
 
         sizevars = V.graph.sizevars
-        reduction_numel = sizevars.simplify(
-            sizevars.remove_precomputed_replacements(reduction_numel)
-        )
-        if not reduction_numel.free_symbols:
+        reduction_numels = []
+        for prefix, numel in self.numels.items():
+            if not prefix_is_reduction(prefix):
+                continue
+            numel = sizevars.simplify(sizevars.remove_precomputed_replacements(numel))
+            if numel.free_symbols:
+                reduction_numels.append(
+                    (
+                        numel,
+                        sympy.Symbol(f"{prefix}numel", integer=True, nonnegative=True),
+                    )
+                )
+
+        if not reduction_numels:
             return index
 
-        r0_numel = sympy.Symbol("r0_numel", integer=True, nonnegative=True)
+        reduction_numel_symbols = OrderedSet(symbol for _, symbol in reduction_numels)
         allowed_symbol_types = (
             SymT.SIZE,
             SymT.UNBACKED_INT,
             SymT.PRECOMPUTED_SIZE,
         )
 
-        def matches(candidate: sympy.Basic) -> bool:
+        def replacement(candidate: sympy.Basic) -> sympy.Symbol | None:
             if not isinstance(candidate, sympy.Expr):
-                return False
-            if candidate == r0_numel or not candidate.free_symbols:
-                return False
+                return None
+            if candidate in reduction_numel_symbols or not candidate.free_symbols:
+                return None
             if any(
                 not symbol_is_type(symbol, allowed_symbol_types)
                 for symbol in candidate.free_symbols
             ):
-                return False
+                return None
+            if not force and not candidate.free_symbols.intersection(
+                self._eliminated_reduction_numel_symbols_for_indexing
+            ):
+                return None
 
-            candidate = sizevars.simplify(
+            normalized_candidate = sizevars.simplify(
                 sizevars.remove_precomputed_replacements(candidate)
             )
-            return candidate == reduction_numel or sizevars.statically_known_equals(
-                candidate, reduction_numel
-            )
+            for reduction_numel, reduction_numel_symbol in reduction_numels:
+                if (
+                    normalized_candidate == reduction_numel
+                    or sizevars.statically_known_equals(
+                        normalized_candidate, reduction_numel
+                    )
+                ):
+                    return reduction_numel_symbol
+            return None
 
-        return index.replace(matches, lambda _: r0_numel)
+        # Prefer an enclosing match over nested matches: replacing the whole
+        # expression removes a superset of its children's symbol uses.
+        replacements = {
+            candidate: replacement_symbol
+            for candidate in sympy.preorder_traversal(index)
+            if (replacement_symbol := replacement(candidate)) is not None
+        }
+        return index.xreplace(replacements)
 
     def index_to_str(self, index: sympy.Expr) -> str:
-        if not isinstance(index, list):
+        if isinstance(index, sympy.Expr):
             index = self._replace_reduction_numel_in_index(index)
         return super().index_to_str(index)
 
@@ -3410,7 +3434,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     ) -> None:
         self.optimize_mask: bool = optimize_mask
         self.fixed_config = fixed_config
-        self._reuse_reduction_numel_for_indexing = False
+        self._eliminated_reduction_numel_symbols_for_indexing: OrderedSet[
+            sympy.Symbol
+        ] = OrderedSet()
         self.is_combo_kernel: bool = is_combo_kernel
         self.per_subkernel_blocks: bool = per_subkernel_blocks
         super().__init__(tiling, **kwargs)
@@ -4635,7 +4661,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         index_str = indexing.index_str
         mask_str = indexing.mask_str if indexing.has_mask() else None
-        size_str = texpr(self.rename_indexing(size)) if upper else None
+        size_str = self.index_to_str(size) if upper else None
 
         # expr is already wrapped
         line = self.indirect_assert(
@@ -7850,7 +7876,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
             if tree.is_reduction and self.persistent_reduction:
                 if self.cooperative_reduction:
-                    numel = self.kexpr(self.rename_indexing(tree.numel))
+                    numel = self.index_to_str(tree.numel)
                     val = f"triton_helpers.constexpr_next_power_of_2(({numel} + RSPLIT - 1) // RSPLIT)"
                 else:
                     val = self._get_persistent_reduction_block(tree.numel)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3332,8 +3332,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         1. Collect size symbols from all ordinary indexing and range-tree
            expressions.
-        2. Simulate every statically valid replacement with the corresponding
-           existing ``rN_numel`` argument. Simulating them together detects
+        2. Simulate every exact reduction-extent replacement with the
+           corresponding existing ``rN_numel`` argument. Simulating them
+           together detects
            arguments that become unused only after multiple replacements.
         3. Record the size symbols absent from the fully rewritten expressions.
         4. During source emission, keep only replacements involving one of
@@ -3346,11 +3347,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if self.features.indexing_node_schedule is not self.features.node_schedule:
             return
 
-        sizevars = V.graph.sizevars
         for prefix, numel in self.numels.items():
             if not prefix_is_reduction(prefix):
                 continue
-            numel = sizevars.simplify(sizevars.remove_precomputed_replacements(numel))
             if has_free_symbols(numel):
                 r_numel_symbol = sympy.Symbol(
                     f"{prefix}numel", integer=True, nonnegative=True
@@ -3391,47 +3390,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if not self._r_numel_reuse_replacements:
             return index
 
-        sizevars = V.graph.sizevars
-
-        def replacement(candidate: sympy.Basic) -> sympy.Symbol | None:
-            if not isinstance(candidate, sympy.Expr):
-                return None
-            if not candidate.free_symbols:
-                return None
-            if any(
-                not symbol_is_type(symbol, _R_NUMEL_REUSE_SYMBOL_TYPES)
-                for symbol in candidate.free_symbols
-            ):
-                return None
+        replacements = {}
+        for (
+            r_numel_symbol,
+            equivalent_extent_expr,
+        ) in self._r_numel_reuse_replacements.items():
             # Keep only replacements that eliminate a scalar kernel argument.
-            if not simulate and not candidate.free_symbols.intersection(
+            if simulate or equivalent_extent_expr.free_symbols.intersection(
                 self._r_numel_reuse_eliminated_symbols
             ):
-                return None
-
-            normalized_candidate = sizevars.simplify(
-                sizevars.remove_precomputed_replacements(candidate)
-            )
-            for (
-                r_numel_symbol,
-                equivalent_extent_expr,
-            ) in self._r_numel_reuse_replacements.items():
-                if (
-                    normalized_candidate == equivalent_extent_expr
-                    or sizevars.statically_known_equals(
-                        normalized_candidate, equivalent_extent_expr
-                    )
-                ):
-                    return r_numel_symbol
-            return None
-
-        # Prefer an enclosing match over nested matches: replacing the whole
-        # expression removes a superset of its children's symbol uses.
-        replacements = {
-            candidate: replacement_symbol
-            for candidate in sympy.preorder_traversal(index)
-            if (replacement_symbol := replacement(candidate)) is not None
-        }
+                replacements.setdefault(equivalent_extent_expr, r_numel_symbol)
         return index.xreplace(replacements)
 
     def index_to_str(self, index: sympy.Expr) -> str:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3396,16 +3396,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         def replacement(candidate: sympy.Basic) -> sympy.Symbol | None:
             if not isinstance(candidate, sympy.Expr):
                 return None
-            if (
-                candidate in self._r_numel_reuse_replacements
-                or not candidate.free_symbols
-            ):
+            if not candidate.free_symbols:
                 return None
             if any(
                 not symbol_is_type(symbol, _R_NUMEL_REUSE_SYMBOL_TYPES)
                 for symbol in candidate.free_symbols
             ):
                 return None
+            # Keep only replacements that eliminate a scalar kernel argument.
             if not simulate and not candidate.free_symbols.intersection(
                 self._r_numel_reuse_eliminated_symbols
             ):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -161,6 +161,12 @@ schedule_log = torch._logging.getArtifactLogger(__name__, "schedule")
 fusion_log = torch._logging.getArtifactLogger(__name__, "fusion")
 async_compile = AsyncCompile()
 
+_R_NUMEL_REUSE_SYMBOL_TYPES = (
+    SymT.SIZE,
+    SymT.UNBACKED_INT,
+    SymT.PRECOMPUTED_SIZE,
+)
+
 
 def get_triton_reduction_function(reduction_type):
     use_helper = reduction_type in ("any", "max", "min", "prod", "fmax")
@@ -3341,7 +3347,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return
 
         sizevars = V.graph.sizevars
-        replacements = {}
         for prefix, numel in self.numels.items():
             if not prefix_is_reduction(prefix):
                 continue
@@ -3350,14 +3355,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 r_numel_symbol = sympy.Symbol(
                     f"{prefix}numel", integer=True, nonnegative=True
                 )
-                replacements[r_numel_symbol] = numel
-        self._r_numel_reuse_replacements.update(replacements)
-
-        allowed_symbol_types = (
-            SymT.SIZE,
-            SymT.UNBACKED_INT,
-            SymT.PRECOMPUTED_SIZE,
-        )
+                self._r_numel_reuse_replacements[r_numel_symbol] = numel
 
         # Only these symbols become ordinary ks* size arguments, which are the
         # kernel arguments this profitability check is intended to eliminate.
@@ -3366,7 +3364,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 symbol
                 for expr in exprs
                 for symbol in expr.free_symbols
-                if symbol_is_type(symbol, allowed_symbol_types)
+                if symbol_is_type(symbol, _R_NUMEL_REUSE_SYMBOL_TYPES)
             )
 
         all_indexing_exprs = [
@@ -3385,18 +3383,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
     def _replace_reduction_numel_in_index(
         self, index: sympy.Expr, *, simulate: bool = False
     ) -> sympy.Expr:
+        # Real emission has nothing profitable to rewrite.
         if not simulate and not self._r_numel_reuse_eliminated_symbols:
             return index
 
+        # The kernel has no dynamic reduction extent available for reuse.
         if not self._r_numel_reuse_replacements:
             return index
 
         sizevars = V.graph.sizevars
-        allowed_symbol_types = (
-            SymT.SIZE,
-            SymT.UNBACKED_INT,
-            SymT.PRECOMPUTED_SIZE,
-        )
 
         def replacement(candidate: sympy.Basic) -> sympy.Symbol | None:
             if not isinstance(candidate, sympy.Expr):
@@ -3407,7 +3402,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             ):
                 return None
             if any(
-                not symbol_is_type(symbol, allowed_symbol_types)
+                not symbol_is_type(symbol, _R_NUMEL_REUSE_SYMBOL_TYPES)
                 for symbol in candidate.free_symbols
             ):
                 return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196362

While comparing static and dynamic kernels, I noticed that some indexing expressions repeatedly reconstruct a value already passed as a kernel argument.

For example, the wrapper computes and passes r0_numel:
```
r0_numel = (349 + s110) // 350

kernel.run(
    ...,
    s110,       # ks0
    r0_numel,
)
```
but the generated kernel reconstructs the same exact expression in several indices:
```
def kernel(..., ks0, r0_numel, ...):
    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
        ...
        index = r0_2 + x1 * ((349 + ks0) // 350)
```
This can instead reuse the existing argument:
```
def kernel(..., r0_numel, ...):
    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
        ...
        index = r0_2 + x1 * r0_numel
```
Replacing every occurrence produced 1–4% kernel-level wins in several benchmarks, but regressed other kernels by about 0.5%. Digging deeper, the wins consistently occurred when the replacement removed the final use of a symbolic ks* argument, allowing that argument to disappear from the kernel signature. When all original arguments remained necessary elsewhere, the rewrite was neutral or slightly slower.

This PR therefore limits the optimization to replacements that reduce the number of kernel arguments.
<details>

Reuse existing r0_numel and r1_numel kernel arguments in Triton indexing expressions when doing so removes a redundant scalar size argument from the kernel signature.

Inductor already passes reduction extents to Triton for reduction loop bounds and masks. Tensor indexing is generated separately from tensor layout and stride expressions, so the same expression can also appear as an ordinary symbolic ks* argument. This commonly happens when a reduction  is used as the stride of an outer dimension or is reconstructed from dynamic input sizes.

For example:

#### Before
```
def kernel(..., ks0, r0_numel, ...):
    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
        value = tl.load(
            in_ptr + r0_index + ks0 * xindex,
            ...
        )
```
When ks0 is exactly the same expression as r0_numel, this becomes:

#### After
```
def kernel(..., r0_numel, ...):
    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
        value = tl.load(
            in_ptr + r0_index + r0_numel * xindex,
            ...
        )
 ```
 
This removes ks0 from the kernel signature if it has no remaining uses.

### The optimization:

- Supports the ordinary r0_ and r1_ reduction families.
- Collects indexing and range-tree expressions before source emission.
- Simulates all exact reduction-extent replacements together, allowing multiple replacements to jointly eliminate an argument.
- Applies only replacements that contribute to removing a scalar kernel argument.
-0 Skips staged reductions because they can emit symbolic indexing expressions after the indexing prepass.

### Performance
The following programs and kernel classes were evaluated:

- Production model.
- Dynamic LayerNorm forward and backward standalone reproduction.
- DistilBERT dynamic training.
- Ten-model dynamic inference sweep, including DistilGPT2 and T5Small.
- Tiny and medium raw Triton reductions.
- Exact production-style ceil-div reconstruction.
- Forced cooperative reduction.
- Large 4096 x 4096 reduction.
- Three preserved LayerNorm forward/backward kernels.
- Six non-eliminating LayerNorm-backward shape configurations.
- Dynamic two-dimensional r0_/r1_ tiled reduction.
333
Representative results:

#### Production corpus:
  -   12 / 14 affected kernels improved
  - 2.69% median affected-kernel improvement
   -  1.01% combined improvement
   - 2.88% representative-kernel improvement

####  Preserved LayerNorm kernels removing ks*:
    4.73% faster
    2.33% faster

####  Raw production-style r0_numel:
    1.64-3.17% faster

####  Dynamic ND r1_numel:
    0.97% faster
    95% CI: [0.72%, 1.32%]

NOTE: why limiting only when args reduced. 
#### Forced rewrite without argument removal:
    0.47% slower
    95% CI: [0.46%, 0.48%]
    

</details>


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo