### PR TITLE
 [Feature Refactoring] Read KernelInputs device name from DeviceInterface registry

### DIFF
--- a/test/inductor/test_kernel_inputs.py
+++ b/test/inductor/test_kernel_inputs.py
@@ -1,0 +1,39 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch._dynamo.device_interface import (
+    get_interface_for_device,
+    get_registered_device_interfaces,
+)
+from torch._inductor.kernel_inputs import MMKernelInputs
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class _TensorNode:
+    def __init__(self, tensor: torch.Tensor) -> None:
+        self.tensor = tensor
+
+    def get_device(self) -> torch.device:
+        return self.tensor.device
+
+
+class TestKernelInputsDeviceName(TestCase):
+    def test_device_name_matches_device_interface(self):
+        for name, device_interface in get_registered_device_interfaces():
+            if ":" in name or not device_interface.is_available():
+                continue
+            device = torch.device(name)
+            with self.subTest(device=str(device)):
+                node = _TensorNode(torch.empty(2, 2, device=device))
+                try:
+                    iface = get_interface_for_device(device)
+                    props = iface.get_device_properties(device)
+                except NotImplementedError:
+                    expected = None
+                else:
+                    expected = getattr(props, "gcnArchName", None)
+                self.assertEqual(MMKernelInputs([node, node]).device_name(), expected)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_kernel_inputs.py
+++ b/test/inductor/test_kernel_inputs.py
@@ -1,38 +1,156 @@
 # Owner(s): ["module: inductor"]
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import torch
 from torch._dynamo.device_interface import (
+    device_interfaces,
+    DeviceInterface,
     get_interface_for_device,
     get_registered_device_interfaces,
+    register_interface_for_device,
 )
-from torch._inductor.kernel_inputs import MMKernelInputs
+from torch._inductor import config as inductor_config
+from torch._inductor.kernel_inputs import architecture_name_from_device, MMKernelInputs
+from torch._inductor.lookup_table.choices import LookupTableChoices
 from torch._inductor.test_case import run_tests, TestCase
 
 
 class _TensorNode:
-    def __init__(self, tensor: torch.Tensor) -> None:
-        self.tensor = tensor
+    def __init__(self, device: torch.device) -> None:
+        self._device = device
 
     def get_device(self) -> torch.device:
-        return self.tensor.device
+        return self._device
+
+    def get_dtype(self) -> torch.dtype:
+        return torch.float32
+
+    def get_size(self) -> tuple[int, ...]:
+        return (2, 2)
+
+    def get_stride(self) -> tuple[int, ...]:
+        return (2, 1)
+
+
+class _TestMMKernelInputs(MMKernelInputs):
+    def shapes_hinted(self) -> tuple[tuple[int, ...], ...]:
+        return self.shapes_symbolic()
+
+    def strides_hinted(self) -> tuple[tuple[int, ...], ...]:
+        return self.strides_symbolic()
+
+
+class _NameOnlyInterface(DeviceInterface):
+    @staticmethod
+    def get_device_properties(device=None):
+        return SimpleNamespace(name="TestArch910", gcnArchName=None)
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
 
 
 class TestKernelInputsDeviceName(TestCase):
+    def setUp(self):
+        super().setUp()
+        architecture_name_from_device.cache_clear()
+        self._prev_pua = device_interfaces.get("privateuseone")
+
+    def tearDown(self):
+        architecture_name_from_device.cache_clear()
+        if self._prev_pua is None:
+            device_interfaces.pop("privateuseone", None)
+        else:
+            device_interfaces["privateuseone"] = self._prev_pua
+        super().tearDown()
+
     def test_device_name_matches_device_interface(self):
         for name, device_interface in get_registered_device_interfaces():
             if ":" in name or not device_interface.is_available():
                 continue
             device = torch.device(name)
             with self.subTest(device=str(device)):
-                node = _TensorNode(torch.empty(2, 2, device=device))
+                node = _TensorNode(device)
                 try:
                     iface = get_interface_for_device(device)
                     props = iface.get_device_properties(device)
                 except NotImplementedError:
                     expected = None
                 else:
-                    expected = getattr(props, "gcnArchName", None)
+                    expected = getattr(props, "gcnArchName", None) or getattr(
+                        props, "name", None
+                    )
                 self.assertEqual(MMKernelInputs([node, node]).device_name(), expected)
