### PR TITLE
Fix XPUGraph capture failure with XCCL collectives

### DIFF
--- a/aten/src/ATen/xpu/XPUGraph.cpp
+++ b/aten/src/ATen/xpu/XPUGraph.cpp
@@ -128,6 +128,7 @@ void XPUGraphImpl::capture_begin(
   auto graph_impl = xpuGraph_t(capture_stream_.queue(), sycl_property);
   graph_ = std::make_unique<xpuGraph_t>(std::move(graph_impl));
   graph_->begin_recording(capture_stream_.queue());
+  c10::xpu::XPUGraphCaptureRegistry::get().setActiveGraph(graph_.get());
 
   TORCH_INTERNAL_ASSERT(
       capture_stream_.queue().ext_oneapi_get_state() == queue_state::recording);
@@ -143,6 +144,7 @@ void XPUGraphImpl::capture_end() {
       "Capture must end on the same stream it began on.");
 
   graph_->end_recording();
+  c10::xpu::XPUGraphCaptureRegistry::get().clearActiveGraph();
 
   c10::xpu::XPUCachingAllocator::markCaptureEnd(capture_dev_);
 

--- a/c10/xpu/XPUGraphsC10Utils.h
+++ b/c10/xpu/XPUGraphsC10Utils.h
@@ -2,6 +2,7 @@
 
 #include <c10/xpu/XPUStream.h>
 #include <iostream>
+#include <mutex>
 
 // XPU Graphs utils used by c10 and aten.
 using namespace sycl::ext::oneapi::experimental;
@@ -37,6 +38,59 @@ inline std::ostream& operator<<(std::ostream& os, CaptureStatus status) {
 inline CaptureStatus currentStreamCaptureStatusMayInitCtx() {
   auto state = c10::xpu::getCurrentXPUStream().queue().ext_oneapi_get_state();
   return CaptureStatus(state);
+}
+
+// SYCL graph capture only records ops submitted to the queue(s) passed to
+// begin_recording(). A queue that is never registered is not part of the
+// graph, so any cross-queue wait involving one of its events fails during
+// capture ("Graph nodes cannot depend on events from outside the graph").
+// This tracks the graph currently being recorded (if any) so components
+// that run work on a queue other than the capturing stream -- e.g. a
+// communication library's internal collective stream -- can register that
+// queue into the same recording session and make ordinary cross-queue
+// synchronization (XPUEvent::block(), i.e. ext_oneapi_submit_barrier) work
+// during capture, with no change needed to the wait itself.
+class C10_XPU_API XPUGraphCaptureRegistry {
+ public:
+  static XPUGraphCaptureRegistry& get() {
+    static XPUGraphCaptureRegistry instance;
+    return instance;
+  }
+
+  // Called by XPUGraphImpl::capture_begin() once recording has started on
+  // the capturing stream. `graph` must outlive the capture.
+  void setActiveGraph(command_graph<graph_state::modifiable>* graph) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    active_graph_ = graph;
+  }
+
+  // Called by XPUGraphImpl::capture_end().
+  void clearActiveGraph() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    active_graph_ = nullptr;
+  }
+
+  // Registers `queue` into the currently-recording graph, if any. No-op if
+  // no capture is active or `queue` is already part of a recording session
+  // (begin_recording() puts the queue itself into queue_state::recording,
+  // so that state doubles as the "already registered" check).
+  void addQueueIfCapturing(sycl::queue& queue) {
+    if (queue.ext_oneapi_get_state() == queue_state::recording) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (active_graph_ != nullptr) {
+      active_graph_->begin_recording(queue);
+    }
+  }
+
+ private:
+  std::mutex mutex_;
+  command_graph<graph_state::modifiable>* active_graph_ = nullptr;
+};
+
+inline void addStreamToCurrentCaptureIfCapturing(const XPUStream& stream) {
+  XPUGraphCaptureRegistry::get().addQueueIfCapturing(stream.queue());
 }
 
 } // namespace c10::xpu

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -798,6 +798,191 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             inductor_out = compiled_fn(*inputs)
             self.assertTrue(same(eager_out, inductor_out, tol=0.001))
 
+    @unittest.skipUnless(TEST_XPU, "XPUGraph test requires XPU")
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @skip_if_lt_x_gpu(2)
+    def test_allgather_into_tensor_inductor_xpugraph(self):
+        def example(a, b, *, tag, ranks, group_size):
+            c = torch.matmul(a, b)
+            ag = torch.ops.c10d_functional.all_gather_into_tensor(
+                c, tag, ranks, group_size
+            )
+            ag = torch.ops.c10d_functional.wait_tensor(ag)
+            return ag * 2
+
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+            example = functools.partial(
+                example,
+                **self.get_world_trs(),
+            )
+            static_a = torch.ones(4, 4, device=self.device) + self.rank
+            static_b = torch.ones(4, 4, device=self.device) + self.rank
+
+            compiled_fn = torch.compile(
+                example,
+                backend="inductor",
+                fullgraph=True,
+            )
+
+            # Compile the function and initialize XCCL resources before capture.
+            compiled_out = compiled_fn(static_a, static_b)
+            for _ in range(2):
+                compiled_out = compiled_fn(static_a, static_b)
+            torch.xpu.synchronize()
+
+            static_output = torch.empty_like(compiled_out)
+            graph = torch.xpu.XPUGraph()
+
+            with torch.xpu.graph(graph):
+                static_output.copy_(compiled_fn(static_a, static_b))
+
+            torch.xpu.synchronize()
+
+            for iteration in range(10):
+                value = float(self.rank + iteration + 1)
+                static_a.fill_(value)
+                static_b.fill_(value)
+
+                graph.replay()
+                torch.xpu.synchronize()
+
+                expected = torch.cat(
+                    [
+                        torch.full(
+                            (4, 4),
+                            8.0 * float(rank + iteration + 1) ** 2,
+                            device=self.device,
+                        )
+                        for rank in range(self.world_size)
+                    ],
+                    dim=0,
+                )
+                if not same(expected, static_output, tol=0.001):
+                    self.fail(
+                        f"rank={self.rank}, iteration={iteration}, "
+                        f"expected={expected.cpu()}, actual={static_output.cpu()}"
+                    )
+
+            graph.reset()
+
+    @unittest.skipUnless(TEST_XPU, "XPUGraph test requires XPU")
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @skip_if_lt_x_gpu(2)
+    def test_reduce_scatter_tensor_inductor_xpugraph(self):
+        def example(a, b, *, tag, ranks, group_size):
+            c = torch.matmul(a, b)
+            rs = torch.ops.c10d_functional.reduce_scatter_tensor(
+                c, "sum", tag, ranks, group_size
+            )
+            rs = torch.ops.c10d_functional.wait_tensor(rs)
+            return rs * 2
+
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+            example = functools.partial(
+                example,
+                **self.get_world_trs(),
+            )
+            static_a = torch.ones(4, 4, device=self.device) + self.rank
+            static_b = torch.ones(4, 4, device=self.device) + self.rank
+
+            compiled_fn = torch.compile(
+                example,
+                backend="inductor",
+                fullgraph=True,
+            )
+
+            # Compile the function and initialize XCCL resources before capture.
+            compiled_out = compiled_fn(static_a, static_b)
+            for _ in range(2):
+                compiled_out = compiled_fn(static_a, static_b)
+            torch.xpu.synchronize()
+
+            static_output = torch.empty_like(compiled_out)
+            graph = torch.xpu.XPUGraph()
+
+            with torch.xpu.graph(graph):
+                static_output.copy_(compiled_fn(static_a, static_b))
+
+            torch.xpu.synchronize()
+
+            for iteration in range(10):
+                value = float(self.rank + iteration + 1)
+                static_a.fill_(value)
+                static_b.fill_(value)
+
+                graph.replay()
+                torch.xpu.synchronize()
+
+                expected_value = 8.0 * sum(
+                    float(rank + iteration + 1) ** 2 for rank in range(self.world_size)
+                )
+                expected = torch.full_like(static_output, expected_value)
+                if not same(expected, static_output, tol=0.001):
+                    self.fail(
+                        f"rank={self.rank}, iteration={iteration}, "
+                        f"expected={expected.cpu()}, actual={static_output.cpu()}"
+                    )
+
+            graph.reset()
+
+    @unittest.skipUnless(TEST_XPU, "XPUGraph test requires XPU")
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @skip_if_lt_x_gpu(2)
+    def test_allreduce_inductor_xpugraph(self):
+        def example(a, b, *, tag, ranks, group_size):
+            c = torch.matmul(a, b)
+            ar = torch.ops.c10d_functional.all_reduce(c, "sum", tag, ranks, group_size)
+            ar = torch.ops.c10d_functional.wait_tensor(ar)
+            return ar * 2
+
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+            example = functools.partial(
+                example,
+                **self.get_world_trs(),
+            )
+            static_a = torch.ones(4, 4, device=self.device) + self.rank
+            static_b = torch.ones(4, 4, device=self.device) + self.rank
+
+            compiled_fn = torch.compile(
+                example,
+                backend="inductor",
+                fullgraph=True,
+            )
+
+            # Compile and initialize XCCL resources before XPUGraph capture.
+            compiled_out = compiled_fn(static_a, static_b)
+            for _ in range(2):
+                compiled_out = compiled_fn(static_a, static_b)
+            torch.xpu.synchronize()
+
+            static_output = torch.empty_like(compiled_out)
+            graph = torch.xpu.XPUGraph()
+
+            with torch.xpu.graph(graph):
+                static_output.copy_(compiled_fn(static_a, static_b))
+
+            torch.xpu.synchronize()
+
+            for iteration in range(10):
+                value = float(self.rank + iteration + 1)
+                static_a.fill_(value)
+                static_b.fill_(value)
+
+                graph.replay()
+                torch.xpu.synchronize()
+
+                expected_value = 8.0 * sum(
+                    float(rank + iteration + 1) ** 2 for rank in range(self.world_size)
+                )
+                expected = torch.full_like(static_output, expected_value)
+                if not same(expected, static_output, tol=0.001):
+                    self.fail(
+                        f"rank={self.rank}, iteration={iteration}, "
+                        f"expected={expected.cpu()}, actual={static_output.cpu()}"
+                    )
+
+            graph.reset()
+
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)


### PR DESCRIPTION
This PR adds a small registry, which tracks which SYCL command graph is currently being recorded, so that a queue outside the capturing stream can be pulled into the same recording session. 