### PR TITLE
Fix dead cppdocs links caught by nightly URL lint

### DIFF
--- a/docs/cpp/source/index.md
+++ b/docs/cpp/source/index.md
@@ -49,7 +49,7 @@ auto c = a + b.to(at::kInt);
 
 This `Tensor` class and all other symbols in ATen are found in the `at::`
 namespace, documented
-[here](https://pytorch.org/cppdocs/api/namespace_at.html#namespace-at).
+[here](https://docs.pytorch.org/cppdocs/api/aten/index.html).
 
 ## Autograd
 
@@ -96,11 +96,11 @@ frontend includes the following:
 
 See [this document](https://pytorch.org/cppdocs/frontend.html) for a more
 detailed description of the C++ frontend. Relevant sections of the `torch::`
-namespace related to the C++ Frontend include [torch::nn](https://pytorch.org/cppdocs/api/namespace_torch__nn.html#namespace-torch-nn),
-[torch::optim](https://pytorch.org/cppdocs/api/namespace_torch__optim.html#namespace-torch-optim),
-[torch::data](https://pytorch.org/cppdocs/api/namespace_torch__data.html#namespace-torch-data),
+namespace related to the C++ Frontend include [torch::nn](https://docs.pytorch.org/cppdocs/api/nn/index.html),
+[torch::optim](https://docs.pytorch.org/cppdocs/api/optim/index.html),
+[torch::data](https://docs.pytorch.org/cppdocs/api/data/index.html),
 [torch::serialize](https://docs.pytorch.org/cppdocs/api/serialize/index.html),
-[torch::jit](https://pytorch.org/cppdocs/api/namespace_torch__jit.html#namespace-torch-jit)
+`torch::jit`
 and `torch::python`.
 Examples of the C++ frontend can be found in [this repository](https://github.com/pytorch/examples/tree/master/cpp) which is being
 expanded on a continuous and active basis.

--- a/docs/source/cpp_index.md
+++ b/docs/source/cpp_index.md
@@ -14,8 +14,8 @@ PyTorch provides several features for working with C++, and it’s best to choos
 
 Most of the tensor and autograd operations in PyTorch Python API are also available in the C++ API. These include:
 
-- `torch::Tensor` methods such as `add` / `reshape` / `clone`. For the full list of methods available, please see: <https://pytorch.org/cppdocs/api/classat_1_1_tensor.html>
-- C++ tensor indexing API that looks and behaves the same as the Python API. For details on its usage, please see: <https://pytorch.org/cppdocs/notes/tensor_indexing.html>
+- `torch::Tensor` methods such as `add` / `reshape` / `clone`. For the full list of methods available, please see: <https://docs.pytorch.org/cppdocs/api/aten/tensor.html>
+- C++ tensor indexing API that looks and behaves the same as the Python API. For details on its usage, please see: <https://docs.pytorch.org/cppdocs/api/aten/indexing.html>
 - The tensor autograd APIs and the `torch::autograd` package that are crucial for building dynamic neural networks in C++ frontend. For more details, please see: <https://pytorch.org/tutorials/advanced/cpp_autograd.html>
 
 ## Authoring Models in C++
@@ -24,7 +24,7 @@ We provide the full capability of authoring and training a neural net model pure
 
 - For an overview of the PyTorch C++ model authoring and training API, please see: <https://pytorch.org/cppdocs/frontend.html>
 - For a detailed tutorial on how to use the API, please see: <https://pytorch.org/tutorials/advanced/cpp_frontend.html>
-- Docs for components such as `torch::nn` / `torch::nn::functional` / `torch::optim` can be found at: <https://pytorch.org/cppdocs/api/library_root.html>
+- Docs for components such as `torch::nn` / `torch::nn::functional` / `torch::optim` can be found at: <https://docs.pytorch.org/cppdocs/api/index.html>
 
 ## Packaging for C++
 


### PR DESCRIPTION
Follow-up to #189619, towards #189557.

The cppdocs site no longer serves the flat Doxygen/Breathe pages under
`cppdocs/api/namespace_*.html` — those sections are now per-module pages at
`cppdocs/api/<module>/index.html`. Eight links across two files still point at the
old layout and 404. This restructure appears to postdate #189619, so those links
were still live when that PR ran.

### Remapping

Each destination was opened and title-checked, not just status-checked:

| Old (404) | New (200) | Page title |
| --- | --- | --- |
| `api/namespace_at.html#namespace-at` | `api/aten/index.html` | ATen: Tensor Library |
| `api/namespace_torch__nn.html#namespace-torch-nn` | `api/nn/index.html` | Neural Network Modules (torch::nn) |
| `api/namespace_torch__optim.html#namespace-torch-optim` | `api/optim/index.html` | Optimizers (torch::optim) |
| `api/namespace_torch__data.html#namespace-torch-data` | `api/data/index.html` | Data Loading (torch::data) |
| `api/classat_1_1_tensor.html` | `api/aten/tensor.html` | Tensor Class |
| `notes/tensor_indexing.html` | `api/aten/indexing.html` | Tensor Indexing |
| `api/library_root.html` | `api/index.html` | C++ API Reference |

`torch::jit` has no replacement page in the new layout, so the hyperlink is dropped
and the name kept in backticks — matching how `torch::python` and `torch::jit::compile`
were handled in #189619. The `docs.pytorch.org` host follows the `torch::serialize`
line already landed in that PR.

### Verification

- `./scripts/lint_urls.sh <base> <head>` passes (exit 0) on this branch.
- Every URL in both touched files was re-checked live: 16/16 return 200.

### Note: three of these are invisible to the URL lint

`scripts/lint_urls.sh` uses

```
(?![^\s<>\")]*[<>\{\}\$])
```

which makes it skip Markdown autolinks written as `<https://...>`. That is why the three
rotten links in `docs/source/cpp_index.md` (all autolinks) never appeared in #189557's
failure list, while the five in `docs/cpp/source/index.md` (ordinary `[text](url)` links) did.

So this PR fixes the lint-visible rot plus three more the linter cannot currently see — it
should help #189557 but I would not claim it turns that job green on its own. Happy to file
a separate issue for the autolink blind spot if that is useful.
