### PR TITLE
[CMake] Propagate vecLib discovery results to BLAS

### DIFF
--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -140,6 +140,8 @@ if((NOT BLAS_LIBRARIES)
   FIND_PACKAGE(vecLib)
   if(vecLib_FOUND)
     SET(BLAS_INFO "veclib")
+    SET(BLAS_LIBRARIES ${vecLib_LINKER_LIBS})
+    SET(BLAS_INCLUDE_DIR ${vecLib_INCLUDE_DIR})
   else()
     check_fortran_libraries(
       BLAS_LIBRARIES


### PR DESCRIPTION
Related issue: #196426

Successful vecLib discovery leaves `BLAS_LIBRARIES` unset, so the final BLAS success check fails. This patch forwards `vecLib_LINKER_LIBS` and `vecLib_INCLUDE_DIR` to the generic BLAS outputs.

AI-generated summary:

> ## Test plan
>
> Full CPU builds on macOS 26.6.2 arm64 with Python 3.14.5 succeeded both at baseline `6ee9ad6564b` and at this standalone fix `5127ac095b2`, using `WITH_BLAS=veclib`. BLAS/LAPACK changed from disabled to enabled; the same five runtime checks changed from one failure and four errors to five passes with no skips. They cover float64/complex128, unbatched/batched matrix multiplication, eig, SVD, solve and Cholesky. The fixed libtorch_cpu directly links Apple vecLib/Accelerate. Earlier SDK finder/link probes also passed with the fix, and the Accelerate control remained successful.
