### PR TITLE
[Inductor][Host-side TMA] Make the static launcher tolerate triton/CUDA build skew (#196410)

### DIFF
--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import os
 from functools import cached_property
 from typing import Any
@@ -12,13 +13,22 @@ from .triton_helpers import get_constexprs
 @functools.lru_cache(None)
 def _tma_arg_helpers():
     """Cached (make_arg, TensorDescriptor) for host-side TMA arg expansion.
-    make_arg(arg, metadata) -> [CUtensorMap, *shape, *strides]; the nvidia
-    backend's make_tensordesc_arg ignores its third arg, so we pass None."""
+    make_arg(arg, metadata) -> [CUtensorMap, *shape, *strides]."""
     from triton.backends.nvidia.driver import make_tensordesc_arg
     from triton.tools.tensor_descriptor import TensorDescriptor
 
-    def make_arg(arg, metadata):
-        return make_tensordesc_arg(arg, metadata, None)
+    # triton 3.5.0 and earlier take (arg, metadata); 3.8.0 added a third
+    # argument the nvidia backend ignores. Resolve the arity once, not per
+    # launch.
+    if len(inspect.signature(make_tensordesc_arg).parameters) >= 3:
+
+        def make_arg(arg, metadata):
+            return make_tensordesc_arg(arg, metadata, None)
+
+    else:
+
+        def make_arg(arg, metadata):
+            return make_tensordesc_arg(arg, metadata)
 
     return make_arg, TensorDescriptor
 

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -113,31 +113,28 @@ static_assert(
     sizeof(CUtensorMap) == 128,
     "CUtensorMap is expected to be 128 bytes (CUDA ABI change?)");
 
-// Mirror of triton's PyCUtensorMap object (nvidia/backend/driver.c) so we can
-// read its embedded CUtensorMap.
-struct PyCUtensorMapObject {
-  PyObject_HEAD
-  alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
-};
-
 // Pointer to the CUtensorMap in a host-side TMA descriptor arg (triton's
 // PyCUtensorMap, or a duck-typed tma_desc_cpu_ptr()). Owned by `obj`, which
 // must stay alive across the launch.
 void* getTmaDescPtr(PyObject* obj) {
   if (std::strcmp(
           Py_TYPE(obj)->tp_name, "triton.backends.nvidia.PyCUtensorMap") == 0) {
-    // Fail loudly if triton's object no longer matches our mirror: tp_basicsize
-    // catches a resized field or a CUDA-major mismatch (alignof is 64 on 12.x
-    // vs 128 on 13.x). A same-size reorder isn't caught here; correctness tests
-    // are.
+    // triton stores the CUtensorMap as the trailing field of a PyObject_HEAD
+    // struct, so derive its offset from tp_basicsize instead of mirroring the
+    // struct: triton may be built against a different CUDA major than we are,
+    // and alignof(CUtensorMap) is 64 on 12.x vs 128 on 13.x. 64 is the weaker
+    // of the two, so checking against it accepts either build.
+    constexpr Py_ssize_t kMinTensorMapAlign = 64;
+    const Py_ssize_t basicsize = Py_TYPE(obj)->tp_basicsize;
+    const Py_ssize_t offset =
+        basicsize - static_cast<Py_ssize_t>(sizeof(CUtensorMap));
     TORCH_CHECK(
-        Py_TYPE(obj)->tp_basicsize == sizeof(PyCUtensorMapObject),
+        offset >= static_cast<Py_ssize_t>(sizeof(PyObject)) &&
+            offset % kMinTensorMapAlign == 0,
         "triton PyCUtensorMap layout changed (tp_basicsize=",
-        Py_TYPE(obj)->tp_basicsize,
-        ", expected ",
-        sizeof(PyCUtensorMapObject),
-        "); the static launcher's CUtensorMap mirror is stale");
-    return &reinterpret_cast<PyCUtensorMapObject*>(obj)->tensorMap;
+        basicsize,
+        "); the static launcher cannot locate its CUtensorMap");
+    return reinterpret_cast<char*>(obj) + offset;
   }
   // Duck-typed fallback: tma_desc_cpu_ptr() -> host pointer to a CUtensorMap.
   THPObjectPtr method{PyObject_GetAttrString(obj, "tma_desc_cpu_ptr")};


### PR DESCRIPTION
Summary:

Makes the static CUDA launcher work when torch and triton are built against different triton API and CUDA versions.

Test Plan: Fixes the failing `host_side_tma` tests in `fbcode//caffe2/test/inductor:max_autotune_blackwell`.

Differential Revision: D119262571




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo