### PR TITLE
[dynamo] Type source keys and region hashes as object

### DIFF
--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -396,6 +396,10 @@ class DynamoGraphTransformer(torch.fx.Transformer):
                 new_outputs.append(original_outputs[cast(int, val)])
             elif output_type == "input":
                 input_idx = cast(GetItemSource, val).index
+                if type(input_idx) is not int:
+                    raise AssertionError(
+                        f"Expected an integer input index, got {input_idx!r}"
+                    )
                 new_outputs.append(self.new_input_nodes[input_idx])
             elif output_type == "constant":
                 new_outputs.append(val)
@@ -1067,6 +1071,10 @@ def _dynamo_graph_capture_for_export(
             for inp in graph_inputs:
                 source = graph_inputs[inp]
                 if isinstance(source, torch._dynamo.source.GetItemSource):
+                    if type(source.index) is not int:
+                        raise AssertionError(
+                            f"Expected an integer input index, got {source.index!r}"
+                        )
                     graph_input_order[source.index] = len(graph_input_order)
 
             for real_idx, graph_idx in graph_input_order.items():

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -395,7 +395,8 @@ class DynamoGraphTransformer(torch.fx.Transformer):
             if output_type == "graph_out":
                 new_outputs.append(original_outputs[cast(int, val)])
             elif output_type == "input":
-                input_idx = cast(int, cast(GetItemSource, val).index)
+                input_source = cast(GetItemSource, val)
+                input_idx = cast(int, input_source.index)
                 new_outputs.append(self.new_input_nodes[input_idx])
             elif output_type == "constant":
                 new_outputs.append(val)
@@ -1066,9 +1067,7 @@ def _dynamo_graph_capture_for_export(
             graph_input_order: dict[int, int] = {}
             for inp in graph_inputs:
                 source = graph_inputs[inp]
-                if isinstance(
-                    source, torch._dynamo.source.GetItemSource
-                ) and isinstance(source.index, int):
+                if isinstance(source, GetItemSource) and isinstance(source.index, int):
                     graph_input_order[source.index] = len(graph_input_order)
 
             for real_idx, graph_idx in graph_input_order.items():

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -395,11 +395,7 @@ class DynamoGraphTransformer(torch.fx.Transformer):
             if output_type == "graph_out":
                 new_outputs.append(original_outputs[cast(int, val)])
             elif output_type == "input":
-                input_idx = cast(GetItemSource, val).index
-                if type(input_idx) is not int:
-                    raise AssertionError(
-                        f"Expected an integer input index, got {input_idx!r}"
-                    )
+                input_idx = cast(int, cast(GetItemSource, val).index)
                 new_outputs.append(self.new_input_nodes[input_idx])
             elif output_type == "constant":
                 new_outputs.append(val)
@@ -1070,11 +1066,9 @@ def _dynamo_graph_capture_for_export(
             graph_input_order: dict[int, int] = {}
             for inp in graph_inputs:
                 source = graph_inputs[inp]
-                if isinstance(source, torch._dynamo.source.GetItemSource):
-                    if type(source.index) is not int:
-                        raise AssertionError(
-                            f"Expected an integer input index, got {source.index!r}"
-                        )
+                if isinstance(
+                    source, torch._dynamo.source.GetItemSource
+                ) and isinstance(source.index, int):
                     graph_input_order[source.index] = len(graph_input_order)
 
             for real_idx, graph_idx in graph_input_order.items():

--- a/torch/_dynamo/graph_region_tracker.py
+++ b/torch/_dynamo/graph_region_tracker.py
@@ -71,7 +71,7 @@ def debug_log(msg: str, *args) -> None:  # type: ignore[no-untyped-def]
 
 def _extract_tensor_metadata_for_node_hash(
     x: torch.Tensor,
-) -> tuple[Callable[[T], T], tuple[Any, ...]]:
+) -> tuple[Callable[[T], T], tuple[object, ...]]:
     from torch._inductor.codecache import _ident, extract_tensor_metadata_for_cache_key
 
     out = []
@@ -104,7 +104,7 @@ class InputPickler(pickle.Pickler):
         )
         self.fast = True
 
-    def dumps(self, obj: Any) -> bytes:
+    def dumps(self, obj: object) -> bytes:
         """
         Pickle an object and return a byte string.
         """
@@ -118,7 +118,7 @@ class InputPickler(pickle.Pickler):
             self._stream.truncate(0)
 
 
-def _extract_args(arg: Any) -> Any:
+def _extract_args(arg: object) -> object | None:
     if isinstance(arg, Node):
         return arg.meta.get("example_value")
     elif isinstance(arg, (torch.Tensor, int)):
@@ -129,7 +129,7 @@ def _extract_args(arg: Any) -> Any:
 
 def _normalize_args(
     node: Node,
-) -> tuple[tuple[str, ...], tuple[Any | None, ...]]:
+) -> tuple[tuple[str, ...], tuple[object | None, ...]]:
     flat_args, _ = tree_flatten(node.args)
     sorted_kwargs = sorted(node.kwargs.items(), key=operator.itemgetter(0))
     sorted_keys = tuple(sorted(node.kwargs.keys()))
