### PR TITLE
[Inductor] Amortize CUDA-graph autotune benchmarking over a configurable number of captured calls

### DIFF
--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -432,7 +432,7 @@ class TestBenchmarker(TestCase):
         self.assertEqual(result, 3.0)
         self.assertEqual(calls, ["enter", (1, 2, True), "fn", "exit"])
 
-    def test_benchmark_gpu_with_cuda_graph_uses_gpu_benchmark_lock(self):
+    def _run_fake_cuda_graph_benchmark(self, iters):
         from torch._inductor.runtime import benchmarking as _bench
 
         class FakeCUDAGraph:
@@ -469,6 +469,11 @@ class TestBenchmarker(TestCase):
         previous = _bench.set_gpu_benchmark_lock_context(custom_context)
         try:
             with (
+                patch.object(
+                    _bench.inductor_config,
+                    "autotune_cudagraph_benchmarking_iters",
+                    iters,
+                ),
                 patch("torch.cuda.synchronize"),
                 patch("torch.cuda.Stream", FakeStream),
                 patch("torch.cuda.current_stream", return_value=current_stream),
@@ -481,7 +486,10 @@ class TestBenchmarker(TestCase):
                 )
         finally:
             _bench.set_gpu_benchmark_lock_context(previous)
+        return result, calls
 
+    def test_benchmark_gpu_with_cuda_graph_uses_gpu_benchmark_lock(self):
+        result, calls = self._run_fake_cuda_graph_benchmark(iters=1)
         self.assertEqual(result, 9.0)
         self.assertEqual(
             calls,
@@ -497,6 +505,13 @@ class TestBenchmarker(TestCase):
                 "exit",
             ],
         )
+
+    def test_benchmark_gpu_with_cuda_graph_amortizes_launches(self):
+        # 10 calls captured per graph; the replay time is reported per call
+        result, calls = self._run_fake_cuda_graph_benchmark(iters=10)
+        self.assertEqual(result, 0.9)
+        self.assertEqual(calls.count("call"), 2 + 10)
+        self.assertEqual(calls[-4:], ["benchmark_gpu", "replay", "exit", "exit"])
 
     def test_autotune_cudagraph_benchmarking_requires_max_autotune(self):
         from torch._inductor.runtime import benchmarking as _bench

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -588,6 +588,16 @@ autotune_cudagraph_benchmarking: bool = (
     os.environ.get("TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING") == "1"
 )
 
+# Number of calls of the benchmarked callable captured into each CUDA graph by
+# benchmark_gpu_with_cuda_graph; the replay time is divided by this count so the
+# graph launch and inter-kernel gaps are amortized. With 1 (the default) each
+# timed sample is a full graph launch, which for microsecond kernels exceeds the
+# kernel time and hides the differences between autotune choices; 20 or more
+# ranks such kernels by kernel time.
+autotune_cudagraph_benchmarking_iters: int = int(
+    os.environ.get("TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING_ITERS", "1")
+)
+
 
 # Modifies the number of autotuning choices displayed, set to None for all
 def _autotune_num_choices_displayed_default() -> int | None:

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -367,6 +367,14 @@ class Benchmarker:
         which eliminates kernel launch overhead for fair comparison between different
         implementations.
         """
+
+        def clear_grads() -> None:
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+
+        n_iters = max(1, inductor_config.autotune_cudagraph_benchmarking_iters)
+
         # Warmup
         torch.cuda.synchronize()
         _callable()
@@ -376,9 +384,7 @@ class Benchmarker:
         stream = torch.cuda.Stream()
         stream.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(stream):
-            if grad_to_none is not None:
-                for x in grad_to_none:
-                    x.grad = None
+            clear_grads()
             _callable()
         stream.synchronize()
 
@@ -386,16 +392,18 @@ class Benchmarker:
         with torch.cuda.graph(
             cuda_graph, stream=stream, capture_error_mode="thread_local"
         ):
-            if grad_to_none is not None:
-                for x in grad_to_none:
-                    x.grad = None
-            _callable()
+            clear_grads()
+            for _ in range(n_iters):
+                _callable()
 
         torch.cuda.current_stream().wait_stream(stream)
         torch.cuda.synchronize()
 
         # grad clearing is captured in the graph, don't pass it through.
-        return self.benchmark_gpu(cuda_graph.replay, **kwargs)
+        result = self.benchmark_gpu(cuda_graph.replay, **kwargs)
+        if isinstance(result, list):
+            return [t / n_iters for t in result]  # type: ignore[return-value]
+        return result / n_iters
 
 
 # Make built-in defaults explicit via the registry


### PR DESCRIPTION
For tiny kernels, even `TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING_ITERS` with only 1 graph replay is too noisy.

This pr allows multiple (hot L2) repetitions inside the benchmarked function.

Drafted with an AI assistant from measurements collected by the author; the quoted text below is AI-written and reviewed by me.

> ## Summary
>
> `Benchmarker.benchmark_gpu_with_cuda_graph`, used for every autotune choice when `TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING=1` and for choices benchmarked with `benchmark_with_cudagraphs`, captured a single call of the kernel into a CUDA graph and timed single replays. Each timed sample therefore still pays a full graph launch plus the event overhead, about 5 to 7 us on GB200. For microsecond kernels that is larger than the kernel itself, so every choice reads about the same and the ranking among them is noise; the flag could make the selection worse than the default eager timing it was meant to improve.
>
> This PR unrolls `config.autotune_cudagraph_benchmarking_iters` calls of the callable into the captured graph and divides the replay time by that count, the same scheme as `triton.testing.do_bench_cudagraph`. The count is exposed as `TORCHINDUCTOR_AUTOTUNE_CUDAGRAPH_BENCHMARKING_ITERS` and defaults to 1, which keeps the current behavior; callers still receive milliseconds per call. An explicit count was preferred over sizing the graph to a target replay time so that autotune cost stays predictable.
>
> ## Example: tiny GEMM autotuning
>
> bf16 `torch.mm` compiled with `max_autotune` and `max_autotune_gemm_backends="TRITON"` (19 to 21 Triton `mm` configs offered), GB200, clocks locked at 2048 MHz, Triton 3.8.0. Ground truth per config: force it with `test_configs.autotune_choice_desc_regex` and time the compiled function with `do_bench_cudagraph` (best of two medians). "Autotuner-measured" is the time the autotuner itself recorded for each choice.
>
> | Shape (M x N x K) | Autotune mode | Choices | True kernel time range (us) | Autotuner-measured range (us) | Spearman | Autotuner pick vs fastest |
> |---|---|---:|---|---|---:|---|
> | 256x256x128 | flag off (eager timing, current default) | 21 | 1.91 to 5.10 | 5.90 to 10.90 | 0.77 | +1% (rank 2) |
> | 256x256x128 | flag on, iters=1 (current flag behavior) | 21 | 1.91 to 5.10 | 6.80 to 12.00 | 0.69 | +1% (rank 2) |
> | 256x256x128 | flag on, iters=5 | 21 | 1.91 to 5.10 | 2.90 to 6.30 | 0.94 | fastest |
> | 256x256x128 | flag on, iters=20 | 21 | 1.91 to 5.10 | 1.90 to 5.50 | 0.95 | fastest |
> | 256x256x128 | flag on, iters=100 | 21 | 1.91 to 5.10 | 1.70 to 5.30 | 0.95 | fastest |
> | 16x256x256 | flag off (eager timing, current default) | 19 | 1.82 to 4.61 | 6.10 to 14.60 | 0.67 | fastest |
> | 16x256x256 | flag on, iters=1 (current flag behavior) | 19 | 1.82 to 4.61 | 6.50 to 15.00 | 0.81 | +20% (rank 5) |
> | 16x256x256 | flag on, iters=5 | 19 | 1.82 to 4.61 | 2.90 to 6.70 | 0.95 | +4% (rank 2) |
> | 16x256x256 | flag on, iters=20 | 19 | 1.82 to 4.61 | 2.00 to 4.90 | 0.98 | +4% (rank 2) |
> | 16x256x256 | flag on, iters=100 | 19 | 1.82 to 4.61 | 1.70 to 4.50 | 0.98 | +4% (rank 2) |
> | 512x512x512 | flag off (eager timing, current default) | 21 | 3.57 to 12.36 | 7.40 to 28.30 | 0.91 | fastest |
> | 512x512x512 | flag on, iters=1 (current flag behavior) | 21 | 3.57 to 12.36 | 8.30 to 29.00 | 0.91 | fastest |
> | 512x512x512 | flag on, iters=5 | 21 | 3.57 to 12.36 | 4.60 to 15.70 | 0.98 | fastest |
> | 512x512x512 | flag on, iters=20 | 21 | 3.57 to 12.36 | 3.80 to 13.20 | 1.00 | fastest |
> | 512x512x512 | flag on, iters=100 | 21 | 3.57 to 12.36 | 3.60 to 12.60 | 1.00 | fastest |
> | 4096x4096x4096 | flag off (eager timing, current default) | 21 | 124.6 to 1351.3 | 119.9 to 1353.8 | 1.00 | fastest |
> | 4096x4096x4096 | flag on, iters=1 (current flag behavior) | 21 | 124.6 to 1351.3 | 121.1 to 1354.2 | 1.00 | fastest |
> | 4096x4096x4096 | flag on, iters=5 | 21 | 124.6 to 1351.3 | 110.7 to 1351.0 | 1.00 | fastest |
> | 4096x4096x4096 | flag on, iters=20 | 21 | 124.6 to 1351.3 | 112.6 to 1351.3 | 1.00 | fastest |
> | 4096x4096x4096 | flag on, iters=100 | 21 | 124.6 to 1351.3 | 110.5 to 1351.5 | 1.00 | fastest |
>
> With one captured call the autotuner's readings sit 4 to 5 us above the true kernel times of the 2 to 5 us shapes, and on 16x256x256 it picks a config 20% slower than the fastest (rank 5 of 19). Five captured calls already fix the ranking on these shapes; 20 or more brings the readings within 0.1 to 0.3 us of kernel time. The 125 us GEMM is ranked correctly in every mode. Autotune wall time per GEMM went from about 6.3 s to 7.5 s at 100 captured calls on the tiny shapes and from 7.1 s to 12 s on the large one, which is why the default stays at 1 and the knob is opt-in.
>
> ## Test plan
>
> ```
> python3 test/inductor/test_benchmarking.py
> python3 test/inductor/test_custom_op_autotune.py -k test_cudagraph_memory_cleanup_benchmarker -k test_benchmark_with_cudagraphs_uses_cuda_graph_benchmarking
> ```
>
> The existing call-sequence test is kept at one captured call through a shared fake-CUDA harness, and a new test checks that ten captured calls report the replay time per call.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo