### PR TITLE
[inductor] Fix remove_noop_ops for slice with negative start normalizing to zero

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9201,6 +9201,32 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             ignore_empty_lines=True,
         )
 
+    def test_remove_noop_slice_negative_start(self):
+        """Negative start normalizing to zero should be treated as noop (#196358)."""
+
+        def f(x):
+            x = x + 1
+            # start=-4 on dim 0 of size 4 normalizes to start=0, so full-range
+            y = torch.ops.aten.slice(x, 0, -4, 4, 1)
+            return y + 1
+
+        f = torch.compile(f)
+
+        x = torch.ones((4, 8), device=self.device)
+
+        post_grad_graph = get_post_grad_graph(f, (x,))
+        expected_graph = f"""\
+def forward(self, arg0_1: "f32[4, 8][8, 1]{str(x.device)}"):
+        add: "f32[4, 8][8, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
+        add_9: "f32[4, 8][8, 1]{str(x.device)}" = torch.ops.aten.add.Tensor(add, 1);  add = None
+        return (add_9,)"""
+        self.assertExpectedInline(
+            post_grad_graph,
+            expected_graph,
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
+
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW,
         "https://github.com/pytorch/pytorch/issues/151381",

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1244,8 +1244,14 @@ def slice_noop(self, dim=0, start=None, end=None, step=1):
         return False
 
     slice_dim_size = self.shape[dim]
+    # Normalize a negative start: e.g. start=-4 on a dim of size 4
+    # is equivalent to start=0.
+    start_is_zero = statically_known_true(sym_eq(start, 0)) or (
+        statically_known_true(start < 0)
+        and statically_known_true(sym_eq(start + slice_dim_size, 0))
+    )
     if (
-        statically_known_true(sym_eq(start, 0))
+        start_is_zero
         and (
             statically_known_true(end >= 2**63 - 1)
             or statically_known_true(end >= slice_dim_size)


### PR DESCRIPTION
Fixes #196358

## Summary
`slice_noop` in `remove_noop_ops` only recognized full-range slices when `start` was literally `0`. A negative `start` that normalizes to zero (e.g., `start=-4` on a dimension of size `4`) was not eliminated, leaving a redundant `aten.slice` in the post-grad graph.

This patch adds a normalization check: if `start < 0` and `start + dim_size == 0`, then `start` is equivalent to `0` and the slice covers the full dimension.

## Changes
- **`torch/_inductor/fx_passes/post_grad.py`**: In `slice_noop`, compute `start_is_zero` that also accounts for negative starts normalizing to zero.
- **`test/inductor/test_torchinductor.py`**: Added `test_remove_noop_slice_negative_start` verifying the fix with `aten.slice(x, 0, -4, 4, 1)` on a tensor of shape `(4, 8)`.

## Reproducer (from issue)
```python
import torch

class Model(torch.nn.Module):
    def forward(self, x):
        y = torch.ops.aten.slice.Tensor(x, 0, -4, 4, 1)
        return y + 1

x = torch.randn(4, 8, device="cuda")
eager = Model()(x)

torch._dynamo.reset()
compiled = torch.compile(Model(), fullgraph=True)
actual = compiled(x)
torch.testing.assert_close(actual, eager)
```

Before this fix, the `aten.slice` remained in the post-grad graph. After, it is correctly identified as a no-op and removed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo