### PR TITLE
[dynamo] Type metrics storage as object

### DIFF
--- a/test/dynamo/test_metrics_context.py
+++ b/test/dynamo/test_metrics_context.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
-from torch._dynamo.metrics_context import MetricsContext, TopN
+from torch._dynamo.metrics_context import MetricsContext, RuntimeMetricsContext, TopN
 from torch._dynamo.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import HardwareClassification
 
@@ -8,15 +8,22 @@ from torch.testing._internal.common_utils import HardwareClassification
 class TestMetricsContext(TestCase):
     hw_classification = HardwareClassification.GENERIC
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
-        self.metrics = {}
+        self.metrics: dict[str, object] = {}
 
-    def _on_exit(self, start_ns, end_ns, metrics, exc_type, exc_value):
+    def _on_exit(
+        self,
+        start_ns: int,
+        end_ns: int,
+        metrics: dict[str, object],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+    ) -> None:
         # Save away the metrics to be validated in the test.
         self.metrics = metrics.copy()
 
-    def test_context_exists(self):
+    def test_context_exists(self) -> None:
         """
         Setting a value without entering the context should raise.
         """
@@ -28,9 +35,9 @@ class TestMetricsContext(TestCase):
             context.set("m", 1)
 
         with self.assertRaisesRegex(RuntimeError, "outside of a MetricsContext"):
-            context.update({"m", 1})
+            context.update({"m": 1})
 
-    def test_nested_context(self):
+    def test_nested_context(self) -> None:
         """
         Only the outermost context should get an on_exit call, and it should
         include everything.
@@ -43,7 +50,7 @@ class TestMetricsContext(TestCase):
             context.set("m2", 2)
         self.assertEqual(self.metrics, {"m1": 1, "m2": 2})
 
-    def test_set(self):
+    def test_set(self) -> None:
         """
         Validate various ways to set metrics.
         """
@@ -54,7 +61,7 @@ class TestMetricsContext(TestCase):
 
         self.assertEqual(self.metrics, {"m1": 1, "m2": 2, "m3": 3, "m4": 4})
 
-    def test_set_disallow_overwrite(self):
+    def test_set_disallow_overwrite(self) -> None:
         """
         Validate set won't overwrite.
         """
@@ -65,7 +72,7 @@ class TestMetricsContext(TestCase):
 
         self.assertEqual(self.metrics, {"m1": 1})
 
-    def test_update_disallow_overwrite(self):
+    def test_update_disallow_overwrite(self) -> None:
         """
         Validate update won't overwrite.
         """
@@ -74,7 +81,7 @@ class TestMetricsContext(TestCase):
             with self.assertRaisesRegex(RuntimeError, "already been set"):
                 context.update({"m1": 7, "m3": 3})
 
-    def test_update_allow_overwrite(self):
+    def test_update_allow_overwrite(self) -> None:
         """
         Validate update will overwrite when given param.
         """
@@ -84,7 +91,7 @@ class TestMetricsContext(TestCase):
 
         self.assertEqual(self.metrics, {"m1": 7, "m2": 2, "m3": 3})
 
-    def test_add_to_set(self):
+    def test_add_to_set(self) -> None:
         """
         Validate add_to_set.
         """
@@ -98,7 +105,7 @@ class TestMetricsContext(TestCase):
         self.assertTrue(isinstance(self.metrics["m1"], set))
         self.assertTrue(isinstance(self.metrics["m2"], set))
 
-    def test_set_key_value(self):
+    def test_set_key_value(self) -> None:
         with MetricsContext(self._on_exit) as context:
             context.set_key_value("feature_usage", "k", True)
             # Overrides allowed
@@ -107,7 +114,7 @@ class TestMetricsContext(TestCase):
 
         self.assertEqual(self.metrics, {"feature_usage": {"k": True, "k2": False}})
 
-    def test_top_n(self):
+    def test_top_n(self) -> None:
         top_n = TopN(3)
         for k, v in (("seven", 7), ("four", 4), ("five", 5), ("six", 6), ("eight", 8)):
             top_n.add(k, v)
@@ -115,6 +122,23 @@ class TestMetricsContext(TestCase):
         self.assertEqual(len(top_n), 3)
         print(list(top_n))
         self.assertEqual(list(top_n), [("eight", 8), ("seven", 7), ("six", 6)])
+
+    def test_runtime_metrics(self) -> None:
+        context = RuntimeMetricsContext(self._on_exit)
+        context.increment(
+            "m1", 1, {"compile_id": None, "is_runtime": True, "metadata": {"k": 1}}
+        )
+        context.increment("m1", 2, {"metadata": {"ignored": 2}})
+        context.finish()
+
+        self.assertEqual(
+            self.metrics,
+            {
+                "m1": 3,
+                "is_runtime": True,
+                "metadata": {"k": 1},
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -40,9 +40,9 @@ class TopN:
 
     def __init__(self, at_most: int = 25) -> None:
         self.at_most = at_most
-        self.heap: list[tuple[int, object]] = []
+        self.heap: list[tuple[int, str]] = []
 
-    def add(self, key: object, val: int) -> None:
+    def add(self, key: str, val: int) -> None:
         # Push if we haven't reached the max size, else push and pop the smallest
         fn = heapq.heappush if len(self.heap) < self.at_most else heapq.heappushpop
         fn(self.heap, (val, key))
@@ -50,7 +50,7 @@ class TopN:
     def __len__(self) -> int:
         return len(self.heap)
 
-    def __iter__(self) -> Iterator[tuple[object, int]]:
+    def __iter__(self) -> Iterator[tuple[str, int]]:
         return ((key, val) for val, key in sorted(self.heap, reverse=True))
 
 
@@ -158,7 +158,7 @@ class MetricsContext:
             raise RuntimeError(f"Cannot set {metric} outside of a MetricsContext")
         if metric not in self._metrics:
             self._metrics[metric] = {}
-        cast(dict[str, object], self._metrics[metric])[key] = value
+        cast("dict[str, object]", self._metrics[metric])[key] = value
 
     def update(self, values: dict[str, object], overwrite: bool = False) -> None:
         """
@@ -195,9 +195,9 @@ class MetricsContext:
             raise RuntimeError(f"Cannot add {metric} outside of a MetricsContext")
         if metric not in self._metrics:
             self._metrics[metric] = set()
-        cast(set[object], self._metrics[metric]).add(value)
+        cast("set[object]", self._metrics[metric]).add(value)
 
-    def add_top_n(self, metric: str, key: object, val: int) -> None:
+    def add_top_n(self, metric: str, key: str, val: int) -> None:
         """
         Records a metric as a TopN set of values.
         """

--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -19,12 +19,13 @@ import heapq
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING, TypeAlias
+from typing import cast, TYPE_CHECKING, TypeAlias
 from typing_extensions import Self
 
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from types import TracebackType
 
 from torch.utils._traceback import CapturedTraceback
 
@@ -39,9 +40,9 @@ class TopN:
 
     def __init__(self, at_most: int = 25) -> None:
         self.at_most = at_most
-        self.heap: list[tuple[int, Any]] = []
+        self.heap: list[tuple[int, object]] = []
 
-    def add(self, key: Any, val: int) -> None:
+    def add(self, key: object, val: int) -> None:
         # Push if we haven't reached the max size, else push and pop the smallest
         fn = heapq.heappush if len(self.heap) < self.at_most else heapq.heappushpop
         fn(self.heap, (val, key))
@@ -49,12 +50,12 @@ class TopN:
     def __len__(self) -> int:
         return len(self.heap)
 
-    def __iter__(self) -> Iterator[tuple[Any, int]]:
+    def __iter__(self) -> Iterator[tuple[object, int]]:
         return ((key, val) for val, key in sorted(self.heap, reverse=True))
 
 
 OnExitType: TypeAlias = Callable[
-    [int, int, dict[str, Any], type[BaseException] | None, BaseException | None],
+    [int, int, dict[str, object], type[BaseException] | None, BaseException | None],
     None,
 ]
 
@@ -68,7 +69,7 @@ class MetricsContext:
         all metrics set during the lifetime of the contextmanager.
         """
         self._on_exit = on_exit
-        self._metrics: dict[str, Any] = {}
+        self._metrics: dict[str, object] = {}
         self._start_time_ns: int = 0
         self._level: int = 0
         self._edits: list[tuple[CapturedTraceback, set[str]]] = []
@@ -89,7 +90,7 @@ class MetricsContext:
         self,
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
-        _traceback: Any,
+        _traceback: TracebackType | None,
     ) -> None:
         """
         At exit, call the provided on_exit function.
@@ -120,7 +121,7 @@ class MetricsContext:
             raise RuntimeError(f"Cannot increment {metric} outside of a MetricsContext")
         if metric not in self._metrics:
             self._metrics[metric] = 0
