### PR TITLE
[cuda][nccl] Drop the dead `NCCL_ALLTOALL_SUPPORTED` arm

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -767,8 +767,7 @@ void all2all_single_equal_split(
 #if defined(USE_ROCM)
   // RCCL spells the collective with a capital T.
   NCCL_CHECK(ncclAllToAll(sendbuff, recvbuff, count, type, comm, stream));
-#elif defined(NCCL_ALLTOALL_SUPPORTED) || \
-    NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+#elif NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
   // Using the collective rather than a send/recv loop lets NCCL differentiate
   // send/recv operations issued as part of the collective (e.g. alltoall) vs
   // those inside traditional p2p operations.


### PR DESCRIPTION
Summary:
`NCCL_ALLTOALL_SUPPORTED` is not defined anywhere in the repo. D115674668
("[ncclx][fix-build] Remove NCCL_ALLTOALL_SUPPORTED macro") deleted the
`#define` from `nccl.h.in` in both `v2_29` and `v2_30`, specifically so that an
old PyTorch built against a new NCCLX would stop selecting the capital-`T`
`ncclAllToAll` API. So the `defined(NCCL_ALLTOALL_SUPPORTED)` term in
`all2all_single_equal_split` is now always `0`, and the `#elif` reduces to the
`NCCL_VERSION_CODE` check next to it.

This line is a leftover from the all-to-all de-dup stack. D115510409 shaped the
current three-arm ladder and deliberately kept the macro, reasoning that "NCCLX
keeps defining it, and it still usefully means 'this NCCL has an all-to-all
collective'". D115674668 invalidated that premise the next day. Its follow-ups
swept the other two consumers -- D115678532 removed the now-dead `#ifdef` guards
from `AllToAllTest.cc`, and D115678533 regated the `nccl-tests-suite` benchmark
on `NCCL_VERSION_CODE` -- but `nccl.cpp` was never revisited. This is that
sweep's third file.

Removing the term is not just tidying: while it is there, re-introducing the
`#define` anywhere silently revives the deprecated capital-`T` path that
D115674668 was written to kill, with no build break to catch it.

Behavior is unchanged in every configuration. The `USE_ROCM` arm above and the
pre-2.28 send/recv `#else` fallback below are untouched, as is the separate
`ncclAllToAllv` ladder further down -- `NCCL_ALLTOALLV_SUPPORTED` (with the `V`)
is a different macro and is still genuinely defined, in
`comms/ncclx/v2_29/src/nccl.h.in:43` and `v2_30/src/nccl.h.in:43`.

`xplat/caffe2/torch/csrc/cuda/nccl.cpp` is an hg-dirsync mirror of this file
(`.hgdirsync`: `caffe2.fbcode = fbcode/caffe2` / `caffe2.xplat = xplat/caffe2`,
no exclude covering `torch/csrc/cuda/`), so it is updated by the commit rather
than hand-edited.

Test Plan:
Confirmed the macro has zero definitions repo-wide -- no `#define`, and no `-D`
flag in any BUCK/`.bzl`/CMake/Makefile -- across `fbcode/comms`,
`fbcode/hpc_comms`, `fbcode/param_bench`, `fbcode/caffe2`, `third-party/nccl`,
`third-party/nccl-tests`, `third-party/aws_ofi_nccl` and `third-party/rccl`. The
single remaining occurrence in the repo is the one this diff deletes.

To prove the removed term was `0` at compile time rather than infer it, I
temporarily added a probe after `#include <nccl.h>`:

```
#if defined(NCCL_ALLTOALL_SUPPORTED)
#error "..."
#endif
```

and built `fbcode//caffe2:torch-cpp-cuda` with:

```
--modifier=ovr_config//cpu:x86_64 \
--modifier=ovr_config//runtime/constraints:platform010
```

under each NCCL variant. The probe never fired, so `defined(...)` is `0` in
every config and `0 || X` is exactly `X`:

| config | result |
| default (upstream `third-party/nccl`) | builds, probe silent |
| `-c hpc_comms.use_ncclx=2.29` | builds, probe silent |
| `-c hpc_comms.use_ncclx=2.30` | builds, probe silent |
| `-c hpc_comms.use_ncclx=2.31` | pre-existing unrelated break, see below |

The probe was removed before committing; the diff is the single `#elif` hunk.

`use_ncclx=2.31` fails to build, but not because of this change: a pristine tree
fails identically, same header, same target, same
`cfg:dev-linux-x86_64-fbcode-platform010-clang21-asan-ubsan-dev` hash.

```
gin_gdaki.h:27:10: fatal error: 'doca_gpunetio/doca_gpunetio_device.h' file not found
```

It enters through `torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp:15` ->
`nccl_device.h` -> `gin_gdaki.h`, a different TU from `nccl.cpp`. The header
exists in-tree at `v2_31/src/transport/net_ib/gdaki/doca-gpunetio/include/`, so
this looks like an include-path gap in that config; `hpc_comms` also has no
`2.31` wiring today. Out of scope here. `v2_31` is covered by the header search
above instead -- it does not define the macro either.

The `USE_ROCM` arm cannot be built on this host, and is unchanged code.

`arc f`: no changes needed. `arc lint fbcode/caffe2/torch/csrc/cuda/nccl.cpp`:
`ok No lint issues.`

Differential Revision: D119277069


