### PR TITLE
[TorchInductor] fuse_seed_creation_pass: handle keyword device= in seed()

### DIFF
--- a/torch/_inductor/fx_passes/replace_random.py
+++ b/torch/_inductor/fx_passes/replace_random.py
@@ -136,7 +136,9 @@ def fuse_seed_creation_pass(graph: torch.fx.Graph):
     device_seeds = collections.defaultdict(list)
     for node in graph.nodes:
         if CallFunctionVarArgs(inductor_prims.seed).match(node):
-            device_seeds[node.args[0]].append(node)
+            # Handle both positional seed(device) and keyword seed(device=...) forms
+            device = node.args[0] if node.args else node.kwargs.get("device")
+            device_seeds[device].append(node)
 
     if not device_seeds:
         return 0


### PR DESCRIPTION
## Summary

`fuse_seed_creation_pass` crashes with `IndexError: tuple index out of range` when `inductor_prims.seed()` is called with keyword arguments (`seed(device=...)`) instead of positional arguments (`seed(device)`).

`CallFunctionVarArgs` matches both forms, but the pass unconditionally reads `node.args[0]` for the device — which is empty when only kwargs are provided.

## Fix

Read device from `node.args[0]` when positional args exist, otherwise fall back to `node.kwargs.get("device")`.

```python
# Before
device_seeds[node.args[0]].append(node)

# After
device = node.args[0] if node.args else node.kwargs.get("device")
device_seeds[device].append(node)
```

## Test

```python
from __future__ import annotations
from torch._dynamo.utils import detect_fake_mode
from torch._inductor.fx_passes.replace_random import replace_random_passes
from torch._inductor.virtualized import V
from torch.fx.experimental.proxy_tensor import make_fx
import torch
from torch._inductor import inductor_prims

def traced_fn(x):
    seed = inductor_prims.seed(torch.device("cpu"))
    return x + seed.to(x.dtype)

x = torch.randn(4)
gm = make_fx(traced_fn, tracing_mode="fake")(x)
seed_node = next(n for n in gm.graph.nodes if n.target == torch.ops.prims.inductor_seed.default)

# Keyword form — triggers the bug on main
seed_node.args = ()
seed_node.kwargs = {"device": torch.device("cpu")}
fake_mode = detect_fake_mode([n.meta.get("val") for n in gm.graph.nodes if n.op == "placeholder"])
with V.set_fake_mode(fake_mode):
    replace_random_passes(gm)  # No longer crashes
```

Fixes pytorch/pytorch#196361


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo