### PR TITLE
[inductor] Fall back when decomposed-K has no valid split

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2871,6 +2871,55 @@ class TestMaxAutotune(TestCase):
         finally:
             clear_preprocessing_fns(clear_defaults=False)
 
+    @fresh_cache()
+    @unittest.skipIf(
+        config.triton.native_matmul,
+        "native matmul takes different tuning configs",
+    )
+    @config.patch(
+        max_autotune=True,
+        max_autotune_gemm_backends="TRITON",
+        autotune_fallback_to_aten=False,
+    )
+    def test_decompose_k_without_valid_splits_falls_back(self):
+        a, b = self._make_matrices(
+            M=64,
+            K=64,
+            N=64,
+            dtype=torch.float16,
+            device=GPU_TYPE,
+            requires_grad=False,
+        )
+        names: list[str] = []
+
+        def record(choices):
+            names.extend(choice.name for choice in choices)
+            return choices
+
+        torch._dynamo.reset()
+        get_k_splits.cache_clear()
+        use_decompose_k_choice.cache_clear()
+        add_preprocessing_fn(record)
+        try:
+            with config.patch(
+                {
+                    "test_configs.max_mm_configs": 1,
+                    "triton.decompose_k_threshold": 0,
+                    "triton.num_decompose_k_splits": 1,
+                }
+            ):
+                actual = torch.compile(lambda x, y: x @ y)(a, b)
+        finally:
+            clear_preprocessing_fns(clear_defaults=False)
+            get_k_splits.cache_clear()
+            use_decompose_k_choice.cache_clear()
+
+        self.assertEqual(actual, a @ b)
+        self.assertTrue(any(name.startswith("triton_mm") for name in names), names)
+        self.assertFalse(
+            any(name.startswith("decompose_k_mm") for name in names), names
+        )
+
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "TRITON"}
     )

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2410,6 +2410,8 @@ def use_decompose_k_choice(
         and not V.graph.aot_mode  # TODO: Support AOTI for decomposeK
         and not V.graph.cpp_wrapper
         and config.triton.num_decompose_k_splits > 0
+        # Callers rely on False to retain the regular MM fallback.
+        and bool(get_k_splits(m, n, k))
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #196453

Decomposed-K selection only checked the configured threshold and split count. When `get_k_splits()` produced no legal split, callers had already suppressed the regular MM template, leaving no choices and raising `NoValidChoicesError`.

Check for a realizable split in `use_decompose_k_choice()` so invalid decomposed-K selections retain the regular Triton MM fallback. Validating at the predicate keeps invalid choices out of selection instead of catching the downstream error.

This change was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo