### PR TITLE
[dynamo] Record the container edge on __defaults__ and instance mappings, not just the base object

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -446,6 +446,29 @@ class DecoratedDictAttributeForwardModule(torch.nn.Module):
         return x * 2
 
 
+def keep_whole_dict_attribute(func):
+    func.tag = 2.0
+    func.cache = threading.Lock()  # unpicklable and unguarded sibling
+
+    @functools.wraps(func)
+    def wrapper(self, x):
+        # Reads the WHOLE __dict__ (a DunderDict guard keeps the mapping
+        # verbatim) AND an element through it. The generic edge keys on the
+        # function, not its __dict__, so without the mapping edge the verbatim
+        # dict drags func.cache in.
+        if type(func.__dict__) is dict and func.tag == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+class DecoratedWholeDictAttributeForwardModule(torch.nn.Module):
+    @keep_whole_dict_attribute
+    def forward(self, x):
+        return x * 2
+
+
 def keep_defaults_element(func):
     @functools.wraps(func)
     def wrapper(self, x):
@@ -458,6 +481,16 @@ def keep_defaults_element(func):
 
 class DecoratedDefaultsElementForwardModule(torch.nn.Module):
     @keep_defaults_element
+    def forward(self, x, scale=2.0, junk=threading.Lock()):  # unpicklable sibling
+        return x * scale
+
+
+class DecoratedCalledDefaultForwardModule(torch.nn.Module):
+    # keep_attribute roots the guard at the function via scale_flag (not through
+    # __defaults__). The tuple is pulled in only by the call-site default binding
+    # of `scale` -- the ordinary DefaultsSource shape whose base is the function,
+    # not the tuple.
+    @keep_attribute
     def forward(self, x, scale=2.0, junk=threading.Lock()):  # unpicklable sibling
         return x * scale
 
@@ -1552,6 +1585,35 @@ class TestGuardSerialization(TestGuardSerializationBase):
             self._test_check_fn(ref, loaded, inputs, False)
         finally:
             inner.__defaults__ = original
+
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_fqn_mismatched_function_prunes_an_unpicklable_called_default(self):
+        # The call-site default binding (DefaultsSource, base = the function)
+        # registers the __defaults__ tuple via SEQUENCE_LENGTH, but the generic
+        # container->element edge keys on the function, not the tuple, so the
+        # tuple is carried verbatim and drags in the unpicklable sibling default.
+        # This shape is unreachable through _test_serialization: its guard filter
+        # drops the whole-tuple SEQUENCE_LENGTH guard, so the tuple is never
+        # _keep and gets pruned regardless. Only the full compile path (all
+        # guards live) puts the tuple in guard_tree_values while the guarded
+        # element is rooted at the function -- so drive a real compile here.
+        mod = DecoratedCalledDefaultForwardModule()
+        # Serializes cleanly with the edge recorded on the tuple; without it this
+        # raises PackageError("cannot pickle '_thread.lock' object").
+        torch.compile(mod, backend="eager")(torch.randn(3))
+
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_fqn_mismatched_function_prunes_a_verbatim_dict_read(self):
+        # A guard that reads the WHOLE __dict__ (DunderDict keeps the mapping)
+        # plus an element through it records no child edge on __dict__ under the
+        # generic rule (it keys on the function, not its dict), so the mapping
+        # was carried verbatim and an unpicklable unguarded sibling (func.cache)
+        # bypassed the frame. Like the called-default shape this only survives
+        # the full compile path -- _test_serialization's filter drops the
+        # whole-dict guard. The mapping edge in get_guard_manager_from_source
+        # prunes per value; without it this raises PackageError on the lock.
+        mod = DecoratedWholeDictAttributeForwardModule()
+        torch.compile(mod, backend="eager")(torch.randn(3))
 
     def test_fqn_mismatched_function_prunes_a_none_valued_guarded_default(self):
         # The container->element edge is recorded on the source, not the

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1740,6 +1740,33 @@ class GuardBuilder(GuardBuilderBase):
                 self.guard_tree_children.setdefault(id(base_example_value), set()).add(
                     id(example_value)
                 )
