### PR TITLE
[CI] Introduce macOS 27 for binary builds and MPS tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -81,6 +81,7 @@ self-hosted-runner:
     - macos-14-xlarge
     - macos-26
     - macos-26-xlarge
+    - xcode-27-xlarge
     # Organization-wide Intel hosted XPU runners
     - linux.idc.xpu
     # Organization-wide Google Cloud TPU runners

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -203,7 +203,7 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         os=OperatingSystem.MACOS_ARM64,
         package_type="wheel",
         build_configs=_MACOS_ARM64_WHEEL_CONFIGS,
-        macos_runner="macos-26-xlarge",
+        macos_runner="xcode-27-xlarge",
         ciflow_config=CIFlowConfig(
             labels={
                 LABEL_CIFLOW_BINARIES,

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -90,6 +90,8 @@ jobs:
       - name: Install libomp
         run: |
           "${PYTORCH_ROOT}/.ci/macwheel/install_libomp.sh"
+      - name: Install Metal toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
       - name: Install uv
         uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -39,7 +39,7 @@ jobs:
   # tools/setup_helpers/cmake.py.
   wheel-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: macos-26-xlarge
+    runs-on: xcode-27-xlarge
     timeout-minutes: 280
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
@@ -75,6 +75,8 @@ jobs:
       - name: Install libomp
         run: |
           "${PYTORCH_ROOT}/.ci/macwheel/install_libomp.sh"
+      - name: Install Metal toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
       - name: Install uv
         uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:
@@ -224,7 +226,7 @@ jobs:
   libtorch-cpu-shared-with-deps-release-extract:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: wheel-build
-    runs-on: macos-26-xlarge
+    runs-on: xcode-27-xlarge
     timeout-minutes: 60
     env:
       DESIRED_CUDA: cpu


### PR DESCRIPTION
Move binary builds to `xcode-27-xlarge`, which now runs macOS 27 and add it to the MPS test matrix. See: https://github.com/actions/runner-images/blob/main/images/macos/xcode-27-arm64-Readme.md#macos-27

Metal toolchain installation conditional is kept because runner is missing toolchain. See: https://github.com/actions/runner-images/issues/14548
We can remove it once the issue is closed
