### PR TITLE
Fix efficient_conv_bn_eval to honor conv keyword arguments (gh-196165)

### DIFF
--- a/test/inductor/test_efficient_conv_bn_eval.py
+++ b/test/inductor/test_efficient_conv_bn_eval.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 
@@ -264,6 +265,100 @@ class EfficientConvBNEvalTemplate(TestCase):
             test_conv_bn_eval(
                 test_class, use_bias, module, sync_bn, decompose_nn_module
             )
+
+    @tf32_on_and_off(0.003)
+    @inductor_config.patch({"efficient_conv_bn_eval_fx_passes": True})
+    def test_conv_bn_eval_kwarg_conv_args(self):
+        """Regression test for gh-196165.
+
+        F.conv2d may pass bias, stride and padding by keyword.  The
+        conv-bn fusion used to read the conv node positionally, dropping
+        the keyword arguments and silently computing with the defaults.
+        """
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(4, 3, 3, 3))
+                self.bias = torch.nn.Parameter(torch.randn(4))
+                self.register_buffer("running_mean", torch.randn(4))
+                self.register_buffer("running_var", torch.rand(4) + 1.0)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                conv = F.conv2d(
+                    x,
+                    self.weight,
+                    bias=self.bias,
+                    stride=2,
+                    padding=1,
+                )
+                return F.batch_norm(conv, self.running_mean, self.running_var)
+
+        torch.manual_seed(1703)
+        model = Model().eval().to(self.device)
+        x = torch.randn(2, 3, 16, 16).to(self.device)
+        with torch.no_grad():
+            expected = model(x)
+            compiled = torch.compile(model, backend="inductor")(x)
+
+        self.assertEqual(compiled, expected)
+
+    @tf32_on_and_off(0.003)
+    @inductor_config.patch({"efficient_conv_bn_eval_fx_passes": True})
+    def test_conv_bn_eval_kwarg_input_weight(self):
+        """gh-196165: conv input and weight may themselves be passed by
+        keyword, leaving no positional args to read."""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(4, 3, 3, 3))
+                self.register_buffer("running_mean", torch.randn(4))
+                self.register_buffer("running_var", torch.rand(4) + 1.0)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                conv = torch.conv2d(input=x, weight=self.weight, stride=2, padding=1)
+                return F.batch_norm(conv, self.running_mean, self.running_var)
+
+        torch.manual_seed(1703)
+        model = Model().eval().to(self.device)
+        x = torch.randn(2, 3, 16, 16).to(self.device)
+        with torch.no_grad():
+            expected = model(x)
+            compiled = torch.compile(model, backend="inductor")(x)
+
+        self.assertEqual(compiled, expected)
+
+    @tf32_on_and_off(0.003)
+    @inductor_config.patch({"efficient_conv_bn_eval_fx_passes": True})
+    def test_conv_transpose_bn_eval_kwarg_conv_args(self):
+        """gh-196165: keyword conv args on the transposed-conv path."""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(3, 4, 3, 3))
+                self.register_buffer("running_mean", torch.randn(4))
+                self.register_buffer("running_var", torch.rand(4) + 1.0)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                conv = F.conv_transpose2d(
+                    x,
+                    self.weight,
+                    stride=2,
+                    padding=1,
+                    output_padding=1,
+                )
+                return F.batch_norm(conv, self.running_mean, self.running_var)
+
+        torch.manual_seed(1703)
+        model = Model().eval().to(self.device)
+        x = torch.randn(2, 3, 8, 8).to(self.device)
+        with torch.no_grad():
+            expected = model(x)
+            compiled = torch.compile(model, backend="inductor")(x)
+
+        self.assertEqual(compiled, expected)
 
 
 if HAS_CPU and not torch.backends.mps.is_available():

--- a/torch/_inductor/fx_passes/efficient_conv_bn_eval.py
+++ b/torch/_inductor/fx_passes/efficient_conv_bn_eval.py
@@ -21,6 +21,176 @@ from .pre_grad import efficient_conv_bn_eval_pass
 _BATCH_NORM_SIGNATURE = inspect.signature(torch.nn.functional.batch_norm)
 
 
