### PR TITLE
[BE][Ez]: Improve ranges support for aten custom collections

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -86,6 +86,8 @@ public:
   ~DictEntryRef() = default;
 
 private:
+  DictEntryRef() = default;
+
   // allow copying and moving, but only our friends (i.e. the Dict class) can do
   // it. Copying/moving this reference wrapper would be too ambiguous to allow it
   // in the public API.
@@ -104,7 +106,7 @@ private:
 template<class Key, class Value, class Iterator>
 class DictIterator final {
 public:
-   // C++17 friendly std::iterator implementation
+  using iterator_concept = std::forward_iterator_tag;
   using iterator_category = std::forward_iterator_tag;
   using value_type = DictEntryRef<Key, Value, Iterator>;
   using difference_type = std::ptrdiff_t;

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -1,6 +1,8 @@
 #include <ATen/core/List.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 using namespace c10;
 
 namespace {
@@ -17,6 +19,22 @@ constexpr bool list_iterators_conform =
      ...);
 
 static_assert(list_iterators_conform<
+              c10::IValue,
+              int64_t,
+              at::Tensor,
+              std::optional<std::string>>);
+
+template <class T>
+using ListMoveIter = std::move_iterator<ListIter<T>>;
+
+template <class... Ts>
+constexpr bool list_move_iterators_conform =
+    ((std::random_access_iterator<ListMoveIter<Ts>> &&
+      std::same_as<std::iter_rvalue_reference_t<ListIter<Ts>>, Ts> &&
+      std::same_as<std::iter_reference_t<ListMoveIter<Ts>>, Ts>) &&
+     ...);
+
+static_assert(list_move_iterators_conform<
               c10::IValue,
               int64_t,
               at::Tensor,
@@ -1230,6 +1248,15 @@ TEST(ListTest, canAccessStringByReference) {
   const std::string& strRef = listRef[1];
   EXPECT_EQ("two", str);
   EXPECT_EQ("two", strRef);
+}
+
+TEST(ListTest, rangesMoveTransfersElements) {
+  List<std::string> source({"one", "two"});
+  std::vector<std::string> destination;
+
+  std::ranges::move(source, std::back_inserter(destination));
+
+  EXPECT_EQ((std::vector<std::string>{"one", "two"}), destination);
 }
 
 TEST(ListTest, canAccessOptionalStringByReference) {

--- a/aten/src/ATen/test/Dict_test.cpp
+++ b/aten/src/ATen/test/Dict_test.cpp
@@ -2,7 +2,15 @@
 #include <ATen/ATen.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <ranges>
 #include <string>
+
+namespace {
+using DictIterator = c10::Dict<int64_t, std::string>::iterator;
+
+static_assert(std::forward_iterator<DictIterator>);
+static_assert(std::ranges::forward_range<c10::Dict<int64_t, std::string>>);
+} // namespace
 
 using std::string;
 using c10::Dict;

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -526,6 +526,7 @@ class DispatchKeySet final {
   class iterator {
    public:
     using self_type = iterator;
+    using iterator_concept = std::input_iterator_tag;
     using iterator_category = std::input_iterator_tag;
     using value_type = DispatchKey;
     using difference_type = ptrdiff_t;
@@ -536,6 +537,8 @@ class DispatchKeySet final {
         num_backends + num_functionality_keys;
     // final key value should be the last DispatchKey
     static constexpr uint8_t end_iter_key_val = num_functionality_keys;
+
+    iterator() = default;
 
     // current_dispatchkey_idx_ will iterate through all functionality bits.
     // current_backendcomponent_idx_ will iterate through all backend bits.
@@ -604,7 +607,7 @@ class DispatchKeySet final {
     }
 
    private:
-    const uint64_t* data_ptr_;
+    const uint64_t* data_ptr_ = nullptr;
     uint8_t next_functionality_;
     uint8_t next_backend_;
     // These are in an invalid state at construction time, and set by the

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -608,8 +608,8 @@ class DispatchKeySet final {
 
    private:
     const uint64_t* data_ptr_ = nullptr;
-    uint8_t next_functionality_;
-    uint8_t next_backend_;
+    uint8_t next_functionality_ = end_iter_mask_val;
+    uint8_t next_backend_ = 0;
     // These are in an invalid state at construction time, and set by the
     // first increment call
     uint8_t current_dispatchkey_idx_{end_iter_key_val};

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -2,12 +2,15 @@
 
 #include <cstddef>
 #include <iterator>
+#include <ranges>
 #include <unordered_set>
 
 #include <c10/core/DispatchKeySet.h>
 #include <c10/util/irange.h>
 
 using namespace c10;
+
+static_assert(std::ranges::input_range<DispatchKeySet>);
 
 // This test exists not to be comprehensive, but to more clearly show
 // what the semantics of DispatchKeySet are.

--- a/c10/test/util/Enumerate_test.cpp
+++ b/c10/test/util/Enumerate_test.cpp
@@ -5,8 +5,14 @@
 #include <c10/util/Enumerate.h>
 #include <gtest/gtest.h>
 #include <array>
+#include <ranges>
+#include <vector>
 
 namespace {
+
+using EnumeratedVector =
+    decltype(c10::enumerate(std::declval<std::vector<int>&>()));
+static_assert(std::ranges::input_range<EnumeratedVector>);
 
 template <class T>
 struct IsConstReference {

--- a/c10/test/util/IntrusiveList_test.cpp
+++ b/c10/test/util/IntrusiveList_test.cpp
@@ -3,9 +3,13 @@
 
 #include <gtest/gtest.h>
 
+#include <ranges>
+
 namespace {
 
 class ListItem : public c10::IntrusiveListHook {};
+
+static_assert(std::ranges::bidirectional_range<c10::IntrusiveList<ListItem>>);
 
 template <typename TItem>
 void check_containers_equal(

--- a/c10/util/Enumerate.h
+++ b/c10/util/Enumerate.h
@@ -69,11 +69,8 @@ class Enumerator {
 
   class Proxy {
    public:
-    using difference_type = ssize_t;
-    using value_type = typename std::iterator_traits<Iterator>::value_type;
     using reference = typename std::iterator_traits<Iterator>::reference;
     using pointer = typename std::iterator_traits<Iterator>::pointer;
-    using iterator_category = std::input_iterator_tag;
 
     C10_ALWAYS_INLINE constexpr explicit Proxy(const Enumerator& e)
         : index(e.idx_), element(*e.it_) {}
@@ -101,6 +98,13 @@ class Enumerator {
     reference element;
   };
 
+  using iterator_concept = std::input_iterator_tag;
+  using iterator_category = std::input_iterator_tag;
+  using value_type = Proxy;
+  using difference_type = ssize_t;
+
+  Enumerator() = default;
+
   C10_ALWAYS_INLINE constexpr Proxy operator*() const {
     return Proxy(*this);
   }
@@ -109,6 +113,12 @@ class Enumerator {
     ++it_;
     ++idx_;
     return *this;
+  }
+
+  C10_ALWAYS_INLINE constexpr Enumerator operator++(int) {
+    auto old = *this;
+    ++*this;
+    return old;
   }
 
   template <typename OtherIterator>

--- a/c10/util/IntrusiveList.h
+++ b/c10/util/IntrusiveList.h
@@ -55,17 +55,19 @@ template <typename P, typename T>
 class ListIterator {
   static_assert(std::is_same_v<std::remove_const_t<P>, IntrusiveListHook>);
   static_assert(std::is_base_of_v<IntrusiveListHook, T>);
-  P* ptr_;
+  P* ptr_ = nullptr;
 
   friend class IntrusiveList<T>;
 
  public:
+  using iterator_concept = std::bidirectional_iterator_tag;
   using iterator_category = std::bidirectional_iterator_tag;
   using value_type = std::conditional_t<std::is_const_v<P>, const T, T>;
   using difference_type = std::ptrdiff_t;
   using pointer = value_type*;
   using reference = value_type&;
 
+  ListIterator() = default;
   explicit ListIterator(P* ptr) : ptr_(ptr) {}
   ~ListIterator() = default;
 
@@ -107,10 +109,22 @@ class ListIterator {
     return *this;
   }
 
+  ListIterator operator++(int) {
+    auto old = *this;
+    ++*this;
+    return old;
+  }
+
   ListIterator& operator--() {
     TORCH_CHECK(ptr_);
     ptr_ = ptr_->prev_;
     return *this;
+  }
+
+  ListIterator operator--(int) {
+    auto old = *this;
+    --*this;
+    return old;
   }
 
   [[nodiscard]] auto* operator->() const {


### PR DESCRIPTION
Improves iterator standards compliance and adds static_asserts + tests to ensure compliance.

Used Codex to modernize the iterators to work with std::ranges