### PR TITLE
 [Feature Refactoring] Generalize accelerator synchronization and profiler activity in benchmark_utils

### DIFF
--- a/test/test_functorch_benchmark_utils.py
+++ b/test/test_functorch_benchmark_utils.py
@@ -1,0 +1,175 @@
+# Owner(s): ["module: functorch"]
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import torch
+from torch._functorch import benchmark_utils
+from torch.profiler import ProfilerActivity
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class _FakeProf:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def export_chrome_trace(self, filename: str) -> None:
+        with open(filename, "w") as handle:
+            handle.write('{"traceEvents":[]}')
+
+
+class TestFunctorchBenchmarkUtils(TestCase):
+    def _mock_accelerator(self, acc_type: str):
+        return patch.object(
+            torch.accelerator,
+            "current_accelerator",
+            return_value=type("Acc", (), {"type": acc_type})(),
+        )
+
+    def _dump(self, devices=None, num_runs=1, acc_type="cuda"):
+        calls: list[object] = []
+
+        def fake_sync(device=None, /):
+            calls.append(device)
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.object(benchmark_utils, "profile", return_value=_FakeProf()),
+            patch.object(torch.accelerator, "is_available", return_value=True),
+            self._mock_accelerator(acc_type),
+            patch.object(torch.accelerator, "synchronize", side_effect=fake_sync),
+        ):
+            kwargs = {}
+            if devices is not None:
+                kwargs["devices"] = devices
+            benchmark_utils.dump_chrome_trace(
+                lambda x: x,
+                (0,),
+                os.path.join(tmp, "t.json"),
+                torch.enable_grad(),
+                [],
+                num_runs=num_runs,
+                **kwargs,
+            )
+        return calls
+
+    def test_devices_cpu_does_not_sync(self):
+        before = benchmark_utils.synchronize
+        calls = self._dump(devices=["cpu"])
+        self.assertEqual(calls, [])
+        self.assertIs(benchmark_utils.synchronize, before)
+
+    def test_default_devices_syncs_current_accelerator(self):
+        calls = self._dump()
+        self.assertEqual(len(calls), 8)
+        self.assertTrue(all(c is None for c in calls))
+
+    def test_cuda_sentinel_falls_back_when_accelerator_type_differs(self):
+        calls = self._dump(acc_type="xpu")
+        self.assertEqual(len(calls), 8)
+        self.assertTrue(all(c is None for c in calls))
+
+    def test_does_not_rebind_module_synchronize(self):
+        before = benchmark_utils.synchronize
+        self._dump(devices=["cuda"])
+        self.assertIs(benchmark_utils.synchronize, before)
+        before()
+
+    def test_explicit_device_index_is_passed_through(self):
+        calls = self._dump(devices=["cuda:1"])
+        self.assertEqual(len(calls), 8)
+        self.assertTrue(all(c == torch.device("cuda:1") for c in calls))
+
+    def test_explicit_wrong_device_type_raises(self):
+        with self.assertRaisesRegex(ValueError, "do not match current accelerator"):
+            self._dump(devices=["cuda:0"], acc_type="xpu")
+
+    def test_cpu_then_accelerator_does_not_leak_global_sync(self):
+        before = benchmark_utils.synchronize
+        cpu_calls = self._dump(devices=["cpu"])
+        gpu_calls = self._dump(devices=["cuda"])
+        self.assertEqual(cpu_calls, [])
+        self.assertEqual(len(gpu_calls), 8)
+        self.assertIs(benchmark_utils.synchronize, before)
+
+    def test_empty_devices_raises(self):
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            self._dump(devices=[])
+
+    def test_multiple_cpu_devices_does_not_sync(self):
+        calls = self._dump(devices=["cpu", "cpu"])
+        self.assertEqual(calls, [])
+
+    def test_mixed_cpu_and_accelerator_devices(self):
+        calls = self._dump(devices=["cpu", "cuda:1"])
+        self.assertEqual(len(calls), 8)
+        self.assertTrue(all(c == torch.device("cuda:1") for c in calls))
+
+    def test_is_device_process_label_accepts_npu_trace(self):
+        with self._mock_accelerator("npu"):
+            self.assertTrue(benchmark_utils._is_device_process_label("NPU 0"))
+
+    def test_builtin_accelerator_without_profiler_activity_raises(self):
+        with (
+            patch.object(torch.accelerator, "is_available", return_value=True),
+            self._mock_accelerator("mps"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "not supported for accelerator 'mps'"):
+                benchmark_utils._device_profiler_activity()
+
+    def test_privateuse1_fallback_only_for_registered_backend(self):
+        privateuse1_name = torch._C._get_privateuse1_backend_name()
+        with (
+            patch.object(torch.accelerator, "is_available", return_value=True),
+            self._mock_accelerator(privateuse1_name),
+        ):
+            self.assertEqual(
+                benchmark_utils._device_profiler_activity(),
+                ProfilerActivity.PrivateUse1,
+            )
+
+    def test_renamed_privateuse1_without_enum_uses_privateuse1(self):
+        with (
+            patch.object(torch.accelerator, "is_available", return_value=True),
+            self._mock_accelerator("npu"),
+            patch.object(torch._C, "_get_privateuse1_backend_name", return_value="npu"),
+        ):
+            if hasattr(ProfilerActivity, "NPU"):
+                self.skipTest("ProfilerActivity.NPU is present in this build")
+            self.assertEqual(
+                benchmark_utils._device_profiler_activity(),
+                ProfilerActivity.PrivateUse1,
+            )
+
+    def test_unregistered_accelerator_name_raises(self):
+        with (
+            patch.object(torch.accelerator, "is_available", return_value=True),
+            self._mock_accelerator("npu"),
+        ):
+            if hasattr(ProfilerActivity, "NPU"):
+                self.skipTest("ProfilerActivity.NPU aliases npu in this build")
+            if torch._C._get_privateuse1_backend_name() == "npu":
+                self.skipTest("privateuse1 backend is registered as npu")
+            with self.assertRaisesRegex(RuntimeError, "not supported for accelerator 'npu'"):
+                benchmark_utils._device_profiler_activity()
+
+    def test_renamed_privateuse1_with_enum_uses_enum(self):
+        with (
+            patch.object(torch.accelerator, "is_available", return_value=True),
+            self._mock_accelerator("npu"),
+            patch.object(torch._C, "_get_privateuse1_backend_name", return_value="npu"),
+        ):
+            if not hasattr(ProfilerActivity, "NPU"):
+                self.skipTest("ProfilerActivity.NPU is not present in this build")
+            self.assertEqual(
+                benchmark_utils._device_profiler_activity(),
+                ProfilerActivity.NPU,
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_functorch/benchmark_utils.py
+++ b/torch/_functorch/benchmark_utils.py
@@ -24,6 +24,80 @@ def synchronize() -> None:
     pass
 
 
+_CUDA_SYNC_SENTINEL = ["cuda"]
+
+
+def _is_cuda_sync_sentinel(devices: list[str] | None) -> bool:
+    return devices is None or devices == _CUDA_SYNC_SENTINEL
+
+
+def _is_cpu_only_devices(devices: list[str]) -> bool:
+    return len(devices) > 0 and all(spec == "cpu" for spec in devices)
+
+
+def _is_device_process_label(labels: str) -> bool:
+    if "GPU" in labels:
+        return True
+    acc = torch.accelerator.current_accelerator()
+    return acc is not None and acc.type.upper() in labels
+
+
+def _device_profiler_activity() -> ProfilerActivity:
+    if not torch.accelerator.is_available():
+        return ProfilerActivity.CUDA
+    acc = torch.accelerator.current_accelerator()
+    if acc is None or acc.type == "cuda":
+        return ProfilerActivity.CUDA
+    activity_name = acc.type.upper()
+    activity = getattr(ProfilerActivity, activity_name, None)
+    if activity is not None:
+        return activity
+    privateuse1_name = torch._C._get_privateuse1_backend_name()
+    if acc.type == privateuse1_name:
+        return ProfilerActivity.PrivateUse1
+    raise RuntimeError(
+        f"Profiler activity is not supported for accelerator {acc.type!r}"
+    )
+
+
+def _synchronize_for_devices(devices: list[str] | None) -> None:
+    if devices is not None and len(devices) == 0:
+        raise ValueError("devices must not be empty")
+    if devices is not None and _is_cpu_only_devices(devices):
+        return
+    if not torch.accelerator.is_available():
+        return
+    acc = torch.accelerator.current_accelerator()
+    if acc is None:
+        return
+    if _is_cuda_sync_sentinel(devices):
+        torch.accelerator.synchronize()
+        return
+    targets: list[torch.device] = []
+    mismatched: list[str] = []
+    for spec in devices or []:
+        if spec == "cpu":
+            continue
+        try:
+            dev = torch.device(spec)
+        except (RuntimeError, ValueError) as exc:
+            raise ValueError(f"Invalid device entry in devices: {spec!r}") from exc
+        if dev.type != acc.type:
+            mismatched.append(spec)
+            continue
+        targets.append(dev)
+    if mismatched:
+        raise ValueError(
+            f"devices {mismatched!r} do not match current accelerator {acc.type!r}"
+        )
+    if not targets:
+        raise ValueError(
+            f"No accelerator entries in devices {devices!r} for current accelerator {acc.type!r}"
+        )
+    for dev in targets:
+        torch.accelerator.synchronize(dev)
+
+
 def dump_chrome_trace(
     f: Callable[[tuple[Any, ...]], _R],
     input_: tuple[Any, ...],
@@ -43,14 +117,18 @@ def dump_chrome_trace(
     Return total runtime without the profiler
 
     Outputs to trace_filename
+
+    ``devices`` defaults to ``["cuda"]`` (a historical sentinel meaning "sync
+    the current accelerator"). Any list containing only ``"cpu"`` skips
+    accelerator sync. ``[]`` is invalid. Explicit device strings must match the
+    current accelerator type or a ``ValueError`` is raised.
     """
 
     if devices is None:
         devices = ["cuda"]
 
-    global synchronize
-    if devices != ["cpu"] and torch.accelerator.is_available():
-        synchronize = torch.accelerator.synchronize
+    def _sync() -> None:
+        _synchronize_for_devices(devices)
 
     if kwargs_for_f is None:
         kwargs_for_f = {}
@@ -61,22 +139,22 @@ def dump_chrome_trace(
         torch.manual_seed(1337)
         for _ in range(5):  # warmup runs
             f(input_, **kwargs_for_f)
-            synchronize()
+            _sync()
         torch.manual_seed(1337)
         t0 = time.perf_counter()
         for _ in range(num_runs):
             f(input_, **kwargs_for_f)
-            synchronize()
+            _sync()
         t1 = time.perf_counter()
     timing = t1 - t0
 
     with profile(activities=activities, **kwargs_for_profiler) as prof:
         with optimize_ctx:
-            synchronize()
+            _sync()
             torch.manual_seed(1337)
             for _ in range(num_runs):
                 f(input_, **kwargs_for_f)
-                synchronize()
+                _sync()
     prof.export_chrome_trace(trace_filename)
 
     return timing
@@ -164,7 +242,9 @@ def compute_utilization(filename: str, total_length: float) -> tuple[float, floa
     for event in events:
         if "name" not in event:
             continue
-        if event["name"] == "process_labels" and "GPU" in event["args"]["labels"]:
+        if event["name"] == "process_labels" and _is_device_process_label(
+            event["args"]["labels"]
+        ):
             gpu_pids.append(event["pid"])
 
     total_length = total_length * 1e6
@@ -234,7 +314,7 @@ def benchmark_utilization(
         input_,
         chrome_trace_file_name,
         optimize_ctx,
-        [ProfilerActivity.CUDA],
+        [_device_profiler_activity()],
         num_runs=num_runs,
         devices=["cuda"],
     )


### PR DESCRIPTION
## Summary

`torch._functorch.benchmark_utils` previously hard-coded CUDA when
synchronizing benchmark timings and selecting the profiler activity.

`dump_chrome_trace()` also rebound the module-level `synchronize` function,
which could leak state across calls. For example, running a CPU benchmark
could affect synchronization behavior in a later accelerator benchmark.

This PR generalizes synchronization and profiler activity selection through
`torch.accelerator`, while preserving the historical default
`devices=["cuda"]` behavior.

## Changes

- Treat only the default `devices=["cuda"]` as a compatibility sentinel meaning
  "synchronize the current accelerator".
- Skip accelerator synchronization when `devices` contains only CPU entries.
- Synchronize explicitly specified devices, including device indices such as
  `cuda:1`.
- Raise `ValueError` for:
  - an empty `devices` list;
  - invalid device strings;
  - devices that do not match the current accelerator.
- Stop rebinding the module-level `synchronize` function.
- Select `ProfilerActivity` from the current accelerator in
  `benchmark_utilization()`.
- Use `ProfilerActivity.PrivateUse1` only when the current accelerator is the
  registered PrivateUse1 backend.
- Recognize current-accelerator process labels, including NPU-style labels,
  when parsing utilization traces

## Test Plan

### Unit tests

```bash
python test/test_functorch_benchmark_utils.py
```
The tests cover:
- CPU-only devices skip accelerator synchronization.
- The default ["cuda"] sentinel synchronizes the current accelerator.
- The sentinel works when the current accelerator is not CUDA.
- Explicit device indices are passed to torch.accelerator.synchronize().
- Empty, invalid, and mismatched device specifications raise errors.
- Mixed CPU and accelerator devices synchronize only the accelerator.
- Consecutive calls do not leak synchronization state.
- NPU-style process labels are recognized.
- Built-in accelerators without a supported profiler activity raise an error.
- Registered PrivateUse1 backends use ProfilerActivity.PrivateUse1.


### NPU smoke test
Tested with torch_npu imported directly, without transfer_to_npu:
- torch.accelerator.current_accelerator() returned npu.
- The profiler activity resolved to ProfilerActivity.NPU.
- The default devices=["cuda"] sentinel synchronized the current NPU
  accelerator.
- The exported trace contained device process labels recognized by
  compute_utilization().
The trace produced in this environment did not contain cat="kernel" events,
so non-zero NPU kernel utilization was not validated by this PR. Kernel-event
export is outside the synchronization and profiler-activity selection changes
made here.