### PR TITLE
Replace `Linear` `inner_product` calls with `matmul`

### DIFF
--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -112,14 +112,15 @@ Tensor mkldnn_linear(
   const ideep::tensor x = itensor_from_mkldnn(self_reshaped);
   // weight_t can be a mkldnn tensor or dense tensor.
   const Tensor weight = (weight_t.is_mkldnn() || weight_t.is_contiguous()) ? weight_t : weight_t.contiguous();
-  const ideep::tensor w = itensor_from_tensor(weight);
+  auto w = itensor_from_tensor(weight);
+  w.transpose_(0, 1);
 
   ideep::tensor y;
   if (bias.defined()) {
-    const ideep::tensor b = itensor_from_tensor(bias);
-    ideep::inner_product_forward::compute(x, w, b, y);
+    const ideep::tensor b = itensor_from_tensor(bias.reshape({1, bias.size(0)}));
+    ideep::matmul_forward::compute(x, w, b, y);
   } else {
-    ideep::inner_product_forward::compute(x, w, y);
+    ideep::matmul_forward::compute(x, w, y);
   }
 
   auto input_size = self.sizes();
@@ -214,14 +215,6 @@ Tensor mkldnn_linear_pointwise(
     std::string_view attr,
     c10::List<std::optional<at::Scalar>> scalars,
     std::optional<std::string_view> algorithm) {
-  auto aprop_kind = ideep::prop_kind::forward;
-  bool maybe_backward = GradMode::is_enabled() &&
-      (input_t.requires_grad() || weight_t.requires_grad() ||
-       (bias_opt.has_value() && bias_opt->defined() &&
-        bias_opt->requires_grad()));
-  if (!maybe_backward) {
-    aprop_kind = ideep::prop_kind::forward_inference;
-  }
   auto input = input_t.contiguous();
   auto input_size = input.sizes();
 
@@ -255,9 +248,10 @@ Tensor mkldnn_linear_pointwise(
 
   std::optional<ideep::tensor> mkldnn_bias{std::nullopt};
   if (bias.defined()) {
-    mkldnn_bias = itensor_from_tensor(bias);
+    mkldnn_bias = itensor_from_tensor(bias.reshape({1, bias.size(0)}));
   }
-  const ideep::tensor w = itensor_from_tensor(weight_t);
+  auto w = itensor_from_tensor(weight_t);
+  w.transpose_(0, 1);
 
   ideep::attr_t op_attr = ideep::attr_t();
   if (attr != "none") {
@@ -272,21 +266,25 @@ Tensor mkldnn_linear_pointwise(
   if (use_mkldnn_tf32_linear() && input_t.scalar_type() == at::kFloat){
     op_attr.set_fpmath_mode(dnnl_fpmath_mode_tf32);
   }
+  // Reorder dense weights to primitive-selected layouts, which may be packed
+  // on AArch64.
   if (mkldnn_bias.has_value()) {
-    ideep::inner_product_forward::compute</*reorder_src=*/false, /*reorder_weight=*/false>(
+    ideep::matmul_forward::compute</*reorder_src=*/false, /*reorder_weight=*/true>(
         mkldnn_input,
         w,
         mkldnn_bias.value(),
         mkldnn_output,
-        op_attr,
-        aprop_kind);
+        /*dst_coeff=*/1.0f,
+        /*sum_coeff=*/1.0f,
+        op_attr);
   } else {
-    ideep::inner_product_forward::compute</*reorder_src=*/false, /*reorder_weight=*/false>(
+    ideep::matmul_forward::compute</*reorder_src=*/false, /*reorder_weight=*/true>(
         mkldnn_input,
         w,
         mkldnn_output,
-        op_attr,
-        aprop_kind);
+        /*dst_coeff=*/1.0f,
+        /*sum_coeff=*/1.0f,
+        op_attr);
   }
 
   if (dim != 2) {
@@ -353,13 +351,13 @@ Tensor mkldnn_linear_pointwise_binary(
 
   std::optional<ideep::tensor> mkldnn_bias{std::nullopt};
   if (bias.defined()) {
-    mkldnn_bias = itensor_from_tensor(bias);
+    mkldnn_bias = itensor_from_tensor(bias.reshape({1, bias.size(0)}));
   }
-  const ideep::tensor w = itensor_from_tensor(weight_t);
+  auto w = itensor_from_tensor(weight_t);
+  w.transpose_(0, 1);
 
   auto other_desc = mkldnn_other.get_desc();
   auto op_attr = ideep::attr_t::fuse_binary(it_binary->second, other_desc);
-  auto aprop_kind = ideep::prop_kind::forward_inference;
 
   if (use_mkldnn_bf32_linear() && input_t.scalar_type() == at::kFloat){
     op_attr.set_fpmath_mode(dnnl_fpmath_mode_bf16);
@@ -369,18 +367,22 @@ Tensor mkldnn_linear_pointwise_binary(
     op_attr.set_fpmath_mode(dnnl_fpmath_mode_tf32);
   }
 
+  // Keep source reordering disabled because ideep also applies it to the
+  // binary post-op input, which breaks supported broadcast cases on x86.
+  // Weight reordering supports primitive-selected packed layouts on AArch64.
+
   if (mkldnn_bias.has_value()) {
-    ideep::inner_product_forward::compute_binary</*reorder_src=*/false, /*reorder_weight=*/false>(
+    ideep::matmul_forward::compute_binary</*reorder_src=*/false, /*reorder_weight=*/true>(
         mkldnn_input,
         mkldnn_other,
         w,
         mkldnn_bias.value(),
         mkldnn_output,
-        op_attr,
-        aprop_kind);
+        /*dst_coeff=*/1.0f,
+        op_attr);
   } else {
-    ideep::inner_product_forward::compute_binary</*reorder_src=*/false, /*reorder_weight=*/false>(
-        mkldnn_input, mkldnn_other, w, mkldnn_output, op_attr, aprop_kind);
+    ideep::matmul_forward::compute_binary</*reorder_src=*/false, /*reorder_weight=*/true>(
+        mkldnn_input, mkldnn_other, w, mkldnn_output, /*dst_coeff=*/1.0f, op_attr);
   }
 
   if (dim != 2) {

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -278,14 +278,16 @@ static Tensor mkldnn_reorder_linear_weight(
   if (batch_size_opt.has_value()) {
     input_size = {batch_size_opt.value(), in_features};
   }
-  auto packed_desc = ideep::inner_product_forward::expected_weights_desc(
-      {out_features, in_features},
+  auto packed_desc = ideep::matmul_forward::expected_weights_desc(
+      {in_features, out_features},
       input_size,
       /* weight dtype */ dtype,
-      /* src dtype */ dtype,
-      ideep::prop_kind::forward_inference);
+      /* src dtype */ dtype);
   ideep::tensor result;
-  result.init(packed_desc);
+  // Store the transposed matmul-packed descriptor so the tensor keeps Linear's
+  // public {out_features, in_features} shape. Linear transposes the descriptor
+  // back before execution.
+  result.init(packed_desc.transpose(0, 1));
   result.feed_from(w);
   return new_with_itensor_mkldnn(std::move(result), optTypeMetaToScalarType(self.options().dtype_opt()), self.options().device_opt());
 }

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -1324,6 +1324,93 @@ class TestMkldnn(TestCase):
             self._test_serialization(mkldnn_linear, (x.to_mkldnn(),))
             self._test_tracing(mkldnn_linear, (x.to_mkldnn(),))
 
+    def _linear_reference(self, x, weight, bias):
+        import numpy as np
+        x_np = x.detach().cpu().numpy()
+        weight_np = weight.detach().cpu().numpy()
+        expected = np.matmul(x_np, weight_np.T)
+        if bias is not None:
+            expected += bias.detach().cpu().numpy()
+        return torch.from_numpy(expected)
+
+    @parametrize("input_shape", [(1, 256, 10), (2, 3, 10), (2, 3, 4, 10)])
+    @parametrize("with_bias", [True, False])
+    def test_mkldnn_linear_higher_rank(self, input_shape, with_bias):
+        in_features = input_shape[-1]
+        out_features = 7
+        x = torch.randn(input_shape, dtype=torch.float32)
+        weight = torch.randn(out_features, in_features, dtype=torch.float32)
+        bias = torch.randn(out_features, dtype=torch.float32) if with_bias else None
+        expected = self._linear_reference(x, weight, bias)
+        actual = torch._C._nn.mkldnn_linear(
+            x.to_mkldnn(),
+            weight.to_mkldnn(),
+            bias.to_mkldnn() if bias is not None else None,
+        ).to_dense()
+        self.assertEqual(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @parametrize("input_shape", [(1, 256, 10), (2, 3, 10), (2, 3, 4, 10)])
+    @parametrize("with_bias", [True, False])
+    def test_mkldnn_linear_higher_rank_packed_weight(self, input_shape, with_bias):
+        x = torch.randn(input_shape, dtype=torch.float32)
+        weight = torch.randn(7, 10, dtype=torch.float32)
+        bias = torch.randn(7, dtype=torch.float32) if with_bias else None
+        flattened_m = x.numel() // x.size(-1)
+        packed_weight = torch.ops.mkldnn._reorder_linear_weight(weight, flattened_m)
+        expected = self._linear_reference(x, weight, bias)
+        actual = torch._C._nn.mkldnn_linear(
+            x.to_mkldnn(),
+            packed_weight,
+            bias.to_mkldnn() if bias is not None else None,
+        ).to_dense()
+        self.assertEqual(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @parametrize("input_shape", [(2, 3, 10), (2, 3, 4, 10)])
+    @parametrize("with_bias", [True, False])
+    @parametrize("packed_weight", [True, False])
+    @parametrize("is_binary", [True, False])
+    @parametrize("dtype", (torch.float32, torch.float16, torch.bfloat16))
+    def test_mkldnn_linear_fused_higher_rank(
+        self,
+        dtype,
+        input_shape,
+        with_bias,
+        packed_weight,
+        is_binary,
+    ):
+        lowp_support = {
+            torch.bfloat16: torch.ops.mkldnn._is_mkldnn_bf16_supported,
+            torch.float16: torch.ops.mkldnn._is_mkldnn_fp16_supported,
+        }
+        if dtype in lowp_support and not lowp_support[dtype]():
+            self.skipTest(f"MKLDNN does not support {dtype} on this CPU")
+        in_features = input_shape[-1]
+        out_features = 7
+        x = torch.randn(input_shape, dtype=dtype)
+        weight = torch.randn(out_features, in_features, dtype=dtype)
+        bias = None
+        if with_bias:
+            bias = torch.randn(out_features, dtype=dtype)
+        linear_ref = self._linear_reference(
+            x.float(),
+            weight.float(),
+            bias.float() if bias is not None else None,
+        )
+        op_weight = weight
+        if packed_weight:
+            flattened_m = x.numel() // x.size(-1)
+            op_weight = torch.ops.mkldnn._reorder_linear_weight(weight, flattened_m)
+        if is_binary:
+            other = torch.randn(*input_shape[:-1], out_features, dtype=dtype)
+            expected = linear_ref + other.float()
+            actual = torch.ops.mkldnn._linear_pointwise(x, other, op_weight, bias, "add")
+        else:
+            expected = torch.relu(linear_ref)
+            actual = torch.ops.mkldnn._linear_pointwise(x, op_weight, bias, "relu", [], "")
+        atol = {torch.float32: 1e-5, torch.float16: 5e-3, torch.bfloat16: 1e-1}[dtype]
+        rtol = 1e-5 if dtype == torch.float32 else 1e-3
+        self.assertEqual(actual.float(), expected, atol=atol, rtol=rtol)
+
     def test_linear_backward(self):
         in_features = torch.randint(3, 10, (1,)).item()
         out_features = torch.randint(3, 100, (1,)).item()


### PR DESCRIPTION
## Summary

Replace direct inner-product calls in MKLDNN Linear with matmul calls for forward. Backward is left as inner-product.

oneDNN already attempts to redirect eligible inner-product operations to matmul on both AArch64 and x86. Calling matmul directly removes this intermediate inner-product dispatch step and allows the appropriate matmul implementation to be selected immediately.

This changes the MKLDNN Linear path on both AArch64 and x86, so input and validation from the x86 stakeholders is requested before merging.

## Tests

With regards to testing, this PR...

  - extends the existing MKLDNN Linear tests
  - adds new FP32 tests with 3D/4D inputs
  - adds tests with bias and no-bias 
  - adds tests with batch-specific packed weights

cc: @jondea

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal