### PR TITLE
[Test][XPU] remove skipXPU on some functions of test_ops, updated fft.py for know…

### DIFF
--- a/test/nn/test_lazy_modules.py
+++ b/test/nn/test_lazy_modules.py
@@ -860,7 +860,7 @@ class TestLazyModulesDevice(NNTestCase):
         self.assertEqual(module.test_param.device.type, device.split(":")[0])
 
 
-instantiate_device_type_tests(TestLazyModulesDevice, globals())
+instantiate_device_type_tests(TestLazyModulesDevice, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -707,7 +707,6 @@ class TestCommon(TestCase):
     # Tests that experimental Python References perform the same computation
     # as the operators they reference, when operator calls in the torch
     # namespace are remapped to the refs namespace (torch.foo becomes refs.foo).
-    @skipXPU
     @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")
@@ -720,7 +719,6 @@ class TestCommon(TestCase):
     # Tests that experimental Python References perform the same computation
     # as the operators they reference, when operator calls in the torch
     # namespace are preserved (torch.foo remains torch.foo).
-    @skipXPU
     @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(python_ref_db)
     @skipIfTorchInductor("Takes too long for inductor")

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -802,6 +802,16 @@ python_ref_db: list[OpInfo] = [
                 dtypes=(torch.float16,),
                 device_type="cuda",
             ),
+            # AssertionError: Reference result was farther from the precise
+            # computation than the torch result was.
+            # See https://github.com/intel/torch-xpu-ops/issues/5271 for more details.
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref_torch_fallback",
+                dtypes=(torch.float16,),
+                device_type="xpu",
+            ),
             # AssertionError: Reference result was farther (0.10395266714717796) from the precise
             # computation than the torch result was (0.10251794906889385)
             # See https://github.com/pytorch/pytorch/pull/170856 for more details.
@@ -811,6 +821,16 @@ python_ref_db: list[OpInfo] = [
                 "test_python_ref",
                 dtypes=(torch.float16,),
                 device_type="cuda",
+            ),
+            # AssertionError: Reference result was farther from the precise
+            # computation than the torch result was.
+            # See https://github.com/intel/torch-xpu-ops/issues/5271 for more details.
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref",
+                dtypes=(torch.float16,),
+                device_type="xpu",
             ),
             # AssertionError: Reference result was farther (0.0953431016138116) from the precise
             # computation than the torch result was (0.09305490684430734)
@@ -891,6 +911,16 @@ python_ref_db: list[OpInfo] = [
                 "test_python_ref",
                 dtypes=(torch.float16,),
                 device_type="cuda",
+            ),
+            # AssertionError: Reference result was farther from the precise
+            # computation than the torch result was.
+            # See https://github.com/intel/torch-xpu-ops/issues/5271 for more details.
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref",
+                dtypes=(torch.float16,),
+                device_type="xpu",
             ),
         ],
     ),


### PR DESCRIPTION
enabled xpu on test_lazy_modules.py
enable more test functions on test_ops.py by remove some skipXPU