+def _make_conv_signature(names, defaults):
+    """Build an inspect.Signature for a conv/linear target from its parameter
+    names, mirroring the public torch.* API (the builtins are not
+    introspectable and the aten ops only expose their schema)."""
+    return inspect.Signature(
+        [
+            inspect.Parameter(
+                name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=defaults.get(name, inspect.Parameter.empty),
+            )
+            for name in names
+        ]
+    )
+
+
+_CONV_DEFAULTS = {
+    "bias": None,
+    "stride": 1,
+    "padding": 0,
+    "dilation": 1,
+    "groups": 1,
+    "output_padding": 0,
+}
+
+_CONV_SIGNATURES = {
+    torch.conv1d: _make_conv_signature(
+        ["input", "weight", "bias", "stride", "padding", "dilation", "groups"],
+        _CONV_DEFAULTS,
+    ),
+    torch.conv2d: _make_conv_signature(
+        ["input", "weight", "bias", "stride", "padding", "dilation", "groups"],
+        _CONV_DEFAULTS,
+    ),
+    torch.conv3d: _make_conv_signature(
+        ["input", "weight", "bias", "stride", "padding", "dilation", "groups"],
+        _CONV_DEFAULTS,
+    ),
+    torch.conv_transpose1d: _make_conv_signature(
+        [
+            "input",
+            "weight",
+            "bias",
+            "stride",
+            "padding",
+            "output_padding",
+            "groups",
+            "dilation",
+        ],
+        _CONV_DEFAULTS,
+    ),
+    torch.conv_transpose2d: _make_conv_signature(
+        [
+            "input",
+            "weight",
+            "bias",
+            "stride",
+            "padding",
+            "output_padding",
+            "groups",
+            "dilation",
+        ],
+        _CONV_DEFAULTS,
+    ),
+    torch.conv_transpose3d: _make_conv_signature(
+        [
+            "input",
+            "weight",
+            "bias",
+            "stride",
+            "padding",
+            "output_padding",
+            "groups",
+            "dilation",
+        ],
+        _CONV_DEFAULTS,
+    ),
+    torch._C._nn.linear: _make_conv_signature(
+        ["input", "weight", "bias"], _CONV_DEFAULTS
+    ),
+    torch.ops.aten.linear.default: _make_conv_signature(
+        ["input", "weight", "bias"], _CONV_DEFAULTS
+    ),
+    torch.ops.aten.conv1d.default: _make_conv_signature(
+        ["input", "weight", "bias", "stride", "padding", "dilation", "groups"],
+        _CONV_DEFAULTS,
+    ),
+    torch.ops.aten.conv2d.default: _make_conv_signature(
+        ["input", "weight", "bias", "stride", "padding", "dilation", "groups"],
+        _CONV_DEFAULTS,
+    ),
+    torch.ops.aten.conv3d.default: _make_conv_signature(
+        ["input", "weight", "bias", "stride", "padding", "dilation", "groups"],
+        _CONV_DEFAULTS,
+    ),
+    torch.ops.aten.conv_transpose1d.default: _make_conv_signature(
+        [
+            "input",
+            "weight",
+            "bias",
+            "stride",
+            "padding",
+            "output_padding",
+            "groups",
+            "dilation",
+        ],
+        _CONV_DEFAULTS,
+    ),
+    torch.ops.aten.conv_transpose2d.input: _make_conv_signature(
+        [
+            "input",
+            "weight",
+            "bias",
+            "stride",
+            "padding",
+            "output_padding",
+            "groups",
+            "dilation",
+        ],
+        _CONV_DEFAULTS,
+    ),
+    torch.ops.aten.conv_transpose3d.input: _make_conv_signature(
+        [
+            "input",
+            "weight",
+            "bias",
+            "stride",
+            "padding",
+            "output_padding",
+            "groups",
+            "dilation",
+        ],
+        _CONV_DEFAULTS,
+    ),
+}
+
+
+def _normalize_conv_args(conv_node, conv_signature):
+    """Merge a conv node's positional args and kwargs against its signature.
+
+    FX records F.conv2d-style calls with the arguments the user spelled,
+    which may be passed by keyword (bias=, stride=, padding=, ...).  Return
+    (input, weight, bias, remaining_args) with the defaults filled in so the
+    decomposed call reproduces the original semantics.  See gh-196165.
+    """
+    bound = conv_signature.bind_partial(*conv_node.args, **conv_node.kwargs)
+    if not isinstance(conv_node.target, torch._ops.OpOverload):
+        # The torch.* Python API fills in defaults like stride=1, padding=0;
+        # reproduce that so the fused call matches the original semantics.
+        bound.apply_defaults()
+    else:
+        # aten ops with trailing args omitted from the graph rely on the
+        # op's own C++ defaults, so leave them unbound here rather than
+        # substituting Python-level int defaults for their List[int] args.
+        pass
+    if "input" not in bound.arguments or "weight" not in bound.arguments:
+        return None
+    remaining = tuple(
+        v
+        for name, v in bound.arguments.items()
+        if name not in ("input", "weight", "bias")
+    )
+    return (
+        bound.arguments["input"],
+        bound.arguments["weight"],
+        bound.arguments.get("bias"),
+        remaining,
+    )
+
+
 def efficient_conv_bn_eval(
     bn: nn.modules.batchnorm._BatchNorm, conv: nn.modules.conv._ConvNd, x: torch.Tensor
 ):
