### PR TITLE
[CUDA] Fix borrowed reference handling in memory snapshot

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8762,6 +8762,32 @@ class TestMemPool(TestCase):
         # increments the id
         self.assertTrue(abs(pool2[1] - pool1[1]) > 0)
 
+    def test_memory_snapshot_preserves_argument_references(self):
+        for tuple_size in (2, 3):
+            with self.subTest(tuple_size=tuple_size):
+                script = f"""
+import os
+import sys
+import torch
+
+pool_id_component = int("1000000")
+args = (
+    (0, pool_id_component)
+    if {tuple_size} == 2
+    else (0, pool_id_component, False)
+)
+before = sys.getrefcount(pool_id_component)
+torch._C._cuda_memorySnapshot(args)
+after = sys.getrefcount(pool_id_component)
+if after != before:
+    print(f"reference count changed from {{before}} to {{after}}", file=sys.stderr)
+    os._exit(1)
+"""
+                proc = subprocess.run(
+                    [sys.executable, "-c", script], capture_output=True, text=True
+                )
+                self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -740,8 +740,8 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
 
     if (size == 2) {
       // (int, int) - mempool_id only
-      auto id1 = THPObjectPtr(PyTuple_GetItem(arg, 0));
-      auto id2 = THPObjectPtr(PyTuple_GetItem(arg, 1));
+      PyObject* id1 = PyTuple_GetItem(arg, 0);
+      PyObject* id2 = PyTuple_GetItem(arg, 1);
       TORCH_CHECK(
           THPUtils_checkLong(id1) && THPUtils_checkLong(id2),
           "mempool_id elements must be integers");
@@ -749,17 +749,17 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* arg) {
           THPUtils_unpackLong(id1), THPUtils_unpackLong(id2));
     } else if (size == 3) {
       // (int, int, bool) - mempool_id + include_traces
-      auto id1 = THPObjectPtr(PyTuple_GetItem(arg, 0));
-      auto id2 = THPObjectPtr(PyTuple_GetItem(arg, 1));
-      auto traces = THPObjectPtr(PyTuple_GetItem(arg, 2));
+      PyObject* id1 = PyTuple_GetItem(arg, 0);
+      PyObject* id2 = PyTuple_GetItem(arg, 1);
+      PyObject* traces = PyTuple_GetItem(arg, 2);
       TORCH_CHECK(
           THPUtils_checkLong(id1) && THPUtils_checkLong(id2),
           "mempool_id elements must be integers");
       TORCH_CHECK(
-          PyBool_Check(traces.get()), "include_traces must be a boolean");
+          PyBool_Check(traces), "include_traces must be a boolean");
       mempool_id = c10::cuda::MempoolId_t(
           THPUtils_unpackLong(id1), THPUtils_unpackLong(id2));
-      include_traces = (Py_IsTrue(traces.get()));
+      include_traces = Py_IsTrue(traces);
     } else {
       TORCH_CHECK(false, "Expected tuple of size 2 or 3");
     }


### PR DESCRIPTION
## Summary

`PyTuple_GetItem` returns a borrowed reference. `THCPModule_memorySnapshot` wrapped the returned tuple elements in owning `THPObjectPtr` instances, so returning from the function decremented references still owned by the input tuple.

This is usually hidden for small immortal integers, but can corrupt heap-allocated pool ID components. Use raw borrowed `PyObject*` pointers for both accepted tuple forms and add a subprocess regression test that checks the two- and three-item paths preserve their argument reference counts.

## Test plan

- `git diff --check origin/main..HEAD`
- Python syntax compilation of `test/test_cuda.py`
- CUDA 13.1 source build on GB200: confirmed the affected two-item path changes the pool ID component refcount from 3 to 2 before the fix and preserves it at 3 after the fix
- 512 fresh `torch.cuda.MemPool` create/allocate/snapshot/destroy lifecycles through pool ID 512 with a clean process exit

The binary used for the source-build validation exposes only the two-item form. The newer three-item branch uses the identical borrowed-reference pattern and correction and is covered by the regression test, but has not yet been separately binary-tested.