### PR TITLE
[dynamo] Restore __dict__, __doc__, __annotations__ and __type_params__ on a rebuilt function

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -99,6 +99,18 @@ def keep_kwdefaults(func):
     return wrapper
 
 
+def keep_attribute(func):
+    func.scale_flag = 2.0
+
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.scale_flag == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
 def keep_renamed_name(func):
     # __name__ differs from co_name, so a co_name fallback reads "forward".
     func.__name__ = "renamed_forward"
@@ -106,6 +118,21 @@ def keep_renamed_name(func):
     @functools.wraps(func)
     def wrapper(self, x):
         if func.__name__ == "renamed_forward":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_annotations(func):
+    # A guard reading an annotation value reads through the __annotations__
+    # dict and bakes an ID_MATCH on the value, so the by-value function
+    # reconstruction must restore __annotations__.
+    func.__annotations__ = {"x": int}
+
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__annotations__["x"] is int:
             x = x + 1
         return func(self, x)
 
@@ -133,10 +160,42 @@ class DecoratedKwdefaultsForwardModule(torch.nn.Module):
         return x * scale
 
 
+class DecoratedAttributeForwardModule(torch.nn.Module):
+    @keep_attribute
+    def forward(self, x):
+        return x * 2
+
+
 class DecoratedRenamedNameForwardModule(torch.nn.Module):
     @keep_renamed_name
     def forward(self, x):
         return x * 2
+
+
+class DecoratedAnnotationsForwardModule(torch.nn.Module):
+    @keep_annotations
+    def forward(self, x):
+        return x * 2
+
+
+def self_referencing_wrapper(func):
+    @functools.wraps(func)
+    def wrapper(x):
+        # Reaches itself through both a closure cell and __dict__["me"].
+        if wrapper.flag == 2.0:
+            x = x + 1
+        return func(x)
+
+    wrapper.flag = 2.0
+    wrapper.me = wrapper
+    return wrapper
+
+
+def _self_referencing_base(x):
+    return x * 2
+
+
+SELF_REFERENCING_WRAPPED = self_referencing_wrapper(_self_referencing_base)
 
 
 def none_cell_wrapper(func):
@@ -156,6 +215,22 @@ def _none_cell_base(x):
 
 
 NONE_CELL_WRAPPED = none_cell_wrapper(_none_cell_base)
+
+
+def _doc_base(x):
+    """base doc"""
+    return x * 2
+
+
+def doc_wrapper(func):
+    @functools.wraps(func)
+    def wrapper(x):
+        return func(x)
+
+    return wrapper
+
+
+DOC_WRAPPED = doc_wrapper(_doc_base)
 
 
 def keep_name_with_empty_cell(func):
@@ -212,6 +287,11 @@ class GuardedDefaultsTupleModule(torch.nn.Module):
         return x + 2
 
 
+# A module-level lambda's qualname is "<lambda>", which resolves to nothing.
+GLOBAL_LAMBDA = lambda x: x * 2  # noqa: E731
+GLOBAL_LAMBDA.scale_flag = 2.0
+
+
 def keep_fn_name(func):
     @functools.wraps(func)
     def wrapper(x):
@@ -253,8 +333,20 @@ FQN_MISMATCH_CASES = [
         name="kwdefaults_keys",
     ),
     subtest(
+        ("EQUALS_MATCH", DecoratedAttributeForwardModule, ("scale_flag", 3.0)),
+        name="attribute",
+    ),
+    subtest(
         ("EQUALS_MATCH", DecoratedRenamedNameForwardModule, ("__name__", "forward")),
         name="renamed_name",
+    ),
+    subtest(
+        (
+            "ID_MATCH",
+            DecoratedAnnotationsForwardModule,
+            ("__annotations__", {"x": str}),
+        ),
+        name="annotations",
     ),
 ]
 
@@ -760,6 +852,19 @@ class TestGuardsStatePickler(torch._inductor.test_case.TestCase):
         self.assertFalse(_cell_is_empty(out.__closure__[0]))
         self.assertIsNone(out())
 
+    def test_function_reaching_itself_through_its_dict(self):
+        # wrapper.me = wrapper, and wrapper is its own free variable; identity
+        # has to survive the round trip through both.
+        w = SELF_REFERENCING_WRAPPED
+        cell = [i for i, c in enumerate(w.__closure__) if c.cell_contents is w]
+        self.assertEqual(len(cell), 1)
+        buf = io.BytesIO()
+        gtv = {id(w): w, id(w.__dict__): w.__dict__}
+        GuardsStatePickler(gtv, {}, {}, buf).dump({"w": w})
+        out = pickle.loads(buf.getvalue())["w"]
+        self.assertIs(out.me, out)
+        self.assertIs(out.__closure__[cell[0]].cell_contents, out)
+
     def test_bound_method_under_a_name_self_lacks(self):
         # types.MethodType can bind a function under a name self has no
         # attribute for. _reduce_bound_method looked that name up unguarded,
