### PR TITLE
[BE] Remove test for reciprocal, logaddexp and logaddexp2 from test_mps

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7852,36 +7852,6 @@ class TestMPS(TestCaseMPS):
         # https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf Table 8.2
         self.ulpAssertAllClose(log_result.cpu(), log_result_cpu, n_ulps=4)
 
-    def test_logaddexp(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            x = cpu_x.detach().clone().to('mps')
-
-            cpu_y = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            y = cpu_y.detach().clone().to('mps')
-
-            log_result = torch.logaddexp(x, y)
-            log_result_cpu = torch.logaddexp(cpu_x, cpu_y)
-
-            self.assertEqual(log_result, log_result_cpu)
-
-        helper((2, 8, 4, 5))
-
-    def test_logaddexp2(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            x = cpu_x.detach().clone().to('mps')
-
-            cpu_y = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            y = cpu_y.detach().clone().to('mps')
-
-            log_result = torch.logaddexp2(x, y)
-            log_result_cpu = torch.logaddexp2(cpu_x, cpu_y)
-
-            self.assertEqual(log_result, log_result_cpu)
-
-        helper((2, 8, 4, 5))
-
     def test_logsumexp(self):
         def helper(shape):
             cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
@@ -7950,26 +7920,6 @@ class TestMPS(TestCaseMPS):
             self.assertEqual(isnan_result, isnan_result_cpu)
 
         helper((8, 2, 4, 5))
-
-    # Test reciprocal
-    def test_reciprocal(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)
-            x = cpu_x.detach().clone().to('mps').requires_grad_()
-
-            reciprocal_result = torch.reciprocal(x)
-            reciprocal_result_cpu = torch.reciprocal(cpu_x)
-
-            cpu_grad = torch.ones_like(reciprocal_result_cpu)
-            grad = cpu_grad.to('mps')
-
-            reciprocal_result.backward(gradient=grad)
-            reciprocal_result_cpu.backward(gradient=cpu_grad)
-
-            self.assertEqual(reciprocal_result, reciprocal_result_cpu)
-            self.assertEqual(x.grad, cpu_x.grad)
-
-        helper((2, 8, 4, 5))
 
     # Test sqrt
     def test_sqrt(self):


### PR DESCRIPTION
Remove `test_logaddexp`, `test_logaddexp2` and `test_reciprocal` from `test/test_mps.py`. These ops are already covered by the MPS OpInfo consistency tests.

Shape coverage for the removed float32 cases:

| Deleted test | Removed input | Comparable MPS OpInfo input |
| --- | --- | --- |
| `test_logaddexp` | Contiguous `(2, 8, 4, 5)` per operand | Contiguous `(5, 10, 5)` per operand |
| `test_logaddexp2` | Contiguous `(2, 8, 4, 5)` per operand | Contiguous `(5, 5)` per operand |
| `test_reciprocal` | Contiguous `(2, 8, 4, 5)` | Contiguous `(20,)` |

These are elementwise ops using TensorIterator and Metal kernels, so replacing the 4D inputs with the smaller shapes above keeps the same dense kernel paths.

Run the existing MPS OpInfo checks with:

```bash
python test/test_mps.py -v \
  TestConsistencyMPS.test_output_match_logaddexp_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_logaddexp_mps_float32 \
  TestConsistencyMPS.test_output_match_logaddexp2_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_logaddexp2_mps_float32 \
  TestConsistencyMPS.test_output_match_reciprocal_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_reciprocal_mps_float32
```