### PR TITLE
[ROCm] Re-enable test_record_stream_on_shifted_view

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2012,7 +2012,6 @@ print(mem_after_first, mem_after_set, torch.cuda.memory_allocated())
                 tmp3 = torch.cuda.FloatTensor(t.size())
                 self.assertEqual(tmp3.data_ptr(), ptr[0], msg="allocation not reused")
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/120318")
     def test_record_stream_on_shifted_view(self):
         # See issue #27366
 


### PR DESCRIPTION
Re-enables TestCuda.test_record_stream_on_shifted_view on ROCm. The skip was an auto-disabler inlining (#185013) of DISABLED issue #120318, whose failures date to a much older ROCm stack; the test now passes deterministically on ROCm 10.0 (HIP 7.15) on gfx950 (25 consecutive isolated runs, zero failures).

The other three test_cuda candidates from the same flaky-history investigation stay skipped, each with fresh evidence: test_graph_concurrent_replay asserts that a deliberately provoked mempool-sharing data race manifests, and ROCm kernel scheduling does not reliably manifest it (2 of 50 runs fail the assertNotEqual); test_out_of_memory_retry's fixed-size allocation fits within a 288GB MI355X so the expected OOM never raises (its DISABLED history also lists linux, consistent with large NVIDIA parts; sizing the allocation relative to device capacity would fix both); test_repeat_graph_capture_cublas_workspace_memory fails 5 of 25 isolated runs on its workspace-growth assertion under repeated capture (related to the cuBLAS workspace lifecycle work in #194311).

Test plan: 25 consecutive isolated runs on gfx950 (ROCm 10.0, HIP 7.15) with zero failures. gfx942/gfx90a validation via the ciflow labels below; the auto-disabler remains as the safety net.

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang