### PR TITLE
[inductor] Scalar accumulators for all reductions in large inner loops

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -1506,17 +1506,17 @@ def helper(x):
             override_persistent_reduction=False,
             override_cooperative_reduction=False,
         )
-        kernel.autotune_hints.add(AutotuneHint.SCALAR_ONLINE_SOFTMAX)
+        kernel.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
         kernel.autotune_hints.add(AutotuneHint.ONE_ELEMENT_PER_THREAD)
         with V.set_kernel_handler(kernel):
             hints = kernel.inductor_meta_per_kernel()["autotune_hints"]
         self.assertEqual(
             hints,
-            (AutotuneHint.ONE_ELEMENT_PER_THREAD, AutotuneHint.SCALAR_ONLINE_SOFTMAX),
+            (AutotuneHint.ONE_ELEMENT_PER_THREAD, AutotuneHint.SCALAR_ACCUMULATORS),
         )
         self.assertEqual(
             repr(hints),
-            "(AutotuneHint.ONE_ELEMENT_PER_THREAD, AutotuneHint.SCALAR_ONLINE_SOFTMAX)",
+            "(AutotuneHint.ONE_ELEMENT_PER_THREAD, AutotuneHint.SCALAR_ACCUMULATORS)",
         )
 
 

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -686,7 +686,7 @@ class TestScalarAccumulators(TestCase):
         x[5].fill_(2.0)
         x[7, 8192] = x[7].amax() + 1
         _, code = self.check_codegen(f, x, marker=self.HINT)
-        self.assertIn("_block = triton_helpers.max_with_index(", code)
+        self.assertIn("_block = triton_helpers.max_with_first_index(", code)
         self.assertIn("_block = triton_helpers.min_with_index(", code)
         self.assertIn("tl.full([XBLOCK, 1], ", code)
 
@@ -778,9 +778,8 @@ class TestScalarAccumulators(TestCase):
         act, _ = self.check_codegen(_prepare_softmax, x, -1, uses_scalar=False)
         self.assertEqual(ref_max.view(torch.int32), act[0].view(torch.int32))
 
-    @inductor_config.patch(strict_signed_zero=True)
     @parametrize("n", [33, 8193])
-    def test_strict_signed_zero_arg_value(self, n):
+    def test_max_value_signed_zero_tie(self, n):
         x = torch.zeros(2, n, device=GPU_TYPE)
         x[:, 0] = -0.0
         values, indices = torch.compile(lambda t: torch.max(t, -1))(x)

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -553,14 +553,11 @@ class TestScalarOnlineSoftmax(TestCase):
     }
 
     def check_codegen(
-        self, fn, *args, uses_scalar=True, rtol=1e-3, atol=1e-3, marker=None
+        self, fn, *args, uses_scalar=True, rtol=1e-3, atol=1e-3, marker=MARKER
     ):
         act, (code,) = run_and_get_code(torch.compile(fn), *args)
         self.assertEqual(fn(*args), act, rtol=rtol, atol=atol, equal_nan=True)
-        if uses_scalar:
-            self.assertIn(marker or self.MARKER, code)
-        else:
-            self.assertNotIn(marker or self.MARKER, code)
+        (self.assertIn if uses_scalar else self.assertNotIn)(marker, code)
         return act, code
 
     @inductor_config.patch("triton.scalar_accumulators", False)
@@ -713,7 +710,7 @@ class TestScalarOnlineSoftmax(TestCase):
     def test_strict_signed_zero_max_stays_vector(self):
         x = torch.randn(4, 8193, device=GPU_TYPE)
         _, code = self.check_codegen(
-            lambda t: t.amax(-1), x, uses_scalar=False, marker=self.HINT
+            lambda t: (t.amax(-1), t.argmax(-1)), x, uses_scalar=False, marker=self.HINT
         )
         self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
 
@@ -763,6 +760,15 @@ class TestScalarOnlineSoftmax(TestCase):
         ref_max = torch.compile(lambda t: t.amax(dim=-1, keepdim=True))(x)
         act, _ = self.check_codegen(_prepare_softmax, x, -1, uses_scalar=False)
         self.assertEqual(ref_max.view(torch.int32), act[0].view(torch.int32))
+
+    @inductor_config.patch(strict_signed_zero=True)
+    @parametrize("n", [33, 8193])
+    def test_strict_signed_zero_arg_value(self, n):
+        x = torch.zeros(2, n, device=GPU_TYPE)
+        x[:, 0] = -0.0
+        values, indices = torch.compile(lambda t: torch.max(t, -1))(x)
+        self.assertTrue(torch.signbit(values).all())
+        self.assertEqual(indices, torch.zeros_like(indices))
 
     @inductor_config.patch({"triton.max_tiles": 3, "triton.prefer_nd_tiling": True})
     def test_3d_tiling(self):

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -539,8 +539,8 @@ class TestOnlineSoftmax(TestCase):
 @requires_nvidia_cuda
 @inductor_config.patch(SCALAR_ACCUMULATOR_CONFIG)
 @instantiate_parametrized_tests
-class TestScalarOnlineSoftmax(TestCase):
-    """Per-row max/sum accumulators for large non-persistent online softmax."""
+class TestScalarAccumulators(TestCase):
+    """Per-row accumulators for large non-persistent inner reductions."""
 
     MARKER = "online_softmax_reduce_scalar_combine"
     HINT = "AutotuneHint.SCALAR_ACCUMULATORS"
@@ -677,8 +677,9 @@ class TestScalarOnlineSoftmax(TestCase):
 
     def test_arg_reductions(self):
         def f(x):
+            xmax, xsum = _prepare_softmax(x, -1)
             values, indices = torch.min(x, -1)
-            return x.logsumexp(-1), x.argmax(-1), values, indices, x.sum(-1)
+            return xmax, xsum, x.argmax(-1), values, indices, x.sum(-1)
 
         x = torch.randn(64, 8193, device=GPU_TYPE)
         x[3, 4097] = float("nan")
@@ -689,10 +690,27 @@ class TestScalarOnlineSoftmax(TestCase):
         self.assertIn("_block = triton_helpers.min_with_index(", code)
         self.assertIn("tl.full([XBLOCK, 1], ", code)
 
-    @parametrize("dtype", [torch.int32, torch.int64, torch.bfloat16])
-    def test_paired_and_plain_reductions(self, dtype):
+    def test_arg_reductions_alone_stay_vector(self):
+        x = torch.randn(64, 8193, device=GPU_TYPE)
+        f = lambda t: (t.argmax(-1), t.sum(-1))  # noqa: E731
+        _, code = self.check_codegen(f, x, uses_scalar=False, marker=self.HINT)
+        self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
+
+    def test_scalar_loop_ops(self):
         def f(x):
-            return torch.max(x, -1).values, x.argmin(-1), x.sum(-1)
+            xmax, xsum = _prepare_softmax(x, -1)
+            y = (1 + x / 4096).double()
+            return xmax, xsum, x.amax(-1), x.amin(-1), y.prod(-1)
+
+        x = torch.randn(16, 8200, device=GPU_TYPE)
+        _, code = self.check_codegen(f, x, marker=self.HINT)
+        self.assertEqual(code.count("tl.full([XBLOCK, 1], "), 3)
+
+    @parametrize("dtype", [torch.int32, torch.int64, torch.bfloat16])
+    def test_reductions_beside_softmax(self, dtype):
+        def f(x):
+            xmax, xsum = _prepare_softmax(x.float(), -1)
+            return xmax, xsum, torch.max(x, -1).values, x.argmin(-1), x.sum(-1)
 
         x = torch.randint(-50, 50, (16, 8200), device=GPU_TYPE).to(dtype)
         if dtype.is_floating_point:
@@ -709,9 +727,8 @@ class TestScalarOnlineSoftmax(TestCase):
     @inductor_config.patch(strict_signed_zero=True)
     def test_strict_signed_zero_max_stays_vector(self):
         x = torch.randn(4, 8193, device=GPU_TYPE)
-        _, code = self.check_codegen(
-            lambda t: (t.amax(-1), t.argmax(-1)), x, uses_scalar=False, marker=self.HINT
-        )
+        f = lambda t: (*_prepare_softmax(t, -1), t.amax(-1))  # noqa: E731
+        _, code = self.check_codegen(f, x, uses_scalar=False, marker=self.HINT)
         self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
 
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64])

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -666,6 +666,7 @@ class TestScalarAccumulators(TestCase):
         x = torch.randn(128, 8192, device=GPU_TYPE)
         _, code = self.check_codegen(f, x)
         self.assertNotIn("online_softmax_combine(", code)
+        self.assertIn("tl.full([XBLOCK, 1], ", code)
 
     def test_plain_reductions_stay_vector(self):
         def f(x):
@@ -685,6 +686,8 @@ class TestScalarAccumulators(TestCase):
         x[3, 4097] = float("nan")
         x[5].fill_(2.0)
         x[7, 8192] = x[7].amax() + 1
+        x[8].fill_(float("inf"))
+        x[9, 8192] = float("nan")
         _, code = self.check_codegen(f, x, marker=self.HINT)
         self.assertIn("_block = triton_helpers.max_with_first_index(", code)
         self.assertIn("_block = triton_helpers.min_with_index(", code)
@@ -720,16 +723,8 @@ class TestScalarAccumulators(TestCase):
 
     def test_welford_stays_vector(self):
         x = torch.randn(64, 8193, device=GPU_TYPE)
-        self.check_codegen(
-            lambda t: torch.var_mean(t, dim=-1), x, uses_scalar=False, marker=self.HINT
-        )
-
-    @inductor_config.patch(strict_signed_zero=True)
-    def test_strict_signed_zero_max_stays_vector(self):
-        x = torch.randn(4, 8193, device=GPU_TYPE)
-        f = lambda t: (*_prepare_softmax(t, -1), t.amax(-1))  # noqa: E731
-        _, code = self.check_codegen(f, x, uses_scalar=False, marker=self.HINT)
-        self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
+        f = lambda t: (*_prepare_softmax(t, -1), *torch.var_mean(t, -1))  # noqa: E731
+        self.check_codegen(f, x, uses_scalar=False, marker=self.HINT)
 
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64])
     def test_nan_and_inf_rows(self, dtype):
@@ -775,14 +770,17 @@ class TestScalarAccumulators(TestCase):
         x[0, 1::2] = -0.0
         x[1, ::2] = -0.0
         ref_max = torch.compile(lambda t: t.amax(dim=-1, keepdim=True))(x)
-        act, _ = self.check_codegen(_prepare_softmax, x, -1, uses_scalar=False)
+        f = lambda t: (*_prepare_softmax(t, -1), t.amax(-1))  # noqa: E731
+        act, code = self.check_codegen(f, x, uses_scalar=False)
         self.assertEqual(ref_max.view(torch.int32), act[0].view(torch.int32))
+        self.assertNotIn(self.HINT, code)
 
     @parametrize("n", [33, 8193])
     def test_max_value_signed_zero_tie(self, n):
         x = torch.zeros(2, n, device=GPU_TYPE)
         x[:, 0] = -0.0
-        values, indices = torch.compile(lambda t: torch.max(t, -1))(x)
+        f = lambda t: (*_prepare_softmax(t, -1), *torch.max(t, -1))  # noqa: E731
+        _, _, values, indices = torch.compile(f)(x)
         self.assertTrue(torch.signbit(values).all())
         self.assertEqual(indices, torch.zeros_like(indices))
 

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -21,10 +21,10 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, HAS_TRITON
 
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 USE_LARGE_INPUT = os.environ.get("USE_LARGE_INPUT") == "1" or DO_PERF_TEST
-SCALAR_ONLINE_SOFTMAX_CONFIG = {
+SCALAR_ACCUMULATOR_CONFIG = {
     "triton.persistent_reductions": False,
     "split_reductions": False,
-    "triton.scalar_online_softmax_accumulators": True,
+    "triton.scalar_accumulators": True,
 }
 requires_nvidia_cuda = unittest.skipUnless(
     GPU_TYPE == "cuda" and torch.version.hip is None,
@@ -537,12 +537,13 @@ class TestOnlineSoftmax(TestCase):
 
 
 @requires_nvidia_cuda
-@inductor_config.patch(SCALAR_ONLINE_SOFTMAX_CONFIG)
+@inductor_config.patch(SCALAR_ACCUMULATOR_CONFIG)
 @instantiate_parametrized_tests
 class TestScalarOnlineSoftmax(TestCase):
     """Per-row max/sum accumulators for large non-persistent online softmax."""
 
     MARKER = "online_softmax_reduce_scalar_combine"
+    HINT = "AutotuneHint.SCALAR_ACCUMULATORS"
     COMBO_KERNEL_CONFIG = {
         "combo_kernels": True,
         "combo_kernel_per_subkernel_blocks": True,
@@ -551,16 +552,18 @@ class TestScalarOnlineSoftmax(TestCase):
         "combo_kernel_peak_memory_pct_threshold": None,
     }
 
-    def check_codegen(self, fn, *args, uses_scalar=True, rtol=1e-3, atol=1e-3):
+    def check_codegen(
+        self, fn, *args, uses_scalar=True, rtol=1e-3, atol=1e-3, marker=None
+    ):
         act, (code,) = run_and_get_code(torch.compile(fn), *args)
-        self.assertEqual(fn(*args), act, rtol=rtol, atol=atol)
+        self.assertEqual(fn(*args), act, rtol=rtol, atol=atol, equal_nan=True)
         if uses_scalar:
-            self.assertIn(self.MARKER, code)
+            self.assertIn(marker or self.MARKER, code)
         else:
-            self.assertNotIn(self.MARKER, code)
+            self.assertNotIn(marker or self.MARKER, code)
         return act, code
 
-    @inductor_config.patch("triton.scalar_online_softmax_accumulators", False)
+    @inductor_config.patch("triton.scalar_accumulators", False)
     def test_disabled(self):
         x = torch.randn(1024, 8192, device=GPU_TYPE)
         _, code = self.check_codegen(_prepare_softmax, x, -1, uses_scalar=False)
@@ -576,7 +579,7 @@ class TestScalarOnlineSoftmax(TestCase):
         _, code = self.check_codegen(
             _prepare_softmax, storage[:, :50265], -1, rtol=1e-2, atol=1e-2
         )
-        self.assertIn("AutotuneHint.SCALAR_ONLINE_SOFTMAX", code)
+        self.assertIn(self.HINT, code)
 
     @parametrize("reduction_numel,uses_scalar", [(4096, False), (4097, True)])
     def test_reduction_size_threshold(self, reduction_numel, uses_scalar):
@@ -658,14 +661,61 @@ class TestScalarOnlineSoftmax(TestCase):
         self.assertNotIn(self.MARKER, code)
         self.assertIn("online_softmax_combine(", code)
 
-    def test_skips_extra_reductions(self):
+    def test_extra_reduction_stays_scalar(self):
         def f(x):
             xmax, xsum = _prepare_softmax(x, -1)
             return xmax, xsum, (x - xmax).sum(dim=-1, keepdim=True)
 
         x = torch.randn(128, 8192, device=GPU_TYPE)
-        _, code = self.check_codegen(f, x, uses_scalar=False)
-        self.assertIn("online_softmax_combine(", code)
+        _, code = self.check_codegen(f, x)
+        self.assertNotIn("online_softmax_combine(", code)
+
+    def test_plain_reductions_stay_vector(self):
+        def f(x):
+            return x.sum(-1), x.amax(-1), (x * x).amin(-1)
+
+        x = torch.randn(32, 16385, device=GPU_TYPE)
+        _, code = self.check_codegen(f, x, uses_scalar=False, marker=self.HINT)
+        self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
+
+    def test_arg_reductions(self):
+        def f(x):
+            values, indices = torch.min(x, -1)
+            return x.logsumexp(-1), x.argmax(-1), values, indices, x.sum(-1)
+
+        x = torch.randn(64, 8193, device=GPU_TYPE)
+        x[3, 4097] = float("nan")
+        x[5].fill_(2.0)
+        x[7, 8192] = x[7].amax() + 1
+        _, code = self.check_codegen(f, x, marker=self.HINT)
+        self.assertIn("_block = triton_helpers.max_with_index(", code)
+        self.assertIn("_block = triton_helpers.min_with_index(", code)
+        self.assertIn("tl.full([XBLOCK, 1], ", code)
+
+    @parametrize("dtype", [torch.int32, torch.int64, torch.bfloat16])
+    def test_paired_and_plain_reductions(self, dtype):
+        def f(x):
+            return torch.max(x, -1).values, x.argmin(-1), x.sum(-1)
+
+        x = torch.randint(-50, 50, (16, 8200), device=GPU_TYPE).to(dtype)
+        if dtype.is_floating_point:
+            x[2, 100] = float("nan")
+        _, code = self.check_codegen(f, x, marker=self.HINT)
+        self.assertIn("_block = triton_helpers.max_with_index(", code)
+
+    def test_welford_stays_vector(self):
+        x = torch.randn(64, 8193, device=GPU_TYPE)
+        self.check_codegen(
+            lambda t: torch.var_mean(t, dim=-1), x, uses_scalar=False, marker=self.HINT
+        )
+
+    @inductor_config.patch(strict_signed_zero=True)
+    def test_strict_signed_zero_max_stays_vector(self):
+        x = torch.randn(4, 8193, device=GPU_TYPE)
+        _, code = self.check_codegen(
+            lambda t: t.amax(-1), x, uses_scalar=False, marker=self.HINT
+        )
+        self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
 
     @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64])
     def test_nan_and_inf_rows(self, dtype):

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -709,6 +709,14 @@ class TestScalarAccumulators(TestCase):
         _, code = self.check_codegen(f, x, marker=self.HINT)
         self.assertEqual(code.count("tl.full([XBLOCK, 1], "), 3)
 
+    def test_narrow_int_sum_beside_softmax(self):
+        def f(x):
+            xmax, xsum = _prepare_softmax(x.float(), -1)
+            return xmax, xsum, x.sum(-1, dtype=torch.uint8), x.amax(-1)
+
+        x = torch.randint(0, 256, (16, 8200), device=GPU_TYPE, dtype=torch.uint8)
+        self.check_codegen(f, x, marker=self.HINT)
+
     @parametrize("dtype", [torch.int32, torch.int64, torch.bfloat16])
     def test_reductions_beside_softmax(self, dtype):
         def f(x):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19438,7 +19438,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         else:
             code = run_and_get_triton_code(compiled, x)
             self.assertEqual(code.count("@triton_heuristics."), 1)
-            self.assertEqual(code.count("triton_helpers.max_with_index"), 1)
+            self.assertEqual(code.count("triton_helpers.max_with_first_index"), 1)
 
     @skip_if_halide
     @requires_gpu_and_triton
@@ -19490,7 +19490,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         code = run_and_get_triton_code(torch.compile(fn, fullgraph=True), x)
         self.assertEqual(code.count("@triton_heuristics."), 1)
         # Equivalent value/index pairs merge; the distinct mapping does not.
-        self.assertEqual(code.count("triton_helpers.max_with_index"), 2)
+        self.assertEqual(code.count("triton_helpers.max_with_first_index"), 2)
 
     @skip_if_halide
     @requires_gpu_and_triton

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19438,7 +19438,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         else:
             code = run_and_get_triton_code(compiled, x)
             self.assertEqual(code.count("@triton_heuristics."), 1)
-            self.assertEqual(code.count("triton_helpers.max_with_first_index"), 1)
+            self.assertEqual(code.count("triton_helpers.max_with_"), 1)
 
     @skip_if_halide
     @requires_gpu_and_triton
@@ -19490,7 +19490,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         code = run_and_get_triton_code(torch.compile(fn, fullgraph=True), x)
         self.assertEqual(code.count("@triton_heuristics."), 1)
         # Equivalent value/index pairs merge; the distinct mapping does not.
-        self.assertEqual(code.count("triton_helpers.max_with_first_index"), 2)
+        self.assertEqual(code.count("triton_helpers.max_with_"), 2)
 
     @skip_if_halide
     @requires_gpu_and_triton

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -258,7 +258,7 @@ class TestTritonHeuristics(TestCase):
             ),
         ],
     )
-    def test_scalar_online_softmax_reduction_configs(
+    def test_scalar_accumulator_reduction_configs(
         self, major, cc, expected_baseline_configs, expected_scalar_configs
     ):
         device = self._fake_cuda_device_properties()._replace(major=major, cc=cc)
@@ -307,14 +307,12 @@ class TestTritonHeuristics(TestCase):
             expected_baseline_configs,
         )
         self.assertEqual(
-            config_values({AutotuneHint.SCALAR_ONLINE_SOFTMAX}),
+            config_values({AutotuneHint.SCALAR_ACCUMULATORS}),
             expected_scalar_configs,
         )
         baseline_rblock = expected_baseline_configs[0][1]
         self.assertEqual(tiled_block_products(set())[0], baseline_rblock)
-        scalar_tiled_products = tiled_block_products(
-            {AutotuneHint.SCALAR_ONLINE_SOFTMAX}
-        )
+        scalar_tiled_products = tiled_block_products({AutotuneHint.SCALAR_ACCUMULATORS})
         self.assertEqual(scalar_tiled_products[0], 4096)
         self.assertIn(baseline_rblock, scalar_tiled_products)
 
@@ -574,7 +572,7 @@ class TestTritonHeuristics(TestCase):
         self.assertTrue(8 in seen_num_elements_per_warp)
         self.assertEqual(
             autotune_hints_to_configs(
-                {AutotuneHint.SCALAR_ONLINE_SOFTMAX},
+                {AutotuneHint.SCALAR_ACCUMULATORS},
                 size_hints,
                 block_size,
                 device_props,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3318,6 +3318,18 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         TensorDescriptorOptions
     )
     transpose_discontiguous_tensor_descriptors_override: bool | None = None
+    # Reductions carrying a pair per row; their vector accumulators are what
+    # spills in large inner loops, so a kernel needs one to take the scalar path.
+    PAIRED_REDUCTION_TYPES = (
+        "online_softmax_reduce",
+        "argmax",
+        "argmin",
+        "argmax_value",
+        "argmin_value",
+        "argmax_with_value",
+        "argmin_with_value",
+    )
+    SCALAR_LOOP_REDUCTION_TYPES = ("sum", "prod", "max", "min", "xor_sum")
 
     def __init__(
         self,
@@ -5403,20 +5415,20 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             shape=tuple(target_shape),
         )
 
-    def use_scalar_online_softmax(
-        self, value: CSEVariable | tuple[CSEVariable, ...]
-    ) -> bool:
+    @functools.cached_property
+    def use_scalar_accumulators(self) -> bool:
         """
-        Per-row max/sum accumulators for a reduction loop whose only reductions
-        are the two outputs of one online softmax. The reduction size, load and
-        full-size output limits come from the performance sweep of fused
-        softmax kernels.
+        Per-row accumulators for every reduction of a large inner reduction
+        loop: each block is reduced along the reduction dim before it is folded
+        into the running state, so only the per-row state stays live. Plain
+        sums and maxes alone gain nothing from this and lose for a few very
+        long rows, so a kernel takes the path only around an arg reduction or
+        online softmax. The size, load and full-size output limits come from
+        the performance sweep of fused softmax kernels.
         """
         features = self.features
         if (
-            # Split-reduction combines pass partial (max, sum) tuples.
-            isinstance(value, tuple)
-            or not config.triton.scalar_online_softmax_accumulators
+            not config.triton.scalar_accumulators
             # Which signed zero wins a strict max depends on the reduction
             # block, so strict mode keeps the single-config vector path.
             or config.strict_signed_zero
@@ -5431,16 +5443,18 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             or V.graph.sizevars.optimization_hint(features.reduction_numel) <= 4096
         ):
             return False
-
-        # Each output of the online softmax is its own scheduler node.
-        reduction_nodes = features.reduction_nodes()
-        if len(reduction_nodes) not in (1, 2) or any(
-            not isinstance(node.node, ir.ComputedBuffer)
-            or node.node.get_reduction_type() != "online_softmax_reduce"
-            for node in reduction_nodes
-        ):
+        paired = False
+        for node in features.reduction_nodes():
+            buf = node.node
+            if not isinstance(buf, ir.ComputedBuffer) or buf.get_dtype() == torch.bool:
+                return False
+            reduction_type = buf.get_reduction_type()
+            if reduction_type in self.PAIRED_REDUCTION_TYPES:
+                paired = True
+            elif reduction_type not in self.SCALAR_LOOP_REDUCTION_TYPES:
+                return False
+        if not paired:
             return False
-
         nodes = OrderedSet(features.scheduler_nodes())
         produced = OrderedSet(
             buf.get_name() for node in nodes for buf in node.get_outputs()
@@ -5464,6 +5478,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             for buf in node.get_outputs()
         )
         return full_size_outputs <= 1
+
+    def use_scalar_online_softmax(
+        self, value: CSEVariable | tuple[CSEVariable, ...]
+    ) -> bool:
+        # Split-reduction combines pass partial (max, sum) tuples. Checked out
+        # of line so the type checker does not narrow `value` to a tuple in
+        # the reduction() branches that follow.
+        return not isinstance(value, tuple) and self.use_scalar_accumulators
 
     def reduction(
         self,
@@ -5514,8 +5536,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             and reduction_type in ("sum", "prod")
         )
         strict_reduction_loop = strict_reduction and not self.persistent_reduction
-        # Inner-tree combiner used to linear-accumulate the per-tile trees:
-        # "+" for sum, "*" for prod (identity 0.0 / 1.0 comes from `default`).
+        # Combiner for the persistent strict path: "+" for sum, "*" for prod
+        # (identity 0.0 / 1.0 comes from `default`); the loop uses combine_fn.
         strict_op = "*" if reduction_type == "prod" else "+"
 
         # When we do native matmtul codegen,
@@ -5878,6 +5900,18 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             )
             default = ir.Reduction.default_accumulator(reduction_type, src_dtype)
             default = self._map_tuple_or_scalar(constant_repr, default)
+            scalar_loop = (
+                reduction_type in self.SCALAR_LOOP_REDUCTION_TYPES
+                and self.use_scalar_accumulators
+            )
+            scalar_argreduce = (
+                reduction_type in arg_reduction_types and self.use_scalar_accumulators
+            )
+            scalar_online_softmax = (
+                reduction_type == "online_softmax_reduce"
+                and self.use_scalar_online_softmax(value)
+            )
+            scalar_size_str = f"[{', '.join(self.dense_size_list()[:dim])}]"
             if not isinstance(default, tuple):
                 if reduction_type == "dot":
                     dense_sizes = self.dense_size_list()
@@ -5893,11 +5927,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     self.body.writeline(
                         f"{accumulator} = tl.full({dense_size_str}, {default}, {acc_type})"
                     )
-                elif strict_reduction_loop:
+                elif strict_reduction_loop or scalar_loop:
                     accumulator.shape = tuple(result_shape)
                     result_size_str = f"[{', '.join(result_shape)}]"
                     self.body.writeline(
                         f"{accumulator} = tl.full({result_size_str}, {default}, {acc_type})"
+                    )
+                elif scalar_argreduce:
+                    accumulator.shape = tuple(self.dense_size_list()[:dim])
+                    self.body.writeline(
+                        f"{accumulator} = tl.full({scalar_size_str}, {default}, {acc_type})"
                     )
                 else:
                     self.body.writeline(
@@ -5908,52 +5947,82 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 accumulator_index = f"_{result_prefix}_index"
                 if index_dtype is None:
                     raise AssertionError("index_dtype must be set for arg reductions")
+                index_max = torch.iinfo(index_dtype).max
+                index_type = self.dtype_to_str(index_dtype)
+                acc_size_str = (
+                    scalar_size_str if scalar_argreduce else self.dense_size_str()
+                )
                 self.body.writeline(
-                    f"{accumulator_index} = tl.full({self.dense_size_str()}, "
-                    f"{torch.iinfo(index_dtype).max}, {self.dtype_to_str(index_dtype)})"
+                    f"{accumulator_index} = tl.full({acc_size_str}, {index_max}, {index_type})"
                 )
                 root_op = arg_root_ops[reduction_type]
                 # Use logical_index if it was unpacked, otherwise fall back to physical index
                 index_var = (
-                    f"({str(logical_index)}).to({self.dtype_to_str(index_dtype)})"
+                    f"({str(logical_index)}).to({index_type})"
                     if logical_index is not None
                     else f"{reduction_range_prefix}index"
                 )
-                self.compute.splice(
-                    f"""\
-                {accumulator}_next, {accumulator_index}_next = triton_helpers.{root_op}imum_with_index(
-                    {accumulator}, {accumulator_index}, {value}, {index_var}
-                )
-                {accumulator} = {where_cond(f"{accumulator}_next", accumulator)}
-                {accumulator_index} = {where_cond(f"{accumulator_index}_next", accumulator_index)}
-                """
-                )
-                final_argreduce(
-                    self.post_loop_combine,
-                    result_var,
-                    accumulator,
-                    accumulator_index,
-                    argreduce_result_kind(),
-                )
+                if scalar_argreduce:
+                    self.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
+                    block_index = f"tl.broadcast_to({where_cond(index_var, index_max)}, {self.dense_size_str()})"
+                    self.compute.splice(
+                        f"""\
+                    {accumulator}_block, {accumulator_index}_block = triton_helpers.{root_op}_with_index(
+                        {where_cond(value, default)}, {block_index}, {dim}
+                    )
+                    {accumulator}, {accumulator_index} = triton_helpers.{root_op}imum_with_index(
+                        {accumulator}, {accumulator_index}, {accumulator}_block, {accumulator_index}_block
+                    )
+                    """
+                    )
+                    result_kind = argreduce_result_kind()
+                    if result_kind == "value_and_index":
+                        result_value, result_index = cast(tuple[Any, Any], result_var)
+                        self.post_loop_combine.writeline(
+                            f"{result_value} = {self.reduction_resize(accumulator)}"
+                        )
+                        self.post_loop_combine.writeline(
+                            f"{result_index} = {self.reduction_resize(accumulator_index)}"
+                        )
+                    else:
+                        source = (
+                            accumulator if result_kind == "value" else accumulator_index
+                        )
+                        self.post_loop_combine.writeline(
+                            f"{result_var} = {self.reduction_resize(source)}"
+                        )
+                else:
+                    self.compute.splice(
+                        f"""\
+                    {accumulator}_next, {accumulator_index}_next = triton_helpers.{root_op}imum_with_index(
+                        {accumulator}, {accumulator_index}, {value}, {index_var}
+                    )
+                    {accumulator} = {where_cond(f"{accumulator}_next", accumulator)}
+                    {accumulator_index} = {where_cond(f"{accumulator_index}_next", accumulator_index)}
+                    """
+                    )
+                    final_argreduce(
+                        self.post_loop_combine,
+                        result_var,
+                        accumulator,
+                        accumulator_index,
+                        argreduce_result_kind(),
+                    )
             elif is_welford_reduction(reduction_type):
                 result_var = self.welford_reduce(
                     result_var, reduction_type, value, where_cond, acc_type, dtype
                 )
-            elif (
-                reduction_type == "online_softmax_reduce"
-                and self.use_scalar_online_softmax(value)
-            ):
+            elif scalar_online_softmax:
                 # Per-row accumulators: each block is reduced along the
                 # reduction dim before it is folded into the running state.
-                self.autotune_hints.add(AutotuneHint.SCALAR_ONLINE_SOFTMAX)
+                self.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
                 accumulator_max = f"_{result_var}_max"
                 accumulator_sum = f"_{result_var}_sum"
-                acc_size = f"[{', '.join(self.dense_size_list()[:dim])}]"
                 self.body.writeline(
-                    f"{accumulator_max} = tl.full({acc_size}, float('-inf'), {acc_type})"
+                    f"{accumulator_max} = tl.full({scalar_size_str}, float('-inf'), {acc_type})"
                 )
                 self.body.writeline(
-                    f"{accumulator_sum} = tl.full({acc_size}, 0.0, {acc_type})"
+                    f"{accumulator_sum} = tl.full({scalar_size_str}, 0.0, {acc_type})"
                 )
                 self.compute.splice(
                     f"""
@@ -6031,11 +6100,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     dim,
                     dtype,
                 )
-            elif strict_reduction_loop:
-                zero = cast(str, default)
+            elif strict_reduction_loop or scalar_loop:
+                if scalar_loop:
+                    self.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
+                combine_fn = ir.get_reduction_combine_fn(reduction_type, src_dtype)
                 masked = self.cse.generate(
                     self.compute,
-                    where_cond(value, zero),
+                    where_cond(value, cast(str, default)),
                     dtype=value.dtype,
                     shape=value.shape,
                 )
@@ -6049,7 +6120,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     shape=chunk_shape,
                 )
                 self.compute.writeline(
-                    f"{accumulator} = {accumulator} {strict_op} {chunk}"
+                    f"{accumulator} = {combine_fn(accumulator, chunk)}"
                 )
                 self.post_loop_combine.writeline(f"{result_var} = {accumulator}")
             else:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5661,9 +5661,13 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             value, _, _ = final_reduction(buffer, value, result_type)
             buffer.splice(f"{result_var} = {value}")
 
-        def final_argreduce(buffer, result_var, value, index, result_kind="index"):
-            # Only the index-only kinds may take the two-pass helper.
-            suffix = "_with_first_index" if result_kind == "index" else "_with_index"
+        def final_argreduce(
+            buffer, result_var, value, index, result_kind="index", whole_tile=False
+        ):
+            # The two-pass helper pays off over a whole row tile, not on the
+            # tail of a loop, and only where the index alone is consumed.
+            two_pass = whole_tile and result_kind == "index"
+            suffix = "_with_first_index" if two_pass else "_with_index"
             value = self.reduction_collapse_dims(buffer, value, value.dtype)
             index = self.reduction_collapse_dims(
                 buffer,
@@ -5828,6 +5832,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     masked_value,
                     accumulator_index,
                     argreduce_result_kind(),
+                    whole_tile=True,
                 )
             elif reduction_type == "welford_reduce":
                 if self.cooperative_reduction:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5661,6 +5661,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             buffer.splice(f"{result_var} = {value}")
 
         def final_argreduce(buffer, result_var, value, index, result_kind="index"):
+            strict = "_strict" if config.strict_signed_zero else ""
             value = self.reduction_collapse_dims(buffer, value, value.dtype)
             index = self.reduction_collapse_dims(
                 buffer,
@@ -5673,7 +5674,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 result_value, result_index = result_var
                 buffer.splice(
                     f"""\
-                    {result_value}, {result_index} = triton_helpers.{root_op}_with_index({value}, {index}, {dim})
+                    {result_value}, {result_index} = triton_helpers.{root_op}_with_index{strict}({value}, {index}, {dim})
                     {result_value} = {self.reduction_resize(f"{result_value}")}
                     {result_index} = {self.reduction_resize(f"{result_index}")}
                     """
@@ -5681,14 +5682,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             elif result_kind == "value":
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_val")}
                     """
                 )
             else:
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_idx")}
                     """
                 )
@@ -5911,6 +5912,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 reduction_type == "online_softmax_reduce"
                 and self.use_scalar_online_softmax(value)
             )
+            if scalar_loop or scalar_argreduce or scalar_online_softmax:
+                self.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
             scalar_size_str = f"[{', '.join(self.dense_size_list()[:dim])}]"
             if not isinstance(default, tuple):
                 if reduction_type == "dot":
@@ -5963,7 +5966,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     else f"{reduction_range_prefix}index"
                 )
                 if scalar_argreduce:
-                    self.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
                     block_index = f"tl.broadcast_to({where_cond(index_var, index_max)}, {self.dense_size_str()})"
                     self.compute.splice(
                         f"""\
@@ -6015,7 +6017,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             elif scalar_online_softmax:
                 # Per-row accumulators: each block is reduced along the
                 # reduction dim before it is folded into the running state.
-                self.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
                 accumulator_max = f"_{result_var}_max"
                 accumulator_sum = f"_{result_var}_sum"
                 self.body.writeline(
@@ -6101,8 +6102,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     dtype,
                 )
             elif strict_reduction_loop or scalar_loop:
-                if scalar_loop:
-                    self.autotune_hints.add(AutotuneHint.SCALAR_ACCUMULATORS)
                 combine_fn = ir.get_reduction_combine_fn(reduction_type, src_dtype)
                 masked = self.cse.generate(
                     self.compute,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6130,9 +6130,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 chunk_expr, chunk_dtype, chunk_shape = final_reduction(
                     self.compute, masked, None
                 )
+                # tl.sum widens sub-32-bit ints; keep the loop-carried type.
                 chunk = self.cse.generate(
                     self.compute,
-                    chunk_expr,
+                    f"({chunk_expr}).to({acc_type})",
                     dtype=chunk_dtype,
                     shape=chunk_shape,
                 )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3303,6 +3303,19 @@ class TMACompatibilityChecker:
         return self.force
 
 
+# Reductions that may share a scalar kernel with an online softmax. Alone they
+# keep the vector path until their shapes are swept like softmax was.
+ARG_REDUCTION_TYPES = (
+    "argmax",
+    "argmin",
+    "argmax_value",
+    "argmin_value",
+    "argmax_with_value",
+    "argmin_with_value",
+)
+PLAIN_REDUCTION_TYPES = ("sum", "prod", "max", "min", "xor_sum")
+
+
 class TritonKernel(SIMDKernel[TritonCSEVariable]):
     """A class to represent a triton kernel and helpers to generate
     triton kernel programmatically
@@ -3318,17 +3331,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         TensorDescriptorOptions
     )
     transpose_discontiguous_tensor_descriptors_override: bool | None = None
-    # Reductions that may share a scalar kernel with an online softmax. Alone
-    # they keep the vector path until their shapes are swept like softmax was.
-    SCALAR_ARG_REDUCTION_TYPES = (
-        "argmax",
-        "argmin",
-        "argmax_value",
-        "argmin_value",
-        "argmax_with_value",
-        "argmin_with_value",
-    )
-    SCALAR_LOOP_REDUCTION_TYPES = ("sum", "prod", "max", "min", "xor_sum")
 
     def __init__(
         self,
@@ -5438,23 +5440,24 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             or self.num_reduction_dims != 1
             or torch.version.hip is not None
             or V.graph.get_current_device_or_throw().type != "cuda"
-            or features.get_reduction_hint(self.tiling_scores) != ReductionHint.INNER
             or V.graph.sizevars.optimization_hint(features.reduction_numel) <= 4096
+            or features.get_reduction_hint(self.tiling_scores) != ReductionHint.INNER
         ):
             return False
-        allowed = self.SCALAR_ARG_REDUCTION_TYPES + self.SCALAR_LOOP_REDUCTION_TYPES
-        has_online_softmax = False
+        online_softmax_nodes = 0
         for node in features.reduction_nodes():
             buf = node.node
-            # tl.reduce cannot take int1; bool outputs cast after the vector loop.
+            # tl.reduce cannot take int1; bool-typed reductions keep the vector
+            # path, which casts after the loop.
             if not isinstance(buf, ir.ComputedBuffer) or buf.get_dtype() == torch.bool:
                 return False
             reduction_type = buf.get_reduction_type()
             if reduction_type == "online_softmax_reduce":
-                has_online_softmax = True
-            elif reduction_type not in allowed:
+                online_softmax_nodes += 1
+            elif reduction_type not in ARG_REDUCTION_TYPES + PLAIN_REDUCTION_TYPES:
                 return False
-        if not has_online_softmax:
+        # The sweep covered kernels with one or two online softmaxes.
+        if online_softmax_nodes not in (1, 2):
             return False
         nodes = OrderedSet(features.scheduler_nodes())
         produced = OrderedSet(
@@ -5581,11 +5584,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         arg_index_reduction_types = ("argmax", "argmin")
         arg_value_reduction_types = ("argmax_value", "argmin_value")
         arg_with_value_reduction_types = ("argmax_with_value", "argmin_with_value")
-        arg_reduction_types = (
-            arg_index_reduction_types
-            + arg_value_reduction_types
-            + arg_with_value_reduction_types
-        )
+        arg_reduction_types = ARG_REDUCTION_TYPES
         arg_root_ops = {
             "argmax": "max",
             "argmin": "min",
@@ -5664,16 +5663,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         def final_argreduce(
             buffer, result_var, value, index, result_kind="index", whole_tile=False
         ):
-            # The two-pass helper pays off over a whole row tile, not on the
-            # tail of a loop, and only where the index alone is consumed. The
-            # Triton CPU backend computes a different index from it, so CUDA only.
-            two_pass = (
-                whole_tile
-                and result_kind == "index"
-                and torch.version.hip is None
-                and V.graph.get_current_device_or_throw().type == "cuda"
-            )
-            suffix = "_with_first_index" if two_pass else "_with_index"
+            helper = argreduce_helper(whole_tile)
             value = self.reduction_collapse_dims(buffer, value, value.dtype)
             index = self.reduction_collapse_dims(
                 buffer,
@@ -5686,7 +5676,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 result_value, result_index = result_var
                 buffer.splice(
                     f"""\
-                    {result_value}, {result_index} = triton_helpers.{root_op}{suffix}({value}, {index}, {dim})
+                    {result_value}, {result_index} = triton_helpers.{helper}({value}, {index}, {dim})
                     {result_value} = {self.reduction_resize(f"{result_value}")}
                     {result_index} = {self.reduction_resize(f"{result_index}")}
                     """
@@ -5694,14 +5684,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             elif result_kind == "value":
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}{suffix}({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{helper}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_val")}
                     """
                 )
             else:
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}{suffix}({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{helper}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_idx")}
                     """
                 )
@@ -5712,6 +5702,21 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             if reduction_type in arg_value_reduction_types:
                 return "value"
             return "index"
+
+        def argreduce_helper(whole_tile: bool) -> str:
+            # The two-pass helper pays off over a whole row tile, not on the
+            # tail of a loop, and only where the index alone is consumed. It is
+            # CUDA-only and behind the scalar flag: the Triton CPU backend
+            # returns a different index from it (test_2d_reductions_mixed_indexing).
+            two_pass = (
+                whole_tile
+                and argreduce_result_kind() == "index"
+                and config.triton.scalar_accumulators
+                and torch.version.hip is None
+                and V.graph.get_current_device_or_throw().type == "cuda"
+            )
+            suffix = "_with_first_index" if two_pass else "_with_index"
+            return f"{root_op}{suffix}"
 
         cache_key = (
             src_dtype,
@@ -5915,8 +5920,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             default = ir.Reduction.default_accumulator(reduction_type, src_dtype)
             default = self._map_tuple_or_scalar(constant_repr, default)
             scalar_loop = (
-                reduction_type in self.SCALAR_LOOP_REDUCTION_TYPES
-                and self.use_scalar_accumulators
+                reduction_type in PLAIN_REDUCTION_TYPES and self.use_scalar_accumulators
             )
             scalar_argreduce = (
                 reduction_type in arg_reduction_types and self.use_scalar_accumulators
@@ -5979,12 +5983,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     else f"{reduction_range_prefix}index"
                 )
                 if scalar_argreduce:
-                    index_only = argreduce_result_kind() == "index"
-                    block_suffix = "_with_first_index" if index_only else "_with_index"
+                    helper = argreduce_helper(True)
                     block_index = f"tl.broadcast_to({where_cond(index_var, index_max)}, {self.dense_size_str()})"
                     self.compute.splice(
                         f"""\
-                    {accumulator}_block, {accumulator_index}_block = triton_helpers.{root_op}{block_suffix}(
+                    {accumulator}_block, {accumulator_index}_block = triton_helpers.{helper}(
                         {where_cond(value, default)}, {block_index}, {dim}
                     )
                     {accumulator}, {accumulator_index} = triton_helpers.{root_op}imum_with_index(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3318,10 +3318,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         TensorDescriptorOptions
     )
     transpose_discontiguous_tensor_descriptors_override: bool | None = None
-    # Reductions carrying a pair per row; their vector accumulators are what
-    # spills in large inner loops, so a kernel needs one to take the scalar path.
-    PAIRED_REDUCTION_TYPES = (
-        "online_softmax_reduce",
+    # Reductions that may share a scalar kernel with an online softmax. Alone
+    # they keep the vector path until their shapes are swept like softmax was.
+    SCALAR_ARG_REDUCTION_TYPES = (
         "argmax",
         "argmin",
         "argmax_value",
@@ -5420,11 +5419,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         """
         Per-row accumulators for every reduction of a large inner reduction
         loop: each block is reduced along the reduction dim before it is folded
-        into the running state, so only the per-row state stays live. Plain
-        sums and maxes alone gain nothing from this and lose for a few very
-        long rows, so a kernel takes the path only around an arg reduction or
-        online softmax. The size, load and full-size output limits come from
-        the performance sweep of fused softmax kernels.
+        into the running state, so only the per-row state stays live. The path
+        is taken around an online softmax, whose shapes were swept; the arg and
+        plain reductions fused with it (Domino cross entropy) are scalarized
+        alongside. The size, load and full-size output limits come from that
+        sweep.
         """
         features = self.features
         if (
@@ -5443,17 +5442,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             or V.graph.sizevars.optimization_hint(features.reduction_numel) <= 4096
         ):
             return False
-        paired = False
+        allowed = self.SCALAR_ARG_REDUCTION_TYPES + self.SCALAR_LOOP_REDUCTION_TYPES
+        has_online_softmax = False
         for node in features.reduction_nodes():
             buf = node.node
+            # tl.reduce cannot take int1; bool outputs cast after the vector loop.
             if not isinstance(buf, ir.ComputedBuffer) or buf.get_dtype() == torch.bool:
                 return False
             reduction_type = buf.get_reduction_type()
-            if reduction_type in self.PAIRED_REDUCTION_TYPES:
-                paired = True
-            elif reduction_type not in self.SCALAR_LOOP_REDUCTION_TYPES:
+            if reduction_type == "online_softmax_reduce":
+                has_online_softmax = True
+            elif reduction_type not in allowed:
                 return False
-        if not paired:
+        if not has_online_softmax:
             return False
         nodes = OrderedSet(features.scheduler_nodes())
         produced = OrderedSet(
@@ -5536,6 +5537,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             and reduction_type in ("sum", "prod")
         )
         strict_reduction_loop = strict_reduction and not self.persistent_reduction
+        # Ordered signed-zero ties need the tuple-reduce arg helpers.
+        strict_suffix = "_strict" if config.strict_signed_zero else ""
         # Combiner for the persistent strict path: "+" for sum, "*" for prod
         # (identity 0.0 / 1.0 comes from `default`); the loop uses combine_fn.
         strict_op = "*" if reduction_type == "prod" else "+"
@@ -5661,7 +5664,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             buffer.splice(f"{result_var} = {value}")
 
         def final_argreduce(buffer, result_var, value, index, result_kind="index"):
-            strict = "_strict" if config.strict_signed_zero else ""
             value = self.reduction_collapse_dims(buffer, value, value.dtype)
             index = self.reduction_collapse_dims(
                 buffer,
@@ -5674,7 +5676,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 result_value, result_index = result_var
                 buffer.splice(
                     f"""\
-                    {result_value}, {result_index} = triton_helpers.{root_op}_with_index{strict}({value}, {index}, {dim})
+                    {result_value}, {result_index} = triton_helpers.{root_op}_with_index{strict_suffix}({value}, {index}, {dim})
                     {result_value} = {self.reduction_resize(f"{result_value}")}
                     {result_index} = {self.reduction_resize(f"{result_index}")}
                     """
@@ -5682,14 +5684,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             elif result_kind == "value":
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict}({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict_suffix}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_val")}
                     """
                 )
             else:
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict}({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict_suffix}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_idx")}
                     """
                 )
@@ -5969,7 +5971,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     block_index = f"tl.broadcast_to({where_cond(index_var, index_max)}, {self.dense_size_str()})"
                     self.compute.splice(
                         f"""\
-                    {accumulator}_block, {accumulator_index}_block = triton_helpers.{root_op}_with_index(
+                    {accumulator}_block, {accumulator_index}_block = triton_helpers.{root_op}_with_index{strict_suffix}(
                         {where_cond(value, default)}, {block_index}, {dim}
                     )
                     {accumulator}, {accumulator_index} = triton_helpers.{root_op}imum_with_index(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5665,8 +5665,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             buffer, result_var, value, index, result_kind="index", whole_tile=False
         ):
             # The two-pass helper pays off over a whole row tile, not on the
-            # tail of a loop, and only where the index alone is consumed.
-            two_pass = whole_tile and result_kind == "index"
+            # tail of a loop, and only where the index alone is consumed. The
+            # Triton CPU backend computes a different index from it, so CUDA only.
+            two_pass = (
+                whole_tile
+                and result_kind == "index"
+                and torch.version.hip is None
+                and V.graph.get_current_device_or_throw().type == "cuda"
+            )
             suffix = "_with_first_index" if two_pass else "_with_index"
             value = self.reduction_collapse_dims(buffer, value, value.dtype)
             index = self.reduction_collapse_dims(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5537,8 +5537,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             and reduction_type in ("sum", "prod")
         )
         strict_reduction_loop = strict_reduction and not self.persistent_reduction
-        # Ordered signed-zero ties need the tuple-reduce arg helpers.
-        strict_suffix = "_strict" if config.strict_signed_zero else ""
         # Combiner for the persistent strict path: "+" for sum, "*" for prod
         # (identity 0.0 / 1.0 comes from `default`); the loop uses combine_fn.
         strict_op = "*" if reduction_type == "prod" else "+"
@@ -5664,6 +5662,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             buffer.splice(f"{result_var} = {value}")
 
         def final_argreduce(buffer, result_var, value, index, result_kind="index"):
+            # Only the index-only kinds may take the two-pass helper.
+            suffix = "_with_first_index" if result_kind == "index" else "_with_index"
             value = self.reduction_collapse_dims(buffer, value, value.dtype)
             index = self.reduction_collapse_dims(
                 buffer,
@@ -5676,7 +5676,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 result_value, result_index = result_var
                 buffer.splice(
                     f"""\
-                    {result_value}, {result_index} = triton_helpers.{root_op}_with_index{strict_suffix}({value}, {index}, {dim})
+                    {result_value}, {result_index} = triton_helpers.{root_op}{suffix}({value}, {index}, {dim})
                     {result_value} = {self.reduction_resize(f"{result_value}")}
                     {result_index} = {self.reduction_resize(f"{result_index}")}
                     """
@@ -5684,14 +5684,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             elif result_kind == "value":
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict_suffix}({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}{suffix}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_val")}
                     """
                 )
             else:
                 buffer.splice(
                     f"""\
-                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}_with_index{strict_suffix}({value}, {index}, {dim})
+                    {result_var}_val, {result_var}_idx = triton_helpers.{root_op}{suffix}({value}, {index}, {dim})
                     {result_var} = {self.reduction_resize(f"{result_var}_idx")}
                     """
                 )
@@ -5968,10 +5968,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     else f"{reduction_range_prefix}index"
                 )
                 if scalar_argreduce:
+                    index_only = argreduce_result_kind() == "index"
+                    block_suffix = "_with_first_index" if index_only else "_with_index"
                     block_index = f"tl.broadcast_to({where_cond(index_var, index_max)}, {self.dense_size_str()})"
                     self.compute.splice(
                         f"""\
-                    {accumulator}_block, {accumulator_index}_block = triton_helpers.{root_op}_with_index{strict_suffix}(
+                    {accumulator}_block, {accumulator_index}_block = triton_helpers.{root_op}{block_suffix}(
                         {where_cond(value, default)}, {block_index}, {dim}
                     )
                     {accumulator}, {accumulator_index} = triton_helpers.{root_op}imum_with_index(

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2208,10 +2208,9 @@ class triton:
     # We should revisit this once we understand more of the source of register spills.
     spill_threshold: int = 32 if torch.version.hip else 16
 
-    # Use scalar accumulators for online softmax in non-persistent CUDA
-    # reduction loops.
-    scalar_online_softmax_accumulators: bool = (
-        os.environ.get("TORCHINDUCTOR_SCALAR_ONLINE_SOFTMAX_ACCUMULATORS", "1") == "1"
+    # Use per-row scalar accumulators for large CUDA inner reduction loops.
+    scalar_accumulators: bool = (
+        os.environ.get("TORCHINDUCTOR_SCALAR_ACCUMULATORS", "1") == "1"
     )
 
     # Generate code using the tl.make_block_ptr() API for loads/stores. Block

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2208,7 +2208,8 @@ class triton:
     # We should revisit this once we understand more of the source of register spills.
     spill_threshold: int = 32 if torch.version.hip else 16
 
-    # Use per-row scalar accumulators for large CUDA inner reduction loops.
+    # Per-row scalar accumulators for large CUDA inner reduction loops that hold
+    # an online softmax.
     scalar_accumulators: bool = (
         os.environ.get("TORCHINDUCTOR_SCALAR_ACCUMULATORS", "1") == "1"
     )

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -210,9 +210,9 @@ class ReductionHeuristic(CodegenConfigHeuristics):
 
         device_major = triton_meta["device"].major
         warp_size = triton_meta["device"].warp_size_or_default
-        # Kernels with per-row online-softmax state have room for larger
-        # reduction blocks than the contiguous default.
-        scalar_online_softmax = AutotuneHint.SCALAR_ONLINE_SOFTMAX in inductor_meta.get(
+        # Kernels with per-row accumulators have room for larger reduction
+        # blocks than the contiguous default.
+        scalar_accumulators = AutotuneHint.SCALAR_ACCUMULATORS in inductor_meta.get(
             "autotune_hints", ()
         )
         MAX_R0_BLOCK = 1024 if device_major is not None and device_major >= 10 else 2048
@@ -271,7 +271,7 @@ class ReductionHeuristic(CodegenConfigHeuristics):
                 )
 
         contiguous_rblock = (
-            4096 if scalar_online_softmax and "y" in size_hints else MAX_R0_BLOCK
+            4096 if scalar_accumulators and "y" in size_hints else MAX_R0_BLOCK
         )
         contiguous_config = make_config(
             # Default XBLOCK=2 launches too few programs to fill
@@ -322,7 +322,7 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         )
 
         scalar_acc_configs: list[Config] = []
-        if scalar_online_softmax and "y" not in size_hints:
+        if scalar_accumulators and "y" not in size_hints:
             scalar_acc_configs = [
                 make_config(1, min(rnumel, 4096)),
                 make_config(1, min(rnumel, 8192), num_warps=4),

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -157,7 +157,7 @@ class HeuristicType(Enum):
 
 class AutotuneHint(Enum):
     ONE_ELEMENT_PER_THREAD = 0
-    SCALAR_ONLINE_SOFTMAX = 1
+    SCALAR_ACCUMULATORS = 1
 
     # Triton codegen tries to codegen set of AutotuneHints.
     # Enum.__repr__ looks like "<AutotuneHint.ELEMENTS_PER_WARP_32: 0>""

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -335,12 +335,28 @@ def maximum_with_index(a_value, a_index, b_value, b_index):
 
 @triton.jit
 def min_with_index(value, index, dim):
-    return tl.reduce((value, index), dim, minimum_with_index)
+    min_value = min2(value, dim)
+    keep = tl.expand_dims(min_value, dim)
+    hit = tl.where(keep != keep, value != value, value == keep)
+    return min_value, _first_index_where(hit, index, dim)
+
+
+@triton.jit
+def _first_index_where(hit, index, dim):
+    sentinel = tl.full(
+        [1], (1 << (index.dtype.primitive_bitwidth - 1)) - 1, index.dtype
+    )
+    return tl.min(tl.where(hit, index, sentinel), dim)
 
 
 @triton.jit
 def max_with_index(value, index, dim):
-    return tl.reduce((value, index), dim, maximum_with_index)
+    # Two native reductions (NaN-propagating max, then the smallest index that
+    # attains it) are much cheaper than a tuple reduce with a NaN-aware combine.
+    max_value = max2(value, dim)
+    keep = tl.expand_dims(max_value, dim)
+    hit = tl.where(keep != keep, value != value, value == keep)
+    return max_value, _first_index_where(hit, index, dim)
 
 
 @triton.jit

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -335,7 +335,11 @@ def maximum_with_index(a_value, a_index, b_value, b_index):
 
 @triton.jit
 def _first_index_of(value, result, index, dim):
-    # min2/max2 propagate NaN, so a NaN result is attained by the NaN lanes.
+    # The smallest index whose lane attains `result` from max2/min2 (the NaN
+    # lanes when it is NaN): the index a NaN-aware tuple reduce would pick, at
+    # the cost of two native reductions instead of a combine of about ten
+    # instructions per element. The paired value is the extremum, not the
+    # winning lane's, which differs on a tie between -0.0 and 0.0.
     hit = (value == tl.expand_dims(result, dim)) | (value != value)
     sentinel = tl.full(
         [1], (1 << (index.dtype.primitive_bitwidth - 1)) - 1, index.dtype
@@ -351,10 +355,6 @@ def min_with_first_index(value, index, dim):
 
 @triton.jit
 def max_with_first_index(value, index, dim):
-    # Two native reductions (NaN-propagating max, then the smallest index that
-    # attains it) are much cheaper than a tuple reduce with a NaN-aware combine.
-    # The index is the one the combine picks; the value is the max rather than
-    # the winning lane's, which differs on a tie between -0.0 and 0.0.
     max_value = max2(value, dim)
     return max_value, _first_index_of(value, max_value, index, dim)
 

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -334,15 +334,9 @@ def maximum_with_index(a_value, a_index, b_value, b_index):
 
 
 @triton.jit
-def min_with_index(value, index, dim):
-    min_value = min2(value, dim)
-    keep = tl.expand_dims(min_value, dim)
-    hit = tl.where(keep != keep, value != value, value == keep)
-    return min_value, _first_index_where(hit, index, dim)
-
-
-@triton.jit
-def _first_index_where(hit, index, dim):
+def _first_index_of(value, result, index, dim):
+    # min2/max2 propagate NaN, so a NaN result is attained by the NaN lanes.
+    hit = (value == tl.expand_dims(result, dim)) | (value != value)
     sentinel = tl.full(
         [1], (1 << (index.dtype.primitive_bitwidth - 1)) - 1, index.dtype
     )
@@ -350,13 +344,29 @@ def _first_index_where(hit, index, dim):
 
 
 @triton.jit
+def min_with_index(value, index, dim):
+    min_value = min2(value, dim)
+    return min_value, _first_index_of(value, min_value, index, dim)
+
+
+@triton.jit
 def max_with_index(value, index, dim):
     # Two native reductions (NaN-propagating max, then the smallest index that
     # attains it) are much cheaper than a tuple reduce with a NaN-aware combine.
     max_value = max2(value, dim)
-    keep = tl.expand_dims(max_value, dim)
-    hit = tl.where(keep != keep, value != value, value == keep)
-    return max_value, _first_index_where(hit, index, dim)
+    return max_value, _first_index_of(value, max_value, index, dim)
+
+
+@triton.jit
+def min_with_index_strict(value, index, dim):
+    return tl.reduce((value, index), dim, minimum_with_index)
+
+
+@triton.jit
+def max_with_index_strict(value, index, dim):
+    # The tuple reduce returns the value of the winning lane, which differs
+    # from the two-pass form only for a tie between -0.0 and 0.0.
+    return tl.reduce((value, index), dim, maximum_with_index)
 
 
 @triton.jit

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -344,28 +344,28 @@ def _first_index_of(value, result, index, dim):
 
 
 @triton.jit
-def min_with_index(value, index, dim):
+def min_with_first_index(value, index, dim):
     min_value = min2(value, dim)
     return min_value, _first_index_of(value, min_value, index, dim)
 
 
 @triton.jit
-def max_with_index(value, index, dim):
+def max_with_first_index(value, index, dim):
     # Two native reductions (NaN-propagating max, then the smallest index that
     # attains it) are much cheaper than a tuple reduce with a NaN-aware combine.
+    # The index is the one the combine picks; the value is the max rather than
+    # the winning lane's, which differs on a tie between -0.0 and 0.0.
     max_value = max2(value, dim)
     return max_value, _first_index_of(value, max_value, index, dim)
 
 
 @triton.jit
-def min_with_index_strict(value, index, dim):
+def min_with_index(value, index, dim):
     return tl.reduce((value, index), dim, minimum_with_index)
 
 
 @triton.jit
-def max_with_index_strict(value, index, dim):
-    # The tuple reduce returns the value of the winning lane, which differs
-    # from the two-pass form only for a tie between -0.0 and 0.0.
+def max_with_index(value, index, dim):
     return tl.reduce((value, index), dim, maximum_with_index)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196371

#190692 gave online softmax per-row scalar accumulators in large inner reduction loops. This extends them to every reduction of such a kernel when one or two online softmaxes are present, the cases that were swept: argmax/argmin and their value variants fold a per-block reduction into per-row state, and sum/prod/max/min/xor_sum reuse the strict-reduction loop structure with the reduction's combine function, casting each block's result back to the accumulator type because tl.sum widens narrow ints. Eligibility is all-or-nothing per kernel, since a kernel mixing scalar and vector accumulators spills on the large blocks the hint enables. Kernels without an online softmax are unchanged: lone arg reductions and plain sums have nothing to spill and measured slower on some shapes, so they wait for their own sweep. Under strict_signed_zero the whole kernel keeps the vector path. The flag and hint become triton.scalar_accumulators and AutotuneHint.SCALAR_ACCUMULATORS.

Review order: use_scalar_accumulators in triton.py, the reduction() branches, then triton_helpers.py.

Arg reductions also get max_with_first_index / min_with_first_index: max2/min2 followed by the smallest index attaining the result, instead of a tuple reduce with a NaN-aware combine. They apply only where the index alone is consumed and a whole tile is reduced at once (persistent kernels and the scalar per-block path), CUDA only and behind the same flag; max(dim)/min(dim) with a live value keep the tuple reduce, which returns the winning lane's signed zero.

GB300 bf16, measurement scripts not in tree: Domino cross entropy (#190718) 3.23 -> 1.71 ms at 4096x248320 and 3.43 -> 1.77 ms at 8192x128256 (hand-written Triton kernel: 2.03 / 2.07 ms); cross entropy fused with argmax 0.55x; online-softmax-only kernels unchanged; better-benchmark's persistent arg-reduction repros 0.88x geomean. The scalar configs autotune within a few percent of each other at small row counts, so fp32 sums in a scalar kernel can round differently between compiles; deterministic mode picks a fixed one.

Test Plan:

```bash
export TORCHINDUCTOR_FORCE_DISABLE_CACHES=1
python test/inductor/test_online_softmax.py
python test/inductor/test_triton_heuristics.py
python test/inductor/test_codegen_triton.py -k autotune_hints
python test/inductor/test_torchinductor.py -k "argm or reduction or max_min"
python test/inductor/test_torchinductor_strided_blocks.py -k 2d_reductions
lintrunner -a
```

All pass on a GB300 (CUDA 13.0, triton 3.8). Differential fuzzers over sum, amax, amin, argmax, argmin, max/min with indices, prod and fused combinations across four dtypes with NaN, inf and tied inputs matched the vector path and eager.

Authored with assistance from Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo