### PR TITLE
[Test] Clear process cache in _tunableop_ctx

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9763,6 +9763,7 @@ class TestLinalgCudaOnly(TestCase):
             else None
         )
         self._set_tunableop_defaults()
+        torch.cuda.tunable._clear_all()
         torch.cuda.tunable.enable(True)
 
         try:


### PR DESCRIPTION
`TestLinalgCudaOnlyCUDA.test_tf32_tunableop_cuda_float32` is failing on GB200 because `test_bfx9_tunableop_cuda_float32` is "poisoning" the cache state by tuning the same tf32-off case that `test_tf32_tunableop` is expecting to tune for the first time. This causes the change in cache size to be 0 instead of 1, since the relevant algorithm is already cached. See failure below. This PR adds `torch.cuda.tunable._clear_all()` to the context wrapper so that the process cache resets before each relevant TunableOp test.

```
FAIL: test_tf32_tunableop_cuda_float32 (__main__.TestLinalgCudaOnlyCUDA.test_tf32_tunableop_cuda_float32)                                                                
----------------------------------------------------------------------                                                                                                   
Traceback (most recent call last):                                                                                                                                       
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3886, in wrapper                                                          
    method(*args, **kwargs)                                                                                                                                              
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3886, in wrapper                                                          
    method(*args, **kwargs)                                                                                                                                              
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 672, in instantiated_test                                           
    result = test(self, **param_kwargs)                                                                                                                                  
             ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                  
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 2495, in wrap_fn                                                          
    return fn(self, *args, **kwargs)                                                                                                                                     
           ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                     
  File "/opt/pytorch/pytorch/test/test_linalg.py", line 10922, in test_tf32_tunableop                                                                                    
    self.assertEqual((total_num_results - ref_num_results), 1)                                                                                                           
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 4936, in assertEqual                                                      
    raise error_metas.pop()[0].to_error(  # type: ignore[index]                                                                                                          
AssertionError: Scalars are not equal!                                                                                                                                   
                                                                                                                                                                         
Expected 1 but got 0.                                                                                                                                                    
Absolute difference: 1                                                                                                                                                   
Relative difference: 1.0                                                                                                                                                 
                                                                                                                                                                         
To execute this test, run the following from the base repo dir:                                                                                                          
    python test/test_linalg.py TestLinalgCudaOnlyCUDA.test_tf32_tunableop_cuda_float32                                                                                   
                                                                                                                                                                         
This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0 
```

Authored with assistance from agents

cc @eqy @drisspg 