-        self._metrics[metric] += value
+        self._metrics[metric] = cast(int, self._metrics[metric]) + value
 
     def _render_edits(self, pred: set[str]) -> str:
         return "\n\n" + "\n\n".join(
@@ -129,7 +130,7 @@ class MetricsContext:
             if k & pred
         )
 
-    def set(self, metric: str, value: Any, overwrite: bool = False) -> None:
+    def set(self, metric: str, value: object, overwrite: bool = False) -> None:
         """
         Set a metric to a given value. Raises if the metric has been assigned previously
         in the current context.
@@ -145,7 +146,7 @@ class MetricsContext:
         self._edits.append((CapturedTraceback.extract(skip=1), {metric}))
         self._metrics[metric] = value
 
-    def set_key_value(self, metric: str, key: str, value: Any) -> None:
+    def set_key_value(self, metric: str, key: str, value: object) -> None:
         """
         Treats a given metric as a dictionary and set the k and value within it.
         Note that the metric must be a dictionary or not present.
@@ -157,9 +158,9 @@ class MetricsContext:
             raise RuntimeError(f"Cannot set {metric} outside of a MetricsContext")
         if metric not in self._metrics:
             self._metrics[metric] = {}
-        self._metrics[metric][key] = value
+        cast(dict[str, object], self._metrics[metric])[key] = value
 
-    def update(self, values: dict[str, Any], overwrite: bool = False) -> None:
+    def update(self, values: dict[str, object], overwrite: bool = False) -> None:
         """
         Set multiple metrics directly. This method does NOT increment. Raises if any
         metric has been assigned previously in the current context and overwrite is
@@ -177,7 +178,7 @@ class MetricsContext:
         self._edits.append((CapturedTraceback.extract(skip=1), set(values.keys())))
         self._metrics.update(values)
 
-    def update_outer(self, values: dict[str, Any]) -> None:
+    def update_outer(self, values: dict[str, object]) -> None:
         """
         Update, but only when at the outermost context.
         """
@@ -186,7 +187,7 @@ class MetricsContext:
         if self._level == 1:
             self.update(values)
 
-    def add_to_set(self, metric: str, value: Any) -> None:
+    def add_to_set(self, metric: str, value: object) -> None:
         """
         Records a metric as a set() of values.
         """
@@ -194,9 +195,9 @@ class MetricsContext:
             raise RuntimeError(f"Cannot add {metric} outside of a MetricsContext")
         if metric not in self._metrics:
             self._metrics[metric] = set()
-        self._metrics[metric].add(value)
+        cast(set[object], self._metrics[metric]).add(value)
 
-    def add_top_n(self, metric: str, key: Any, val: int) -> None:
+    def add_top_n(self, metric: str, key: object, val: int) -> None:
         """
         Records a metric as a TopN set of values.
         """
@@ -204,7 +205,7 @@ class MetricsContext:
             return
         if metric not in self._metrics:
             self._metrics[metric] = TopN()
-        self._metrics[metric].add(key, val)
+        cast(TopN, self._metrics[metric]).add(key, val)
 
 
 class RuntimeMetricsContext:
@@ -215,11 +216,11 @@ class RuntimeMetricsContext:
         context manager.
         """
         self._on_exit = on_exit
-        self._metrics: dict[str, Any] = {}
+        self._metrics: dict[str, object] = {}
         self._start_time_ns: int = 0
 
     def increment(
-        self, metric: str, value: int, extra: dict[str, Any] | None = None
+        self, metric: str, value: int, extra: dict[str, object] | None = None
     ) -> None:
         """
         Increment a metric by a given amount.
@@ -229,7 +230,7 @@ class RuntimeMetricsContext:
             self._start_time_ns = time.time_ns()
         if metric not in self._metrics:
             self._metrics[metric] = 0
-        self._metrics[metric] += value
+        self._metrics[metric] = cast(int, self._metrics[metric]) + value
 
         if extra:
             for k, v in extra.items():

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -552,7 +552,7 @@ class CompileEventLogger:
 
     @staticmethod
     def add_to_set(
-        event_name: str, log_level: CompileEventLogLevel, key: str, value: Any
+        event_name: str, log_level: CompileEventLogLevel, key: str, value: object
     ) -> None:
         """
         Add metadata <value> to a set of values with key <key>. Creates a set if it doesn't exist.
