### PR TITLE
[BE] Unify reflection/replication padding shape checks

### DIFF
--- a/aten/src/ATen/native/Padding.h
+++ b/aten/src/ATen/native/Padding.h
@@ -58,6 +58,18 @@ inline void check_valid_input(const Tensor& input, IntArrayRef padding, int64_t 
       input.sizes());
 }
 
+// TODO(#196457): remove this overload once the torch-xpu-ops pin in
+// third_party/xpu.txt passes the rank as an argument. Its ReflectionPadKernels
+// still calls check_valid_input<2>(input, padding). torch-xpu-ops compiles every
+// TU with -DUSE_XPU (see its cmake/BuildFlags.cmake), while in-tree USE_XPU is
+// PRIVATE to torch_xpu, so this stays out of torch_cpu.
+#ifdef USE_XPU
+template <int dim>
+inline void check_valid_input(const Tensor& input, IntArrayRef padding) {
+  check_valid_input(input, padding, dim);
+}
+#endif
+
 // Renders the spatial extents as "D: 1 H: 2 W: 3", using the trailing
 // `sizes.size()` labels. Only ever called to build an error message.
 inline std::string spatial_sizes_str(IntArrayRef sizes, const char* sep) {

--- a/aten/src/ATen/native/Padding.h
+++ b/aten/src/ATen/native/Padding.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <ATen/core/DimVector.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/DispatchStub.h>
+#include <c10/util/irange.h>
+
+#include <array>
+#include <string>
 
 namespace at::native {
 
@@ -23,41 +28,120 @@ DECLARE_DISPATCH(padding_fn, replication_pad2d_backward_kernel)
 DECLARE_DISPATCH(padding_fn, replication_pad3d_kernel)
 DECLARE_DISPATCH(padding_fn, replication_pad3d_backward_kernel)
 
+// Shape checks shared by reflection_pad{1,2,3}d and replication_pad{1,2,3}d, on
+// every backend. The messages match the meta implementations in
+// _meta_registrations.py (_pad{1,2,3}d_common and friends) so that eager and
+// torch.compile report failures identically; keep the two in sync.
+//
+// `padding` follows the torch.nn.functional.pad convention: pair `i` covers the
+// input dimension `input.dim() - 1 - i`, i.e. the pairs run inwards-out while
+// the D/H/W labels in the messages run the other way.
 namespace padding {
 
-template <int dim>
-inline void check_valid_input(const Tensor& input, IntArrayRef padding) {
-
-  TORCH_CHECK(padding.size() == 2 * dim,
+inline void check_valid_input(const Tensor& input, IntArrayRef padding, int64_t dim) {
+  TORCH_CHECK(static_cast<int64_t>(padding.size()) == 2 * dim,
       "padding size is expected to be ", 2 * dim,
       ", but got: ", padding.size());
 
-  int input_dim = input.dim();
+  const int64_t input_dim = input.dim();
+  const bool is_batch_mode = input_dim == dim + 2;
 
-  bool is_batch_mode = input_dim == (dim + 2);
-  bool is_non_batch_mode = input_dim == (dim + 1);
-
-  bool valid_batch_mode = is_batch_mode;
-  bool valid_non_batch_mode = is_non_batch_mode;
-
-  if (is_batch_mode) {
-    // allow batch size of 0-dim.
-    for (const auto d : c10::irange(1, input_dim)) {
-      valid_batch_mode = valid_batch_mode && input.size(d) != 0;
-    }
-  } else {
-    for (const auto d : c10::irange(0, input_dim)) {
-      valid_non_batch_mode = valid_non_batch_mode && input.size(d) != 0;
-    }
+  // Allow an empty batch size, but no other empty dimension.
+  bool valid = is_batch_mode || input_dim == dim + 1;
+  for (const auto d : c10::irange(is_batch_mode ? 1 : 0, input_dim)) {
+    valid = valid && input.size(d) != 0;
   }
 
-  // allow empty batch size but not other dimensions.
-  TORCH_CHECK(valid_batch_mode || valid_non_batch_mode,
+  TORCH_CHECK(valid,
       "Expected ", dim + 1, "D or ", dim + 2,
       "D (batch mode) tensor with possibly 0 batch size and other non-zero dimensions for input, but got: ",
       input.sizes());
 }
 
+// Renders the spatial extents as "D: 1 H: 2 W: 3", using the trailing
+// `sizes.size()` labels. Only ever called to build an error message.
+inline std::string spatial_sizes_str(IntArrayRef sizes, const char* sep) {
+  constexpr std::array<const char*, 3> labels = {"D: ", "H: ", "W: "};
+  std::string out;
+  for (const auto i : c10::irange(sizes.size())) {
+    if (i > 0) {
+      out += sep;
+    }
+    out += labels[labels.size() - sizes.size() + i];
+    out += std::to_string(sizes[i]);
+  }
+  return out;
+}
+
+// A reflection cannot reach past the edge of the input, so every pad must be
+// strictly smaller than the dimension it pads. Replication has no such limit.
+inline void check_pad_within_input(const Tensor& input, IntArrayRef padding, int64_t dim) {
+  const int64_t ndim = input.dim();
+  for (const auto i : c10::irange(dim)) {
+    const auto d = ndim - 1 - i;
+    TORCH_CHECK(padding[2 * i] < input.size(d) && padding[2 * i + 1] < input.size(d),
+        "Argument #", 4 + 2 * i, ": Padding size should be less than the corresponding "
+        "input dimension, but got: padding (", padding[2 * i], ", ", padding[2 * i + 1],
+        ") at dimension ", d, " of input ", input.sizes());
+  }
+}
+
+// Validates the forward inputs and returns the full output shape; only the
+// trailing `dim` dimensions differ from the input.
+inline DimVector pad_shape_check(
+    const Tensor& input, IntArrayRef padding, int64_t dim, bool is_reflection) {
+  check_valid_input(input, padding, dim);
+  if (is_reflection) {
+    check_pad_within_input(input, padding, dim);
+  }
+
+  const int64_t ndim = input.dim();
+  DimVector output_size(input.sizes());
+  bool valid_output = true;
+
+  for (const auto i : c10::irange(dim)) {
+    const auto d = ndim - 1 - i;
+    output_size[d] = input.size(d) + padding[2 * i] + padding[2 * i + 1];
+    valid_output = valid_output && output_size[d] >= 1;
+  }
+
+  const auto in_spatial = input.sizes().slice(ndim - dim);
+  const auto out_spatial = IntArrayRef(output_size).slice(ndim - dim);
+  if (dim == 1) {
+    TORCH_CHECK(valid_output,
+        "input (W: ", in_spatial[0], ") is too small."
+        " Calculated output W: ", out_spatial[0]);
+  } else {
+    TORCH_CHECK(valid_output,
+        "Calculated output ", spatial_sizes_str(out_spatial, " "),
+        " must be >= 1 in every dimension"
+        " (input ", spatial_sizes_str(in_spatial, ", "), ")");
+  }
+  return output_size;
+}
+
+// Validates gradOutput against the shape the forward pass would have produced.
+// The channel check guards a segfault: the kernels iterate over the input's
+// channels and index gradOutput with the same counter (pytorch/pytorch#142834).
+inline void pad_backward_shape_check(
+    const Tensor& grad_output, const Tensor& input, IntArrayRef padding, int64_t dim) {
+  constexpr std::array<const char*, 3> labels = {"depth", "height", "width"};
+  const int64_t ndim = input.dim();
+
+  const auto channel_dim = ndim - dim - 1;
+  TORCH_CHECK(input.size(channel_dim) == grad_output.size(channel_dim),
+      "grad_output channel unexpected. Expected: ", input.size(channel_dim),
+      ", Got: ", grad_output.size(channel_dim));
+
+  for (const auto i : c10::irange(dim)) {
+    const auto d = ndim - 1 - i;
+    const auto output_size = input.size(d) + padding[2 * i] + padding[2 * i + 1];
+    TORCH_CHECK(output_size == grad_output.size(d),
+        "grad_output ", labels[labels.size() - 1 - i], " unexpected. Expected: ", output_size,
+        ", Got: ", grad_output.size(d));
+  }
+}
+
 } // namespace padding
 
-} // at::native
+} // namespace at::native

--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -22,140 +22,23 @@
 namespace at::meta {
 
 TORCH_META_FUNC(reflection_pad1d)(const Tensor& input, IntArrayRef padding) {
-  int64_t dim_plane = 0;
-  int64_t dim_w = 1;
-  int64_t nbatch = 1;
-
-  if (input.ndimension() == 3) {
-    nbatch = input.size(0);
-    dim_w++;
-    dim_plane++;
-  }
-
-  at::native::padding::check_valid_input<1>(input, padding);
-
-  /* sizes */
-  auto pad_l = padding[0];
-  auto pad_r = padding[1];
-
-  int64_t nplane = input.size(dim_plane);
-  int64_t input_w = input.size(dim_w);
-  int64_t output_w = input_w + pad_l + pad_r;
-
-  TORCH_CHECK(
-      pad_l < input_w && pad_r < input_w,
-      "Argument #4: Padding size "
-      "should be less than the corresponding input dimension, but got: padding (",
-      pad_l,
-      ", ",
-      pad_r,
-      ") at dimension ",
-      dim_w,
-      " of input ",
-      input.sizes());
-
-  TORCH_CHECK(
-      output_w >= 1,
-      "input (W: ",
-      input_w,
-      ") is too small. Calculated output W: ",
-      output_w);
-
-  if (input.ndimension() == 2) {
-    set_output_raw_strided(0, {nplane, output_w}, {}, input.options());
-  } else {
-    set_output_raw_strided(0, {nbatch, nplane, output_w}, {}, input.options());
-  }
+  auto output_size = at::native::padding::pad_shape_check(
+      input, padding, /*dim=*/1, /*is_reflection=*/true);
+  set_output_raw_strided(0, output_size, {}, input.options());
 }
 
 TORCH_META_FUNC(reflection_pad1d_backward)(const Tensor& grad_output,
     const Tensor& input,
     IntArrayRef padding) {
-  int64_t dim_w = 1;
-  if (input.ndimension() == 3) {
-    dim_w++;
-  }
-
-  /* sizes */
-  auto pad_l = padding[0];
-  auto pad_r = padding[1];
-  int64_t input_w = input.size(dim_w);
-  int64_t output_w  = input_w + pad_l + pad_r;
-
-  TORCH_CHECK(
-      pad_l < input_w && pad_r < input_w,
-      "Argument #4: Padding size "
-      "should be less than the corresponding input dimension, but got: padding (",
-      pad_l,
-      ", ",
-      pad_r,
-      ") at dimension ",
-      dim_w,
-      " of input ",
-      input.sizes());
-
-  TORCH_CHECK(output_w == grad_output.size(dim_w), "grad_output width unexpected."
-    " Expected: ", output_w, ", Got: ", grad_output.size(dim_w));
-
+  at::native::padding::check_pad_within_input(input, padding, /*dim=*/1);
+  at::native::padding::pad_backward_shape_check(grad_output, input, padding, /*dim=*/1);
   set_output_raw_strided(0, input.sizes(), {}, input.options());
 }
 
 TORCH_META_FUNC(reflection_pad3d)(const Tensor& input, IntArrayRef padding) {
-  at::native::padding::check_valid_input<3>(input, padding);
-
-  int64_t pad_left = padding[0];
-  int64_t pad_right = padding[1];
-  int64_t pad_top = padding[2];
-  int64_t pad_bottom = padding[3];
-  int64_t pad_front = padding[4];
-  int64_t pad_back = padding[5];
-  int64_t dim_w = 3;
-  int64_t dim_h = 2;
-  int64_t dim_d = 1;
-  int64_t dim_plane = 0;
-
-  bool batch_mode = (input.dim() == 5);
-  if (batch_mode) {
-    dim_w++;
-    dim_h++;
-    dim_d++;
-    dim_plane++;
-  }
-
-  int64_t nplane = input.size(dim_plane);
-  int64_t input_d = input.size(dim_d);
-  int64_t input_h = input.size(dim_h);
-  int64_t input_w = input.size(dim_w);
-  int64_t output_d = input_d + pad_front + pad_back;
-  int64_t output_h = input_h + pad_top + pad_bottom;
-  int64_t output_w = input_w + pad_left + pad_right;
-
-  TORCH_CHECK(
-      pad_left < input_w && pad_right < input_w,
-      "Argument #4: Padding size "
-      "should be less than the corresponding input dimension, but got: padding (",
-      pad_left, ", ", pad_right, ") at dimension ", dim_w, " of input ", input.sizes());
-  TORCH_CHECK(
-      pad_top < input_h && pad_bottom < input_h,
-      "Argument #6: Padding size "
-      "should be less than the corresponding input dimension, but got: padding (",
-      pad_top, ", ", pad_bottom, ") at dimension ", dim_h, " of input ", input.sizes());
-  TORCH_CHECK(
-      pad_front < input_d && pad_back < input_d,
-      "Argument #8: Padding size "
-      "should be less than the corresponding input dimension, but got: padding (",
-      pad_front, ", ", pad_back, ") at dimension ", dim_d, " of input ", input.sizes());
-
-  TORCH_CHECK(output_w >= 1 || output_h >=1 || output_d >= 1,
-      "input (D: ", input_d, " H: ", input_h, ", W: ", input_w,
-      ") is too small."
-      " Calculated output D: ", output_d, " H: ", output_h, " W: ", output_w);
-
-  if (batch_mode) {
-    set_output_raw_strided(0, {input.size(0), nplane, output_d, output_h, output_w}, {}, input.options());
-  } else {
-    set_output_raw_strided(0, {nplane, output_d, output_h, output_w}, {}, input.options());
-  }
+  auto output_size = at::native::padding::pad_shape_check(
+      input, padding, /*dim=*/3, /*is_reflection=*/true);
+  set_output_raw_strided(0, output_size, {}, input.options());
 }
 
 TORCH_META_FUNC(reflection_pad3d_backward)(
@@ -170,36 +53,7 @@ TORCH_META_FUNC(reflection_pad3d_backward)(
   TORCH_CHECK(input.dim() > 3);
   TORCH_CHECK(grad_output.dim() == input.dim());
 
-  int64_t pad_left = padding[0];
-  int64_t pad_right = padding[1];
-  int64_t pad_top = padding[2];
-  int64_t pad_bottom = padding[3];
-  int64_t pad_front = padding[4];
-  int64_t pad_back = padding[5];
-  int64_t dim_w = 3;
-  int64_t dim_h = 2;
-  int64_t dim_d = 1;
-
-  if (input.dim() == 5) {
-    // batch mode
-    dim_w++;
-    dim_h++;
-    dim_d++;
-  }
-
-  int64_t input_d = input.size(dim_d);
-  int64_t input_h = input.size(dim_h);
-  int64_t input_w = input.size(dim_w);
-  int64_t output_d = input_d + pad_front + pad_back;
-  int64_t output_h = input_h + pad_top + pad_bottom;
-  int64_t output_w = input_w + pad_left + pad_right;
-
-  TORCH_CHECK(output_w == grad_output.size(dim_w), "grad_output width unexpected."
-    " Expected: ", output_w, ", Got: ", grad_output.size(dim_w));
-  TORCH_CHECK(output_h == grad_output.size(dim_h), "grad_output height unexpected."
-    " Expected: ", output_h, ", Got: ", grad_output.size(dim_h));
-  TORCH_CHECK(output_d == grad_output.size(dim_d), "grad_output depth unexpected."
-    " Expected: ", output_d, ", Got: ", grad_output.size(dim_d));
+  at::native::padding::pad_backward_shape_check(grad_output, input, padding, /*dim=*/3);
 
   set_output_raw_strided(0, input.sizes(), {}, input.options());
 }
@@ -211,57 +65,15 @@ namespace {
 
 void reflection_pad2d_out_template(
     Tensor &output, const Tensor &input, IntArrayRef padding) {
-  int dim_w = 2;
-  int dim_h = 1;
-  int dim_slices = 0;
-  int64_t nbatch = 1;
-
-  at::native::padding::check_valid_input<2>(input, padding);
-
-  int ndim = input.dim();
-  if (ndim == 4) {
-    nbatch = input.size(0);
-    dim_w++;
-    dim_h++;
-    dim_slices++;
-  }
-
-  /* sizes */
-  int64_t pad_l = padding[0];
-  int64_t pad_r = padding[1];
-  int64_t pad_t = padding[2];
-  int64_t pad_b = padding[3];
-
-  int64_t nplane = input.size(dim_slices);
-  int64_t input_h = input.size(dim_h);
-  int64_t input_w = input.size(dim_w);
-  int64_t output_h = input_h + pad_t + pad_b;
-  int64_t output_w  = input_w + pad_l + pad_r;
-
-  TORCH_CHECK(pad_l < input_w && pad_r < input_w,
-    "Argument #4: Padding size should be less than the corresponding "
-    "input dimension, but got: padding (", pad_l, ", ", pad_r,
-    ") at dimension ", dim_w, " of input ", input.sizes());
-
-  TORCH_CHECK(pad_t < input_h && pad_b < input_h,
-    "Argument #6: Padding size should be less than the corresponding "
-    "input dimension, but got: padding (", pad_t, ", ", pad_b,
-    ") at dimension ", dim_h, " of input ", input.sizes());
-
-  TORCH_CHECK(output_w >= 1 || output_h >= 1,
-    "input (H: ", input_h, ", W: ", input_w, ") is too small. Calculated "
-    "output H: ", output_h, " W: ", output_w);
+  auto output_size = at::native::padding::pad_shape_check(
+      input, padding, /*dim=*/2, /*is_reflection=*/true);
 
   /* resize output */
-  if (ndim == 3) {
-    output.resize_({nplane, output_h, output_w});
+  if (input.dim() == 3 || input.is_quantized()) {
+    // quantized tensor can not be resized with argument `memory_format`
+    output.resize_(output_size);
   } else {
-    if (input.is_quantized()) {
-      // quantized tensor can not be resized with argument `memory_format`
-      output.resize_({nbatch, nplane, output_h, output_w});
-    } else {
-      output.resize_({nbatch, nplane, output_h, output_w}, input.suggest_memory_format());
-    }
+    output.resize_(output_size, input.suggest_memory_format());
   }
   reflection_pad2d_kernel(kCPU, output, input, padding);
 }
@@ -269,33 +81,7 @@ void reflection_pad2d_out_template(
 void reflection_pad2d_backward_out_template(
     Tensor &grad_input, const Tensor &grad_output,
     const Tensor &input, IntArrayRef padding) {
-  int dim_w = 2;
-  int dim_h = 1;
-
-  if (input.ndimension() == 4) {
-    dim_w++;
-    dim_h++;
-  }
-
-  /* sizes */
-  int64_t pad_l = padding[0];
-  int64_t pad_r = padding[1];
-  int64_t pad_t = padding[2];
-  int64_t pad_b = padding[3];
-
-  int64_t input_h = input.size(dim_h);
-  int64_t input_w = input.size(dim_w);
-  int64_t output_h = input_h + pad_t + pad_b;
-  int64_t output_w  = input_w + pad_l + pad_r;
-
-  TORCH_CHECK(output_w == grad_output.size(dim_w),
-    "gradOutput width unexpected. Expected: ", output_w, ", Got: ",
-    grad_output.size(dim_w));
-
-  TORCH_CHECK(output_h == grad_output.size(dim_h),
-    "gradOutput height unexpected. Expected: ", output_h, ", Got: ",
-    grad_output.size(dim_h));
-
+  at::native::padding::pad_backward_shape_check(grad_output, input, padding, /*dim=*/2);
   reflection_pad2d_backward_kernel(kCPU, grad_input, grad_output, padding);
 }
 

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -19,39 +19,11 @@
 namespace at::meta {
 
 TORCH_META_FUNC(replication_pad1d) (
-  const Tensor& input, IntArrayRef paddingSize  // no out argument!
+  const Tensor& input, IntArrayRef paddingSize
 ) {
-  TORCH_CHECK(paddingSize.size() == 2, "padding size is expected to be 2");
-
-  int64_t dimw = 1;
-  int64_t dimslices = 0;
-  int64_t nbatch = 1;
-
-  int64_t pad_l = paddingSize[0];
-  int64_t pad_r = paddingSize[1];
-
-  at::native::padding::check_valid_input<1>(input, paddingSize);
-
-  if (input.ndimension() == 3) {
-    nbatch = input.size(0);
-    dimw++;
-    dimslices++;
-  }
-
-  /* sizes */
-  int64_t nslices = input.size(dimslices);
-  int64_t iwidth = input.size(dimw);
-  int64_t owidth = iwidth + pad_l + pad_r;
-
-  TORCH_CHECK(owidth >= 1,
-      "input (W: ", iwidth, ") is too small."
-      " Calculated output W: ", owidth);
-
-  if (input.ndimension() == 2) {
-    set_output_raw_strided(0, {nslices, owidth}, {}, input.options());
-  } else {
-    set_output_raw_strided(0, {nbatch, nslices, owidth}, {}, input.options());
-  }
+  auto output_size = at::native::padding::pad_shape_check(
+      input, paddingSize, /*dim=*/1, /*is_reflection=*/false);
+  set_output_raw_strided(0, output_size, {}, input.options());
 }
 
 TORCH_META_FUNC(replication_pad1d_backward) (
@@ -59,119 +31,25 @@ TORCH_META_FUNC(replication_pad1d_backward) (
   const Tensor& input,
   IntArrayRef paddingSize
 ) {
-  int64_t dimw = 1;
-  int64_t dimc = 0;
-  TORCH_CHECK(paddingSize.size() == 2, "padding size is expected to be 2");
-  int64_t pad_l = paddingSize[0];
-  int64_t pad_r = paddingSize[1];
-
-  if (input.ndimension() == 3) {
-    dimw++;
-    dimc++;
-  }
-
-  /* sizes */
-  int64_t ichannel = input.size(dimc);
-  int64_t iwidth = input.size(dimw);
-  int64_t owidth  = iwidth + pad_l + pad_r;
-
-  TORCH_CHECK(ichannel == gradOutput.size(dimc),
-      "gradOutput channel unexpected. Expected: ", ichannel,
-      ", Got: ", gradOutput.size(dimc));
-  TORCH_CHECK(owidth == gradOutput.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth,
-      " Got: ", gradOutput.size(dimw));
-
+  TORCH_CHECK(paddingSize.size() == 2, "padding size is expected to be 2, but got: ", paddingSize.size());
+  at::native::padding::pad_backward_shape_check(gradOutput, input, paddingSize, /*dim=*/1);
   set_output_raw_strided(0, input.sizes(), {}, input.options());
 }
 
 TORCH_META_FUNC(replication_pad2d) (
   const Tensor& input, IntArrayRef paddingSize
 ) {
-  TORCH_CHECK(paddingSize.size() == 4, "padding size is expected to be 4");
-  int64_t pad_l = paddingSize[0];
-  int64_t pad_r = paddingSize[1];
-  int64_t pad_t = paddingSize[2];
-  int64_t pad_b = paddingSize[3];
-  int64_t dimw = 2;
-  int64_t dimh = 1;
-  int64_t dimslices = 0;
-  int64_t nbatch = 1;
-
-  at::native::padding::check_valid_input<2>(input, paddingSize);
-
-  if (input.dim() == 4) {
-    nbatch = input.size(0);
-    dimw++;
-    dimh++;
-    dimslices++;
-  }
-
-  /* sizes */
-  int64_t nslices = input.size(dimslices);
-  int64_t iheight = input.size(dimh);
-  int64_t iwidth = input.size(dimw);
-  int64_t oheight = iheight + pad_t + pad_b;
-  int64_t owidth  = iwidth + pad_l + pad_r;
-
-  TORCH_CHECK(owidth >= 1 && oheight >= 1,
-      "Calculated output H: ", oheight, " W: ", owidth,
-      " must be >= 1 in every dimension"
-      " (input H: ", iheight, ", W: ", iwidth, ")");
-
-  if (input.dim() == 3) {
-    set_output_raw_strided(0, {nslices, oheight, owidth}, {}, input.options());
-  } else {
-    set_output_raw_strided(0, {nbatch, nslices, oheight, owidth}, {}, input.options());
-  }
+  auto output_size = at::native::padding::pad_shape_check(
+      input, paddingSize, /*dim=*/2, /*is_reflection=*/false);
+  set_output_raw_strided(0, output_size, {}, input.options());
 }
 
 TORCH_META_FUNC(replication_pad3d) (
   const Tensor& input, IntArrayRef paddingSize
 ) {
-  TORCH_CHECK(paddingSize.size() == 6, "padding size is expected to be 6");
-  int64_t pleft = paddingSize[0];
-  int64_t pright = paddingSize[1];
-  int64_t ptop = paddingSize[2];
-  int64_t pbottom = paddingSize[3];
-  int64_t pfront = paddingSize[4];
-  int64_t pback = paddingSize[5];
-  int64_t dimw = 3;
-  int64_t dimh = 2;
-  int64_t dimd = 1;
-  int64_t dimslices = 0;
-  int64_t nbatch = 1;
-
-  at::native::padding::check_valid_input<3>(input, paddingSize);
-
-  if (input.dim() == 5) {
-    nbatch = input.size(0);
-    dimw++;
-    dimh++;
-    dimd++;
-    dimslices++;
-  }
-
-  /* sizes */
-  int64_t nslices = input.size(dimslices);
-  int64_t idepth = input.size(dimd);
-  int64_t iheight = input.size(dimh);
-  int64_t iwidth = input.size(dimw);
-  int64_t odepth = idepth + pfront + pback;
-  int64_t oheight = iheight + ptop + pbottom;
-  int64_t owidth  = iwidth + pleft + pright;
-
-  TORCH_CHECK(owidth >= 1 && oheight >= 1 && odepth >= 1,
-      "Calculated output D: ", odepth, " H: ", oheight, " W: ", owidth,
-      " must be >= 1 in every dimension"
-      " (input D: ", idepth, ", H: ", iheight, ", W: ", iwidth, ")");
-
-  /* resize output */
-  if (input.dim() == 4) {
-    set_output_raw_strided(0, {nslices, odepth, oheight, owidth}, {}, input.options());
-  } else {
-    set_output_raw_strided(0, {nbatch, nslices, odepth, oheight, owidth}, {}, input.options());
-  }
+  auto output_size = at::native::padding::pad_shape_check(
+      input, paddingSize, /*dim=*/3, /*is_reflection=*/false);
+  set_output_raw_strided(0, output_size, {}, input.options());
 }
 
 } // namespace at::meta
@@ -186,37 +64,8 @@ void replication_pad2d_backward_out_cpu_template(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  TORCH_CHECK(paddingSize.size() == 4, "padding size is expected to be 4");
-  int pad_l = paddingSize[0];
-  int pad_r = paddingSize[1];
-  int pad_t = paddingSize[2];
-  int pad_b = paddingSize[3];
-  int dimc = 0;
-  int dimw = 2;
-  int dimh = 1;
-
-  if (input.dim() == 4) {
-    dimc++;
-    dimw++;
-    dimh++;
-  }
-
-  /* sizes */
-  int64_t ichannel = input.size(dimc);
-  int64_t iheight = input.size(dimh);
-  int64_t iwidth = input.size(dimw);
-  int64_t oheight = iheight + pad_t + pad_b;
-  int64_t owidth  = iwidth + pad_l + pad_r;
-
-  TORCH_CHECK(ichannel == gradOutput.size(dimc),
-      "gradOutput channel unexpected. Expected: ", ichannel, ", Got: ",
-      gradOutput.size(dimc));
-  TORCH_CHECK(owidth == gradOutput.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
-      gradOutput.size(dimw));
-  TORCH_CHECK(oheight == gradOutput.size(dimh),
-      "gradOutput height unexpected. Expected: ", oheight, ", Got: ",
-      gradOutput.size(dimh));
+  at::native::padding::check_valid_input(input, paddingSize, /*dim=*/2);
+  at::native::padding::pad_backward_shape_check(gradOutput, input, paddingSize, /*dim=*/2);
 
   if (gradInput.numel() == 0) {
     return;
@@ -231,48 +80,8 @@ void replication_pad3d_backward_out_cpu_template(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  TORCH_CHECK(paddingSize.size() == 6, "padding size is expected to be 6");
-  int pleft = paddingSize[0];
-  int pright = paddingSize[1];
-  int ptop = paddingSize[2];
-  int pbottom = paddingSize[3];
-  int pfront = paddingSize[4];
-  int pback = paddingSize[5];
-  int dimc = 0;
-  int dimw = 3;
-  int dimh = 2;
-  int dimd = 1;
-
-  if (input.dim() == 5) {
-    dimc++;
-    dimw++;
-    dimh++;
-    dimd++;
-  }
-
-  /* sizes */
-  int64_t ichannel = input.size(dimc);
-  int64_t idepth = input.size(dimd);
-  int64_t iheight = input.size(dimh);
-  int64_t iwidth = input.size(dimw);
-  int64_t odepth = idepth + pfront + pback;
-  int64_t oheight = iheight + ptop + pbottom;
-  int64_t owidth  = iwidth + pleft + pright;
-
-  at::native::padding::check_valid_input<3>(input, paddingSize);
-
-  TORCH_CHECK(ichannel == gradOutput.size(dimc),
-      "gradOutput channel unexpected. Expected: ", ichannel, ", Got: ",
-      gradOutput.size(dimc));
-  TORCH_CHECK(owidth == gradOutput.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
-      gradOutput.size(dimw));
-  TORCH_CHECK(oheight == gradOutput.size(dimh),
-      "gradOutput height unexpected. Expected: ", oheight, ", Got: ",
-      gradOutput.size(dimh));
-  TORCH_CHECK(odepth == gradOutput.size(dimd),
-      "gradOutput depth unexpected. Expected: ", odepth, ", Got: ",
-      gradOutput.size(dimd));
+  at::native::padding::check_valid_input(input, paddingSize, /*dim=*/3);
+  at::native::padding::pad_backward_shape_check(gradOutput, input, paddingSize, /*dim=*/3);
 
   if (gradInput.numel() == 0) {
     return;

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -540,51 +540,21 @@ void reflection_pad2d_out_template(
   TORCH_CHECK(canUse32BitIndexMath(input_),
     "input tensor must fit into 32-bit index math");
 
-  int plane_dim = 0;
-  int dim_h = 1;
-  int dim_w = 2;
-  int nbatch = 1;
+  const auto output_size = at::native::padding::pad_shape_check(
+      input_, padding, /*dim=*/2, /*is_reflection=*/true);
+  output.resize_(output_size);
 
-  at::native::padding::check_valid_input<2>(input_, padding);
-
-  if (input_.ndimension() == 4) {
-    nbatch = input_.size(0);
-    plane_dim++;
-    dim_h++;
-    dim_w++;
-  }
-
-  int64_t pad_l = padding[0];
-  int64_t pad_r = padding[1];
-  int64_t pad_t = padding[2];
-  int64_t pad_b = padding[3];
-
-  int nplane = input_.size(plane_dim);
-  int input_h = input_.size(dim_h);
-  int input_w = input_.size(dim_w);
-
-  TORCH_CHECK(pad_l < input_w && pad_r < input_w,
-    "Padding size should be less than the corresponding input dimension, but "
-    "got: padding (", pad_l, ", ", pad_r, ") at dimension ", dim_w,
-    " of input ", input_.sizes());
-
-  TORCH_CHECK(pad_t < input_h && pad_b < input_h,
-    "Padding size should be less than the corresponding input dimension, but "
-    "got: padding (", pad_t, ", ", pad_b, ") at dimension ", dim_h,
-    " of input ", input_.sizes());
-
-  int output_h = input_h + pad_t + pad_b;
-  int output_w  = input_w + pad_l + pad_r;
-
-  TORCH_CHECK(output_w >= 1 || output_h >= 1,
-    "input (H: ", input_h, ", W: ", input_w, ") is too small.  Calculated "
-    "output H: ", output_h, " W: ", output_w);
-
-  if (input_.ndimension() == 3) {
-    output.resize_({nplane, output_h, output_w});
-  } else {
-    output.resize_({nbatch, nplane, output_h, output_w});
-  }
+  const auto ndim = input_.ndimension();
+  const int nbatch = ndim == 4 ? input_.size(0) : 1;
+  const int nplane = input_.size(ndim - 3);
+  const int64_t input_h = input_.size(ndim - 2);
+  const int64_t input_w = input_.size(ndim - 1);
+  const int64_t output_h = output_size[ndim - 2];
+  const int64_t output_w = output_size[ndim - 1];
+  const int pad_l = padding[0];
+  const int pad_r = padding[1];
+  const int pad_t = padding[2];
+  const int pad_b = padding[3];
   if (output.numel() == 0) {
     return;
   }
@@ -628,44 +598,19 @@ void reflection_pad2d_backward_out_template(
     return;
   }
 
-  int plane_dim = 0;
-  int dim_h = 1;
-  int dim_w = 2;
-  int nbatch = 1;
+  at::native::padding::pad_backward_shape_check(grad_output_, input, padding, /*dim=*/2);
 
-  if (input.ndimension() == 4) {
-    nbatch = input.size(0);
-    plane_dim++;
-    dim_h++;
-    dim_w++;
-  }
-
-  int64_t pad_l = padding[0];
-  int64_t pad_r = padding[1];
-  int64_t pad_t = padding[2];
-  int64_t pad_b = padding[3];
-
-  int nplane = input.size(plane_dim);
-  int input_h = input.size(dim_h);
-  int input_w = input.size(dim_w);
-
-  int output_h = input_h + pad_t + pad_b;
-  int output_w = input_w + pad_l + pad_r;
-
-  TORCH_CHECK(
-      output_w == grad_output_.size(dim_w),
-      "grad_output width "
-      "unexpected. Expected: ",
-      output_w,
-      ", Got: ",
-      grad_output_.size(dim_w));
-  TORCH_CHECK(
-      output_h == grad_output_.size(dim_h),
-      "grad_output height "
-      "unexpected. Expected: ",
-      output_h,
-      ", Got: ",
-      grad_output_.size(dim_h));
+  const auto ndim = input.ndimension();
+  const int nbatch = ndim == 4 ? input.size(0) : 1;
+  const int nplane = input.size(ndim - 3);
+  const int64_t input_h = input.size(ndim - 2);
+  const int64_t input_w = input.size(ndim - 1);
+  const int64_t output_h = input_h + padding[2] + padding[3];
+  const int64_t output_w = input_w + padding[0] + padding[1];
+  const int pad_l = padding[0];
+  const int pad_r = padding[1];
+  const int pad_t = padding[2];
+  const int pad_b = padding[3];
 
   Tensor grad_output = grad_output_.contiguous();
 

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -5,6 +5,7 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/native/Padding.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/Utils.h>
 #include <c10/util/Exception.h>
@@ -236,37 +237,12 @@ void replication_pad2d_backward_out_cuda_template(
       "input tensor must fit into 32-bit index math");
   TORCH_CHECK(at::cuda::detail::canUse32BitIndexMath(gradOutput),
       "output gradient tensor must fit into 32-bit index math");
-  TORCH_CHECK(paddingSize.size() == 4, "padding Size is expected to be 4");
+  at::native::padding::check_valid_input(input, paddingSize, /*dim=*/2);
+  at::native::padding::pad_backward_shape_check(gradOutput, input, paddingSize, /*dim=*/2);
 
   const auto padL = paddingSize[0];
-  const auto padR = paddingSize[1];
   const auto padT = paddingSize[2];
-  const auto padB = paddingSize[3];
-  int dimc = 0;
-  int dimh = 1;
-  int dimw = 2;
-
-  int numInputDims = input.dim();
-  if (numInputDims == 4) {
-    dimc++;
-    dimh++;
-    dimw++;
-  }
-  const auto ichannel = input.size(dimc);
-  const auto iheight = input.size(dimh);
-  const auto iwidth = input.size(dimw);
-  const auto oheight = iheight + padT + padB;
-  const auto owidth  = iwidth + padL + padR;
-
-  TORCH_CHECK(ichannel == gradOutput.size(dimc),
-      "gradOutput channel unexpected. Expected: ", ichannel, ", Got: ",
-      gradOutput.size(dimc));
-  TORCH_CHECK(owidth == gradOutput.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
-      gradOutput.size(dimw));
-  TORCH_CHECK(oheight == gradOutput.size(dimh),
-      "gradOutput height unexpected. Expected: ", oheight, ", Got: ",
-      gradOutput.size(dimh));
+  const int numInputDims = input.dim();
 
   gradInput.resize_as_(input);
   if (gradInput.numel() == 0) {
@@ -310,58 +286,14 @@ void replication_pad2d_backward_out_cuda_template(
 static inline void shapeAndGradOutputCheck3d(
     const Tensor& input,
     const Tensor& gradOutput,
-    int pleft, int pright,
-    int ptop, int pbottom,
-    int pfront, int pback) {
+    IntArrayRef paddingSize) {
   TORCH_CHECK(at::cuda::detail::canUse32BitIndexMath(input),
       "input tensor must fit into 32-bit index math");
-  int numInputDims = input.dim();
-
-  bool valid_dims = input.size(1) != 0 && input.size(2) != 0 && input.size(3) != 0;
-  TORCH_CHECK(
-      (numInputDims == 4 && valid_dims) ||
-      (numInputDims == 5 && valid_dims && input.size(4) != 0),
-      "Expected 4D or 5D (batch mode) tensor with possibly 0 batch size and other non-zero dimensions for input, but got: ",
-      input.sizes());
-
-  int planeDim = 0;
-  int dimd = 1;
-  int dimh = 2;
-  int dimw = 3;
-  if (numInputDims == 5) {
-    planeDim++;
-    dimd++;
-    dimh++;
-    dimw++;
-  }
-
-  int numPlanes = input.size(planeDim);
-  int idepth = input.size(dimd);
-  int iheight = input.size(dimh);
-  int iwidth = input.size(dimw);
-  int odepth = idepth + pfront + pback;
-  int oheight = iheight + ptop + pbottom;
-  int owidth  = iwidth + pleft + pright;
-  TORCH_CHECK(owidth >= 1 || oheight >= 1 || odepth >= 1,
-      "input (D: ", idepth, " H: ", iheight, ", W: ", iwidth,
-      ") is too small."
-      " Calculated output D: ", odepth, " H: ", oheight, " W: ", owidth);
-
   TORCH_CHECK(at::cuda::detail::canUse32BitIndexMath(gradOutput),
       "output gradient tensor must fit into 32-bit index math");
-
-  TORCH_CHECK(numPlanes == gradOutput.size(planeDim),
-      "gradOutput width unexpected. Expected: ", numPlanes, ", Got: ",
-      gradOutput.size(planeDim));
-  TORCH_CHECK(owidth == gradOutput.size(dimw),
-      "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
-      gradOutput.size(dimw));
-  TORCH_CHECK(oheight == gradOutput.size(dimh),
-      "gradOutput height unexpected. Expected: ", oheight, ", Got: ",
-      gradOutput.size(dimh));
-  TORCH_CHECK(odepth == gradOutput.size(dimd),
-      "gradOutput depth unexpected. Expected: ", odepth, ", Got: ",
-      gradOutput.size(dimd));
+  at::native::padding::pad_shape_check(
+      input, paddingSize, /*dim=*/3, /*is_reflection=*/false);
+  at::native::padding::pad_backward_shape_check(gradOutput, input, paddingSize, /*dim=*/3);
 }
 
 void replication_pad3d_backward_out_cuda_template(
@@ -370,18 +302,12 @@ void replication_pad3d_backward_out_cuda_template(
     const Tensor& input,
     IntArrayRef paddingSize)
 {
-  TORCH_CHECK(paddingSize.size() == 6, "padding Size is expected to be 6");
+  shapeAndGradOutputCheck3d(input, gradOutput, paddingSize);
+
   const auto pleft = paddingSize[0];
-  const auto pright = paddingSize[1];
   const auto ptop = paddingSize[2];
-  const auto pbottom = paddingSize[3];
   const auto pfront = paddingSize[4];
-  const auto pback = paddingSize[5];
-  shapeAndGradOutputCheck3d(input, gradOutput, pleft, pright, ptop,
-      pbottom, pfront, pback);
-
-
-  int numInputDims = input.dim();
+  const int numInputDims = input.dim();
 
   gradInput.resize_as_(input);
   if (gradInput.numel() == 0) {

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/Padding.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/Pad.h>
 #include <c10/metal/common.h>
@@ -46,7 +47,7 @@ static Tensor& pad_out_template(Tensor& output,
                                 const std::string& op_name) {
   using CachedGraph = MPSUnaryGradCachedGraph;
   const int padding_size = (int)padding.size();
-  int padding_dim = padding_size / 2; // either 1D, 2D, or 3D
+  const int64_t padding_dim = padding_size / 2; // either 1D, 2D, or 3D
 
   TORCH_CHECK(
       padding_size == 2 || padding_size == 4 || padding_size == 6, "invalid padding argument of size ", padding_size);
@@ -54,152 +55,25 @@ static Tensor& pad_out_template(Tensor& output,
   const Tensor& grad_output_ = *(at::borrow_from_optional_tensor(grad_output_opt));
   const bool is_backward_pass = grad_output_.defined();
 
-  int64_t nbatch = 1;
   int64_t ndims = input_.ndimension();
-
-  TORCH_CHECK(ndims >= (int64_t)padding_dim,
-              "Length of pad should be no more than twice the number of "
-              "dimensions of the input. Pad length is ",
-              padding_size,
-              "while the input has ",
-              ndims,
-              "dimensions.");
-
-  // number of input dims with ConstantPad could be less than 2
-  int dim_w = padding_dim;
-  int dim_h = padding_dim - 1;
-  int dim_d = padding_dim - 2;
-  int dim_slices = 0;
-
-  if (!is_backward_pass && ndims > padding_dim) {
-    // allow empty batch size but not other dimensions
-    const bool batch_mode = ndims == 2 + padding_dim;
-    const auto non_batch_sizes = input_.sizes().slice(batch_mode ? 1 : 0);
-    TORCH_CHECK((batch_mode || ndims == 1 + padding_dim) &&
-                    std::ranges::all_of(non_batch_sizes, [](int64_t size) { return size != 0; }),
-                "Expected ",
-                1 + padding_dim,
-                "D or ",
-                2 + padding_dim,
-                "D (batch mode) tensor with possibly 0 batch size and other non-zero dimensions for input, but got: ",
-                input_.sizes());
-  }
-
-  if (ndims == padding_dim) {
-    dim_w--;
-    dim_h--;
-    dim_d--;
-  } else if (ndims > padding_dim + 1) {
-    const int dim_diff = (int)ndims - padding_dim - 1;
-    // this virtually inflates the padding with zeros if ndims > padding_dim + 2
-    padding_dim += dim_diff - 1;
-    dim_w += dim_diff;
-    dim_h += dim_diff;
-    dim_d += dim_diff;
-    dim_slices++;
-    nbatch = input_.size(0);
-  }
-
-  int64_t pad_l = padding[0];
-  int64_t pad_r = padding[1];
-  int64_t pad_t = padding_size > 2 ? padding[2] : 0;
-  int64_t pad_b = padding_size > 2 ? padding[3] : 0;
-  int64_t pad_front = padding_size > 4 ? padding[4] : 0;
-  int64_t pad_back = padding_size > 4 ? padding[5] : 0;
-
-  int64_t nplane = input_.size(dim_slices);
-  int64_t input_w = input_.size(dim_w);
-  int64_t output_w = input_w + pad_l + pad_r;
-  int64_t input_h = padding_dim > 1 ? input_.size(dim_h) : 0;
-  int64_t output_h = padding_dim > 1 ? input_h + pad_t + pad_b : 0;
-  int64_t input_d = padding_dim > 2 ? input_.size(dim_d) : 0;
-  int64_t output_d = padding_dim > 2 ? input_d + pad_front + pad_back : 0;
+  const bool is_reflection = mode == MPSGraphPaddingModeReflect;
 
   Tensor grad_output, input = input_;
 
   if (!is_backward_pass) {
-    TORCH_CHECK(output_w >= 1 || output_h >= padding_dim - 1,
-                "input (H: ",
-                input_h,
-                ", W: ",
-                input_w,
-                ") is too small. Calculated "
-                "output H: ",
-                output_h,
-                " W: ",
-                output_w);
-
-    std::vector<int64_t> outputSizes;
-    // these checks are only relevant for reflection padding (code taken from ReflectionPad.cpp)
-    if (mode == MPSGraphPaddingModeReflect) {
-      TORCH_CHECK(pad_l < input_w && pad_r < input_w,
-                  "Argument #4: Padding size should be less than the corresponding "
-                  "input dimension, but got: padding (",
-                  pad_l,
-                  ", ",
-                  pad_r,
-                  ") at dimension ",
-                  dim_w,
-                  " of input ",
-                  input_.sizes());
-
-      if (padding_dim > 1) {
-        TORCH_CHECK(pad_t < input_h && pad_b < input_h,
-                    "Argument #6: Padding size should be less than the corresponding "
-                    "input dimension, but got: padding (",
-                    pad_t,
-                    ", ",
-                    pad_b,
-                    ") at dimension ",
-                    dim_h,
-                    " of input ",
-                    input_.sizes());
-      }
-      if (padding_dim > 2) {
-        TORCH_CHECK(pad_front < input_d && pad_back < input_d,
-                    "Argument #8: Padding size should be less than the corresponding "
-                    "input dimension, but got: padding (",
-                    pad_front,
-                    ", ",
-                    pad_back,
-                    ") at dimension ",
-                    dim_d,
-                    " of input ",
-                    input_.sizes());
-      }
-    }
-    outputSizes.insert(outputSizes.begin(), output_w);
-    if (padding_dim >= 2)
-      outputSizes.insert(outputSizes.begin(), output_h);
-    if (padding_dim >= 3)
-      outputSizes.insert(outputSizes.begin(), output_d);
-    if (ndims >= 1 + padding_dim)
-      outputSizes.insert(outputSizes.begin(), nplane);
-    if (ndims >= 2 + padding_dim)
-      outputSizes.insert(outputSizes.begin(), nbatch);
-
-    output.resize_(outputSizes);
-
+    const auto output_size = at::native::padding::pad_shape_check(input_, padding, padding_dim, is_reflection);
+    output.resize_(output_size);
     if (output.numel() == 0) {
       return output;
     }
     input = input_.contiguous();
   } else {
-    TORCH_CHECK(output_w == grad_output_.size(dim_w),
-                "gradOutput width unexpected. Expected: ",
-                output_w,
-                ", Got: ",
-                grad_output_.size(dim_w));
-    if (padding_dim > 1) {
-      TORCH_CHECK(output_h == grad_output_.size(dim_h),
-                  "gradOutput height unexpected. Expected: ",
-                  output_h,
-                  ", Got: ",
-                  grad_output_.size(dim_h));
-    }
+    at::native::padding::check_valid_input(input_, padding, padding_dim);
+    at::native::padding::pad_backward_shape_check(grad_output_, input_, padding, padding_dim);
     output.resize_as_(input);
-    if (output.numel() == 0 || grad_output_.numel() == 0)
+    if (output.numel() == 0 || grad_output_.numel() == 0) {
       return output;
+    }
     grad_output = grad_output_.contiguous();
   }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8739,19 +8739,19 @@ class TestNNDeviceType(NNTestCase):
                 padding=[0, 0, 0, 0, -2, -2])
 
     @onlyNativeDeviceTypes
-    @skipMPS  # MPS routes through a separate kernel (mps::pad_out_template) that does not validate the channel dim
-    def test_ReplicationPad_backward_channel_mismatch(self, device):
+    def test_Pad_backward_channel_mismatch(self, device):
         # regression test for https://github.com/pytorch/pytorch/issues/142834: a
         # gradOutput whose channel dim doesn't match the input used to segfault in
         # the backward pass instead of raising a clear error.
-        for backward, inp, grad_output, padding in [
-            (torch.ops.aten.replication_pad1d_backward,
-             torch.ones(2, 2, 4, device=device), torch.ones(2, 0, 8, device=device), [2, 2]),
-            (torch.ops.aten.replication_pad2d_backward,
-             torch.ones(2, 2, 4, 4, device=device), torch.ones(2, 0, 6, 8, device=device), [2, 2, 1, 1]),
-        ]:
-            with self.assertRaisesRegex(RuntimeError, "gradOutput channel unexpected"):
-                backward(grad_output, inp, padding)
+        for name in ["reflection", "replication"]:
+            for inp, grad_output, padding in [
+                ((2, 2, 4), (2, 0, 8), [2, 2]),
+                ((2, 2, 4, 4), (2, 0, 6, 8), [2, 2, 1, 1]),
+                ((2, 2, 4, 4, 4), (2, 0, 6, 6, 8), [2, 2, 1, 1, 1, 1]),
+            ]:
+                backward = getattr(torch.ops.aten, f"{name}_pad{len(padding) // 2}d_backward")
+                with self.assertRaisesRegex(RuntimeError, "grad_output channel unexpected"):
+                    backward(torch.ones(grad_output, device=device), torch.ones(inp, device=device), padding)
 
     def test_ReplicationPad1d_large(self, device):
         shapes = ([2, 65736, 4], [65736, 2, 4])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2252,6 +2252,11 @@ def _pad1d_backward_common(grad_output, input, padding, *, is_reflection):
             ),
         )
 
+    dim_c = dim_w - 1
+    torch._check(
+        input.size(dim_c) == grad_output.size(dim_c),
+        lambda: f"grad_output channel unexpected. Expected: {input.size(dim_c)}, Got: {grad_output.size(dim_c)}",
+    )
     torch._check(
         output_w == grad_output.size(dim_w),
         lambda: f"grad_output width unexpected. Expected: {output_w}, Got: {grad_output.size(dim_w)}",
@@ -2388,6 +2393,10 @@ def meta_pad2d_backward(grad_output, self, padding):
     output_w = input_w + pad_l + pad_r
 
     torch._check(
+        self_shape[dim_plane] == grad_output.size(dim_plane),
+        lambda: f"grad_output channel unexpected. Expected: {self_shape[dim_plane]}, Got: {grad_output.size(dim_plane)}",
+    )
+    torch._check(
         output_w == grad_output.size(dim_w),
         lambda: f"grad_output width unexpected. Expected: {output_w}, Got: {grad_output.size(dim_w)}",
     )
@@ -2515,6 +2524,11 @@ def meta_pad3d_backward(grad_output, input, padding):
     output_h = input_h + pad_t + pad_b
     output_w = input_w + pad_l + pad_r
 
+    dim_c = dim_d - 1
+    torch._check(
+        input.size(dim_c) == grad_output.size(dim_c),
+        lambda: f"grad_output channel unexpected. Expected: {input.size(dim_c)}, Got: {grad_output.size(dim_c)}",
+    )
     torch._check(
         output_w == grad_output.size(dim_w),
         lambda: f"grad_output width unexpected. Expected: {output_w}, Got: {grad_output.size(dim_w)}",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #196457

Similar to the pooling input validation unification (https://github.com/pytorch/pytorch/pull/196230), the six pad ops hand-wrote the same shape checks in a dozen places across CPU, CUDA and MPS, and the copies had drifted. Collect them in Padding.h next to the existing check_valid_input, parameterized by rank and by whether the caller is reflection padding, and route every backend through them. All three now report identical errors, matching the already-unified meta implementations in _meta_registrations.py, so eager and torch.compile agree too.

Consolidating turns up two bugs. Reflection's "output too small" guard used || where replication used &&, so a non-positive output dimension slipped through whenever another dimension was fine and F.pad reached the allocator instead of raising; MPS had its own broken spelling of the same guard, which for 1d never fired at all. Separately, the backward channel-dim check added for replication in #142834 was never applied to reflection, which still crashed on a mismatched gradOutput, and MPS validated the channel dim for neither family, so it aborted on a Metal assertion -- the @skipMPS on that regression test is gone. The shared backward helper checks it for both families, and the meta registrations gain the same check so the two do not diverge again.

Review Padding.h first for the new helpers, then the CPU call sites, then CUDA and MPS, which additionally drop dimension bookkeeping that existed only to feed the deleted checks.

This PR was authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>