+
+    def test_unregistered_device_returns_none(self):
+        with patch(
+            "torch._inductor.kernel_inputs.get_interface_for_device",
+            side_effect=NotImplementedError,
+        ):
+            self.assertIsNone(architecture_name_from_device(torch.device("cpu")))
+
+    def test_missing_gcn_arch_falls_back_to_name(self):
+        register_interface_for_device("privateuseone", _NameOnlyInterface)
+        device = torch.device("privateuseone:0")
+        self.assertEqual(architecture_name_from_device(device), "TestArch910")
+        node = _TensorNode(device)
+        self.assertEqual(MMKernelInputs([node, node]).device_name(), "TestArch910")
+
+    def test_unimplemented_properties_return_none(self):
+        class _Broken(DeviceInterface):
+            @staticmethod
+            def get_device_properties(device=None):
+                raise NotImplementedError
+
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+        register_interface_for_device("privateuseone", _Broken)
+        self.assertIsNone(
+            architecture_name_from_device(torch.device("privateuseone:0"))
+        )
+
+    def test_lookup_table_uses_name_without_cuda_gate(self):
+        register_interface_for_device("privateuseone", _NameOnlyInterface)
+        choices = LookupTableChoices()
+        self.assertEqual(
+            choices._get_device_key(torch.device("privateuseone:0")), "TestArch910"
+        )
+        original = inductor_config.lookup_table.table
+        inductor_config.lookup_table.table = {"placeholder": []}
+        try:
+            with patch("torch.cuda.is_available", return_value=False):
+                self.assertEqual(choices._get_lookup_table(), {"placeholder": []})
+        finally:
+            inductor_config.lookup_table.table = original
+
+    def test_lookup_key_hits_table_config(self):
+        register_interface_for_device("privateuseone", _NameOnlyInterface)
+        device = torch.device("privateuseone:0")
+        node = _TensorNode(device)
+        kernel_inputs = _TestMMKernelInputs([node, node])
+        choices = LookupTableChoices()
+        lookup_key = choices.make_lookup_key(kernel_inputs, "mm", include_device=True)
+        self.assertIsNotNone(lookup_key)
+        self.assertTrue(lookup_key.startswith("TestArch910+"))
+        self.assertTrue(lookup_key.endswith("+mm"))
+        self.assertEqual(kernel_inputs.device_name(), "TestArch910")
+        table = {
+            lookup_key: [{"template_id": "triton", "BLOCK_M": 16}],
+        }
+        original = inductor_config.lookup_table.table
+        inductor_config.lookup_table.table = table
+        try:
+            with patch("torch.cuda.is_available", return_value=False):
+                configs = choices.lookup_template_configs(
+                    kernel_inputs, "mm", ["triton"]
+                )
+            self.assertEqual(configs["triton"][0]["BLOCK_M"], 16)
+        finally:
+            inductor_config.lookup_table.table = original
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, TYPE_CHECKING
 
 import torch
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor import config as inductor_config, ir
 from torch._inductor.utils import has_free_symbols
 from torch._inductor.virtualized import V
@@ -100,17 +101,15 @@ class KernelInputs(ABC):
         return self._input_nodes[0].get_device()
 
     def device_name(self) -> str | None:
-        """
-        Get the device name information.
-
-        Returns:
-            A tuple of (gpu_name, vendor, model)
-        """
+        """Architecture name from the device's properties, if present."""
         if self._device_name is None:
             device = self.device()
-            if self.device_type == "cuda":
-                device_properties = torch.cuda.get_device_properties(device)
-                self._device_name = device_properties.gcnArchName
+            try:
+                device_interface = get_interface_for_device(device)
+                device_properties = device_interface.get_device_properties(device)
+            except NotImplementedError:
+                return None
+            self._device_name = getattr(device_properties, "gcnArchName", None)
         return self._device_name
 
     def shapes_symbolic(self) -> tuple[tuple[Any, ...], ...]:

--- a/torch/_inductor/kernel_inputs.py
+++ b/torch/_inductor/kernel_inputs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from abc import ABC, abstractmethod
 from typing import Any, TYPE_CHECKING
 
@@ -10,6 +11,36 @@ from torch._inductor.utils import has_free_symbols
 from torch._inductor.virtualized import V
 
 from .ir import FixedLayout, FlexibleLayout, Layout
+
+
+@functools.lru_cache
+def architecture_name_from_device(device: torch.device) -> str | None:
+    """Return the lookup-table architecture key for ``device``.
+
+    CUDA/HIP read ``gcnArchName`` from ``DeviceInterface.get_device_properties``,
+    which is the canonical architecture id for those backends.
+
+    Other registered backends fall back to ``name`` when ``gcnArchName`` is absent.
+    Third-party lookup tables must key rows using this exact string (spacing and
+    capitalization included). ``name`` is often a driver-exposed product label
+    (e.g. ``Ascend910B``, ``NVIDIA H100 80GB HBM3``) rather than a pure arch id;
+    backends that rely on lookup tables should keep ``name`` stable across runs.
+
+    A dedicated ``DeviceInterface.get_device_architecture`` could replace this
+    fallback later; for now ``gcnArchName or name`` is the contract.
+
+    Returns ``None`` if the device is unregistered or properties are unavailable.
+    """
+    try:
+        device_interface = get_interface_for_device(device)
+        device_properties = device_interface.get_device_properties(device)
+    except (NotImplementedError, RuntimeError):
+        return None
+    arch = getattr(device_properties, "gcnArchName", None)
+    if arch:
+        return arch
+    name = getattr(device_properties, "name", None)
+    return name or None
 
 
 if TYPE_CHECKING:
@@ -103,13 +134,7 @@ class KernelInputs(ABC):
     def device_name(self) -> str | None:
         """Architecture name from the device's properties, if present."""
         if self._device_name is None:
-            device = self.device()
-            try:
-                device_interface = get_interface_for_device(device)
-                device_properties = device_interface.get_device_properties(device)
-            except NotImplementedError:
-                return None
-            self._device_name = getattr(device_properties, "gcnArchName", None)
+            self._device_name = architecture_name_from_device(self.device())
         return self._device_name
 
     def shapes_symbolic(self) -> tuple[tuple[Any, ...], ...]:

--- a/torch/_inductor/lookup_table/choices.py
+++ b/torch/_inductor/lookup_table/choices.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import logging
-from functools import lru_cache
 from typing import Any, TYPE_CHECKING
 
 import torch
@@ -34,26 +33,16 @@ class LookupTableChoices(InductorChoices):
         Get the template lookup table from config.
         Override this method to use custom lookup table sources (database, API, etc.).
         """
-        if not torch.cuda.is_available() or config.lookup_table.table is None:
+        if config.lookup_table.table is None:
             return {}
         return config.lookup_table.table
 
     @staticmethod
-    @lru_cache
     def _get_device_key(device: torch.device) -> str | None:
-        """
-        Generate a device key for lookup table indexing.
-        For CPU devices, returns None.
-        For CUDA devices, returns the props.gcnArchName string.
-        """
-        if device.type != "cuda":
-            # only cuda devices are supported, this indicates that the system is not in use
-            # for this device
-            return None
+        """Architecture key from ``architecture_name_from_device``."""
+        from torch._inductor.kernel_inputs import architecture_name_from_device
 
-        # Get CUDA device properties
-        props = torch.cuda.get_device_properties(device.index)
-        return props.gcnArchName
+        return architecture_name_from_device(device)
 
     @staticmethod
     def _generate_kernel_inputs_key(kernel_inputs: KernelInputs) -> str:


### PR DESCRIPTION
## Summary

Inductor lookup tables key rows by device architecture. `KernelInputs.device_name()` previously called `torch.cuda.get_device_properties()` directly, so only CUDA could produce a lookup key. This change routes architecture resolution through the existing `DeviceInterface` registry and opens the lookup-table path for any registered backend.

## Changes

- Add `architecture_name_from_device()`: read `gcnArchName` when present (CUDA/HIP), otherwise fall back to `name`.
- `KernelInputs.device_name()` delegates to that helper instead of hardcoding CUDA.
- `LookupTableChoices._get_device_key()` reuses the same helper (no `device.type == "cuda"` gate).
- `_get_lookup_table()` no longer requires `torch.cuda.is_available()`; if `config.lookup_table.table` is set, it is used.
- `@lru_cache` on `architecture_name_from_device()` only (replaces the pre-change cache on `_get_device_key()`; both call paths share one cache).

Out of scope:

- Filling lookup table entries for third-party backends (backend responsibility).
- TF32 heuristics in `triton.py` (#17/#18).
- New `DeviceInterface.get_device_architecture()` API.
- Claiming third-party `name` stability has been validated on real hardware (PTA follow-up).

## Design notes

### Architecture key contract (`gcnArchName` vs `name`)

Lookup keys are resolved as:

```python
arch = getattr(device_properties, "gcnArchName", None)
if arch:
    return arch
return getattr(device_properties, "name", None) or None
```

- **`gcnArchName`**: canonical architecture id on CUDA/HIP; preferred when present.
- **`name`**: interim fallback for backends without `gcnArchName`. Often a driver-exposed product label (e.g. `Ascend910B`, `NVIDIA H100 80GB HBM3`) and may vary with SKU, driver, or formatting.

**Contract for third-party backends:** lookup table row keys must match the exact string returned by this helper (spacing and capitalization included). Backends that rely on lookup tables are responsible for keeping that string stable across runs, or for normalizing it before populating tables.

Longer term, `DeviceInterface.get_device_architecture(device) -> str | None` would be cleaner than overloading `name`. This PR does not add that API.

### Caching

`@lru_cache` lives on `architecture_name_from_device()` only. Device properties are effectively immutable for the lifetime of a compile; backends register before Inductor runs lookup. One cache covers both `KernelInputs.device_name()` and `LookupTableChoices._get_device_key()`. Tests that swap registered interfaces clear this cache in `setUp`/`tearDown`.

## Test plan

```bash
python test/inductor/test_kernel_inputs.py -v
```

Six tests cover: registered-device alignment, unregistered device → `None`, `name` fallback when `gcnArchName` is absent, broken properties → `None`, lookup table access without a CUDA availability gate, and end-to-end lookup key generation plus table hit via `lookup_template_configs`.

Authored with an AI assistant.
