### PR TITLE
Apply native_layer_norm's param-dtype check on every backend, not only CUDA

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1179,6 +1179,42 @@ instantiate_device_type_tests(TestDecomp, globals())
 
 class DecompOneOffTests(TestCase):
     @onlyNativeDeviceTypes
+    def test_layer_norm_param_dtype_matches_eager(self, device):
+        # native_layer_norm's ref checks that weight/bias share the input's dtype,
+        # but the check used to fire only for CUDA, so on every other backend the
+        # ref accepted a call eager refuses. Assert agreement rather than a fixed
+        # outcome: if some backend does accept the mismatch, this reports that the
+        # ref needs a carve-out instead of silently passing.
+        input = torch.randn(4, 8, device=device)
+        weight = torch.randn(8, dtype=torch.float16, device=device)
+
+        def rejects(fn):
+            try:
+                fn()
+            except RuntimeError:
+                return True
+            return False
+
+        eager = rejects(
+            lambda: torch.native_layer_norm(input, (8,), weight, None, 1e-5)
+        )
+        ref = rejects(
+            lambda: torch._refs.native_layer_norm(input, (8,), weight, None, 1e-5)
+        )
+        self.assertEqual(
+            ref,
+            eager,
+            msg=f"ref and eager disagree on a mismatched param dtype on {device}",
+        )
+
+        # The matched-dtype path must be untouched.
+        matched = torch.randn(8, device=device)
+        self.assertEqual(
+            torch._refs.native_layer_norm(input, (8,), matched, None, 1e-5)[0],
+            torch.native_layer_norm(input, (8,), matched, None, 1e-5)[0],
+        )
+
+    @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_softmax(self, device):
         size = (2, 4, 3, 3)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3524,15 +3524,21 @@ def _scalar_type_name(dtype: torch.dtype) -> str:
     return dtype_name[:1].upper() + dtype_name[1:]
 
 
-def _check_native_layer_norm_cuda_param_dtype(
+def _check_native_layer_norm_param_dtype(
     input: Tensor,
     normalized_ndim: int,
     weight: Tensor | None,
     bias: Tensor | None,
 ) -> None:
-    if input.device.type != "cuda":
-        return
-
+    # Every backend measured rejects a weight or bias whose dtype differs from the
+    # input: CUDA (which is why this check exists, #185693), CPU with "mixed dtype
+    # (CPU): expect parameter to have scalar type of Float", and Ascend NPU from
+    # aclnnLayerNorm. The restriction is not CUDA's, so gating the check on the
+    # device made the ref accept, on every other backend, a call eager refuses.
+    #
+    # The num_rows carve-out below is left as it was, i.e. still only right for
+    # CUDA: CUDA accepts the mismatch when no rows are processed, CPU rejects it
+    # even then. Narrowing that needs the empty case measured on MPS, XPU and NPU.
     mismatched_dtype = None
     if weight is not None and weight.dtype != input.dtype:
         mismatched_dtype = weight.dtype
@@ -3608,7 +3614,7 @@ def native_layer_norm(
         not input.is_complex(),
         lambda: "native_layer_norm does not support complex inputs",
     )
-    _check_native_layer_norm_cuda_param_dtype(input, normalized_ndim, weight, bias)
+    _check_native_layer_norm_param_dtype(input, normalized_ndim, weight, bias)
 
     input = contiguous(input)
     if weight is not None:


### PR DESCRIPTION
Related to this RFC: #194355


### Summary

`_check_native_layer_norm_cuda_param_dtype` opened with
`if input.device.type != "cuda": return`, so the ref's rejection of a `weight` or
`bias` whose dtype differs from `input` fired for CUDA alone. The restriction it
models is not CUDA's — every backend measured rejects the mismatch in eager:

    CUDA   rejects   the reason the check was added, #185693
    CPU    rejects   mixed dtype (CPU): expect parameter to have scalar type of Float
    NPU    rejects   aclnnLayerNorm: Expected both tensors to have same dtype, but
                     found weightOptional DT_FLOAT16 and input DT_FLOAT

So on every backend except CUDA the ref accepted a call eager refuses. On CPU,
before this change:

    eager : REJECTS   mixed dtype (CPU): expect parameter to have scalar type of Float
    ref   : ACCEPTS   -> out torch.float32

The device gate is removed, and the function loses `cuda` from its name since it
is no longer about CUDA. The message already named only the dtypes, so it needed
no change.

### Scope — three things this deliberately does not do

The `num_rows == 0` carve-out is left exactly as it was, and it is still only
correct for CUDA: CUDA accepts a mismatched parameter dtype when no rows are
processed, while CPU rejects it even for a zero-row input. The ref therefore still
diverges from CPU eager on `(0, 8)`. That predates this change; narrowing it needs
the empty case measured on MPS, XPU and NPU. The code comment says so.

The meta kernel is untouched. Both the ref and the meta accepted the mismatch, and
only the ref changes here.

No `torch.compile` end-to-end divergence was demonstrated: with `aot_eager` the
eager check still surfaces before decomposition, so the laxity is reachable
through `torch._decomp.decomposition_table[aten.native_layer_norm.default]` and
the meta rather than through a compiled user program. This is for the ref agreeing
with eager, not for a demonstrated user-visible break.

MPS and XPU were not measured. If either accepts a mismatched parameter dtype, the
new test reports it as a disagreement rather than passing, which is the signal to
add a carve-out.

### Test plan

`DecompOneOffTests.test_layer_norm_param_dtype_matches_eager`, in a class the file
already runs through `instantiate_device_type_tests`. It asserts the ref and eager
**agree** on the accept/reject decision rather than asserting a fixed outcome, so
a backend that does accept the mismatch is reported rather than silently passing,
and it needs no per-backend branch.

    python test/test_decomp.py -k test_layer_norm_param_dtype_matches_eager
    Ran 1 test -- OK
    python test/test_decomp.py -k DecompOneOffTestsCPU
    Ran 19 tests -- OK (skipped=6, expected failures=1)

    lintrunner -- ok No lint issues.

Restoring the device gate makes the new test fail, so it is not vacuous.

CPU only in this run; see the note above on MPS and XPU.