### PR TITLE
Fix incorrect docstring for register_module_as_pytree_input_node

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1511,10 +1511,7 @@ def register_module_as_pytree_input_node(cls: type[torch.nn.Module]) -> None:
     Registers a module as a valid input type for :func:`torch.export.export`.
 
     Args:
-        mod: the module instance
-        serialized_type_name: The serialized name for the module. This is
-        required if you want to serialize the pytree TreeSpec containing this
-        module.
+        cls: the module type to register
 
     Example::
 
@@ -1530,7 +1527,7 @@ def register_module_as_pytree_input_node(cls: type[torch.nn.Module]) -> None:
                 return self.linear(x)
 
 
-        torch._export.utils.register_module_as_pytree_node(InputDataClass)
+        torch._export.utils.register_module_as_pytree_input_node(Module)
 
 
         class Mod(torch.nn.Module):


### PR DESCRIPTION
## Summary

The docstring for `register_module_as_pytree_input_node` documented parameters that don't exist and its example called a function that doesn't exist:

- Documented `mod: the module instance`, but the signature is `register_module_as_pytree_input_node(cls: type[torch.nn.Module])`, which takes a module **type**, not an instance. Passing an instance fails the `issubclass` check on the first line of the body.
- Documented `serialized_type_name`, which is not a parameter of this function.
- The example called `register_module_as_pytree_node(InputDataClass)`. No such function exists in `torch`, and `InputDataClass` is undefined in the example. Running it raises `AttributeError`.

## Testing

Ran the corrected example directly against an installed torch build (2.13.0) containing this function; it exports successfully end to end:

```
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, x, m_linear_weight, m_linear_bias):
            ...
EXAMPLE RAN SUCCESSFULLY
```

Docs-only change, no functional/behavioral change.

## AI assistance disclosure

Disclosing per [`AI_POLICY.md`](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md): I used an AI coding assistant to help locate this inconsistency and draft the patch. I reviewed every changed line and verified the behavioural claims myself before submitting, rather than taking the tool's word for them.

The assistant's diagnostic output, run against an installed torch 2.13.0:

> ```
> --- ORIGINAL docstring example ---
>   FAILS: AttributeError: module 'torch._export.utils' has no attribute
>          'register_module_as_pytree_node'
>
> --- CORRECTED docstring example ---
>   WORKS: export succeeded, ExportedProgram produced
> ```

I reproduced both of those runs myself, so I believe the docstring is genuinely broken rather than merely stylistically off: the function name in the example does not exist in `torch` at all, which means anyone copying the documented example hits an `AttributeError` immediately. The `mod` vs `cls` discrepancy is the more subtle half — the docstring tells you to pass a module *instance*, but the first statement in the function body is an `issubclass` check, which raises on an instance. Both halves point the reader at something that cannot work.

I've kept this docs-only and made no behavioural change, so the risk surface is limited to the text itself.