@@ -139,7 +139,7 @@ def _normalize_args(
 
 
 def _sort_with_ref_region(
-    index_to_rank: dict[int, int], regions: list[list[Any]]
+    index_to_rank: dict[int, int], regions: list[list[T]]
 ) -> None:
     # sort topologically
     # we need to handle edge cases where some nodes have no dependencies

--- a/torch/_dynamo/graph_region_tracker.py
+++ b/torch/_dynamo/graph_region_tracker.py
@@ -118,7 +118,7 @@ class InputPickler(pickle.Pickler):
             self._stream.truncate(0)
 
 
-def _extract_args(arg: object) -> object | None:
+def _extract_args(arg: object) -> object:
     if isinstance(arg, Node):
         return arg.meta.get("example_value")
     elif isinstance(arg, (torch.Tensor, int)):
@@ -129,7 +129,7 @@ def _extract_args(arg: object) -> object | None:
 
 def _normalize_args(
     node: Node,
-) -> tuple[tuple[str, ...], tuple[object | None, ...]]:
+) -> tuple[tuple[str, ...], tuple[object, ...]]:
     flat_args, _ = tree_flatten(node.args)
     sorted_kwargs = sorted(node.kwargs.items(), key=operator.itemgetter(0))
     sorted_keys = tuple(sorted(node.kwargs.keys()))

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3105,9 +3105,10 @@ class GuardBuilder(GuardBuilderBase):
         if self.save_guards:
             # Record which builtin variables are used for pruning later.
             if isinstance(guard.originating_source, DictGetItemSource):