@@ -814,6 +919,21 @@ class TestGuardSerialization(TestGuardSerializationBase):
 
         self._test_serialization("TENSOR_MATCH", fn, torch.randn(3), foo)
 
+    def test_guard_rooted_at_wrapper_that_reaches_itself(self):
+        # A kept closure cell and a kept attribute both reach back to the
+        # function being reduced; see FunctionPicklerBase for why that has to
+        # travel as pickle state.
+        def fn(x):
+            return SELF_REFERENCING_WRAPPED(x)
+
+        ref, loaded = self._test_serialization("EQUALS_MATCH", fn, torch.randn(3))
+        self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, True)
+        SELF_REFERENCING_WRAPPED.flag = 3.0
+        try:
+            self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, False)
+        finally:
+            SELF_REFERENCING_WRAPPED.flag = 2.0
+
     def test_guard_rooted_at_a_none_valued_closure_cell(self):
         # The cell is reached as a CELL through the wrapper's __closure__, so
         # _reduce_cell has to hand None back as a value, not an empty cell.
@@ -830,6 +950,24 @@ class TestGuardSerialization(TestGuardSerializationBase):
             self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, False)
         finally:
             cell.cell_contents = None
+
+    def test_guard_rooted_at_wrapper_preserves_copied_doc(self):
+        # functools.wraps copies the wrapped function's __doc__ onto a wrapper
+        # whose own code object has none. Rebuilt from the code object alone
+        # the wrapper reads None, the EQUALS_MATCH rebakes against it at load,
+        # and the guard fails forever with no load error.
+        def fn(x):
+            if DOC_WRAPPED.__doc__ == "base doc":
+                x = x + 1
+            return DOC_WRAPPED(x)
+
+        ref, loaded = self._test_serialization("EQUALS_MATCH", fn, torch.randn(3))
+        self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, True)
+        DOC_WRAPPED.__doc__ = "other"
+        try:
+            self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, False)
+        finally:
+            DOC_WRAPPED.__doc__ = "base doc"
 
     def test_fqn_mismatched_function_from_a_module_gone_at_load(self):
         # The rebuilt function's __module__ names a module that only ever lived
@@ -889,6 +1027,22 @@ class TestGuardSerialization(TestGuardSerializationBase):
         mod.fn.__defaults__ = (2.0, 1.0)
         mod.fn.__kwdefaults__ = {"c": 4.0}
         self._test_check_fn(ref, loaded, {"self": mod, "x": torch.randn(3)}, False)
+
+    def test_guard_rooted_at_a_lambda(self):
+        # A module-level lambda is an fqn mismatch too (see GLOBAL_LAMBDA) and
+        # is rebuilt by value with the guarded attribute intact.
+        def fn(x):
+            if GLOBAL_LAMBDA.scale_flag == 2.0:
+                x = x + 1
+            return GLOBAL_LAMBDA(x)
+
+        ref, loaded = self._test_serialization("EQUALS_MATCH", fn, torch.randn(3))
+        self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, True)
+        GLOBAL_LAMBDA.scale_flag = 3.0
+        try:
+            self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, False)
+        finally:
+            GLOBAL_LAMBDA.scale_flag = 2.0
 
     def test_guard_rooted_at_bound_method_under_a_name_self_lacks(self):
         # See TestGuardsStatePickler.test_bound_method_under_a_name_self_lacks.

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4302,6 +4302,10 @@ class GuardsStatePickler(FunctionPicklerBase):
             defaults=obj.__defaults__,
             kwdefaults=obj.__kwdefaults__,
             closure=obj.__closure__,
+            attributes=obj.__dict__,
+            annotations=self._read_raw_annotations(obj),
+            doc=obj.__doc__,
+            type_params=getattr(obj, "__type_params__", None),
         )
 
     # pyrefly: ignore [bad-override]

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -120,11 +120,11 @@ class FunctionPicklerBase(pickle.Pickler):
     decides what a rebuilt function carries; this class fixes HOW it is rebuilt
     so a fix in one pickler cannot be missed in the other.
 
-    Defaults travel as pickle STATE, applied after memoization, so a default
-    that reaches back to its own function ends. A closure cell is a reduce
-    ARGUMENT: a function closing over itself is reduced twice, and
-    save_reduce's recursive-object fallback (present in both the C and the
-    pure-Python pickler) drops the outer copy.
+    Defaults, __doc__, and __dict__ travel as pickle STATE, applied after
+    memoization, so `wrapper.me = wrapper` cycles end.
+    A closure cell is a reduce ARGUMENT: a function closing over itself is
+    reduced twice, and save_reduce's recursive-object fallback (present in both
+    the C and the pure-Python pickler) drops the outer copy.
     """
 
     @classmethod
@@ -204,9 +204,45 @@ class FunctionPicklerBase(pickle.Pickler):
 
     @staticmethod
     def _apply_function_state(fn: types.FunctionType, state: tuple[Any, ...]) -> None:
-        defaults, kwdefaults = state
+        defaults, kwdefaults, attributes, doc, annotations, type_params = state
         fn.__defaults__ = defaults
         fn.__kwdefaults__ = kwdefaults
+        # FunctionType took __doc__/__annotations__/__type_params__ from the code
+        # object; functools.wraps overwrote them on the live function and a guard
+        # rooted there rebakes, so restore what the reducer captured.
+        fn.__doc__ = doc
+        fn.__annotations__ = annotations
+        # Assign __dict__ before __type_params__: on Python < 3.12 the function
+        # has no __type_params__ slot, so that write lands in __dict__ and a
+        # wholesale __dict__ assignment afterwards would discard it.
+        fn.__dict__ = attributes
+        if type_params is not None:
+            fn.__type_params__ = type_params
+
+    @staticmethod
+    def _read_raw_annotations(obj: Any, *, resolve: bool = False) -> dict[str, Any]:
+        # Reading obj.__annotations__ directly forces PEP 649 lazy evaluation on
+        # 3.14+, raising NameError for a TYPE_CHECKING-only name. The guard
+        # pickler wants the unevaluated shape, so it takes FORWARDREF and prunes
+        # the proxies later. A caller that must SERIALIZE the annotations passes
+        # resolve=True instead: it gets real values, and an empty dict when a
+        # name will not resolve, because a ForwardRef -- even nested in
+        # list[Bar] -- is not picklable. This resolves the whole set or nothing;
+        # a caller that also needs per-value picklability filters on top.
+        if sys.version_info >= (3, 14):
+            import annotationlib
+
+            if resolve:
+                try:
+                    return annotationlib.get_annotations(
+                        obj, format=annotationlib.Format.VALUE
+                    )
+                except Exception:
+                    return {}
+            return annotationlib.get_annotations(
+                obj, format=annotationlib.Format.FORWARDREF
+            )
+        return obj.__annotations__
 
     def _reduce_cell(self, cell: types.CellType) -> tuple[Any, ...]:
         try:
@@ -269,12 +305,16 @@ class FunctionPicklerBase(pickle.Pickler):
         defaults: tuple[Any, ...] | None,
         kwdefaults: dict[str, Any] | None,
         closure: tuple[types.CellType, ...] | None,
+        attributes: dict[str, Any],
+        annotations: dict[str, Any],
+        doc: Any,
+        type_params: tuple[Any, ...] | None,
     ) -> tuple[Any, ...]:
-        # defaults/kwdefaults/closure are passed in rather than read off fn so
-        # the subclass decides what the rebuilt function carries.
+        # Everything is passed in rather than read off fn so the subclass
+        # decides what the rebuilt function carries.
         args = (fn.__module__, fn.__code__, fn.__qualname__, fn.__name__, closure)
         unpickle = type(self)._unpickle_fn_from_module
-        state = (defaults, kwdefaults)
+        state = (defaults, kwdefaults, attributes, doc, annotations, type_params)
         return unpickle, args, state, None, None, type(self)._apply_function_state
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196481
* #196480
* #196479
* #196478
* #196477
* #196476
* __->__ #196475
* #196474
* #196473
* #196472
* #196471
* #196470
* #196505

`types.FunctionType(code, ...)` takes `__doc__` and `__annotations__` from the
code object and starts with an empty `__dict__`. `functools.wraps` overwrote
all three on the live function (it copies `__doc__`, `__annotations__` and
updates `__dict__`), and a guard rooted at a wrapper reads them: an
EQUALS_MATCH on `func.scale_flag` or `func.__doc__`, an ID_MATCH on an
annotation value. Rebuilt from the code object alone those read None or empty,
the guard rebakes against that at load, and it fails forever with no load
error (or the load raises, for an attribute that is gone).

Carry `__dict__`, `__doc__`, `__annotations__` and `__type_params__` in the
pickle state next to the defaults. State is applied after memoization, so
`wrapper.me = wrapper` -- a function reaching itself through its own
`__dict__` -- terminates. `__dict__` is assigned before `__type_params__`
because on Python < 3.12 the latter has no slot and would land in `__dict__`,
where a wholesale assignment afterwards would discard it. Annotations are read
with `_read_raw_annotations`, which on 3.14+ takes the FORWARDREF format so a
TYPE_CHECKING-only name does not raise during the dump; its `resolve=True`
mode is for the AOT pickler, which needs real values to serialize.

Test Plan:

```
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_guard_serialization.py -k fqn_mismatched_function_attribute -k fqn_mismatched_function_annotations -k test_guard_rooted_at_wrapper_preserves_copied_doc -k test_guard_rooted_at_wrapper_that_reaches_itself -k test_function_reaching_itself_through_its_dict -k test_guard_rooted_at_a_lambda
```

All six tests fail or error on the previous commit.

Authored with an AI assistant.
