### PR TITLE
[inductor] Type FX argument walkers as object

### DIFF
--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -9,7 +9,7 @@ with control_deps to make dependencies explicit.
 """
 
 from operator import attrgetter
-from typing import Any
+from typing import cast
 
 import torch.fx as fx
 import torch.utils._pytree as pytree
@@ -108,8 +108,8 @@ def get_subgraph_name(gm: fx.GraphModule, name):
 
 
 def _extract_unique_nodes(
-    args: tuple[Any, ...], kwargs: dict[str, Any]
-) -> tuple[list[fx.Node], list[Any], Any]:
+    args: tuple[fx.node.Argument, ...], kwargs: dict[str, fx.node.Argument]
+) -> tuple[list[fx.Node], list[fx.node.Argument], pytree.TreeSpec]:
     """Extract unique fx.Node instances from args/kwargs using pytree.
 
     Args:
@@ -122,6 +122,7 @@ def _extract_unique_nodes(
         - The pytree spec for reconstructing the original structure
     """
     flat_args_kwargs, spec = pytree.tree_flatten((args, kwargs))
+    flat_args_kwargs = cast(list[fx.node.Argument], flat_args_kwargs)
     unique_nodes: list[fx.Node] = []
     seen: OrderedSet[fx.Node] = OrderedSet()
     for item in flat_args_kwargs:
@@ -264,7 +265,7 @@ def _create_subgraph_for_node(
         node_to_placeholder[orig_node] = placeholder
 
     # Replace fx.Node instances with their placeholders
-    def replace_nodes(item: Any) -> Any:
+    def replace_nodes(item: fx.node.Argument) -> fx.node.Argument:
         if isinstance(item, fx.Node):
             return node_to_placeholder[item]
         return item
@@ -277,7 +278,10 @@ def _create_subgraph_for_node(
         additional_deps_placeholders.append(placeholder)
 
     new_flat = [replace_nodes(item) for item in flat_args_kwargs]
-    new_args, new_kwargs = pytree.tree_unflatten(new_flat, spec)
+    new_args, new_kwargs = cast(
+        tuple[tuple[fx.node.Argument, ...], dict[str, fx.node.Argument]],
+        pytree.tree_unflatten(new_flat, spec),
+    )
 
     # Recreate the exact original operation in the subgraph
     if not callable(node.target):
@@ -285,7 +289,7 @@ def _create_subgraph_for_node(
     result = subgraph.call_function(
         node.target,
         tuple(new_args),
-        new_kwargs,  # type: ignore[arg-type]
+        new_kwargs,
     )
 
     # Copy metadata from the original node

--- a/torch/_inductor/fx_passes/profile_guided_estimation.py
+++ b/torch/_inductor/fx_passes/profile_guided_estimation.py
@@ -39,6 +39,8 @@ from torch.utils._ordered_set import OrderedSet
 
 log = logging.getLogger(__name__)
 
+_OpInputMetadata = tuple[tuple[object, ...], ...]
+
 
 def _rank_stride(ranks: tuple[int, ...]) -> int | None:
     """Compute the stride of a sorted rank tuple, or None if non-uniform.
@@ -78,13 +80,13 @@ class OpRecord:
     """A single op observation from the profile (any CPU op with GPU kernels)."""
 
     op_name: str  # normalized name, e.g. "aten::mm", "mylib::my_custom_op"
-    input_shapes: tuple[tuple[int, ...], ...]
-    input_strides: tuple[tuple[int, ...], ...]
+    input_shapes: _OpInputMetadata
+    input_strides: _OpInputMetadata
     dtype: torch.dtype | None
     duration_us: float  # sum of all GPU kernels for this CPU op
 
 
-def _to_nested_tuple(x: Any) -> Any:
+def _to_nested_tuple(x: object) -> object:
     """Recursively convert nested lists to tuples for hashability."""
     if isinstance(x, (list, tuple)):
         return tuple(_to_nested_tuple(i) for i in x)
@@ -116,8 +118,8 @@ class ProfileData:
     _op_index: dict[
         tuple[
             str,
-            tuple[tuple[int, ...], ...],
-            tuple[tuple[int, ...], ...],
+            _OpInputMetadata,
+            _OpInputMetadata,
             torch.dtype | None,
         ],
         float,
@@ -260,15 +262,15 @@ class ProfileData:
             return
         dtype_str = input_types[0] if input_types else ""
         dtype = _dtype_map.get(dtype_str)
-        # Skip empty entries (non-tensor args like scalars/None) so the
-        # tuples match what _get_node_input_shapes/strides extract from FX nodes.
+        # Skip empty entries for non-tensor args. Flat entries match the FX lookup
+        # keys; nested TensorList entries remain hashable but cannot match them.
         shapes = tuple(
-            _to_nested_tuple(d)
+            tuple(_to_nested_tuple(i) for i in d)
             for d in input_dims
             if isinstance(d, (list, tuple)) and d
         )
         strides = tuple(
-            _to_nested_tuple(d)
+            tuple(_to_nested_tuple(i) for i in d)
             for d in input_strides
             if isinstance(d, (list, tuple)) and d
         )
@@ -322,8 +324,8 @@ class ProfileData:
         op_groups: defaultdict[
             tuple[
                 str,
-                tuple[tuple[int, ...], ...],
-                tuple[tuple[int, ...], ...],
+                _OpInputMetadata,
+                _OpInputMetadata,
                 torch.dtype | None,
             ],
             list[float],

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -14,7 +14,7 @@ from collections.abc import (
 from dataclasses import dataclass
 from functools import partial
 from itertools import chain
-from typing import Any
+from typing import Any, cast
 
 import sympy
 
@@ -72,8 +72,8 @@ def matches_module_function_pattern(
 
 
 def _is_fake_tensor_same(
-    new: Any,
-    old: Any,
+    new: object,
+    old: object,
     existing_storages: Mapping[int, int],
     *,
     check_strides: bool = True,
@@ -111,6 +111,7 @@ def _is_fake_tensor_same(
             return old is None
 
         if isinstance(new, Collection):
+            old_collection = cast(Collection[object], old)
             if recursive_ids is None:
                 recursive_ids = OrderedSet()
 
@@ -122,7 +123,7 @@ def _is_fake_tensor_same(
             # this collection have already been validated (or will be validated in the
             # future) by a call at a different layer of recursion.
             return visited or (
-                len(new) == len(old)
+                len(new) == len(old_collection)
                 and all(
                     _is_fake_tensor_same(
                         new_i,
@@ -133,14 +134,15 @@ def _is_fake_tensor_same(
                         node=node,
                         recursive_ids=recursive_ids,
                     )
-                    for new_i, old_i in zip(new, old)
+                    for new_i, old_i in zip(new, old_collection)
                 )
             )
 
         if isinstance(new, torch.types.py_sym_types):
+            old_sym = cast(torch.types.PySymType, old)
             return (
                 not_none(new.node.shape_env)._maybe_evaluate_static(
-                    sympy.Eq(new.node.expr, old.node.expr)
+                    sympy.Eq(new.node.expr, old_sym.node.expr)
                 )
                 == sympy.true
             )
@@ -150,20 +152,22 @@ def _is_fake_tensor_same(
         # implemented __eq__ method will compare IDs.
         return new == old
 
+    old_tensor = cast(torch.Tensor, old)
+
     if (
-        new.layout != old.layout
-        or new.dtype != old.dtype
-        or not is_intlist_same(new.shape, old.shape)
+        new.layout != old_tensor.layout
+        or new.dtype != old_tensor.dtype
+        or not is_intlist_same(new.shape, old_tensor.shape)
     ):
         return False
 
-    if new.device != old.device:
+    if new.device != old_tensor.device:
         return False
 
     if (
         check_strides
         and new.layout == torch.strided
-        and not is_intlist_same(new.stride(), old.stride())
+        and not is_intlist_same(new.stride(), old_tensor.stride())
     ):
         return False
 
@@ -171,8 +175,8 @@ def _is_fake_tensor_same(
         return True
 
     if not statically_known_true(
-        new.storage_offset() == old.storage_offset()
-    ) or get_storage(new) != get_storage(old):
+        new.storage_offset() == old_tensor.storage_offset()
+    ) or get_storage(new) != get_storage(old_tensor):
         return False
 
     def any_user_may_alias(node):
@@ -225,7 +229,7 @@ def _is_fake_tensor_same(
     # else.  If the FakeTensor's storage is fresh and none of the node's users can alias
     # it, then we don't need to update this node.
     if (
-        existing_storages[get_storage(old)] == 1
+        existing_storages[get_storage(old_tensor)] == 1
         and get_storage(new) not in existing_storages
         and not any_user_may_alias(node)
     ):
@@ -403,7 +407,7 @@ def _extract_subgraphs_and_args(
                 )
             wrapped_node = wrapped_nodes[0]
 
-            def replace_placeholder(item: Any) -> Any:
+            def replace_placeholder(item: object) -> object:
                 if isinstance(item, torch.fx.Node):
                     return placeholder_to_arg.get(item, item)
                 return item

--- a/torch/_inductor/kernel/gemm_epilogue.py
+++ b/torch/_inductor/kernel/gemm_epilogue.py
@@ -548,7 +548,7 @@ def normalize_gemm_epilogue_fx_node(node: torch.fx.Node) -> NormalizedNode | Non
     return None
 
 
-def iter_fx_node_inputs(value: Any) -> Iterator[torch.fx.Node]:
+def iter_fx_node_inputs(value: torch.fx.node.Argument) -> Iterator[torch.fx.Node]:
     """Yield FX node inputs nested in args/kwargs-style containers."""
     result: list[torch.fx.Node] = []
     torch.fx.map_arg(value, lambda node: result.append(node))
@@ -577,7 +577,7 @@ class GemmEpilogueGraph:
                 normalized_nodes[node] = normalized
         return cls(dependencies, normalized_nodes)
 
-    def depends_on(self, value: Any, target: torch.fx.Node) -> bool:
+    def depends_on(self, value: torch.fx.node.Argument, target: torch.fx.Node) -> bool:
         """Return whether a value is or transitively depends on the target node."""
         return any(
             node is target or target in self.dependencies.get(node, ())

--- a/torch/_inductor/kernel/gemm_epilogue_analysis.py
+++ b/torch/_inductor/kernel/gemm_epilogue_analysis.py
@@ -454,7 +454,7 @@ class GemmLocalReduceAnalysis:
         )
         return True
 
-    def has_physical_grouped_input(self, value: Any) -> bool:
+    def has_physical_grouped_input(self, value: torch.fx.node.Argument) -> bool:
         """Return whether a value depends on a grouped layout needing callbacks."""
         active_geometries = OrderedSet(
             match.geometry for match in self.matches.values()
@@ -502,7 +502,7 @@ class GemmLocalReduceAnalysis:
 
     def match_feed_value(
         self,
-        value: Any,
+        value: torch.fx.node.Argument,
         grouped_source: torch.fx.Node,
         layout: GemmReductionGeometry,
     ) -> GemmLocalReduceMatch | None:
@@ -540,7 +540,7 @@ class GemmLocalReduceAnalysis:
 
     def validate_hidden_feed_main_reduction_input(
         self,
-        input_node: Any,
+        input_node: torch.fx.node.Argument,
         grouped_source: torch.fx.Node,
     ) -> None:
         """Reject reduction inputs that would need another physical feed-main value."""
@@ -555,7 +555,7 @@ class GemmLocalReduceAnalysis:
 
     def validate_feed_main_source_reductions(
         self,
-        value: Any,
+        value: torch.fx.node.Argument,
         grouped_source: torch.fx.Node,
         selected_reduction: torch.fx.Node,
         seen: OrderedSet[torch.fx.Node] | None = None,


### PR DESCRIPTION
## Summary

Several private Inductor helpers used `Any` for heterogeneous values that they only traverse, compare, or classify. This let unchecked operations flow through recursive FX and pytree walkers.

This PR:

- uses `object` for opaque recursive leaves and dependency-query inputs
- preserves known FX argument-tree structure with `torch.fx.node.Argument`
- narrows collection, symbolic, and tensor pairs before accessing their interfaces
- keeps the unavoidable `torch.fx.map_arg` cast local to the walker

## Test plan

```bash
UV_NO_CONFIG=1 UV_OFFLINE=1 lintrunner -a torch/_inductor/fx_utils.py torch/_inductor/fx_passes/control_dependencies.py torch/_inductor/fx_passes/profile_guided_estimation.py torch/_inductor/kernel/gemm_epilogue.py torch/_inductor/kernel/gemm_epilogue_analysis.py
```

```bash
pyrefly check torch/_inductor/fx_utils.py torch/_inductor/fx_passes/control_dependencies.py torch/_inductor/fx_passes/profile_guided_estimation.py torch/_inductor/kernel/gemm_epilogue.py torch/_inductor/kernel/gemm_epilogue_analysis.py torch/_inductor/kernel/flex_gemm/quack_reductions.py torch/_inductor/kernel/flex_gemm/fx_cutedsl_codegen.py
```

Targeted runtime coverage passed 22 tests: the full `TestFakeTensorUpdater` class, nested control-dependency reconstruction, profile-guided estimation parsing/lookup, and GEMM epilogue FX-node normalization. The tests used a local module overlay because the installed native extension predates this checkout.

Authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo