### PR TITLE
[Inductor] Pass kHz clock rate to Triton tflops estimator instead of MHz

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -350,6 +350,24 @@ class TestUtils(TestCase):
         ret = get_device_tflops(dtype)
         self.assertTrue(type(ret) is float)
 
+    @xfailIfNoAcceleratorTriton
+    @unittest.skipIf(not torch.cuda.is_available(), "skip if no device")
+    def test_get_device_tflops_triton_fallback_magnitude(self):
+        # The Triton fallback feeds max_clock_rate() (MHz) into triton's tflops
+        # helpers, which are dimensioned in kHz. Getting that wrong under-reports
+        # peak throughput by 1000x, which a type-only assertion cannot catch, so
+        # pin the magnitude too: every GPU that reaches this path is well above
+        # 1 TFLOPS, and every pre-fix value was well below it.
+        get_device_tflops.cache_clear()
+        try:
+            with mock.patch.object(inductor_utils, "datasheet_tops", return_value=None):
+                ret = get_device_tflops(torch.float16)
+        finally:
+            # get_device_tflops is functools.cache'd; do not leak the fallback
+            # value into later tests.
+            get_device_tflops.cache_clear()
+        self.assertGreater(ret, 1.0)
+
 
 instantiate_device_type_tests(TestUtils, globals(), allow_xpu=True)
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3428,7 +3428,8 @@ def get_device_tflops(dtype: torch.dtype) -> float:
         # Triton API change in https://github.com/triton-lang/triton/pull/2293
         from torch._utils_internal import max_clock_rate
 
-        sm_clock = max_clock_rate()
+        # Triton's tflops helpers are dimensioned in kHz; max_clock_rate is MHz.
+        sm_clock = max_clock_rate() * 1e3
         if dtype in (torch.float16, torch.bfloat16) and SM80OrLater:
             return get_max_tensorcore_tflops(dtype, sm_clock)
 


### PR DESCRIPTION
Converts the clock from MHz to kHz at the one place that feeds it to Triton, in [`get_device_tflops`](https://github.com/pytorch/pytorch/blob/7475a463f9dc61552e39bd2329cb2fd47fa6aa61/torch/_inductor/utils.py#L3396).

[`max_clock_rate()`](https://github.com/pytorch/pytorch/blob/7475a463f9dc61552e39bd2329cb2fd47fa6aa61/torch/_utils_internal.py#L242) returns **MHz**, as its docstring says. Triton's [`get_max_simd_tflops`](https://github.com/triton-lang/triton/blob/c01b6774b1865984607d89d89d3a10833de92037/python/triton/testing.py#L716-L740) and [`get_max_tensorcore_tflops`](https://github.com/triton-lang/triton/blob/c01b6774b1865984607d89d89d3a10833de92037/python/triton/testing.py#L631-L653) want **kHz**. [`get_device_tflops` passed the MHz value straight through](https://github.com/pytorch/pytorch/blob/7475a463f9dc61552e39bd2329cb2fd47fa6aa61/torch/_inductor/utils.py#L3431), and since 1 MHz is 1000 kHz the clock is read as a thousandth of its real value, making every Triton-fallback estimate **1000x too low**.

The expected unit is not stated in Triton's signature — the parameter is just `clock_rate`, with no unit in the name and no docstring — but it is fixed by the trailing constant in `tflops = num_subcores * clock_rate * ops_per_sub_core * 1e-9`. `num_subcores * ops_per_sub_core` is FLOP per clock cycle, so multiplying by a clock in Hz would give FLOP/s, and reporting TFLOP/s (10^12 FLOP/s) from there would need `1e-12`. The constant is `1e-9`, which is 1000x larger, so the clock going in must already carry 1000 Hz per unit: kHz. The `1e-9` is two conversions folded into one number, kHz to Hz (10^3) and FLOP to TFLOP (10^-12), which is why the input unit is invisible at a glance. This also matches where the value used to come from: before [triton-lang/triton#2293](https://github.com/triton-lang/triton/pull/2293) made the clock a parameter, these helpers read it from device properties themselves, and both CUDA's `cudaDeviceProp::clockRate` and `torch.cuda.get_device_properties().clock_rate` report kHz.

The fallback runs whenever `torch.cuda.get_device_name()` is absent from `_device_mapping` in `torch/_inductor/analysis/device_info.py`, which today is most devices: the table has 16 entries, so MI325X, MI308, gfx11/gfx12 and every consumer part take this path. Three consumers read the result — the shape-padding roofline check at [`pad_mm.py`](https://github.com/pytorch/pytorch/blob/7475a463f9dc61552e39bd2329cb2fd47fa6aa61/torch/_inductor/fx_passes/pad_mm.py#L553), inductor's scheduler runtime model at [`scheduler.py`](https://github.com/pytorch/pytorch/blob/7475a463f9dc61552e39bd2329cb2fd47fa6aa61/torch/_inductor/scheduler.py#L3370), and activation-checkpointing cost estimation at [`_runtime_estimation.py`](https://github.com/pytorch/pytorch/blob/7475a463f9dc61552e39bd2329cb2fd47fa6aa61/torch/utils/_runtime_estimation.py#L97) — so a 1000x-low peak makes every op look compute-bound relative to memory.

Coauthored with Claude

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben