### PR TITLE
Add one retry to nightly binary-build artifact uploads

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -1,10 +1,50 @@
 {%- set upload_artifact_s3_action = "seemethere/upload-artifact-s3@v5" -%}
 {%- set download_artifact_s3_action = "seemethere/download-artifact-s3@v4" -%}
-{%- set upload_artifact_action = "actions/upload-artifact@v4.4.0" -%}
+{%- set upload_artifact_action = "actions/upload-artifact@v4.6.2" -%}
 {%- set download_artifact_action = "actions/download-artifact@v4.1.7" -%}
 
 {%- set timeout_minutes = 280 -%}
 {%- set timeout_minutes_windows_binary = 360 -%}
+
+{#-
+  Upload an artifact, retrying once if the upload fails.
+
+  actions/upload-artifact aborts with "Upload progress stalled." after 300s with
+  no upload progress and does not retry the aborted upload, so a single stalled
+  upload throws away a binary build that already succeeded. The first attempt is
+  continue-on-error so the job survives it; the retry is not, so a genuine
+  failure still fails the job.
+-#}
+{%- macro upload_artifact_with_retry(step_id, name, path, retention_days="", always=False) -%}
+      - uses: !{{ upload_artifact_action }}
+        id: !{{ step_id }}
+        continue-on-error: true
+{%- if always %}
+        if: always()
+{%- endif %}
+        with:
+          name: !{{ name }}
+{%- if retention_days %}
+          retention-days: !{{ retention_days }}
+{%- endif %}
+          if-no-files-found: error
+          path: !{{ path }}
+      - name: Retry artifact upload
+        uses: !{{ upload_artifact_action }}
+        if: !{{ "always() && " if always else "" }}steps.!{{ step_id }}.outcome == 'failure'
+        with:
+          name: !{{ name }}
+{%- if retention_days %}
+          retention-days: !{{ retention_days }}
+{%- endif %}
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: !{{ path }}
+{%- endmacro -%}
 
 {%- macro concurrency(build_environment) -%}
 concurrency:

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -320,11 +320,10 @@ jobs:
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
   {%- for config in group %}
-      - uses: !{{ common.upload_artifact_action }}
-        with:
-          name: !{{ config['build_name'] }}
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/!{{ config['build_name'] }}/*
+      !{{ common.upload_artifact_with_retry(
+            step_id="upload-" ~ config['build_name'],
+            name=config['build_name'],
+            path="${{ runner.temp }}/artifacts/" ~ config['build_name'] ~ "/*") }}
   {%- endfor %}
 {%- endfor %}
 
@@ -657,13 +656,12 @@ jobs:
         run: |
           python3 .ci/libtorch/smoke_test_extract_libtorch.py \
             --output-dir "${GITHUB_WORKSPACE}/libtorch_output"
-      - uses: !{{ common.upload_artifact_action }}
-        if: always()
-        with:
-          name: ${{ matrix.build_name }}
-          retention-days: 14
-          if-no-files-found: error
-          path: "${{ github.workspace }}/libtorch_output/"
+      !{{ common.upload_artifact_with_retry(
+            step_id="upload-libtorch",
+            name="${{ matrix.build_name }}",
+            path='"${{ github.workspace }}/libtorch_output/"',
+            retention_days=14,
+            always=True) }}
 
 {%- if branches == "nightly" %}
 

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -176,13 +176,12 @@ jobs:
         shell: bash
         run: |
           "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
-      - uses: !{{ common.upload_artifact_action }}
-        if: always()
-        with:
-          name: ${{ matrix.build_name }}
-          retention-days: 14
-          if-no-files-found: error
-          path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
+      !{{ common.upload_artifact_with_retry(
+            step_id="upload-wheel",
+            name="${{ matrix.build_name }}",
+            path='"${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"',
+            retention_days=14,
+            always=True) }}
 {%- if os != "windows-arm64" %}
       !{{ common.wait_and_kill_ssh_windows() }}
 {% endif %}
@@ -376,13 +375,12 @@ jobs:
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
             --arch !{{ lt_config["arch"] }}
-      - uses: !{{ common.upload_artifact_action }}
-        if: always()
-        with:
-          name: !{{ lt_config["build_name"] }}
-          retention-days: 14
-          if-no-files-found: error
-          path: "${{ runner.temp }}/libtorch_output/"
+      !{{ common.upload_artifact_with_retry(
+            step_id="upload-libtorch",
+            name=lt_config["build_name"],
+            path='"${{ runner.temp }}/libtorch_output/"',
+            retention_days=14,
+            always=True) }}
   {%- if branches == "nightly" %}
   !{{ upload.upload_extracted_libtorch(lt_config, True) }}
   {%- endif %}

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -193,10 +193,30 @@ jobs:
           docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .ci/pytorch/binary_populate_env.sh"
           docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash .ci/${{ inputs.PACKAGE_TYPE }}/build.sh"
 
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      # actions/upload-artifact aborts with "Upload progress stalled." after 300s
+      # with no upload progress and does not retry the aborted upload, so a single
+      # stalled upload throws away a build that already succeeded. The first
+      # attempt is continue-on-error so the job survives it; the retry is not, so
+      # a genuine failure still fails the job.
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        id: upload-artifact
+        continue-on-error: true
         with:
           name: ${{ inputs.build_name }}
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/*
+
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: steps.upload-artifact.outcome == 'failure'
+        with:
+          name: ${{ inputs.build_name }}
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/*
 
       - name: Cleanup docker

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -187,45 +187,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cpu-aarch64/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cpu-aarch64/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cpu-aarch64/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cpu-aarch64/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cpu-aarch64/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu-aarch64/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cpu-aarch64
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cpu-aarch64/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cpu-aarch64/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cpu-aarch64
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cpu-aarch64
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cpu-aarch64/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cpu-aarch64.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cpu-aarch64
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cpu-aarch64/*
 
   manywheel-cuda-aarch64-cu130-build:
@@ -276,45 +388,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cuda-aarch64-13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cuda-aarch64-13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cuda-aarch64-13_0
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_0/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cuda-aarch64-13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cuda-aarch64-13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_0/*
 
   manywheel-cuda-aarch64-cu132-build:
@@ -365,45 +589,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cuda-aarch64-13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cuda-aarch64-13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cuda-aarch64-13_2
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_2/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cuda-aarch64-13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cuda-aarch64-13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_2/*
 
   manywheel-cuda-aarch64-cu134-build:
@@ -454,45 +790,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cuda-aarch64-13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cuda-aarch64-13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cuda-aarch64-13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cuda-aarch64-13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cuda-aarch64-13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cuda-aarch64-13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cuda-aarch64-13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cuda-aarch64-13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cuda-aarch64-13_4
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_4/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cuda-aarch64-13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cuda-aarch64-13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_4/*
 
   manywheel-cpu-aarch64-test:

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -188,45 +188,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cpu/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cpu/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cpu/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cpu/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cpu/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cpu/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cpu/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cpu/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cpu/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cpu/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cpu/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cpu
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cpu/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cpu/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cpu
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cpu
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cpu/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cpu.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cpu
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cpu/*
 
   manywheel-cuda-cu130-build:
@@ -277,45 +389,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cuda13_0
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_0/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_0/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cuda13_0
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cuda13_0
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_0/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cuda13_0.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cuda13_0
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_0/*
 
   manywheel-cuda-cu132-build:
@@ -366,45 +590,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cuda13_2
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_2/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_2/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cuda13_2
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cuda13_2
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_2/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cuda13_2.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cuda13_2
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_2/*
 
   manywheel-cuda-cu134-build:
@@ -455,45 +791,157 @@ jobs:
           bash .ci/manywheel/build_all.sh
       # One artifact per built Python -- names must match what the test/upload
       # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_10-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_10-cuda13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_10-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_10-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_11-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_11-cuda13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_11-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_11-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_12-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_12-cuda13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_12-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_12-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_13-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_13-cuda13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_13-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_13-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_14-cuda13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_14-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_14t-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_14t-cuda13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_14t-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_14t-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_15-cuda13_4
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_15-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_4/*
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-manywheel-py3_15t-cuda13_4
+        continue-on-error: true
         with:
           name: manywheel-py3_15t-cuda13_4
           if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_4/*
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: steps.upload-manywheel-py3_15t-cuda13_4.outcome == 'failure'
+        with:
+          name: manywheel-py3_15t-cuda13_4
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_4/*
 
   manywheel-build:
@@ -1973,12 +2421,27 @@ jobs:
         run: |
           python3 .ci/libtorch/smoke_test_extract_libtorch.py \
             --output-dir "${GITHUB_WORKSPACE}/libtorch_output"
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-libtorch
+        continue-on-error: true
         if: always()
         with:
           name: ${{ matrix.build_name }}
           retention-days: 14
           if-no-files-found: error
+          path: "${{ github.workspace }}/libtorch_output/"
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: always() && steps.upload-libtorch.outcome == 'failure'
+        with:
+          name: ${{ matrix.build_name }}
+          retention-days: 14
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: "${{ github.workspace }}/libtorch_output/"
 
   libtorch-upload:

--- a/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
@@ -137,12 +137,27 @@ jobs:
         shell: bash
         run: |
           "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-wheel
+        continue-on-error: true
         if: always()
         with:
           name: ${{ matrix.build_name }}
           retention-days: 14
           if-no-files-found: error
+          path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: always() && steps.upload-wheel.outcome == 'failure'
+        with:
+          name: ${{ matrix.build_name }}
+          retention-days: 14
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
 
   wheel-test:
@@ -302,12 +317,27 @@ jobs:
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
             --arch arm64
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-libtorch
+        continue-on-error: true
         if: always()
         with:
           name: libtorch-arm64-cpu-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
+          path: "${{ runner.temp }}/libtorch_output/"
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: always() && steps.upload-libtorch.outcome == 'failure'
+        with:
+          name: libtorch-arm64-cpu-shared-with-deps-release
+          retention-days: 14
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: "${{ runner.temp }}/libtorch_output/"
   libtorch-arm64-cpu-shared-with-deps-release-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -328,12 +328,27 @@ jobs:
         shell: bash
         run: |
           "${PYTORCH_ROOT}/.ci/pytorch/binary_windows_build.sh"
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-wheel
+        continue-on-error: true
         if: always()
         with:
           name: ${{ matrix.build_name }}
           retention-days: 14
           if-no-files-found: error
+          path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: always() && steps.upload-wheel.outcome == 'failure'
+        with:
+          name: ${{ matrix.build_name }}
+          retention-days: 14
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Wait until all sessions have drained
         shell: powershell
@@ -871,12 +886,27 @@ jobs:
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
             --arch x86_64
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-libtorch
+        continue-on-error: true
         if: always()
         with:
           name: libtorch-cpu-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
+          path: "${{ runner.temp }}/libtorch_output/"
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: always() && steps.upload-libtorch.outcome == 'failure'
+        with:
+          name: libtorch-cpu-shared-with-deps-release
+          retention-days: 14
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: "${{ runner.temp }}/libtorch_output/"
   libtorch-cpu-shared-with-deps-release-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -935,12 +965,27 @@ jobs:
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
             --arch x86_64
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-libtorch
+        continue-on-error: true
         if: always()
         with:
           name: libtorch-cuda13_0-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
+          path: "${{ runner.temp }}/libtorch_output/"
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: always() && steps.upload-libtorch.outcome == 'failure'
+        with:
+          name: libtorch-cuda13_0-shared-with-deps-release
+          retention-days: 14
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: "${{ runner.temp }}/libtorch_output/"
   libtorch-cuda13_0-shared-with-deps-release-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -1000,12 +1045,27 @@ jobs:
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
             --arch x86_64
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v4.6.2
+        id: upload-libtorch
+        continue-on-error: true
         if: always()
         with:
           name: libtorch-cuda13_2-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
+          path: "${{ runner.temp }}/libtorch_output/"
+      - name: Retry artifact upload
+        uses: actions/upload-artifact@v4.6.2
+        if: always() && steps.upload-libtorch.outcome == 'failure'
+        with:
+          name: libtorch-cuda13_2-shared-with-deps-release
+          retention-days: 14
+          if-no-files-found: error
+          # Delete any existing artifact under this name -- normally the
+          # registration the failed attempt left behind -- so the retry's
+          # CreateArtifact has a chance to succeed. The action handles deletion
+          # errors on a best-effort basis.
+          overwrite: true
           path: "${{ runner.temp }}/libtorch_output/"
   libtorch-cuda13_2-shared-with-deps-release-upload:  # Uploading
     if: ${{ github.repository_owner == 'pytorch' }}


### PR DESCRIPTION
✴️ iz2: `actions/upload-artifact` aborts with `Upload progress stalled.` after 300s of no upload progress and does not retry the aborted upload, so one stalled upload discards a nightly binary build that already succeeded. Downstream `*-upload` jobs then fail on the missing artifact. Same signature as actions/upload-artifact#527, #623 and #740; there is no retry around the watchdog at `actions/toolkit` HEAD either.

## Change

Every binary-build upload becomes two steps: attempt 1 with `continue-on-error`, attempt 2 only `if` attempt 1 failed. Attempt 2 is not `continue-on-error`, so a real failure still fails the job.

- Four call sites in the linux and windows binary templates go through a new `upload_artifact_with_retry` macro in `common.yml.j2`; the generated workflows are regenerated.
- `.github/workflows/_binary-build-linux.yml` carries the same two steps inline — it is not template-generated, and its legs are otherwise uncovered.
- The pin moves v4.4.0 to v4.6.2 at both sites (the SHA already used by `.github/actions/upload-build-artifacts`). v4.6.0 added `ACTIONS_ARTIFACT_UPLOAD_TIMEOUT_MS`, which makes the 300s watchdog settable and the failure reproducible on demand. The bump adds no retry by itself.

Not a composite action: the Windows libtorch-extract job checks out with `sparse-checkout: .ci/libtorch/`, so `.github/actions/` is not on disk there.

## Open question for the reviewer

`CreateArtifact` registers the artifact name before streaming and the stall throws before `FinalizeArtifact`, so a stalled attempt leaves a name registered and nothing finalized. Whether `overwrite: true` can clear an *unfinalized* registration is something I could not determine from the source. If it cannot, the retry hits the same 409 and this buys nothing for the stall — landing it is then a bet that resolves on the next recurrence, unless someone first forces a stall with the new timeout knob.

- `overwrite: true` deletes *any* artifact under that name, not only the failed attempt's registration. Audited every job in the changed workflows: each artifact name appears only in its own two retry steps, and no distinct uploads within a job share a name.
- If attempt 1 fails *after* the artifact was committed server-side, deletion succeeds, and the retry fails before finalizing a replacement, a previously usable artifact is lost.

Behaviour above was read at `actions/toolkit` / `actions/upload-artifact` HEAD, not in the pinned releases' bundled `dist/`.

## Test plan

- `.github/regenerate.sh`: no-op on a clean tree; after this edit touches only the four generated binary workflows, and no `upload-artifact@v4.4.0` remains in them.
- All five changed workflow files parse as YAML.
- `actionlint` 1.7.7: the same nine pre-existing SC1090 warnings before and after — no new finding.
- Not exercised against a live run; `ciflow/binaries` would be the way to do that.