+                # The generic edge above keys on id(base_example_value); an
+                # attribute read as obj.attr records its edge on the OBJECT, not
+                # on obj.__dict__/obj.__annotations__. But a guard that reads a
+                # whole such mapping makes _keep(mapping) True (DunderDictVariable
+                # registers AttrSource(base, "__dict__")), so without an edge on
+                # the mapping itself _keep_container_verbatim would carry it
+                # verbatim and drag an unpicklable sibling. Mirror the
+                # DefaultsSource repair below: record the edge on the instance
+                # mapping that actually holds this attribute.
+                if isinstance(source, AttrSource):
+                    mappings = [getattr(base_example_value, "__dict__", None)]
+                    # __annotations__ belongs to a class/function/module;
+                    # reading it off an instance would key the edge on the
+                    # class dict and can run a user __getattr__.
+                    if (
+                        isinstance(base_example_value, type)
+                        or inspect.isroutine(base_example_value)
+                        or inspect.ismodule(base_example_value)
+                    ):
+                        mappings.append(
+                            getattr(base_example_value, "__annotations__", None)
+                        )
+                    for mapping in mappings:
+                        if isinstance(mapping, dict) and source.member in mapping:
+                            self.guard_tree_children.setdefault(id(mapping), set()).add(
+                                id(example_value)
+                            )
 
         # Use istype instead of isinstance to check for exact type of source.
         if istype(source, LocalSource):
@@ -1975,6 +2002,21 @@ class GuardBuilder(GuardBuilderBase):
                 raise AssertionError("base_source_name must not be empty")
             if not callable(base_example_value):
                 raise AssertionError("base_example_value must be callable")
+            # The generic edge above keys on id(base_example_value), which for a
+            # DefaultsSource is the FUNCTION, not the __defaults__/__kwdefaults__
+            # container that actually holds this element. Record the edge on the
+            # real container too, so _keep_container_verbatim can prune an
+            # unpicklable sibling default instead of carrying the whole container
+            # verbatim on the ordinary call-site binding shape.
+            if source_name != "" and self.save_guards:
+                container = (
+                    base_example_value.__kwdefaults__
+                    if source.is_kw
+                    else base_example_value.__defaults__
+                )
+                self.guard_tree_children.setdefault(id(container), set()).add(
+                    id(example_value)
+                )
             if not source.is_kw:
                 out = base_guard_manager.func_defaults_manager(
                     source=base_source_name,
@@ -4353,7 +4395,15 @@ class GuardsStatePickler(FunctionPicklerBase):
         (tuple) guard that a pruned value preserves, while a whole-value
         EQUALS_MATCH -- which does bake tuple values -- keeps its container
         verbatim instead; a guard rooted at an element records a child->element
-        edge that forces per-value pruning.
+        edge that forces per-value pruning. The shapes we have identified that
+        read a plain container whole while also rooting an edge at one of their
+        elements are a function's __defaults__ (a whole-tuple EQUALS_MATCH plus a
+        call-site default binding, repaired at the DefaultsSource site) and its
+        __dict__/__annotations__ (a DunderDict guard keeps the mapping whole
+        while an attribute guard reads an element through it).
+        get_guard_manager_from_source records the edge on the container itself so
+        those shapes prune per value here rather than carrying an unpicklable
+        sibling verbatim.
         """
         if not self._keep(container):
             return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196481
* __->__ #196480
* #196479
* #196478
* #196477
* #196476
* #196475
* #196474
* #196473
* #196472
* #196471
* #196470
* #196505

The container->element edge keys on `id(base_example_value)`. Two ordinary
shapes put the guarded element's REAL container somewhere else, so the edge
missed and `_keep_container_verbatim` carried the container whole with its
unpicklable sibling:

- A call-site default binding (`DefaultsSource`, `def forward(self, x,
  scale=2.0, junk=threading.Lock())` called without `scale`) has the FUNCTION
  as its base, while the whole-tuple SEQUENCE_LENGTH guard registers the
  `__defaults__` tuple itself. Record the edge on the `__defaults__` /
  `__kwdefaults__` container too.
- An attribute read `func.tag` records its edge on `func`, while a guard that
  reads the whole `func.__dict__` (DunderDictVariable registers
  `AttrSource(base, "__dict__")`) makes the mapping `_keep`. Record the edge on
  the instance `__dict__` that holds the attribute, and on `__annotations__`
  only when the base is a type, routine or module, since reading it off an
  arbitrary instance would key on the class dict and can run a user
  `__getattr__`.

Neither shape is reachable through `_test_serialization`, whose guard filter
drops the whole-container guard so the container is never `_keep` to begin
with; the two new tests drive a real `torch.compile` under `caching_precompile`
instead.

Test Plan:

```
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_guard_serialization.py -k test_fqn_mismatched_function_prunes_an_unpicklable_called_default -k test_fqn_mismatched_function_prunes_a_verbatim_dict_read
```

Both error on the previous commit with `PackageError: TypeError: cannot pickle
'_thread.lock' object`.

Authored with an AI assistant.
