### PR TITLE
[native] Compute bmm outer-product kernel offsets in int64 (OOB writes for (batch-1)*M*N > INT32_MAX)

### DIFF
--- a/test/test_bmm_outer_product.py
+++ b/test/test_bmm_outer_product.py
@@ -10,6 +10,7 @@ from torch._native.ops.bmm_outer_product.triton_impl import (
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
     instantiate_device_type_tests,
+    largeTensorTest,
     onlyAccelerator,
     onlyCUDA,
     skipCUDAIfNotRocm,
@@ -85,6 +86,24 @@ class TestBmmOuterProductDevice(TestCase):
         a = torch.randn(1, 64, 1, device=device)
         b = torch.randn(1, 1, 128, device=device)
         self.assertEqual(torch.bmm(a, b), a @ b)
+
+    @onlyAccelerator
+    @largeTensorTest("6GB")
+    def test_offsets_past_int32_max(self, device):
+        # The Triton kernel computed its element offsets in int32. With
+        # (batch, M, N) = (512, 8209, 512) the last batch matrix starts at
+        # 511 * 8209 * 512 = 2_147_737_088 > INT32_MAX, so those batches were
+        # written ~4 GiB (bf16) before the output and read back uninitialised
+        # (or faulted). batch = 8208 rows was the last size that worked.
+        batch, m, n = 512, 8209, 512
+        self.assertGreater((batch - 1) * m * n, torch.iinfo(torch.int32).max)
+        a = torch.randn(batch, m, 1, device=device, dtype=torch.bfloat16)
+        b = torch.randn(batch, 1, n, device=device, dtype=torch.bfloat16)
+        out = torch.bmm(a, b)
+        # The broadcast product is the reference: `a @ b` would dispatch to
+        # the kernel under test, and a full reference is another 4 GiB.
+        for i in (0, batch - 2, batch - 1):
+            self.assertEqual(out[i], a[i] * b[i])
 
     @onlyAccelerator
     def test_m_one_n_one(self, device):

--- a/test/test_bmm_outer_product.py
+++ b/test/test_bmm_outer_product.py
@@ -89,21 +89,53 @@ class TestBmmOuterProductDevice(TestCase):
 
     @onlyAccelerator
     @largeTensorTest("6GB")
-    def test_offsets_past_int32_max(self, device):
+    def test_batch_offset_past_int32_max(self, device):
         # The Triton kernel computed its element offsets in int32. With
         # (batch, M, N) = (512, 8209, 512) the last batch matrix starts at
         # 511 * 8209 * 512 = 2_147_737_088 > INT32_MAX, so those batches were
-        # written ~4 GiB (bf16) before the output and read back uninitialised
-        # (or faulted). batch = 8208 rows was the last size that worked.
+        # stored gigabytes before the output buffer: a CUDA fault, or, when
+        # that address was live memory, uninitialised rows read back for the
+        # overflowing batches. Either way the comparison below cannot pass on
+        # the old kernel. batch = 8208 rows was the last size that worked.
+        # Strided views exercise the same arithmetic on the input loads.
         batch, m, n = 512, 8209, 512
         self.assertGreater((batch - 1) * m * n, torch.iinfo(torch.int32).max)
-        a = torch.randn(batch, m, 1, device=device, dtype=torch.bfloat16)
-        b = torch.randn(batch, 1, n, device=device, dtype=torch.bfloat16)
+        for strided in (False, True):
+            with self.subTest(strided=strided):
+                a = torch.randn(batch, m, 2, device=device, dtype=torch.bfloat16)
+                b = torch.randn(batch, 2, n, device=device, dtype=torch.bfloat16)
+                if strided:
+                    a, b = a[:, :, :1], b[:, :1, :]
+                else:
+                    a, b = a[:, :, :1].contiguous(), b[:, :1, :].contiguous()
+                out = torch.bmm(a, b)
+                # The broadcast product is the reference: `a @ b` would
+                # dispatch to the kernel under test, and a full reference
+                # would be another 4 GiB.
+                for i in (0, batch - 2, batch - 1):
+                    self.assertEqual(out[i], a[i] * b[i])
+                del out
+
+    @onlyAccelerator
+    @largeTensorTest("6GB")
+    def test_row_offset_past_int32_max(self, device):
+        # Inside one batch matrix the store offset is rm * stride_om, so with
+        # (M - 1) * N > INT32_MAX (M, N themselves int32) the last row tiles
+        # wrapped as well: (65536 + 4096, 32768) puts the last 4096 rows past
+        # the limit in a 4.25 GiB bf16 output. (M > INT32_MAX on its own is
+        # not reachable: Triton then specialises M as int64 and every index
+        # derived from it is already 64-bit.)
+        m, n = 2**16 + 4096, 2**15
+        self.assertGreater((m - 1) * n, torch.iinfo(torch.int32).max)
+        a = torch.randn(1, m, 1, device=device, dtype=torch.bfloat16)
+        b = torch.randn(1, 1, n, device=device, dtype=torch.bfloat16)
         out = torch.bmm(a, b)
-        # The broadcast product is the reference: `a @ b` would dispatch to
-        # the kernel under test, and a full reference is another 4 GiB.
-        for i in (0, batch - 2, batch - 1):
-            self.assertEqual(out[i], a[i] * b[i])
+        for rows in (
+            slice(0, 1024),
+            slice(2**16 - 1024, 2**16 + 1024),
+            slice(m - 1024, m),
+        ):
+            self.assertEqual(out[0, rows], a[0, rows] * b[0])
 
     @onlyAccelerator
     def test_m_one_n_one(self, device):

--- a/torch/_native/ops/bmm_outer_product/triton_kernels.py
+++ b/torch/_native/ops/bmm_outer_product/triton_kernels.py
@@ -41,17 +41,19 @@ def _bmm_outer_product_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    # The program id is promoted to int64 once, so every index derived from it
+    # (batch, tile, row and column offsets) is 64-bit. Program ids and the
+    # int32-range strides are i32, and both pid_b * stride_ob (once
+    # (batch - 1) * M * N > INT32_MAX, e.g. (512, 8209, 512)) and
+    # pid_m * BLOCK_M (once M > INT32_MAX) used to wrap and write the tail
+    # of the output gigabytes before its buffer.
+    pid = tl.program_id(0).to(tl.int64)
 
     grid_m = tl.cdiv(M, BLOCK_M)
     grid_n = tl.cdiv(N, BLOCK_N)
     tiles_per_batch = grid_m * grid_n
 
-    # Offsets are computed in int64: program ids and int32-range strides are
-    # i32, and pid_b * stride_ob alone passes INT32_MAX once
-    # (batch - 1) * M * N > 2**31 - 1 (e.g. (512, 8209, 512)), which used to
-    # wrap and write the last batch matrices ~8 GiB before the output buffer.
-    pid_b = (pid // tiles_per_batch).to(tl.int64)
+    pid_b = pid // tiles_per_batch
     pid_mn = pid % tiles_per_batch
     pid_m = pid_mn // grid_n
     pid_n = pid_mn % grid_n
@@ -62,19 +64,14 @@ def _bmm_outer_product_kernel(
     mask_m = rm < M
     mask_n = rn < N
 
-    rm64 = rm.to(tl.int64)
-    rn64 = rn.to(tl.int64)
-    a = tl.load(A_ptr + pid_b * stride_ab + rm64 * stride_am, mask=mask_m, other=0.0)
-    b = tl.load(B_ptr + pid_b * stride_bb + rn64 * stride_bn, mask=mask_n, other=0.0)
+    a = tl.load(A_ptr + pid_b * stride_ab + rm * stride_am, mask=mask_m, other=0.0)
+    b = tl.load(B_ptr + pid_b * stride_bb + rn * stride_bn, mask=mask_n, other=0.0)
 
     out = a[:, None] * b[None, :]
 
     mask = mask_m[:, None] & mask_n[None, :]  # pyrefly: ignore[bad-index]
     tl.store(
-        OUT_ptr
-        + pid_b * stride_ob
-        + rm64[:, None] * stride_om
-        + rn64[None, :] * stride_on,
+        OUT_ptr + pid_b * stride_ob + rm[:, None] * stride_om + rn[None, :] * stride_on,
         out,
         mask=mask,
     )

--- a/torch/_native/ops/bmm_outer_product/triton_kernels.py
+++ b/torch/_native/ops/bmm_outer_product/triton_kernels.py
@@ -47,7 +47,11 @@ def _bmm_outer_product_kernel(
     grid_n = tl.cdiv(N, BLOCK_N)
     tiles_per_batch = grid_m * grid_n
 
-    pid_b = pid // tiles_per_batch
+    # Offsets are computed in int64: program ids and int32-range strides are
+    # i32, and pid_b * stride_ob alone passes INT32_MAX once
+    # (batch - 1) * M * N > 2**31 - 1 (e.g. (512, 8209, 512)), which used to
+    # wrap and write the last batch matrices ~8 GiB before the output buffer.
+    pid_b = (pid // tiles_per_batch).to(tl.int64)
     pid_mn = pid % tiles_per_batch
     pid_m = pid_mn // grid_n
     pid_n = pid_mn % grid_n
@@ -58,14 +62,19 @@ def _bmm_outer_product_kernel(
     mask_m = rm < M
     mask_n = rn < N
 
-    a = tl.load(A_ptr + pid_b * stride_ab + rm * stride_am, mask=mask_m, other=0.0)
-    b = tl.load(B_ptr + pid_b * stride_bb + rn * stride_bn, mask=mask_n, other=0.0)
+    rm64 = rm.to(tl.int64)
+    rn64 = rn.to(tl.int64)
+    a = tl.load(A_ptr + pid_b * stride_ab + rm64 * stride_am, mask=mask_m, other=0.0)
+    b = tl.load(B_ptr + pid_b * stride_bb + rn64 * stride_bn, mask=mask_n, other=0.0)
 
     out = a[:, None] * b[None, :]
 
     mask = mask_m[:, None] & mask_n[None, :]  # pyrefly: ignore[bad-index]
     tl.store(
-        OUT_ptr + pid_b * stride_ob + rm[:, None] * stride_om + rn[None, :] * stride_on,
+        OUT_ptr
+        + pid_b * stride_ob
+        + rm64[:, None] * stride_om
+        + rn64[None, :] * stride_on,
         out,
         mask=mask,
     )


### PR DESCRIPTION
## Summary

`torch.bmm` on CUDA is routed to the native Triton kernel `_bmm_outer_product_kernel` (`torch/_native/ops/bmm_outer_product/`) whenever the contraction dimension is 1. That kernel computes its element offsets in int32: `pid_b` is an int32 program id and the strides are int32-specialised Python ints, so `pid_b * stride_ob` wraps as soon as `(batch - 1) * M * N > INT32_MAX`. The wrapped offset is then added to the (64-bit) pointer, and the last batch matrices are stored 8 GiB (fp32) / 16 GiB (fp64) / 4 GiB (bf16) before the output buffer.

- In a small process this is `cudaErrorIllegalAddress`.
- In a process that holds enough other allocations the store can land in live memory: `torch.bmm` then returns the never-written (uninitialised) rows for those batches and silently corrupts whatever lived at the wrapped address. In our production process it did.
- Independent of dtype (fp32 and fp64 fail identically) and of `TORCH_BLAS_PREFER_CUBLASLT`; `TORCH_DISABLE_NATIVE_JIT=1` (cuBLAS path) is correct at every size.

This PR promotes the batch and row/column offsets to int64 before the pointer arithmetic and adds a regression test at the first failing size.

## Reproducer

```python
import torch
u, B, v = 512, 8209, 512                       # B = 8208 works, B = 8209 does not
a = torch.randn(u, B, 1, device="cuda")
w = torch.randn(u, 1, v, device="cuda")
out = torch.bmm(a, w)                          # (512, 8209, 512)
torch.cuda.synchronize()                       # -> cudaErrorIllegalAddress
```

| B | `(u-1)·B·v` | default | `TORCH_DISABLE_NATIVE_JIT=1` |
|---|---|---|---|
| 8191 / 8192 / 8193 / 8208 | ≤ 2 147 475 456 | exact vs CPU | exact |
| **8209** | **2 147 737 088 > INT32_MAX** | `cudaErrorIllegalAddress` | exact |
| 8230 / 8319 / 16384 | … | `cudaErrorIllegalAddress` | exact |

Same table in fp64. The boundary is not `numel >= 2^31` (B = 8192 already has 2^31 output elements and works) but the offset of the last batch matrix: `2^31 / (511 · 512) = 8208.03`. Reproduces on `2.14.0+cu130` and on the nightly `2.15.0.dev20260908+cu130` (triton `3.8.0+gitc01b6774`), GH200 / sm_90.

The profiler shows k = 1 is the only path that reaches the kernel (k = 2 goes to cuBLAS and is fine):

```
bmm k=1: aten::bmm -> _native::bmm_triton_0 -> _bmm_outer_product_kernel
bmm k=2: aten::bmm -> sm80_xmma_gemm_f32f32_f32f32_f32_nn_n_..._cublas
```

## Root cause

Kernel arguments for the failing case, all int32-specialised (`B_dim, M, N` = 512, 8209, 512; `stride_ob` = 4 203 008; grid = 133 120 programs); the largest offset term is `pid_b_max * stride_ob = 511 · 4 203 008 = 2 147 737 088`, which wraps to −2 147 230 208. `rm * stride_om` overflows the same way for a single batch matrix with `(M - 1) * N > INT32_MAX`, and the input expressions (`rm * stride_am`, `rn * stride_bn`) can for strided views, which the dispatch condition allows. None of the caller's tensors carry int32 anything, so user code cannot avoid this except by avoiding the op.

## Fix

The program id is promoted to `tl.int64` once, right after `tl.program_id(0)`, so every index derived from it (`pid_b`, `pid_m`, `pid_n`, `rm`, `rn`) and every offset term is 64-bit. (First push cast `pid_b`, `rm` and `rn` individually before the stride multiplies; same coverage, the early cast is the cleaner statement of it.) The kernel is bandwidth-bound on the `(B, M, N)` store, so the casts cost nothing measurable, and the override stays 1.45× faster than the cuBLAS k = 1 GEMM at these shapes.

Verification of the patched kernel against the broadcast product `a * b` (64-bit TensorIterator indexing), contiguous inputs and strided views (`randn(u, B, 4)[:, :, :1]`, `randn(u, 4, v)[:, :1, :]`), `torch.equal` in every case:

| B | dtype | contiguous | strided |
|---|---|---|---|
| 8208 / 8209 / 8319 | fp32, fp64 | equal | equal |
| 16384 (2^32 elements) | fp32 | equal | equal |

## Test

Two cases in `test/test_bmm_outer_product.py`, both under `@largeTensorTest("6GB")`, comparing against the broadcast product `a[i] * b[i]` (a full `a @ b` reference would dispatch to the kernel under test):

- `test_batch_offset_past_int32_max`: `(512, 8209, 1) @ (512, 1, 512)` in bf16 (4 GiB output), contiguous and as strided input views; batches 0, 510 and 511.
- `test_row_offset_past_int32_max`: `(1, 65536 + 4096, 1) @ (1, 1, 32768)` in bf16 (4.25 GiB output), the `rm * stride_om` overflow inside one batch matrix; rows around 65536 and at the end.

On the unpatched kernel each test fails in its own process (`cudaErrorInvalidAddressSpace` / `cudaErrorIllegalAddress` here; a mismatch if the wrapped address happens to be live memory); with the patch both pass and the rest of the file passes (30 tests, the multi-device / HIP / XPU ones skipped) — run on a GH200 against `2.15.0.dev20260908+cu130` with the patched kernel copied over the installed one. Note that `M > INT32_MAX` on its own cannot overflow `rm`: Triton then specialises `M` as `i64` and the whole index chain follows (the original kernel is exact at `(1, 2^31 + 1000, 1)`); the reachable row overflows are the products with an int32 stride, which the early cast covers.

## How it was found: context, model, and what was ruled out

**Context.** We were benchmarking our own re-implementation of MACE-POLAR-1-M against the official `mace-torch` (0.3.16, with cuEquivariance 0.11.1) on periodic PEO polymer melts of 7 400 → 35 400 atoms on a GH200: step time, peak memory, and energy/force parity at fp32 and fp64. The official model's fp32 forces blew up at 8 850 atoms (max |F| 75 eV/Å against 2, median 8 against 0.34) while its energy per atom stayed right and our implementation agreed with its own fp64 to 2e-4 eV/Å at every size.

**Model used for the whole diagnosis.** The official `MACE-POLAR-1-M.model` checkpoint (15.2 M parameters, 512 channels, l_max = 3, two interactions, GTO/k-space electrostatics with field recursion), run through `mace.calculators.mace_polar` with cuEq enabled, exactly as users run it. The reference was an independent fp64 port of the same checkpoint that reassociates the uvu contraction (`F.linear` first, then the dot over the irrep dimension) and therefore never materialises the (N, 512, 512) pair tensor — its graph contains no k = 1 bmm, which is why it never showed the problem.

**Elimination, in order.**
1. *Not the cell, not precision.* Prefixes of one configuration in the same 42.6 Å box bisected the cliff to between 8 193 and 8 230 atoms; the failure was bit-reproducible run to run, and the official fp64 model — which could not run at that size on 95 GiB — turned out to be irrelevant once the kernel reproducer failed in fp64 too.
2. *Not cuEquivariance.* Re-converting the model with conv fusion off, or with the fully-connected-TP override off, gave bit-identical wrong forces; only the Python-side field blocks were left.
3. *Not the forward.* Forward hooks on all 447 modules, comparing the 7 965-atom prefix with the 8 319-atom box on atoms farther than 18.5 Å from the added atoms: every local module agreed to < 1e-5 relative, the electrostatic ones by the physical field of the added chains, energies per atom identical (591.43 eV).
4. *The backward, and where.* Tensor gradient hooks on the same runs: dE/d(output) exact through the readouts and the field MLP down to the outputs of `SparseUvuTensorProduct`, garbage (relative 5.8e2 on the far atoms) for its inputs — the block's backward breaks, and the k-space electrostatics then spreads the wrong gradient to every atom's force.
5. *Which autograd node.* The block is two einsums, `pair = einsum("bud,bvd->buv")` and `einsum("buv,uv->bu", pair, w)`; running that chain on GPU and CPU with a hook on every autograd node, `BmmBackward0` of the second einsum is the first wrong node (relative error 0.77 at B = 8 230). Hand-written equivalents of every backward piece (`einsum("bu,uv->buv")`, `bmm` with k = 512 on the permuted gradient, `(pair * w).sum(-1)`) were exact at every size, so the bug was in autograd's lowering, not in the math.
6. *Which kernel.* The profiler showed that lowering is a `bmm` with k = 1 that dispatches to `_bmm_outer_product_kernel`, not to cuBLAS (k = 2 goes to `sm80_xmma_gemm_…_cublas` and is fine); the three-line reproducer above, one process per size, put the boundary at B = 8 209 = ⌈2^31 / (511 · 512)⌉ in fp32 and fp64 alike, and `TORCH_DISABLE_NATIVE_JIT=1` made it exact.
7. *Closing the loop on the model.* With `TORCH_DISABLE_NATIVE_JIT=1` the official fp32 forces at 8 319 atoms agree with the fp64 reference to max |ΔF| 2e-4 eV/Å again (default: 64.7 eV/Å), same memory and time.

Every number above comes from a SLURM job on the GH200; the diagnosis and this patch were driven with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNkQBh3bjtxrBcJC3qjy7N
