### PR TITLE
[dynamo] Clear a bypassed package entry and refuse new registrations on it

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -86,6 +86,28 @@ class TestPackage(torch._inductor.test_case.TestCase):
         cache_entry = package.cache_entry()
         self.assertEqual(cache_entry.codes[0].backend_ids, [backend_id])
 
+    def test_bypassed_entry_refuses_new_registrations(self):
+        def fn(x):
+            return x + 1
+
+        (backend_id,) = (
+            compiled_region_with_backend_id_for_package_test.__code__.co_names
+        )
+        package = CompilePackage(fn)
+        with package.code_context(fn.__code__):
+            package.bypass_current_entry()
+            package.add_guarded_code(
+                b"", compiled_region_with_backend_id_for_package_test.__code__
+            )
+            package.add_backend_id(backend_id)
+            package.add_import_source("alias", "os")
+
+        entry = package.cache_entry().codes[0]
+        self.assertTrue(entry.bypassed)
+        self.assertEqual(entry.backend_ids, [])
+        self.assertEqual(entry.guarded_codes, [])
+        self.assertEqual(entry.import_sources, {})
+
     @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
     def test_nn_module(self):
         class MyModule(torch.nn.Module):

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -804,6 +804,13 @@ class CompilePackage:
         if self._current_entry is None:
             raise AssertionError("_current_entry is not set in bypass_current_entry")
         self._current_entry.bypassed = True
+        # install() still imports this entry's import_sources and global names,
+        # but skips its backends and guarded codes (the entry.bypassed check in
+        # install()). Clear those two here, and the add_* methods refuse to
+        # repopulate them once bypassed, so a later serializable recompile that
+        # reuses this same entry cannot resurrect the frame.
+        self._current_entry.backend_ids.clear()
+        self._current_entry.guarded_codes.clear()
 
     def add_resume_function(
         self,
@@ -822,6 +829,8 @@ class CompilePackage:
     def add_import_source(self, alias: str, module_name: str) -> None:
         if self._current_entry is None:
             raise AssertionError("_current_entry is not set in add_import_source")
+        if self._current_entry.bypassed:
+            return
         self._current_entry.import_sources[alias] = module_name
 
     def _add_backend_id(
@@ -829,6 +838,8 @@ class CompilePackage:
     ) -> None:
         if self._current_entry is None:
             raise AssertionError("_current_entry is not set in add_backend_id")
+        if self._current_entry.bypassed:
+            return
         if backend_id not in self._current_entry.backend_ids:
             self._current_entry.backend_ids.append(backend_id)
         if backend is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196481
* #196480
* #196479
* #196478
* #196477
* #196476
* #196475
* #196474
* #196473
* #196472
* #196471
* #196470
* __->__ #196469

A `CompilePackage` keeps one `_GuardedCodeCacheEntry` per Python code object,
and `code_context` hands the SAME entry back every time that code object is
compiled: the first compile of `fn` and every later recompile (a new guard
variant) append into one entry. An entry accumulates `backend_ids` (the
compiled graphs it points at) and `guarded_codes` (serialized guards plus
dynamo bytecode).

When a frame's guards cannot be pickled, `bypass_current_entry` marks the
entry `bypassed = True`. That flag poisons the whole frame: `install()` skips a
bypassed entry entirely, so on reload nothing is installed for that code
object and it recompiles cold. This is deliberate -- a partial install would be
wrong, because the variant that failed to serialize may be the one that would
have matched. Two gaps undercut it:

1. Contents registered BEFORE the bypass stayed behind. Within one compile the
   backend runs (registering a backend id) before guards are built, and the
   bypass happens during guard building, so at bypass time the entry already
   holds a backend id plus any earlier variants' guarded codes. Those were
   written into the artifact even though `install()` would never use them.
   Clear both lists at bypass time.

2. Later registrations could refill the entry. Since recompiles reuse the
   entry, a later variant of the same frame that serialized fine would call
   `add_backend_id`/`add_import_source` and repopulate it. `add_guarded_code`
   already returned early on a bypassed entry; the other two did not. Give them
   the same check, so once bypassed an entry stays empty.

Unchanged: `import_sources` registered before the bypass, and the
package-global `_source_info` checksum set, which has no per-entry attribution.

This is pure bookkeeping with no dependency on the guard-reconstruction work
above it. Landing it first makes bypass semantics well defined before the
later commits make bypasses actually reachable; their end-to-end tests assert
`entry["backend_ids"] == []` after a bypass, which needs (1).

Test Plan:

```
python test/dynamo/test_package.py -k test_bypassed_entry_refuses_new_registrations
```

Authored with an AI assistant.