@@ -587,7 +587,7 @@ class CompileEventLogger:
     @staticmethod
     def add_to_set_toplevel(
         key: str,
-        value: Any,
+        value: object,
         log_level: CompileEventLogLevel = CompileEventLogLevel.COMPILATION_METRIC,
     ) -> None:
         """

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -901,7 +901,7 @@ def dynamo_timed(
                 runtime_context = get_runtime_metrics_context()
                 runtime_context.increment(dynamo_compile_column_us, duration_us)
                 if is_outer_event:
-                    extra = {
+                    extra: dict[str, object] = {
                         "compile_id": compile_id,
                         "is_runtime": True,
                         "is_forward": not is_backward,
@@ -1742,7 +1742,7 @@ class CompilationMetrics:
     functorch_config: str | None = None
 
     @classmethod
-    def create(cls, metrics: dict[str, Any]) -> CompilationMetrics:
+    def create(cls, metrics: dict[str, object]) -> CompilationMetrics:
         """
         Factory method to create a CompilationMetrics from a dict of fields.
         Includes the logic to add legacy fields and any pre-processing, e.g.,
@@ -1781,30 +1781,36 @@ class CompilationMetrics:
         # TODO: The following are legacy fields, populated from the fields that replace
         # them. Remove these when we decide we can really deprecate them.
         legacy_metrics = {
-            "start_time": us_to_s(metrics.get("start_time_us")),
+            "start_time": us_to_s(cast("int | None", metrics.get("start_time_us"))),
             "entire_frame_compile_time_s": us_to_s(
-                metrics.get("dynamo_cumulative_compile_time_us")
+                cast("int | None", metrics.get("dynamo_cumulative_compile_time_us"))
             ),
             "backend_compile_time_s": us_to_s(
-                metrics.get("aot_autograd_cumulative_compile_time_us")
+                cast(
+                    "int | None",
+                    metrics.get("aot_autograd_cumulative_compile_time_us"),
+                )
             ),
             "inductor_compile_time_s": us_to_s(
-                metrics.get("inductor_cumulative_compile_time_us")
+                cast("int | None", metrics.get("inductor_cumulative_compile_time_us"))
             ),
             "code_gen_time_s": us_to_s(
-                metrics.get("inductor_code_gen_cumulative_compile_time_us")
+                cast(
+                    "int | None",
+                    metrics.get("inductor_code_gen_cumulative_compile_time_us"),
+                )
             ),
             "remote_cache_time_saved_s": us_to_s(
-                metrics.get("distributed_ephemeral_timeout_us")
+                cast("int | None", metrics.get("distributed_ephemeral_timeout_us"))
             ),
             "remote_fx_graph_cache_get_time_ms": us_to_ms(
-                metrics.get("remote_fx_graph_cache_get_time_us")
+                cast("int | None", metrics.get("remote_fx_graph_cache_get_time_us"))
             ),
             "remote_fx_graph_cache_put_time_ms": us_to_ms(
-                metrics.get("remote_fx_graph_cache_put_time_us")
+                cast("int | None", metrics.get("remote_fx_graph_cache_put_time_us"))
             ),
             "structured_logging_overhead_s": us_to_s(
-                metrics.get("structured_logging_overhead_us")
+                cast("int | None", metrics.get("structured_logging_overhead_us"))
             ),
         }
 
@@ -2025,7 +2031,7 @@ def _functorch_config_for_logging() -> str | None:
 def record_compilation_metrics(
     start_time_ns: int,
     end_time_ns: int,
-    metrics: dict[str, Any],
+    metrics: dict[str, object],
     exc_type: type[BaseException] | None,
     exc_value: BaseException | None,
 ) -> None:
@@ -2044,7 +2050,7 @@ def record_compilation_metrics(
 
     # Populate the compile_id from the metrics context if it's set. Otherwise,
     # look for it in the current compile context.
-    compile_id = metrics.get("compile_id")
+    compile_id = cast("CompileId | None", metrics.get("compile_id"))
     if not compile_id:
         compile_id = torch._guards.CompileContext.current_compile_id()
 


### PR DESCRIPTION
## Summary

- replace `Any` with `object` at Dynamo's heterogeneous metrics-storage boundary
- make integer, mapping, set, top-N, and compile-ID assumptions explicit with localized casts
- propagate the stricter mapping through callbacks and add coverage for runtime extra metadata

## Test plan

```bash
python test/dynamo/test_metrics_context.py
```

```bash
pyrefly check torch/_dynamo/metrics_context.py
```

```bash
UV_NO_CONFIG=1 UV_OFFLINE=1 lintrunner -a --skip PYREFLY torch/_dynamo/metrics_context.py torch/_dynamo/utils.py test/dynamo/test_metrics_context.py
```

Authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98