-                self.check_fn_manager.used_builtin_vars.add(
-                    guard.originating_source.index
-                )
+                index = guard.originating_source.index
+                if not isinstance(index, str):
+                    raise AssertionError(f"Expected a builtin name, got {index!r}")
+                self.check_fn_manager.used_builtin_vars.add(index)
         return self.id_match_unchecked(guard)
 
     @register_guard_check_spec(

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3104,11 +3104,9 @@ class GuardBuilder(GuardBuilderBase):
     def BUILTIN_MATCH(self, guard: Guard) -> None:
         if self.save_guards:
             # Record which builtin variables are used for pruning later.
-            if isinstance(guard.originating_source, DictGetItemSource):
-                index = guard.originating_source.index
-                if not isinstance(index, str):
-                    raise AssertionError(f"Expected a builtin name, got {index!r}")
-                self.check_fn_manager.used_builtin_vars.add(index)
+            source = guard.originating_source
+            if isinstance(source, DictGetItemSource) and isinstance(source.index, str):
+                self.check_fn_manager.used_builtin_vars.add(source.index)
         return self.id_match_unchecked(guard)
 
     @register_guard_check_spec(

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -758,11 +758,14 @@ class GetItemSource(ChainedSource):
     def unpack_slice(self) -> slice:
         if not self.index_is_slice:
             raise AssertionError("unpack_slice called but index is not a slice")
-        if not isinstance(self.index, tuple) or len(self.index) != 2:
-            raise AssertionError("GetItemSource slice index must be an encoded slice")
+        if not (
+            isinstance(self.index, tuple)
+            and len(self.index) == 2
+            and self.index[0] is slice
+            and isinstance(self.index[1], tuple)
+        ):
+            raise AssertionError(f"Expected an encoded slice, got {self.index!r}")
         slice_class, slice_args = self.index
-        if slice_class is not slice or not isinstance(slice_args, tuple):
-            raise AssertionError("GetItemSource slice index must be an encoded slice")
         return slice_class(*slice_args)
 
     @functools.cached_property

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -128,7 +128,7 @@ def _get_source_debug_name(source: Source | None) -> str:
             return "<unknown source>"
 
 
-def _esc_str(s: Any, apply_repr: bool = False) -> str:
+def _esc_str(s: object, apply_repr: bool = False) -> str:
     """
     Escapes curly brackets for format strings.
     e.g. "frozenset({0})" becomes "frozenset({{0}})".
@@ -736,7 +736,7 @@ class DefaultsSource(ChainedSource):
 
 @dataclass_with_cached_hash(frozen=True)
 class GetItemSource(ChainedSource):
-    index: Any
+    index: object
     index_is_slice: bool = False
 
     def __post_init__(self) -> None:
@@ -758,7 +758,11 @@ class GetItemSource(ChainedSource):
     def unpack_slice(self) -> slice:
         if not self.index_is_slice:
             raise AssertionError("unpack_slice called but index is not a slice")
+        if not isinstance(self.index, tuple) or len(self.index) != 2:
+            raise AssertionError("GetItemSource slice index must be an encoded slice")
         slice_class, slice_args = self.index
+        if slice_class is not slice or not isinstance(slice_args, tuple):
+            raise AssertionError("GetItemSource slice index must be an encoded slice")
         return slice_class(*slice_args)
 
     @functools.cached_property
@@ -778,7 +782,7 @@ class GetItemSource(ChainedSource):
 
 @dataclass_with_cached_hash(frozen=True)
 class ConstDictKeySource(ChainedSource):
-    index: Any
+    index: int
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen.add_push_null(
@@ -846,7 +850,7 @@ class DictGetItemSource(ChainedSource):
     # Key to access in the dictionary. It can be one of the following types
     # 1) ConstDictKeySource
     # 2) constant - like string, integer
-    index: Any
+    index: object
 
     def __post_init__(self) -> None:
         from .variables import ConstantVariable
@@ -892,7 +896,7 @@ class DictSubclassGetItemSource(ChainedSource):
     # Key to access in the dictionary. It can be one of the following types
     # 1) ConstDictKeySource
     # 2) constant - like string, integer
-    index: Any
+    index: object
 
     def __post_init__(self) -> None:
         from .variables import ConstantVariable
@@ -1223,7 +1227,7 @@ class CallMethodItemSource(ChainedSource):
 @dataclass_with_cached_hash(frozen=True)
 class ContextVarGetSource(ChainedSource):
     has_default: bool = False
-    default_value: Any = None
+    default_value: object = None
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         def load_get_method():

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -461,8 +461,10 @@ def _source_to_access_path(source: Source) -> _AccessPath | None:
         # ``DictGetItemSource(UnspecializedParamBufferSource(_,
         # '_parameters'), 'weight')``. Collapse that pair into a single
         # attr token.
-        if isinstance(cur, DictGetItemSource) and isinstance(
-            cur.base, UnspecializedParamBufferSource
+        if (
+            isinstance(cur, DictGetItemSource)
+            and isinstance(cur.base, UnspecializedParamBufferSource)
+            and isinstance(cur.index, str)
         ):
             path.append(_AttrToken(cur.index))
             cur = cur.base.base

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -23,7 +23,7 @@ optimizer-specific optimizations and safety guarantees.
 import logging
 import weakref
 from collections.abc import Iterable
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 import torch
 from torch._dynamo.variables.tensor import TensorVariable
@@ -227,10 +227,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
                 and isinstance(arg.source.base, AttrSource)
                 and arg.source.base.member == "param_groups"
             ):
-                index = arg.source.index
-                if type(index) is not int:
-                    raise ArgMappingException
-                return self.value.param_groups[index]
+                return self.value.param_groups[cast(int, arg.source.index)]
 
             raise ArgMappingException
 

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -227,7 +227,10 @@ class OptimizerVariable(UserDefinedObjectVariable):
                 and isinstance(arg.source.base, AttrSource)
                 and arg.source.base.member == "param_groups"
             ):
-                return self.value.param_groups[arg.source.index]
+                index = arg.source.index
+                if type(index) is not int:
+                    raise ArgMappingException
+                return self.value.param_groups[index]
 
             raise ArgMappingException
 


### PR DESCRIPTION
## Summary

- replace `Any` with `object` for opaque source keys and graph-region hash inputs
- retain `int` for the positional `ConstDictKeySource.index`, and narrow opaque indices at consumers before use
- validate encoded slice data before unpacking and make region sorting generic

These changes expose unchecked assumptions that `Any` previously hid without changing the accepted runtime values.

## Test plan

- `pyrefly check torch/_dynamo/source.py torch/_dynamo/graph_region_tracker.py` (0 errors, 3 pre-existing suppressions)
- `python -m py_compile torch/_dynamo/source.py torch/_dynamo/graph_region_tracker.py torch/_dynamo/functional_export.py torch/_dynamo/guards.py torch/_dynamo/variables/builder.py torch/_dynamo/variables/optimizer.py`
- `lintrunner -a torch/_dynamo/source.py torch/_dynamo/graph_region_tracker.py torch/_dynamo/functional_export.py torch/_dynamo/guards.py torch/_dynamo/variables/builder.py torch/_dynamo/variables/optimizer.py`
- `test/dynamo/test_graph_region_tracker.py` (13 passed, 1 hardware-gated skip)
- `MiscTests.test_hash_getitem_slice`, `SourceCloneTests`, and `test/dynamo/test_contextvars.py` (32 passed)

The local runtime tests loaded the patched Python modules through a scratch import shim because the available compiled extension predates this checkout. Full coverage will run in CI against a fresh build.

Authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98