@@ -152,8 +322,10 @@ def efficient_conv_bn_eval_decomposed(
     ),
     # pyrefly: ignore [bad-argument-type]
     pass_dict=efficient_conv_bn_eval_pass,
-    extra_check=lambda match: not inductor_config.freezing
-    and inductor_config.efficient_conv_bn_eval_fx_passes,
+    extra_check=lambda match: (
+        not inductor_config.freezing
+        and inductor_config.efficient_conv_bn_eval_fx_passes
+    ),
 )
 def efficient_conv_bn_eval_graph_transform_inlined(match: Match, *args, **kwargs):
     """
@@ -212,6 +384,16 @@ def efficient_conv_bn_eval_graph_transform_inlined(match: Match, *args, **kwargs
 
     counters["inductor"]["efficient_conv_bn_eval"] += 1
 
+    # Merge positional args and kwargs before reading them: the conv may
+    # have been called with bias=/stride=/padding= by keyword (gh-196165).
+    normalized_conv_args = _normalize_conv_args(
+        conv_node,
+        _CONV_SIGNATURES[input_fn],  # type: ignore[arg-type]
+    )
+    if normalized_conv_args is None:
+        return
+    conv_input, conv_weight, conv_bias, conv_remaining_args = normalized_conv_args
+
     with graph.inserting_before(bn_node):
         # prepare args for the fused function
         bn_running_mean = normalized_args[1]
@@ -219,14 +401,6 @@ def efficient_conv_bn_eval_graph_transform_inlined(match: Match, *args, **kwargs
         bn_weight = normalized_args[3]
         bn_bias = normalized_args[4]
         bn_eps = normalized_args[7]
-        if len(conv_node.args) < 2:  # type: ignore[union-attr]
-            raise AssertionError(
-                f"expected at least 2 conv_node args, got {len(conv_node.args)}"  # type: ignore[union-attr]
-            )
-        conv_input = conv_node.args[0]  # type: ignore[union-attr]
-        conv_weight = conv_node.args[1]  # type: ignore[union-attr]
-        conv_bias = conv_node.args[2] if len(conv_node.args) >= 3 else None  # type: ignore[union-attr]
-        conv_remaining_args = conv_node.args[3:]  # type: ignore[union-attr]
         args = (
             bn_weight,
             bn_bias,
@@ -267,8 +441,10 @@ def efficient_conv_bn_eval_graph_transform_inlined(match: Match, *args, **kwargs
     ),
     # pyrefly: ignore [bad-argument-type]
     pass_dict=efficient_conv_bn_eval_pass,
-    extra_check=lambda match: not inductor_config.freezing
-    and inductor_config.efficient_conv_bn_eval_fx_passes,
+    extra_check=lambda match: (
+        not inductor_config.freezing
+        and inductor_config.efficient_conv_bn_eval_fx_passes
+    ),
 )
 def efficient_conv_bn_eval_graph_transform_decomposed(match: Match, *args, **kwargs):
     bn_node = match.nodes[0]
@@ -308,6 +484,16 @@ def efficient_conv_bn_eval_graph_transform_decomposed(match: Match, *args, **kwa
 
     counters["inductor"]["efficient_conv_bn_eval"] += 1
 
+    # Merge positional args and kwargs before reading them: the conv may
+    # have been called with bias=/stride=/padding= by keyword (gh-196165).
+    normalized_conv_args = _normalize_conv_args(
+        conv_node,
+        _CONV_SIGNATURES[input_fn],  # type: ignore[arg-type]
+    )
+    if normalized_conv_args is None:
+        return
+    conv_input, conv_weight, conv_bias, conv_remaining_args = normalized_conv_args
+
     with graph.inserting_before(bn_node):
         # prepare args for the fused function
         bn_weight = bn_node.args[1]
@@ -315,14 +501,6 @@ def efficient_conv_bn_eval_graph_transform_decomposed(match: Match, *args, **kwa
         bn_running_mean = bn_node.args[3]
         bn_running_var = bn_node.args[4]
         bn_eps = bn_node.args[7]
-        if len(conv_node.args) < 2:  # type: ignore[union-attr]
-            raise AssertionError(
-                f"expected at least 2 conv_node args, got {len(conv_node.args)}"  # type: ignore[union-attr]
-            )
-        conv_input = conv_node.args[0]  # type: ignore[union-attr]
-        conv_weight = conv_node.args[1]  # type: ignore[union-attr]
-        conv_bias = conv_node.args[2] if len(conv_node.args) >= 3 else None  # type: ignore[union-attr]
-        conv_remaining_args = conv_node.args[3:]  # type: ignore[union-attr]
         args = (
             bn_weight,
             bn_bias,
@@ -367,8 +545,10 @@ def efficient_conv_bn_eval_graph_transform_decomposed(match: Match, *args, **kwa
     ),
     # pyrefly: ignore [bad-argument-type]
     pass_dict=efficient_conv_bn_eval_pass,
-    extra_check=lambda match: not inductor_config.freezing
-    and inductor_config.efficient_conv_bn_eval_fx_passes,
+    extra_check=lambda match: (
+        not inductor_config.freezing
+        and inductor_config.efficient_conv_bn_eval_fx_passes
+    ),
 )
 def efficient_conv_bn_eval_graph_transform(match: Match, *args, **kwargs):
     # We matched a BN node


### PR DESCRIPTION
Fixes #196165

## Summary

The Inductor conv-bn eval fusion passes (`efficient_conv_bn_eval_graph_transform_inlined` and `efficient_conv_bn_eval_graph_transform_decomposed`) read the conv node's arguments positionally:

```python
conv_input = conv_node.args[0]
conv_weight = conv_node.args[1]
conv_bias = conv_node.args[2] if len(conv_node.args) >= 3 else None
conv_remaining_args = conv_node.args[3:]
```

When a model calls the conv with **keyword arguments** — e.g. `F.conv2d(x, w, bias=b, stride=2, padding=1)` or `torch.conv2d(input=x, weight=w, stride=2)` — the bias/stride/padding live in `conv_node.kwargs`, so the fusion silently drops them and computes with the defaults. The compiled model then returns wrong results (e.g. a 14x14 output instead of the correct 8x8 for `stride=2, padding=1`).

## Fix

Merge positional args and kwargs against the target's signature before extracting `input`/`weight`/`bias`/remaining args:

- The `torch.*` builtin conv/linear targets are not introspectable (`inspect.signature` fails), so their signatures (mirroring the public `F.*` APIs) are built explicitly with the documented defaults.
- For `aten` `OpOverload` targets, Python-level defaults are *not* applied — trailing args omitted from the graph rely on the op's own C++ defaults (their schema types are `List[int]`, not plain `int`).

Applies to both the inlined and decomposed graph transforms. Falls back (returns without fusing) if `input`/`weight` can't be located.

## Repro

```python
import torch
import torch.nn.functional as F

class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.weight = torch.nn.Parameter(torch.randn(4, 3, 3, 3))
        self.bias = torch.nn.Parameter(torch.randn(4))
        self.register_buffer("running_mean", torch.randn(4))
        self.register_buffer("running_var", torch.rand(4) + 1.0)

    def forward(self, x):
        conv = F.conv2d(x, self.weight, bias=self.bias, stride=2, padding=1)
        return F.batch_norm(conv, self.running_mean, self.running_var)

model = Model().eval()
x = torch.randn(2, 3, 16, 16)
with torch.no_grad():
    print("eager:", model(x).shape)        # (2, 4, 8, 8)
    print("compiled:", torch.compile(model, backend="inductor")(x).shape)  # was (2, 4, 14, 14)
```

## Tests

Added regression tests covering:
- `F.conv2d` with `bias=`/`stride=`/`padding=` passed by keyword
- `torch.conv2d(input=..., weight=...)` with all args by keyword
- `F.conv_transpose2d` with keyword `stride`/`padding`/`output_padding`
- positional-arg conv (existing behavior)

Verified: new tests fail without the fix and pass with it; full `test_efficient_conv_bn_eval.py` passes.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo