### PR TITLE
[ROCm] Fix hipblasLt handle creation during CUDA graph capture

### DIFF
--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -122,6 +122,12 @@ class TORCH_CUDA_CPP_API CUDABlasHandleWithWorkspace {
 TORCH_CUDA_CPP_API CUDABlasHandleWithWorkspace
 getCurrentCUDABlasHandleWithWorkspace();
 TORCH_CUDA_CPP_API cublasLtHandle_t getCurrentCUDABlasLtHandle();
+#ifdef USE_ROCM
+// hipblaslt handles are pooled per (device, stream) and cannot be created
+// while stream capture is active. Pre-stock the shared free list so other
+// threads (e.g. autograd workers) can reserve one mid-capture.
+TORCH_CUDA_CPP_API void ensureCublasLtHandlesAvailable(size_t n);
+#endif
 
 TORCH_CUDA_CPP_API void clearCublasWorkspaces();
 TORCH_CUDA_CPP_API void clearCublasWorkspacesForStream(cudaStream_t stream);

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -150,6 +150,11 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
   // that are not allowed once stream capture is active.
   if (at::globalContext().blasPreferredBackend() == at::BlasBackend::Cublaslt) {
     (void)at::cuda::getCurrentCUDABlasLtHandle();
+    // The line above only covers this thread. Backward inside the capture
+    // region runs its gemms from an autograd worker thread, whose first
+    // hipblaslt use on the capture stream would create a handle mid-capture;
+    // stock a spare in the shared pool for it to reserve instead.
+    at::cuda::ensureCublasLtHandlesAvailable(1);
   }
 #endif
 

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -597,6 +597,37 @@ CUDABlasHandleWithWorkspace getCurrentCUDABlasHandleWithWorkspace() {
   return scoped_handle;
 }
 
+#ifdef USE_ROCM
+static std::shared_ptr<CuBlasLtPoolType> getCuBlasLtPool() {
+  // Use a leaky singleton for the pool following standard practice around
+  // singletons: https://isocpp.org/wiki/faq/ctors#construct-on-first-use-v2
+  static auto pool = std::shared_ptr<CuBlasLtPoolType>(
+      new CuBlasLtPoolType(), [](CuBlasLtPoolType* p) {
+        // Leak the memory.
+      });
+  return pool;
+}
+
+void ensureCublasLtHandlesAvailable(size_t n) {
+  // Pre-create hipblaslt handles into the shared free list so that a later
+  // reserve() from another thread can hand one out without running
+  // hipblasLtCreate. Called before graph capture begins: creation does raw
+  // hipMalloc/hipMemset calls that fail once capture is active, and the
+  // backward half of a whole-graph capture issues its first gemm on the
+  // capture stream from an autograd worker thread, which cannot have a
+  // handle for that (device, stream) key yet.
+  c10::DeviceIndex device = 0;
+  AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
+  auto pool = getCuBlasLtPool();
+  std::lock_guard<std::mutex> guard(pool->mutex);
+  while (pool->available_handles[device].size() < n) {
+    pool->created_handles[device].emplace_back(true /*create*/);
+    pool->available_handles[device].push_back(
+        pool->created_handles[device].back().handle);
+  }
+}
+#endif
+
 cublasLtHandle_t getCurrentCUDABlasLtHandle() {
 #ifdef USE_ROCM
   c10::DeviceIndex device = 0;
@@ -607,15 +638,8 @@ cublasLtHandle_t getCurrentCUDABlasLtHandle() {
   // See: https://github.com/pytorch/pytorch/pull/22405
   // This thread local unique_ptrs will be destroyed when the thread terminates,
   // releasing its reserved handles back to the pool.
-
-  // Use a leaky singleton for the pool following standard practice around
-  // singletons: https://isocpp.org/wiki/faq/ctors#construct-on-first-use-v2
-  static auto pool = std::shared_ptr<CuBlasLtPoolType>(
-      new CuBlasLtPoolType(), [](CuBlasLtPoolType* p) {
-        // Leak the memory.
-      });
   thread_local std::unique_ptr<CuBlasLtPoolType::PoolWindow> myPoolWindow(
-      pool->newPoolWindow());
+      getCuBlasLtPool()->newPoolWindow());
 
   // hipblaslt cannot share a single handle across multiple streams,
   // so reserve a handle unique to each (device, stream) pair.

--- a/test/test_cuda_graph_debug.py
+++ b/test/test_cuda_graph_debug.py
@@ -6,13 +6,7 @@ import warnings
 
 import torch
 import torch.nn as nn
-from torch.testing._internal.common_utils import (
-    NoTest,
-    run_tests,
-    skipIfRocm,
-    TEST_CUDA,
-    TestCase,
-)
+from torch.testing._internal.common_utils import NoTest, run_tests, TEST_CUDA, TestCase
 
 
 if not TEST_CUDA:
@@ -36,7 +30,6 @@ def _capture_graph(op, **graph_kwargs):
     return g, out
 
 
-@skipIfRocm(msg="input liveness checking is only supported on NVIDIA CUDA")
 class TestCUDAGraphDebugInputs(TestCase):
     def test_nothing_dead_ok(self):
         x = torch.randn(100, device="cuda")
@@ -251,7 +244,6 @@ class TestCUDAGraphDebugInputs(TestCase):
         self.assertEqual(y, x * 2)
 
 
-@skipIfRocm(msg="input liveness checking is only supported on NVIDIA CUDA")
 class TestCUDAGraphDebugBacktraces(TestCase):
     def test_error_message_contains_all_tracebacks(self):
         a = torch.randn(100, device="cuda")
@@ -276,7 +268,6 @@ class TestCUDAGraphDebugBacktraces(TestCase):
         self.assertIn("replay traceback (python)", error_msg)
 
 
-@skipIfRocm(msg="input liveness checking is only supported on NVIDIA CUDA")
 class TestCUDAGraphDebugExternalOps(TestCase):
     def test_custom_autograd_function(self):
         from torch.autograd import Function


### PR DESCRIPTION
Captured backward passes crash or hang on ROCm: the backward half of a whole-graph capture issues its first hipblasLt gemm from an autograd worker thread on the fresh capture stream. hipblasLt handles are pooled per (thread, device, stream) because a handle cannot be shared across streams, so no warmup on another stream can pre-create that handle, and hipblasLtCreate then runs while capture is active. Its internal raw hipMalloc fails with hipErrorStreamCaptureUnsupported, and hipblaslt's CHECK_HIP_ERROR macro calls exit(1); the exit deadlocks in the handle pool's thread-local destructor because the pool mutex is still held, so the failure presents as a silent hang (in CI: a per-file timeout with no diagnostic).

Fix: capture_begin already pre-creates the Lt handle for the capturing thread; this PR extends it to also pre-stock one spare handle in the pool's shared free list (ensureCublasLtHandlesAvailable) before capture begins, so another thread's first reserve() during capture pops a ready handle (a pure map operation, no HIP calls) instead of creating one mid-capture. An alternative, exchanging the thread capture mode around hipblasLtCreate, was tried and rejected: it cures the hipMalloc but the create's follow-up legacy-stream hipMemset still fails with hipErrorStreamCaptureImplicit. The root cause is reported against hipblaslt here: https://github.com/ROCm/rocm-libraries/issues/11838.

The second commit unskips test/test_cuda_graph_debug.py, whose blanket skip reason ("input liveness checking is only supported on NVIDIA CUDA") was inaccurate: the liveness tracker (torch/utils/_cuda_debug.py) is a platform-agnostic TorchDispatchMode and 18 of 19 tests already passed on ROCm with the gates bypassed; the 19th was this bug.

Test plan, validated on gfx950 (ROCm 10.0, HIP 7.15):

```
PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda_graph_debug.py
for i in $(seq 25); do PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda_graph_debug.py -k test_model_training_weight_dead || echo FAIL; done
PYTORCH_TEST_WITH_ROCM=1 python test/test_cuda.py -k graph
PYTORCH_TEST_WITH_ROCM=1 python test/test_matmul_cuda.py -k addmm
```

Results: test_cuda_graph_debug.py 19/19 (previously the process deadlocked mid-file), stress loop and 3 full-file repeats clean, test_matmul_cuda -k addmm 917/917. test_cuda.py -k graph is 146/147: the one failure (test_graph_capture_error_releases_reserved_segments) is order-dependent under this -k selection and reproduces identically on an unpatched build, so it is pre-existing and unrelated (it passes in isolation).

The change is inside `#if defined(USE_ROCM)`; CUDA builds are unaffected. Cost: one spare hipblasLt handle (one-time ~25MB device allocation, reused across captures since torch streams come from a bounded pool).

This PR was authored with the assistance of an AI agent (Claude). The root-cause analysis, fix, and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang