### PR TITLE
[ROCm] Map hsa_queue kineto metadata and unskip its parity test

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4243,7 +4243,6 @@ class TestProfilerEventsParity(TestCase):
                     lambda msg: f"{msg}\nactivity_type mismatch for {e.name}",
                 )
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179944")
     def test_structured_metadata_matches_chrome_trace(self):
         # Compare metadata fields between events() and Chrome trace JSON to make sure they stay in parity
         # 1. Run a dummy workload with profiling enabled and collect the json/events() outputs

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -581,6 +581,8 @@ class EventMetadata(NamedTuple):
     context: int | None
     channel: int | None
     channel_type: int | None
+    # ROCm reports the HSA queue a kernel or copy was dispatched to; None on CUDA.
+    hsa_queue: int | None
     # Memory fields
     bytes: int | None
     bandwidth_gb_s: float | None
@@ -630,6 +632,7 @@ _EVENT_METADATA_KEYS: dict[str, tuple[str, Callable[[str], Any]]] = {
     "context": ("context", int),
     "channel": ("channel", int),
     "channel_type": ("channel_type", int),
+    "hsa_queue": ("hsa_queue", int),
     "bytes": ("bytes", int),
     "memory bandwidth (GB/s)": ("bandwidth_gb_s", float),
     "Collective name": ("collective_name", _to_str),


### PR DESCRIPTION
TestProfilerEventsParity::test_structured_metadata_matches_chrome_trace fails on ROCm because kernel and copy events carry kineto's `hsa_queue` metadata field (libkineto MetadataFieldCatalog kHsaQueue, the HSA queue the activity was dispatched to), which `_EVENT_METADATA_KEYS` never mapped, so the parity check reports it as an unmapped key on four kernels. Following the test's own fix recipe (and the model in #180100): add the key to `_EVENT_METADATA_KEYS`, add the corresponding field to `EventMetadata` (None on CUDA; `EventMetadata` has a single keyword-only construction site, so the added field is backward-safe), and remove the test's ROCm skip.

Test plan, on gfx950 (ROCm 10.0, HIP 7.15): the parity test passes (previously failed with unmapped 'hsa_queue'), 25 consecutive runs clean, and the 12 surrounding metadata/events tests pass.

```
PYTORCH_TEST_WITH_ROCM=1 python test/profiler/test_profiler.py -k test_structured_metadata_matches_chrome_trace
```

gfx942/gfx90a validation via the ciflow labels below; the auto-disabler remains as the safety net.

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang