### PR TITLE
[dynamo] Name a recursion overflow while pickling guard state in its PackageError

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -279,6 +279,23 @@ class DecoratedUnpicklableGuardedDefaultForwardModule(torch.nn.Module):
         return x * 2
 
 
+class RecursingGuardedDefault:
+    flag = 2.0
+
+    def __init__(self, inner=None):
+        self.inner = inner
+
+    def __reduce__(self):
+        # Hands pickle a fresh instance every time, so nothing is ever memoized.
+        return type(self), (type(self)(),)
+
+
+class DecoratedRecursingGuardedDefaultForwardModule(torch.nn.Module):
+    @keep_default_attribute
+    def forward(self, x, cfg=RecursingGuardedDefault()):
+        return x * 2
+
+
 def keep_name_with_empty_cell(func):
     @functools.wraps(func)
     def wrapper(x):
@@ -1141,6 +1158,19 @@ class TestGuardSerialization(TestGuardSerializationBase):
         # crash. strict_precompile is on for this class, so it re-raises.
         mod = DecoratedUnpicklableGuardedDefaultForwardModule()
         with self.assertRaisesRegex(PackageError, "guarded default cannot pickle"):
+            self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+
+    @torch._dynamo.config.patch(strict_precompile=True)
+    def test_recursing_guarded_value_overflow_is_a_package_error(self):
+        # A recursion overflow while pickling a guarded value -- here a
+        # pathological __reduce__ that never memoizes -- is a serialization
+        # limit, not a compiler crash. It surfaces as a PackageError (a bypass
+        # without strict_precompile), never a raw RecursionError that hard-fails
+        # a program that compiled fine before.
+        mod = DecoratedRecursingGuardedDefaultForwardModule()
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.PackageError, "exceeded the recursion limit"
+        ):
             self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
 
     def test_fqn_mismatched_function_from_a_module_gone_at_load(self):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4682,6 +4682,19 @@ def pickle_guards_state(
         pickler.dump(state)
     except torch._dynamo.exc.PackageError:
         raise
+    except RecursionError as e:
+        # A guard rooted at an fqn-mismatched function is now traversed rather
+        # than dropped, so pickle walks whatever user data hangs off it -- and a
+        # deep (but finite, acyclic) object graph, or a pathological __reduce__
+        # that never memoizes, overflows the recursion limit here. That is a
+        # serialization limit, not a compiler bug: bypass it (or raise under
+        # strict_precompile) like any other unpicklable value, rather than
+        # hard-failing a program that compiled fine before. Walking the object
+        # graph to report WHERE the overflow happened is skipped deliberately --
+        # it would recurse again off an already exhausted stack.
+        raise torch._dynamo.exc.PackageError(
+            "guard state exceeded the recursion limit while pickling"
+        ) from e
     except Exception as e:
         # Deliberately broad, AssertionError included: GradScaler.__getstate__
         # asserts mid-iteration, subclasses assert in __tensor_flatten__, users


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196481
* #196480
* #196479
* #196478
* __->__ #196477
* #196476
* #196475
* #196474
* #196473
* #196472
* #196471
* #196470
* #196505

A guard rooted at an fqn-mismatched function is now traversed rather than
dropped, so pickle walks whatever user data hangs off it. A deep but finite
object graph, or a pathological `__reduce__` that hands back a fresh object
every time and never memoizes, overflows the recursion limit inside `dump`.
The previous commit's broad mapping already turns that into a `PackageError`
(a bypass, or an error under `strict_precompile`) rather than a raw
`RecursionError` that hard-fails a program that compiled fine before; this
gives it a dedicated clause and message, since the interpreter's "maximum
recursion depth exceeded while calling a Python object" says nothing about
which stage overflowed. Walking the object graph to report WHERE is skipped
deliberately: it would recurse again off an already exhausted stack.

Test Plan:

```
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_guard_serialization.py -k test_recursing_guarded_value_overflow_is_a_package_error
```

On the previous commit the test gets a PackageError with the interpreter's
message and fails the regex.

Authored with an AI assistant.
