### PR TITLE
[MPS] Make event synchronization and timing reliable

### DIFF
--- a/aten/src/ATen/mps/MPSEvent.h
+++ b/aten/src/ATen/mps/MPSEvent.h
@@ -4,7 +4,7 @@
 
 #include <ATen/mps/MPSStream.h>
 #include <c10/util/intrusive_ptr.h>
-#include <ctime>
+#include <atomic>
 #include <stack>
 
 namespace at::mps {
@@ -20,8 +20,6 @@ class MPSEvent {
   void record(bool needsLock, bool syncEvent = false);
   // makes all future work submitted to the stream wait for this event.
   bool wait(bool needsLock, bool syncEvent = false);
-  // schedules a notifyListener callback for the event.
-  bool notify(bool needsLock, MTLSharedEventNotificationBlock block);
   // checks if events are already signaled.
   bool query() const;
   // blocks the CPU thread until all the GPU work that were scheduled
@@ -34,36 +32,46 @@ class MPSEvent {
   id_t getID() const {
     return m_id;
   }
-  // returns the completion timestamp of the event
-  uint64_t getCompletionTime() const {
-    return m_completion_time;
+  // returns whether timing is enabled for this event
+  bool isTimingEnabled() const {
+    return m_enable_timing;
   }
-  // if already recorded, waits for cpu_sync_cv to be signaled
-  void waitForCpuSync();
+  // returns whether this event has been recorded since it was last acquired
+  bool isRecorded() const {
+    return m_recorded.load();
+  }
 
  private:
   id_t m_id;
-  // enables measuring the completion time of the notifyListener of this event
+  // Enables measuring the GPU completion time of this event.
   bool m_enable_timing;
-  uint64_t m_signalCounter = 0;
+  // Tracks whether this event has been recorded since it was last acquired.
+  std::atomic<bool> m_recorded{false};
+  // Tracks the latest value encoded for the Metal shared event.
+  std::atomic<uint64_t> m_signalCounter{0};
+  // Stream on which this event is recorded.
   MPSStream* m_stream = nullptr;
+  // Metal event used to signal and wait for GPU progress.
   MTLSharedEvent_t m_event = nullptr;
-  MTLSharedEventListener* m_listener = nullptr;
-  // used to sync the events created on this Stream with CPU
+  // Guards timing state shared with command-buffer completion handlers.
   std::mutex m_cpu_sync_mutex{};
   std::condition_variable m_cpu_sync_cv{};
-  // CondVar predicate to sync the events created on this Stream with CPU
-  bool m_cpu_sync_completed = false;
+  // Each timing record receives a monotonically increasing generation. The
+  // completed generation identifies the newest handler whose timestamp is in
+  // m_completion_time. Generations survive pool reuse so a delayed handler
+  // cannot satisfy a wait for, or overwrite the timestamp of, a newer record.
+  uint64_t m_timing_generation = 0;
+  uint64_t m_completed_timing_generation = 0;
   // used to compute elapsed time
-  uint64_t m_completion_time = 0;
+  double m_completion_time = 0.0;
 
   void recordLocked(bool syncEvent);
   bool waitLocked(bool syncEvent);
-  bool notifyLocked(MTLSharedEventNotificationBlock block);
-  void notifyCpuSync();
-  static uint64_t getTime() {
-    return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
-  }
+  void notifyCpuSync(uint64_t timingGeneration, double completionTime);
+  // assumes timing is enabled and waits for the latest recording's timestamp
+  double waitForTiming();
+
+  friend class MPSEventPool;
 };
 
 class MPSEventPool;

--- a/aten/src/ATen/mps/MPSEvent.mm
+++ b/aten/src/ATen/mps/MPSEvent.mm
@@ -12,53 +12,46 @@ MPSEvent::~MPSEvent() {
     [m_event release];
     m_event = nil;
   }
-  if (m_listener) {
-    [m_listener release];
-    m_listener = nil;
-  }
 }
 
 void MPSEvent::recordLocked(bool syncEvent) {
+  TORCH_INTERNAL_ASSERT(!m_enable_timing || syncEvent, "Timing-enabled MPS events must commit when recorded");
   // active encoders must end before encoding or waiting
   m_stream->endKernelCoalescing();
-  ++m_signalCounter;
-  if (m_enable_timing) {
-    notifyLocked(^(id<MTLSharedEvent>, uint64_t) {
-      m_completion_time = getTime();
-      notifyCpuSync();
-    });
-  }
+  const uint64_t signalCounter = ++m_signalCounter;
   id<MTLCommandBuffer> commandBuffer = m_stream->commandBuffer();
-  [commandBuffer encodeSignalEvent:m_event value:m_signalCounter];
+  if (m_enable_timing) {
+    uint64_t timingGeneration;
+    {
+      std::lock_guard<std::mutex> lock(m_cpu_sync_mutex);
+      timingGeneration = ++m_timing_generation;
+    }
+    // Public timing events commit immediately after the signal, making the
+    // command buffer's GPU end time the timestamp for this event boundary.
+    [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> cb) {
+      notifyCpuSync(timingGeneration, cb.GPUEndTime);
+    }];
+  }
+  [commandBuffer encodeSignalEvent:m_event value:signalCounter];
+  m_recorded.store(true);
   if (syncEvent) {
     m_stream->synchronize(SyncType::COMMIT);
   }
 }
 
 bool MPSEvent::waitLocked(bool syncEvent) {
-  // check if event is not recorded yet
-  if (m_event.signaledValue >= m_signalCounter) {
+  const uint64_t signalCounter = m_signalCounter.load();
+  // skip the wait if the event is unrecorded or already signaled
+  if (!m_recorded.load() || m_event.signaledValue >= signalCounter) {
     return false;
   }
   // active encoders must end before encoding or waiting
   m_stream->endKernelCoalescing();
   id<MTLCommandBuffer> commandBuffer = m_stream->commandBuffer();
-  [commandBuffer encodeWaitForEvent:m_event value:m_signalCounter];
+  [commandBuffer encodeWaitForEvent:m_event value:signalCounter];
   if (syncEvent) {
     m_stream->synchronize(SyncType::COMMIT);
   }
-  return true;
-}
-
-bool MPSEvent::notifyLocked(MTLSharedEventNotificationBlock block) {
-  // check if event is not recorded yet
-  if (m_event.signaledValue >= m_signalCounter) {
-    return false;
-  }
-  if (!m_listener) {
-    m_listener = [[MTLSharedEventListener alloc] init];
-  }
-  [m_event notifyListener:m_listener atValue:m_signalCounter block:block];
   return true;
 }
 
@@ -87,59 +80,53 @@ bool MPSEvent::wait(bool needsLock, bool syncEvent) {
   return waited;
 }
 
-bool MPSEvent::notify(bool needsLock, MTLSharedEventNotificationBlock block) {
-  if (!needsLock) {
-    return notifyLocked(block);
-  }
-  __block bool scheduledNotify = false;
-  dispatch_sync(m_stream->queue(), ^() {
-    @autoreleasepool {
-      scheduledNotify = notifyLocked(block);
-    }
-  });
-  return scheduledNotify;
-}
-
-void MPSEvent::notifyCpuSync() {
+void MPSEvent::notifyCpuSync(uint64_t timingGeneration, double completionTime) {
   std::lock_guard<std::mutex> lock(m_cpu_sync_mutex);
-  m_cpu_sync_completed = true;
+  if (timingGeneration > m_completed_timing_generation) {
+    m_completion_time = completionTime;
+    m_completed_timing_generation = timingGeneration;
+  }
   m_cpu_sync_cv.notify_one();
 }
 
-void MPSEvent::waitForCpuSync() {
+double MPSEvent::waitForTiming() {
   std::unique_lock<std::mutex> lock(m_cpu_sync_mutex);
-  m_cpu_sync_cv.wait(lock, [&] { return m_cpu_sync_completed; });
-  m_cpu_sync_completed = false;
+  m_cpu_sync_cv.wait(lock, [&] { return m_completed_timing_generation >= m_timing_generation; });
+  return m_completion_time;
 }
 
 bool MPSEvent::synchronize() {
-  bool scheduledNotify = notifyLocked(^(id<MTLSharedEvent>, uint64_t) {
-    m_completion_time = getTime();
-    notifyCpuSync();
-  });
-
-  if (scheduledNotify) {
-    waitForCpuSync();
-    return true;
+  const uint64_t signalCounter = m_signalCounter.load();
+  if (!m_recorded.load() || m_event.signaledValue >= signalCounter) {
+    return false;
   }
-  return false;
+  // Metal has no documented infinite-timeout value. Retry finite waits to
+  // preserve synchronize()'s unbounded semantics without risking timeout
+  // conversion overflow; a never-signaled event remains blocked as before.
+  constexpr uint64_t wait_interval_ms = 60'000;
+  while (![m_event waitUntilSignaledValue:signalCounter timeoutMS:wait_interval_ms]) {
+  }
+  return true;
 }
 
 bool MPSEvent::query() const {
+  const uint64_t signalCounter = m_signalCounter.load();
   // return false if not recorded or signaled yet
-  return m_signalCounter && (m_event.signaledValue >= m_signalCounter);
+  return m_recorded.load() && (m_event.signaledValue >= signalCounter);
 }
 
 void MPSEvent::reset(MPSStream* stream, bool enable_timing) {
   if (stream != m_stream) {
-    m_signalCounter = 0;
+    m_signalCounter.store(0);
     m_event.signaledValue = 0;
     m_stream = stream;
   }
-  // reset record time
-  m_completion_time = 0;
+  {
+    std::lock_guard<std::mutex> lock(m_cpu_sync_mutex);
+    m_completion_time = 0.0;
+  }
   m_enable_timing = enable_timing;
-  m_cpu_sync_completed = false;
+  m_recorded.store(false);
 };
 
 //-----------------------------------------------------------------
@@ -226,22 +213,25 @@ bool MPSEventPool::queryEvent(id_t event_id) {
 }
 
 double MPSEventPool::elapsedTime(id_t start_event_id, id_t end_event_id) {
-  // first make sure notifyListeners are called to capture events' completion times
+  // First make sure the command buffers containing both events have completed.
   dispatch_sync(m_default_stream->queue(), ^() {
     m_default_stream->synchronize(SyncType::COMMIT_AND_WAIT);
   });
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
   MPSEvent* start_event = getInUseEvent(start_event_id, false);
   MPSEvent* end_event = getInUseEvent(end_event_id, false);
-  // the notify is called on a separate thread, so this waits for that
-  end_event->waitForCpuSync();
-  const uint64_t start_time = start_event->getCompletionTime();
-  const uint64_t end_time = end_event->getCompletionTime();
+  TORCH_CHECK(start_event->isTimingEnabled() && end_event->isTimingEnabled(),
+              "Events were not created with argument 'enable_timing=True'");
+  TORCH_CHECK(start_event->isRecorded() && end_event->isRecorded(),
+              "Both events must be recorded before calculating elapsed time");
+  const double start_time = start_event->waitForTiming();
+  const double end_time = end_event->waitForTiming();
 
-  TORCH_CHECK(start_time > 0 && end_time > 0, "Events were not created with argument 'enable_timing=True'");
+  TORCH_CHECK(start_time > 0.0 && end_time > 0.0,
+              "MPS event timing failed because the GPU work for an event did not complete");
   TORCH_CHECK(
-      end_time > start_time, "End event ", end_event_id, " was not recorded after start event ", start_event_id);
-  return double(end_time - start_time) * 1e-6;
+      end_time >= start_time, "End event ", end_event_id, " was not recorded after start event ", start_event_id);
+  return (end_time - start_time) * 1e3;
 }
 
 MPSEvent* MPSEventPool::getInUseEvent(id_t event_id, bool locked) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9698,6 +9698,62 @@ class TestMPS(TestCaseMPS):
         elapsedTime = startEvent.elapsed_time(endEvent)
         self.assertGreater(elapsedTime, 0.0)
 
+    def test_mps_event_synchronize_then_elapsed_time(self):
+        start_event = torch.mps.Event(enable_timing=True)
+        end_event = torch.mps.Event(enable_timing=True)
+        start_event.record()
+        torch.ones(1, device="mps") + 1
+        end_event.record()
+        end_event.synchronize()
+        self.assertGreaterEqual(start_event.elapsed_time(end_event), 0.0)
+
+    def test_mps_event_empty_elapsed_time(self):
+        for _ in range(100):
+            start_event = torch.mps.Event(enable_timing=True)
+            end_event = torch.mps.Event(enable_timing=True)
+            start_event.record()
+            end_event.record()
+            elapsed_time = start_event.elapsed_time(end_event)
+            self.assertGreaterEqual(elapsed_time, 0.0)
+            self.assertLess(elapsed_time, 1000.0)
+
+    @parametrize("start_timing,end_timing", [(False, True), (True, False)])
+    def test_mps_event_elapsed_time_requires_timing(self, start_timing, end_timing):
+        start_event = torch.mps.Event(enable_timing=start_timing)
+        end_event = torch.mps.Event(enable_timing=end_timing)
+        start_event.record()
+        end_event.record()
+        with self.assertRaisesRegex(RuntimeError, "enable_timing=True"):
+            start_event.elapsed_time(end_event)
+
+    def test_mps_event_rerecord(self):
+        start_event = torch.mps.Event(enable_timing=True)
+        end_event = torch.mps.Event(enable_timing=True)
+        start_event.record()
+        end_event.record()
+        first_elapsed_time = start_event.elapsed_time(end_event)
+        torch.ones(1024, device="mps") + 1
+        end_event.record()
+        self.assertGreater(start_event.elapsed_time(end_event), first_elapsed_time)
+
+    def test_mps_event_synchronize_unrecorded(self):
+        event = torch.mps.Event()
+        event.synchronize()
+        self.assertFalse(event.query())
+
+    def test_mps_event_elapsed_time_requires_recording_after_pool_reuse(self):
+        previous_event = torch.mps.Event(enable_timing=True)
+        previous_event.record()
+        previous_event.synchronize()
+        del previous_event
+        gc.collect()
+
+        start_event = torch.mps.Event(enable_timing=True)
+        end_event = torch.mps.Event(enable_timing=True)
+        end_event.record()
+        with self.assertRaisesRegex(RuntimeError, "must be recorded"):
+            start_event.elapsed_time(end_event)
+
     def test_generic_event(self):
         startEvent = torch.Event('mps', enable_timing=True)
         startEvent.record()


### PR DESCRIPTION
Human reviewer note:

These issues were discovered while enabling Autotuning in Helion Metal backend using MPSEvents to record kernel durations, instead of relying on host timestamps.

## Problem

MPS events could fail in two user-visible ways.

First, synchronizing a timing event and then measuring it could hang:

```python
start.record()
out = x + y
end.record()
end.synchronize()
start.elapsed_time(end)  # could wait forever
```

The GPU work and `end.synchronize()` had already completed. The hang occurred because `record()` and `synchronize()` registered separate callbacks that shared one consumable completion boolean. After `synchronize()` consumed that state, `elapsed_time()` could wait for a notification that had already occurred.

Second, valid short intervals could appear reversed:

```python
start.record()
end.record()
start.elapsed_time(end)  # could report end-before-start
```

Timing was captured by calling `clock_gettime` from independent `MTLSharedEventListener` callback queues. Although the GPU signals were ordered, their host callbacks could execute in the opposite order. Callback scheduling latency also made event measurements sensitive to host-side jitter.

## Changes

Timing-enabled events now use the containing command buffer's `GPUEndTime`. Public MPS event recording commits immediately after encoding the event signal, making command-buffer completion the event boundary. An internal assertion enforces this requirement for every timing-enabled recording.

Timing completion is tracked with monotonically increasing generations rather than a consumable boolean. The latest completed generation identifies which recording produced the stored timestamp. Generations survive event-pool reuse so a delayed completion handler from an older use cannot satisfy a newer wait or overwrite its timestamp.

`synchronize()` now waits directly on the `MTLSharedEvent` value. Because Metal does not document an infinite-timeout sentinel, it retries finite waits while preserving the API's unbounded synchronization semantics. An event that is genuinely never signaled therefore remains blocked, as before.

The implementation also:
 - tracks whether a recycled event has been recorded since acquisition;
 - validates timing, recording, and GPU timestamp state before calculating an interval;
 - accepts equal timestamps for valid zero-duration intervals;
 - removes the obsolete listener machinery;
 - keeps event signal counters atomic for cross-thread access.

`GPUEndTime` measures command-buffer boundaries rather than an intra-command-buffer counter sample. Event timing can therefore include GPU queue gaps between the committed start and end buffers and should not be interpreted as amortized batched-kernel throughput.

## Testing

```bash
BUILD_TEST=0 USE_MPS=1 python -m pip install -e . -v --no-build-isolation
python test/test_mps.py -k 'mps_event'
lintrunner -a
```

The focused tests cover synchronization followed by timing, empty intervals, disabled timing, repeated recording, event-pool reuse, and synchronization of an unrecorded event.

Authored with assistance from an AI coding assistant.