### PR TITLE
Fix stale disallow_in_graph state inherited via id() reuse (gh-196171)

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -304,6 +304,56 @@ class DecoratorTests(PytreeRegisteringTestCase):
         # Check for graph break
         self.assertEqual(cnts.frame_count, 2)
 
+    def test_disallow_in_graph_no_id_reuse(self):
+        # gh-196171: `disallow_in_graph` registers `id(fn)` in a global set
+        # but (unlike `allow_in_graph`) never deregisters it when `fn` is
+        # garbage collected. When CPython reuses the freed id() for an
+        # unrelated function, that function wrongly inherits the stale
+        # "disallowed" state and Dynamo refuses to trace it.
+        def make_old():
+            captured = 11
+
+            def old(x):
+                return x + captured
+
+            return old
+
+        def make_candidate():
+            scale = 2.5
+
+            def candidate(x):
+                return torch.sin(x) * scale
+
+            return candidate
+
+        def find_reused_id(target_id, factory):
+            for _ in range(4096):
+                batch = [factory() for _ in range(128)]
+                for value in batch:
+                    if id(value) == target_id:
+                        return value
+            raise RuntimeError("CPython did not reuse the function id")
+
+        victim = make_old()
+        torch._dynamo.allow_in_graph(victim)
+        torch._dynamo.disallow_in_graph(victim)
+        stale_id = id(victim)
+        del victim
+        candidate = find_reused_id(stale_id, make_candidate)
+        self.assertEqual(id(candidate), stale_id)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def run(a):
+            return candidate(a) + a.square()
+
+        x = torch.tensor([-1.0, 0.25, 2.0])
+        expected = run(x)
+        out = torch.compile(run, backend=cnts, fullgraph=True)(x)
+        # The candidate was never disallowed: it must be traced, not skipped.
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertTrue(torch.allclose(out, expected, atol=1e-5))
+
     def test_incorrect_usage_disallow_in_graph(self):
         with self.assertRaisesRegex(RuntimeError, "disallow_in_graph is expected"):
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -763,9 +763,19 @@ def _disallow_in_graph_helper(throw_if_not_allowed: bool) -> Callable[..., Any]:
                 "disallow_in_graph is expected to be used on an already allowed callable (like torch.* ops). "
                 "Allowed callables means callables that TorchDynamo puts as-is in the extracted graph."
             )
-        trace_rules._allowed_callable_ids.remove(id(fn))
-        trace_rules._nonstrict_trace_callable_ids.remove(id(fn))
-        trace_rules._disallowed_callable_ids.add(id(fn))
+        fn_id = id(fn)
+        trace_rules._allowed_callable_ids.remove(fn_id)
+        trace_rules._nonstrict_trace_callable_ids.remove(fn_id)
+        trace_rules._disallowed_callable_ids.add(fn_id)
+
+        # Avoid id reuse which creates subtle bugs: when fn is garbage
+        # collected, drop its id so a freshly-created unrelated function
+        # that happens to reuse the id() does not inherit the stale
+        # disallowed state (gh-196171).
+        def deregister() -> None:
+            trace_rules._disallowed_callable_ids.remove(fn_id)
+
+        weakref.finalize(fn, deregister)
         return fn
 
     return inner


### PR DESCRIPTION
Fixes #196171

## Summary

`torch._dynamo.disallow_in_graph` registers `id(fn)` in `trace_rules._disallowed_callable_ids` but — unlike its siblings `allow_in_graph`, `nonstrict_trace`, and `leaf_function` — never deregisters the id when `fn` is garbage collected. When CPython later reuses the freed `id()` for an unrelated function, that function incorrectly inherits the stale "disallowed" state and Dynamo refuses to trace it with:

```
torch._dynamo.exc.Unsupported: Attempted to call function marked as skipped
```

## Fix

Register a `weakref.finalize` callback (matching the pattern already used by `allow_in_graph`/`nonstrict_trace`/`leaf_function`) that removes the id from `_disallowed_callable_ids` when the function dies.

## Tests

Added `test_disallow_in_graph_no_id_reuse` to `test/dynamo/test_decorators.py`, a sibling of the existing `test_allow_in_graph_no_id_reuse`. It deterministically allocates functions until one reuses the freed `id()` of a disallowed function and asserts the new function is traced (single frame, correct result). Verified the test fails without the fix and passes with it; the full `test_decorators.py` suite (103 tests) passes.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98