### PR TITLE
Expose InputBuffer as ctx.input_grad_buffers in autograd.Function backward

### DIFF
--- a/aten/src/ATen/ThreadLocalState.cpp
+++ b/aten/src/ATen/ThreadLocalState.cpp
@@ -34,6 +34,10 @@ void ThreadLocalState::set_grad_mode(bool enabled) {
   autograd_tls_.set_grad_mode(enabled);
 }
 
+bool ThreadLocalState::get_grad_mode() const {
+  return autograd_tls_.get_grad_mode();
+}
+
 void ThreadLocalState::set_multithreading_enabled(bool enabled) {
   autograd_tls_.set_multithreading_enabled(enabled);
 }

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -29,6 +29,7 @@ class TORCH_API ThreadLocalState {
   //  the current state object. This is used for example in the
   //  autograd engine.
   void set_grad_mode(bool enabled);
+  bool get_grad_mode() const;
 
   // set_multithreading_enabled - force the value of the multithreadinmaximum
   // threads TLS in

--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -217,7 +217,7 @@ like the following:
 
 ## Context method mixins
 
-When creating a new {class}`Function`, the following methods are available to `ctx`.
+When creating a new {class}`Function`, the following members are available to `ctx`.
 
 ```{eval-rst}
 .. autoclass:: torch.autograd.function.FunctionCtx
@@ -230,6 +230,7 @@ When creating a new {class}`Function`, the following methods are available to `c
     :toctree: generated
     :nosignatures:
 
+    function.FunctionCtx.input_grad_buffers
     function.FunctionCtx.mark_dirty
     function.FunctionCtx.mark_non_differentiable
     function.FunctionCtx.save_for_backward

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -145,7 +145,12 @@ directly into an existing partial sum and returning ``None``.
 During a first-order {meth}`~torch.Tensor.backward` call without an ``inputs``
 argument, ``ctx.input_grad_buffers`` provides a tuple aligned with the inputs to
 {meth}`~Function.forward`. Each entry is either ``None`` or the engine's current
-accumulation buffer for that input. See
+accumulation buffer for that input. These are transient engine buffers, not leaf
+``.grad`` buffers. For a leaf input, the completed buffer later passes through
+``AccumulateGrad``, which updates ``.grad`` and runs the usual hooks. To fuse
+directly into ``.grad`` instead, update the leaf's ``.grad`` and return ``None``
+for that input. The custom backward is then responsible for managing ``.grad``
+state, including initialization, as well as synchronization and hook semantics. See
 {attr}`~torch.autograd.function.FunctionCtx.input_grad_buffers` for an example and
 the complete availability, lifetime, and synchronization contract.
 

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -136,42 +136,50 @@ the autograd engine.
   to calling backward, and so your code will need to handle such objects as if they were
   tensors filled with zeros. The default value of this setting is True.
 
+When a tensor is used by multiple operations during forward, multiple backward
+nodes contribute to its gradient. Normally, each producer returns a separate
+tensor that the engine adds into an ``InputBuffer``. ``ctx.input_grad_buffers``
+lets a custom backward fuse that accumulation into its backward kernel by writing
+directly into an existing partial sum and returning ``None``.
+
 During a first-order {meth}`~torch.Tensor.backward` call without an ``inputs``
 argument, ``ctx.input_grad_buffers`` provides a tuple aligned with the inputs to
 {meth}`~Function.forward`. Each entry is either ``None`` or the autograd engine's
-current accumulation buffer for that input. A custom backward kernel can accumulate
-its contribution directly into a non-``None`` buffer and return ``None`` for that
-input instead of returning a separate gradient tensor::
+current accumulation buffer for that input. For example, ``x`` has another forward
+use here, while ``weight`` does not::
+
+    loss = Matmul.apply(x, weight).sum() + other_op(x).sum()
+
+The custom backward can conditionally fuse only its contribution to ``x``.
+Here, ``matmul_backward_input_acc`` represents a kernel that computes the input
+gradient matmul and accumulates it into ``out``::
 
     @staticmethod
     def backward(ctx, grad_output):
-        x, y = ctx.saved_tensors
-        x_buffer, y_buffer = ctx.input_grad_buffers
+        x, weight = ctx.saved_tensors
+        x_buffer, _ = ctx.input_grad_buffers
 
         if x_buffer is not None:
-            kernel_out(grad_output, y, out=x_buffer)
+            matmul_backward_input_acc(grad_output, weight, out=x_buffer)
             grad_x = None
         else:
-            grad_x = kernel(grad_output, y)
+            grad_x = matmul_backward_input(grad_output, weight)
 
-        if y_buffer is not None:
-            kernel_out(grad_output, x, out=y_buffer)
-            grad_y = None
-        else:
-            grad_y = kernel(grad_output, x)
+        grad_weight = matmul_backward_weight(grad_output, x)
+        return grad_x, grad_weight
 
-        return grad_x, grad_y
+If ``other_op`` produces its contribution first, ``x_buffer`` can expose that
+partial sum. If this custom backward runs first, ``x_buffer`` is ``None`` and it
+returns a separate tensor instead. The gradient for ``weight`` always follows the
+normal return path. Buffer availability depends on backward execution order, so
+the ``None`` fallback is required.
 
-Each input is independent, so neither, either, or both buffers may be available.
-Buffer availability depends on backward execution order, so the ``None`` fallback is
-required. The first producer normally receives ``None``; a later producer can receive
-the partial sum produced so far. The buffer may only be used synchronously while that
-custom ``backward`` method is running. Do not retain it: later producers may replace
-the engine's buffer, making a retained tensor stale. All producers that use or
-subsequently update an exposed buffer must execute on the same device, engine thread,
-and stream. PyTorch diagnoses engine-visible violations, but a custom function that
-launches work on another thread or stream is responsible for synchronizing it before
-returning.
+The buffer may only be used synchronously while that custom ``backward`` method is
+running. Do not retain it: later producers may replace the engine's buffer, making a
+retained tensor stale. All producers that use or subsequently update an exposed
+buffer must execute on the same device, engine thread, and stream. PyTorch diagnoses
+engine-visible violations, but a custom function that launches work on another
+thread or stream is responsible for synchronizing it before returning.
 
 This interface is unavailable with {func}`torch.autograd.grad`, the ``inputs``
 argument to ``backward``, ``create_graph=True``, anomaly detection, or a post-hook on

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -140,19 +140,16 @@ When a tensor is used by multiple operations during forward, multiple backward
 nodes contribute to its gradient. Normally, each producer returns a separate
 tensor that the engine adds into an ``InputBuffer``. ``ctx.input_grad_buffers``
 lets a custom backward fuse that accumulation into its backward kernel by writing
-directly into an existing partial sum and returning ``None``.
-
-During a first-order {meth}`~torch.Tensor.backward` call without an ``inputs``
-argument, ``ctx.input_grad_buffers`` provides a tuple aligned with the inputs to
-{meth}`~Function.forward`. Each entry is either ``None`` or the engine's current
-accumulation buffer for that input. These are transient engine buffers, not leaf
-``.grad`` buffers. For a leaf input, the completed buffer later passes through
-``AccumulateGrad``, which updates ``.grad`` and runs the usual hooks. To fuse
-directly into ``.grad`` instead, update the leaf's ``.grad`` and return ``None``
-for that input. The custom backward is then responsible for managing ``.grad``
-state, including initialization, as well as synchronization and hook semantics. See
+directly into an existing partial sum and returning ``None``. See
 {attr}`~torch.autograd.function.FunctionCtx.input_grad_buffers` for an example and
 the complete availability, lifetime, and synchronization contract.
+
+These are transient engine buffers, not leaf ``.grad`` buffers. For a leaf input,
+the completed buffer later passes through ``AccumulateGrad``, which updates
+``.grad`` and runs the usual hooks. To fuse directly into ``.grad`` instead, update
+the leaf's ``.grad`` and return ``None`` for that input. The custom backward is then
+responsible for managing ``.grad`` state, including initialization, as well as
+synchronization and hook semantics.
 
 In addition to ``ctx`` methods, the {class}`~Function` class supports the following
 class attributes:

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -145,14 +145,24 @@ input instead of returning a separate gradient tensor::
 
     @staticmethod
     def backward(ctx, grad_output):
-        (buffer,) = ctx.input_grad_buffers
-        if buffer is not None:
-            custom_backward_kernel(grad_output, out=buffer, accumulate=True)
-            return None
-        return custom_backward_kernel(grad_output)
+        x, y = ctx.saved_tensors
+        x_buffer, y_buffer = ctx.input_grad_buffers
 
-Each input is independent: for example, a fused linear backward may write
-``grad_input`` into its available buffer while returning ``grad_weight`` normally.
+        if x_buffer is not None:
+            kernel_out(grad_output, y, out=x_buffer)
+            grad_x = None
+        else:
+            grad_x = kernel(grad_output, y)
+
+        if y_buffer is not None:
+            kernel_out(grad_output, x, out=y_buffer)
+            grad_y = None
+        else:
+            grad_y = kernel(grad_output, x)
+
+        return grad_x, grad_y
+
+Each input is independent, so neither, either, or both buffers may be available.
 Buffer availability depends on backward execution order, so the ``None`` fallback is
 required. The first producer normally receives ``None``; a later producer can receive
 the partial sum produced so far. The buffer may only be used synchronously while that

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -171,8 +171,9 @@ gradient matmul and accumulates it into ``out``::
 If ``other_op`` produces its contribution first, ``x_buffer`` can expose that
 partial sum. If this custom backward runs first, ``x_buffer`` is ``None`` and it
 returns a separate tensor instead. The gradient for ``weight`` always follows the
-normal return path. Buffer availability depends on backward execution order, so
-the ``None`` fallback is required.
+normal return path. Buffer availability follows backward execution order: a buffer
+is exposed only after another producer has contributed to that input. The fallback
+above allows the function to work under either ordering.
 
 The buffer may only be used synchronously while that custom ``backward`` method is
 running. Do not retain it: later producers may replace the engine's buffer, making a

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -144,49 +144,10 @@ directly into an existing partial sum and returning ``None``.
 
 During a first-order {meth}`~torch.Tensor.backward` call without an ``inputs``
 argument, ``ctx.input_grad_buffers`` provides a tuple aligned with the inputs to
-{meth}`~Function.forward`. Each entry is either ``None`` or the autograd engine's
-current accumulation buffer for that input. For example, ``x`` has another forward
-use here, while ``weight`` does not::
-
-    loss = Matmul.apply(x, weight).sum() + other_op(x).sum()
-
-The custom backward can conditionally fuse only its contribution to ``x``.
-Here, ``matmul_backward_input_acc`` represents a kernel that computes the input
-gradient matmul and accumulates it into ``out``::
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        x, weight = ctx.saved_tensors
-        x_buffer, _ = ctx.input_grad_buffers
-
-        if x_buffer is not None:
-            matmul_backward_input_acc(grad_output, weight, out=x_buffer)
-            grad_x = None
-        else:
-            grad_x = matmul_backward_input(grad_output, weight)
-
-        grad_weight = matmul_backward_weight(grad_output, x)
-        return grad_x, grad_weight
-
-If ``other_op`` produces its contribution first, ``x_buffer`` can expose that
-partial sum. If this custom backward runs first, ``x_buffer`` is ``None`` and it
-returns a separate tensor instead. The gradient for ``weight`` always follows the
-normal return path. Buffer availability follows backward execution order: a buffer
-is exposed only after another producer has contributed to that input. The fallback
-above allows the function to work under either ordering.
-
-The buffer may only be used synchronously while that custom ``backward`` method is
-running. Do not retain it: later producers may replace the engine's buffer, making a
-retained tensor stale. All producers that use or subsequently update an exposed
-buffer must execute on the same device, engine thread, and stream. PyTorch diagnoses
-engine-visible violations, but a custom function that launches work on another
-thread or stream is responsible for synchronizing it before returning.
-
-This interface is unavailable with {func}`torch.autograd.grad`, the ``inputs``
-argument to ``backward``, ``create_graph=True``, anomaly detection, or a post-hook on
-the producing autograd node. It only exposes the engine's per-backward ``InputBuffer``;
-for a leaf, the completed buffer still passes through ``AccumulateGrad`` and its normal
-tensor and post-accumulate hooks before becoming ``.grad``.
+{meth}`~Function.forward`. Each entry is either ``None`` or the engine's current
+accumulation buffer for that input. See
+{attr}`~torch.autograd.function.FunctionCtx.input_grad_buffers` for an example and
+the complete availability, lifetime, and synchronization contract.
 
 In addition to ``ctx`` methods, the {class}`~Function` class supports the following
 class attributes:

--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -136,6 +136,39 @@ the autograd engine.
   to calling backward, and so your code will need to handle such objects as if they were
   tensors filled with zeros. The default value of this setting is True.
 
+During a first-order {meth}`~torch.Tensor.backward` call without an ``inputs``
+argument, ``ctx.input_grad_buffers`` provides a tuple aligned with the inputs to
+{meth}`~Function.forward`. Each entry is either ``None`` or the autograd engine's
+current accumulation buffer for that input. A custom backward kernel can accumulate
+its contribution directly into a non-``None`` buffer and return ``None`` for that
+input instead of returning a separate gradient tensor::
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (buffer,) = ctx.input_grad_buffers
+        if buffer is not None:
+            custom_backward_kernel(grad_output, out=buffer, accumulate=True)
+            return None
+        return custom_backward_kernel(grad_output)
+
+Each input is independent: for example, a fused linear backward may write
+``grad_input`` into its available buffer while returning ``grad_weight`` normally.
+Buffer availability depends on backward execution order, so the ``None`` fallback is
+required. The first producer normally receives ``None``; a later producer can receive
+the partial sum produced so far. The buffer may only be used synchronously while that
+custom ``backward`` method is running. Do not retain it: later producers may replace
+the engine's buffer, making a retained tensor stale. All producers that use or
+subsequently update an exposed buffer must execute on the same device, engine thread,
+and stream. PyTorch diagnoses engine-visible violations, but a custom function that
+launches work on another thread or stream is responsible for synchronizing it before
+returning.
+
+This interface is unavailable with {func}`torch.autograd.grad`, the ``inputs``
+argument to ``backward``, ``create_graph=True``, anomaly detection, or a post-hook on
+the producing autograd node. It only exposes the engine's per-backward ``InputBuffer``;
+for a leaf, the completed buffer still passes through ``AccumulateGrad`` and its normal
+tensor and post-accumulate hooks before becoming ``.grad``.
+
 In addition to ``ctx`` methods, the {class}`~Function` class supports the following
 class attributes:
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18705,7 +18705,7 @@ class TestInputGradBuffers(TestCase):
         first = _InputGradBufferProducer.apply(x, 1, False, None)
         torch.cuda.synchronize()
 
-        with self.assertRaisesRegex(RuntimeError, "engine thread, device, and stream"):
+        with self.assertRaisesRegex(RuntimeError, "same stream"):
             torch.autograd.backward((last, direct, first), (torch.ones_like(x),) * 3)
 
     @onlyCUDA

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18759,6 +18759,64 @@ class TestInputGradBuffers(TestCase):
         self.assertEqual(errors, [])
         self.assertEqual(x.grad, torch.full_like(x, 10))
 
+    @onlyCPU
+    def test_access_from_reentrant_final_callback_errors(self, device):
+        script = """
+import torch
+from torch.autograd import Function
+
+callback = None
+
+class Inner(Function):
+    @staticmethod
+    def forward(ctx, value):
+        return value.clone()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        torch.autograd.graph.queue_callback(callback)
+        return grad_output
+
+class Outer(Function):
+    @staticmethod
+    def forward(ctx, value):
+        return value.clone()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        global callback
+
+        def check_access():
+            try:
+                ctx.input_grad_buffers
+            except RuntimeError as error:
+                if "post-processing" not in str(error):
+                    raise
+            else:
+                raise RuntimeError("input_grad_buffers access unexpectedly succeeded")
+
+        callback = check_access
+        with torch.enable_grad():
+            inner_input = torch.ones((), requires_grad=True)
+            inner_output = Inner.apply(inner_input)
+        inner_output.backward()
+        return grad_output
+
+x = torch.ones((), requires_grad=True)
+Outer.apply(x).backward()
+"""
+        try:
+            subprocess.check_output(
+                [sys.executable, "-c", script],
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+                timeout=20,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("input_grad_buffers access during post-processing deadlocked")
+        except subprocess.CalledProcessError as error:
+            self.fail(error.output.decode("utf-8"))
+
     @onlyCUDA
     def test_lookup_does_not_deadlock_with_python_dispatch(self, device):
         script = """

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18364,6 +18364,348 @@ class TestFunctionAssertMessages(TestCase):
             F.apply(torch.randn(2, requires_grad=True))
 
 
+class _InputGradBufferProducer(Function):
+    @staticmethod
+    def forward(ctx, x, scale, direct, callback):
+        ctx.scale = scale
+        ctx.direct = direct
+        ctx.callback = callback
+        return x.clone()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        buffers = None
+        if ctx.direct:
+            buffers = ctx.input_grad_buffers
+            buffer = buffers[0]
+            if buffer is not None:
+                if ctx.callback is not None:
+                    ctx.callback(buffers, None)
+                buffer.add_(grad_output, alpha=ctx.scale)
+                return None, None, None, None
+
+        grad_input = grad_output * ctx.scale
+        if ctx.callback is not None:
+            ctx.callback(buffers, grad_input)
+        return grad_input, None, None, None
+
+
+class TestInputGradBuffers(TestCase):
+    def test_first_producer_falls_back(self, device):
+        observed_buffers = []
+
+        class Producer(Function):
+            @staticmethod
+            def forward(ctx, x, unused, scale):
+                ctx.scale = scale
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                buffers = ctx.input_grad_buffers
+                observed_buffers.append(buffers)
+                return grad_output * ctx.scale, None, None
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        unused = torch.randn(4, device=device)
+        Producer.apply(x, unused, 2).sum().backward()
+
+        self.assertEqual(observed_buffers, [(None, None, None)])
+        self.assertEqual(x.grad, torch.full_like(x, 2))
+
+    @parametrize("intermediate", (False, True))
+    def test_mixed_direct_and_returned_gradients(self, device, intermediate):
+        used_buffer = []
+
+        def observe(buffers, _grad_input):
+            buffer, scale_buffer, direct_buffer, callback_buffer = buffers
+            self.assertIsNone(scale_buffer)
+            self.assertIsNone(direct_buffer)
+            self.assertIsNone(callback_buffer)
+            used_buffer.append(buffer is not None)
+
+        leaf = torch.randn(4, device=device, requires_grad=True)
+        x = leaf * 2 if intermediate else leaf
+
+        # Higher sequence numbers execute first, so build the branches in
+        # reverse execution order.
+        last = _InputGradBufferProducer.apply(x, 1, False, None)
+        direct = _InputGradBufferProducer.apply(x, 2, True, observe)
+        first = _InputGradBufferProducer.apply(x, 3, False, None)
+        grad_outputs = tuple(torch.ones_like(out) for out in (last, direct, first))
+        torch.autograd.backward((last, direct, first), grad_outputs)
+
+        self.assertEqual(used_buffer, [True])
+        expected = 12 if intermediate else 6
+        self.assertEqual(leaf.grad, torch.full_like(leaf, expected))
+
+    def test_multiple_direct_producers(self, device):
+        used_buffer = []
+
+        def observe(buffers, _grad_input):
+            used_buffer.append(buffers[0] is not None)
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        outputs = tuple(
+            _InputGradBufferProducer.apply(x, scale, True, observe)
+            for scale in (1, 2, 3)
+        )
+        torch.autograd.backward(outputs, (torch.ones_like(x),) * 3)
+
+        self.assertEqual(used_buffer, [False, True, True])
+        self.assertEqual(x.grad, torch.full_like(x, 6))
+
+    def test_direct_input_grad_and_returned_weight_grad(self, device):
+        observed_buffers = []
+
+        class Multiply(Function):
+            @staticmethod
+            def forward(ctx, x, weight):
+                ctx.save_for_backward(x, weight)
+                return x * weight
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                x, weight = ctx.saved_tensors
+                input_buffer, weight_buffer = ctx.input_grad_buffers
+                observed_buffers.append((input_buffer is not None, weight_buffer))
+                grad_weight = grad_output * x
+                if input_buffer is not None:
+                    input_buffer.addcmul_(grad_output, weight)
+                    return None, grad_weight
+                return grad_output * weight, grad_weight
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        weight = torch.randn(4, device=device, requires_grad=True)
+        fused = Multiply.apply(x, weight)
+        first = x * 3
+        torch.autograd.backward((fused, first), (torch.ones_like(x),) * 2)
+
+        self.assertEqual(observed_buffers, [(True, None)])
+        self.assertEqual(x.grad, weight + 3)
+        self.assertEqual(weight.grad, x)
+
+    def test_retained_buffer_may_become_stale(self, device):
+        retained_buffers = []
+
+        def retain(buffers, _grad_input):
+            self.assertIsNotNone(buffers[0])
+            retained_buffers.append(buffers[0])
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        last = _InputGradBufferProducer.apply(x, 1, False, None)
+        direct = _InputGradBufferProducer.apply(x, 2, True, retain)
+        first = _InputGradBufferProducer.apply(x, 3, False, None)
+        grad_outputs = tuple(torch.ones_like(out) for out in (last, direct, first))
+        torch.autograd.backward((last, direct, first), grad_outputs)
+
+        self.assertEqual(x.grad, torch.full_like(x, 6))
+        self.assertEqual(retained_buffers, [torch.full_like(x, 5)])
+
+    def test_aliased_buffer_is_not_exposed(self, device):
+        producer_grad = []
+        observed_buffer = []
+
+        def retain_grad(_buffers, grad_input):
+            producer_grad.append(grad_input)
+
+        def observe(buffers, _grad_input):
+            observed_buffer.append(buffers[0])
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        direct = _InputGradBufferProducer.apply(x, 2, True, observe)
+        first = _InputGradBufferProducer.apply(x, 3, False, retain_grad)
+        torch.autograd.backward((direct, first), (torch.ones_like(x),) * 2)
+
+        self.assertEqual(observed_buffer, [None])
+        self.assertEqual(x.grad, torch.full_like(x, 5))
+
+    def test_target_hooks_see_accumulated_gradient(self, device):
+        tensor_hook_grads = []
+        node_prehook_grads = []
+        node_posthook_grads = []
+        post_accumulate_grads = []
+
+        def tensor_hook(grad):
+            tensor_hook_grads.append(grad.clone())
+            return grad
+
+        def post_accumulate_hook(tensor):
+            post_accumulate_grads.append(tensor.grad.clone())
+
+        def node_prehook(grads):
+            node_prehook_grads.append(grads[0].clone())
+            return grads
+
+        def node_posthook(grad_inputs, grad_outputs):
+            node_posthook_grads.append(grad_outputs[0].clone())
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        x.register_hook(tensor_hook)
+        x.register_post_accumulate_grad_hook(post_accumulate_hook)
+        accumulate_grad = torch.autograd.graph.get_gradient_edge(x).node
+        accumulate_grad.register_prehook(node_prehook)
+        accumulate_grad.register_hook(node_posthook)
+        direct = _InputGradBufferProducer.apply(x, 2, True, None)
+        first = _InputGradBufferProducer.apply(x, 3, False, None)
+        torch.autograd.backward((direct, first), (torch.ones_like(x),) * 2)
+
+        expected = torch.full_like(x, 5)
+        self.assertEqual(x.grad, expected)
+        self.assertEqual(tensor_hook_grads, [expected])
+        self.assertEqual(node_prehook_grads, [expected])
+        self.assertEqual(node_posthook_grads, [expected])
+        self.assertEqual(post_accumulate_grads, [expected])
+
+    def test_leaf_grad_is_separate_from_input_buffer(self, device):
+        observed_leaf_grads = []
+        shares_storage = []
+
+        def observe(buffers, _grad_input):
+            buffer = buffers[0]
+            self.assertIsNotNone(buffer)
+            observed_leaf_grads.append(x.grad.clone())
+            shares_storage.append(buffer.data_ptr() == x.grad.data_ptr())
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        x.grad = torch.full_like(x, 7)
+        direct = _InputGradBufferProducer.apply(x, 2, True, observe)
+        first = _InputGradBufferProducer.apply(x, 3, False, None)
+        torch.autograd.backward((direct, first), (torch.ones_like(x),) * 2)
+
+        self.assertEqual(observed_leaf_grads, [torch.full_like(x, 7)])
+        self.assertEqual(shares_storage, [False])
+        self.assertEqual(x.grad, torch.full_like(x, 12))
+
+    def test_access_outside_backward_errors(self, device):
+        class Producer(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        out = Producer.apply(x)
+        with self.assertRaisesRegex(RuntimeError, "while autograd is executing"):
+            out.grad_fn.input_grad_buffers
+
+    @parametrize("mode", ("grad", "create_graph", "anomaly", "post_hook"))
+    def test_unsupported_execution_modes_error(self, device, mode):
+        class Producer(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                ctx.input_grad_buffers
+                return grad_output
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        out = Producer.apply(x)
+        if mode == "post_hook":
+            out.grad_fn.register_hook(lambda grad_inputs, grad_outputs: None)
+
+        with self.assertRaisesRegex(RuntimeError, "input_grad_buffers"):
+            if mode == "grad":
+                torch.autograd.grad(out.sum(), x)
+            elif mode == "create_graph":
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    out.sum().backward(create_graph=True)
+            elif mode == "anomaly":
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    with torch.autograd.detect_anomaly():
+                        out.sum().backward()
+            else:
+                out.sum().backward()
+
+    @onlyCUDA
+    def test_different_stream_errors(self, device):
+        x = torch.randn(4, device=device, requires_grad=True)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            direct = _InputGradBufferProducer.apply(x, 1, True, None)
+        first = _InputGradBufferProducer.apply(x, 1, False, None)
+        torch.cuda.synchronize()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with self.assertRaisesRegex(RuntimeError, "same stream"):
+                torch.autograd.backward((direct, first), (torch.ones_like(x),) * 2)
+
+    @onlyCUDA
+    def test_later_producer_on_different_stream_errors(self, device):
+        x = torch.randn(4, device=device, requires_grad=True)
+        accumulate_grad = torch.autograd.graph.get_gradient_edge(x).node
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            last = _InputGradBufferProducer.apply(x, 1, False, None)
+        direct = _InputGradBufferProducer.apply(x, 1, True, None)
+        first = _InputGradBufferProducer.apply(x, 1, False, None)
+        torch.cuda.synchronize()
+
+        with self.assertRaisesRegex(RuntimeError, "engine thread, device, and stream"):
+            torch.autograd.backward((last, direct, first), (torch.ones_like(x),) * 3)
+
+    @onlyCUDA
+    @deviceCountAtLeast(2)
+    def test_different_device_errors(self, devices):
+        class Producer(Function):
+            @staticmethod
+            def forward(ctx, x, direct):
+                ctx.direct = direct
+                return x.to(devices[1])
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                if ctx.direct:
+                    ctx.input_grad_buffers
+                return grad_output.to(devices[0]).clone(), None
+
+        x = torch.randn(4, device=devices[0], requires_grad=True)
+        direct = Producer.apply(x, True)
+        first = Producer.apply(x, False)
+        torch.cuda.synchronize()
+
+        with self.assertRaisesRegex(RuntimeError, "same device"):
+            torch.autograd.backward(
+                (direct, first), (torch.ones_like(direct), torch.ones_like(first))
+            )
+
+    @onlyCPU
+    def test_concurrent_graph_tasks_are_isolated(self, device):
+        x = torch.randn(4, device=device, requires_grad=True)
+        direct = _InputGradBufferProducer.apply(x, 2, True, None)
+        first = _InputGradBufferProducer.apply(x, 3, False, None)
+        errors = []
+
+        def run_backward():
+            try:
+                torch.autograd.backward(
+                    (direct, first),
+                    (torch.ones_like(direct), torch.ones_like(first)),
+                    retain_graph=True,
+                )
+            except Exception as error:
+                errors.append(error)
+
+        threads = [threading.Thread(target=run_backward) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(errors, [])
+        self.assertEqual(x.grad, torch.full_like(x, 10))
+
+
 # Import test cases from below autograd/ here. These are found
 # implicitly by the loader, so Flake8 thinks they are unused, hence
 # the suppressions.
@@ -18385,6 +18727,7 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestAutogradStreamSynchronization, globals(), except_for=None
 )
+instantiate_device_type_tests(TestInputGradBuffers, globals(), only_for=("cpu", "cuda"))
 
 instantiate_parametrized_tests(TestAutograd)
 instantiate_parametrized_tests(TestNestedCheckpoint)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18487,13 +18487,17 @@ class TestInputGradBuffers(TestCase):
 
     def test_retained_buffer_may_become_stale(self, device):
         retained_buffers = []
+        reexposed_buffers = []
 
         def retain(buffers, _grad_input):
             self.assertIsNotNone(buffers[0])
             retained_buffers.append(buffers[0])
 
+        def observe(buffers, _grad_input):
+            reexposed_buffers.append(buffers[0])
+
         x = torch.randn(4, device=device, requires_grad=True)
-        last = _InputGradBufferProducer.apply(x, 1, False, None)
+        last = _InputGradBufferProducer.apply(x, 1, True, observe)
         direct = _InputGradBufferProducer.apply(x, 2, True, retain)
         first = _InputGradBufferProducer.apply(x, 3, False, None)
         grad_outputs = tuple(torch.ones_like(out) for out in (last, direct, first))
@@ -18501,6 +18505,7 @@ class TestInputGradBuffers(TestCase):
 
         self.assertEqual(x.grad, torch.full_like(x, 6))
         self.assertEqual(retained_buffers, [torch.full_like(x, 5)])
+        self.assertEqual(reexposed_buffers, [None])
 
     def test_aliased_buffer_is_not_exposed(self, device):
         producer_grad = []
@@ -18623,6 +18628,36 @@ class TestInputGradBuffers(TestCase):
                         out.sum().backward()
             else:
                 out.sum().backward()
+
+    @onlyCUDA
+    def test_user_stream_switch_does_not_change_execution_stream(self, device):
+        observed_buffers = []
+        other_stream = torch.cuda.Stream()
+
+        class Producer(Function):
+            @staticmethod
+            def forward(ctx, x, direct):
+                ctx.direct = direct
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                if ctx.direct:
+                    with torch.cuda.stream(other_stream):
+                        buffer = ctx.input_grad_buffers[0]
+                    observed_buffers.append(buffer is not None)
+                    if buffer is not None:
+                        buffer.add_(grad_output)
+                        return None, None
+                return grad_output.clone(), None
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        direct = Producer.apply(x, True)
+        first = Producer.apply(x, False)
+        torch.autograd.backward((direct, first), (torch.ones_like(x),) * 2)
+
+        self.assertEqual(observed_buffers, [True])
+        self.assertEqual(x.grad, torch.full_like(x, 2))
 
     @onlyCUDA
     def test_different_stream_errors(self, device):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18709,7 +18709,7 @@ class TestInputGradBuffers(TestCase):
         first = Producer.apply(x, False)
         torch.cuda.synchronize()
 
-        with self.assertRaisesRegex(RuntimeError, "same device"):
+        with self.assertRaisesRegex(RuntimeError, "same stream"):
             torch.autograd.backward(
                 (direct, first), (torch.ones_like(direct), torch.ones_like(first))
             )

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18740,6 +18740,86 @@ class TestInputGradBuffers(TestCase):
         self.assertEqual(errors, [])
         self.assertEqual(x.grad, torch.full_like(x, 10))
 
+    @onlyCUDA
+    def test_lookup_does_not_deadlock_with_python_dispatch(self, device):
+        script = """
+import threading
+import time
+
+import torch
+from torch.autograd import Function
+from torch.utils._pytree import tree_map
+
+dispatch_entered = threading.Event()
+
+class DispatchTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, elem):
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            elem.shape,
+            strides=elem.stride(),
+            storage_offset=elem.storage_offset(),
+            dtype=elem.dtype,
+            layout=elem.layout,
+            device=elem.device,
+            requires_grad=False,
+        )
+
+    def __init__(self, elem):
+        self.elem = elem
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        dispatch_entered.set()
+        time.sleep(0.1)
+        kwargs = {} if kwargs is None else kwargs
+        unwrap = lambda value: value.elem if isinstance(value, cls) else value
+        return func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
+
+class Getter(Function):
+    @staticmethod
+    def forward(ctx, value):
+        return value.clone()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        if not dispatch_entered.wait(timeout=5):
+            raise RuntimeError("timed out waiting for Python dispatch")
+        ctx.input_grad_buffers
+        return grad_output
+
+class Fanout(Function):
+    @staticmethod
+    def forward(ctx, getter_output, duplicated_a, duplicated_b):
+        return duplicated_a.clone()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return (
+            grad_output.cpu(),
+            grad_output.clone(),
+            DispatchTensor(grad_output.clone()),
+        )
+
+seed = torch.ones((), requires_grad=True)
+getter_output = Getter.apply(seed)
+source = torch.ones((), device="cuda", requires_grad=True)
+duplicated = source.clone()
+Fanout.apply(getter_output, duplicated, duplicated).backward()
+"""
+        try:
+            subprocess.check_output(
+                [sys.executable, "-c", script],
+                stderr=subprocess.STDOUT,
+                cwd=os.path.dirname(os.path.realpath(__file__)),
+                timeout=20,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("input_grad_buffers lookup deadlocked")
+        except subprocess.CalledProcessError as error:
+            self.fail(error.output.decode("utf-8"))
+
 
 # Import test cases from below autograd/ here. These are found
 # implicitly by the loader, so Flake8 thinks they are unused, hence

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18390,6 +18390,7 @@ class _InputGradBufferProducer(Function):
         return grad_input, None, None, None
 
 
+@skipIfTorchDynamo("input_grad_buffers requires eager autograd engine state")
 class TestInputGradBuffers(TestCase):
     def test_first_producer_falls_back(self, device):
         observed_buffers = []
@@ -18629,6 +18630,24 @@ class TestInputGradBuffers(TestCase):
             else:
                 out.sum().backward()
 
+    def test_create_graph_cannot_be_masked(self, device):
+        class Producer(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            @once_differentiable
+            def backward(ctx, grad_output):
+                ctx.input_grad_buffers
+                return grad_output
+
+        x = torch.randn(4, device=device, requires_grad=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with self.assertRaisesRegex(RuntimeError, "create_graph=True"):
+                Producer.apply(x).sum().backward(create_graph=True)
+
     @onlyCUDA
     def test_user_stream_switch_does_not_change_execution_stream(self, device):
         observed_buffers = []
@@ -18743,14 +18762,16 @@ class TestInputGradBuffers(TestCase):
     @onlyCUDA
     def test_lookup_does_not_deadlock_with_python_dispatch(self, device):
         script = """
+import sys
 import threading
-import time
 
 import torch
 from torch.autograd import Function
 from torch.utils._pytree import tree_map
 
 dispatch_entered = threading.Event()
+getter_entering_lookup = threading.Event()
+sys.setswitchinterval(10)
 
 class DispatchTensor(torch.Tensor):
     @staticmethod
@@ -18772,7 +18793,8 @@ class DispatchTensor(torch.Tensor):
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
         dispatch_entered.set()
-        time.sleep(0.1)
+        if not getter_entering_lookup.wait(timeout=5):
+            raise RuntimeError("timed out waiting for InputBuffer lookup")
         kwargs = {} if kwargs is None else kwargs
         unwrap = lambda value: value.elem if isinstance(value, cls) else value
         return func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
@@ -18786,6 +18808,7 @@ class Getter(Function):
     def backward(ctx, grad_output):
         if not dispatch_entered.wait(timeout=5):
             raise RuntimeError("timed out waiting for Python dispatch")
+        getter_entering_lookup.set()
         ctx.input_grad_buffers
         return grad_output
 

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -273,7 +273,7 @@ class _FunctionBase:
     _raw_saved_tensors: tuple[Any]
     next_functions: tuple[tuple[Any, _int], ...]
     needs_input_grad: tuple[_bool]
-    input_grad_buffers: tuple[Tensor | None, ...]
+    _input_grad_buffers: tuple[Tensor | None, ...]
     metadata: dict
     _materialize_non_diff_grads: _bool
     # skip adding type hints for the fields that have wrappers defined

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -273,6 +273,7 @@ class _FunctionBase:
     _raw_saved_tensors: tuple[Any]
     next_functions: tuple[tuple[Any, _int], ...]
     needs_input_grad: tuple[_bool]
+    input_grad_buffers: tuple[Tensor | None, ...]
     metadata: dict
     _materialize_non_diff_grads: _bool
     # skip adding type hints for the fields that have wrappers defined

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -36,7 +36,88 @@ _P = ParamSpec("_P")
 
 # Formerly known as: _ContextMethodMixin
 class FunctionCtx:
+    _input_grad_buffers: tuple[torch.Tensor | None, ...]
     output_grad_dtypes: "tuple[torch.dtype | None, ...] | None"
+
+    @property
+    def input_grad_buffers(self) -> tuple[torch.Tensor | None, ...]:
+        r"""Return existing buffers for accumulating gradients of this Function's inputs.
+
+        The tuple is aligned with the inputs passed to :meth:`~Function.forward`.
+        Each entry is ``None`` or the autograd engine's current ``InputBuffer`` for
+        that input. A non-``None`` buffer contains gradient contributions already
+        produced during the current backward. A custom backward may accumulate its
+        contribution directly into the buffer and return ``None`` for that input,
+        fusing gradient computation with accumulation and avoiding a separate
+        gradient tensor.
+
+        A buffer is exposed only after another producer has contributed to that
+        input, so availability follows backward execution order and is independent
+        for each input. An entry may also be ``None`` when its buffer cannot be
+        safely exposed.
+
+        For example, ``x`` has another forward use while ``weight`` does not. The
+        custom backward conditionally fuses accumulation only for ``grad_x``::
+
+            >>> # xdoctest: +SKIP
+            >>> class Matmul(torch.autograd.Function):
+            >>>     @staticmethod
+            >>>     def forward(ctx, x, weight):
+            >>>         ctx.save_for_backward(x, weight)
+            >>>         return x @ weight
+            >>>
+            >>>     @staticmethod
+            >>>     def backward(ctx, grad_output):
+            >>>         x, weight = ctx.saved_tensors
+            >>>         x_buffer, _ = ctx.input_grad_buffers
+            >>>         if x_buffer is not None:
+            >>>             # Computes grad_x and adds it to the existing buffer.
+            >>>             matmul_backward_input_acc(
+            >>>                 grad_output, weight, out=x_buffer
+            >>>             )
+            >>>             grad_x = None
+            >>>         else:
+            >>>             grad_x = matmul_backward_input(grad_output, weight)
+            >>>         grad_weight = matmul_backward_weight(grad_output, x)
+            >>>         return grad_x, grad_weight
+            >>>
+            >>> loss = Matmul.apply(x, weight).sum() + other_op(x).sum()
+
+        If ``other_op`` produces its contribution first, ``x_buffer`` can expose
+        that partial sum. If ``Matmul`` runs first, ``x_buffer`` is ``None`` and it
+        returns a separate tensor instead. The fallback lets the function work
+        under either ordering.
+
+        .. warning::
+            A returned buffer is valid only while the current custom ``backward``
+            invocation is running. Mutate it synchronously and do not retain it.
+            A later producer may replace the engine's buffer, making a retained
+            tensor stale.
+
+            All producers that use or subsequently update an exposed buffer must
+            execute on the same device, autograd engine thread, and stream. PyTorch
+            diagnoses engine-visible violations. A custom function that launches
+            work on another thread or stream is responsible for synchronizing it
+            before returning.
+
+        This property is available only while a Python custom ``backward`` is
+        executing during an eager, first-order :meth:`~torch.Tensor.backward` call
+        without an ``inputs`` argument. It is unavailable with
+        :func:`torch.autograd.grad`, ``create_graph=True``, anomaly detection, a
+        post-hook on the producing autograd node, or stale capture stream overrides.
+
+        .. note::
+            This property never exposes a leaf's ``.grad``. For a leaf input, the
+            completed buffer still passes through ``AccumulateGrad`` and its hooks
+            before becoming ``.grad``.
+
+            A custom backward that instead accumulates directly into a
+            preinitialized leaf ``.grad`` and returns ``None`` does not use this
+            interface. It is responsible for the ``.grad`` buffer's initialization
+            and lifetime, synchronization with all other producers, and any
+            ``AccumulateGrad`` hook behavior bypassed by the direct write.
+        """
+        return self._input_grad_buffers
 
     def save_for_backward(self, *tensors: torch.Tensor):
         r"""Save given tensors for a future call to :func:`~Function.backward`.

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -111,10 +111,10 @@ class FunctionCtx:
             completed buffer still passes through ``AccumulateGrad`` and its hooks
             before becoming ``.grad``.
 
-            A custom backward that instead accumulates directly into a
-            preinitialized leaf ``.grad`` and returns ``None`` does not use this
-            interface. It is responsible for the ``.grad`` buffer's initialization
-            and lifetime, synchronization with all other producers, and any
+            A custom backward that instead accumulates directly into a leaf
+            ``.grad`` and returns ``None`` does not use this interface. It is
+            responsible for managing ``.grad`` state, including initialization and
+            lifetime, synchronization with all other producers, and any
             ``AccumulateGrad`` hook behavior bypassed by the direct write.
         """
         return self._input_grad_buffers

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -423,6 +423,12 @@ variable_list get_current_input_grad_buffers(Node* node) {
       current_node && current_node.get() == node,
       "input_grad_buffers can only be accessed from the currently executing "
       "autograd.Function backward()");
+  // Final callbacks run while the GraphTask mutex is held. During reentrant
+  // backward, current_node can still refer to the suspended outer node, so
+  // reject post-processing before acquiring that mutex below.
+  TORCH_CHECK(
+      !graph_task->future_completed_.load(),
+      "input_grad_buffers cannot be accessed during backward post-processing");
   TORCH_CHECK(
       graph_task->exec_info_.empty(),
       "input_grad_buffers is only supported by backward() without the inputs "

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -443,7 +443,6 @@ variable_list get_current_input_grad_buffers(Node* node) {
       "input_grad_buffers does not support "
       "set_override_stale_capture_stream(True)");
 
-  const auto producer_device = node->device();
   const auto opt_producer_stream = node->stream();
 
   variable_list result(node->next_edges().size());
@@ -465,9 +464,7 @@ variable_list get_current_input_grad_buffers(Node* node) {
         : next.function->stream();
     result[i] = input_buffer.get_for_direct_accumulation(
         next.input_nr,
-        producer_device,
         opt_producer_stream,
-        next.function->device(),
         opt_consumer_stream);
   }
   return result;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -411,6 +411,67 @@ int get_current_graph_task_id() {
   return current_graph_task ? current_graph_task->id_ : -1;
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+variable_list get_current_input_grad_buffers(Node* node) {
+  auto graph_task = current_graph_task;
+  TORCH_CHECK(
+      graph_task,
+      "input_grad_buffers can only be accessed while autograd is executing "
+      "backward()");
+  auto current_node = get_current_node();
+  TORCH_CHECK(
+      current_node && current_node.get() == node,
+      "input_grad_buffers can only be accessed from the currently executing "
+      "autograd.Function backward()");
+  TORCH_CHECK(
+      graph_task->exec_info_.empty(),
+      "input_grad_buffers is only supported by backward() without the inputs "
+      "argument");
+  TORCH_CHECK(
+      !at::GradMode::is_enabled(),
+      "input_grad_buffers does not support backward(create_graph=True)");
+  TORCH_CHECK(
+      !AnomalyMode::is_enabled(),
+      "input_grad_buffers does not support anomaly detection");
+  TORCH_CHECK(
+      node->post_hooks().empty(),
+      "input_grad_buffers does not support hooks registered on the producing "
+      "autograd node");
+
+  const auto producer_device = node->device();
+  auto opt_producer_stream = node->stream();
+  if (opt_producer_stream.has_value()) {
+    opt_producer_stream =
+        at::accelerator::getCurrentStream(producer_device.index());
+  }
+
+  variable_list result(node->next_edges().size());
+  std::lock_guard<std::mutex> lock(graph_task->mutex_);
+  for (const auto i : c10::irange(node->next_edges().size())) {
+    const auto& next = node->next_edge(i);
+    if (!next.is_valid()) {
+      continue;
+    }
+    auto input_buffer_it = graph_task->not_ready_.find(next.function.get());
+    if (input_buffer_it == graph_task->not_ready_.end()) {
+      continue;
+    }
+
+    auto& input_buffer = input_buffer_it->second;
+    const auto opt_consumer_stream =
+        input_buffer.opt_overridden_consumer_stream.has_value()
+        ? input_buffer.opt_overridden_consumer_stream
+        : next.function->stream();
+    result[i] = input_buffer.get_for_direct_accumulation(
+        next.input_nr,
+        producer_device,
+        opt_producer_stream,
+        next.function->device(),
+        opt_consumer_stream);
+  }
+  return result;
+}
+
 bool get_current_graph_task_keep_graph() {
   return current_graph_task ? current_graph_task->keep_graph_ : true;
 }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -428,7 +428,7 @@ variable_list get_current_input_grad_buffers(Node* node) {
       "input_grad_buffers is only supported by backward() without the inputs "
       "argument");
   TORCH_CHECK(
-      !at::GradMode::is_enabled(),
+      !graph_task->thread_locals_.get_grad_mode(),
       "input_grad_buffers does not support backward(create_graph=True)");
   TORCH_CHECK(
       !AnomalyMode::is_enabled(),
@@ -458,9 +458,7 @@ variable_list get_current_input_grad_buffers(Node* node) {
         ? input_buffer.opt_overridden_consumer_stream
         : next.function->stream();
     result[i] = input_buffer.get_for_direct_accumulation(
-        next.input_nr,
-        opt_producer_stream,
-        opt_consumer_stream);
+        next.input_nr, opt_producer_stream, opt_consumer_stream);
   }
   return result;
 }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -23,7 +23,6 @@
 #include <c10/core/StreamGuard.h>
 #include <c10/util/AbortHandler.h>
 #include <c10/util/Exception.h>
-#include <c10/util/ScopeExit.h>
 #include <c10/util/ThreadLocal.h>
 #include <c10/util/irange.h>
 #include <c10/util/thread_name.h>
@@ -120,11 +119,6 @@ static thread_local int total_depth = 0;
 // queue_callback() to find the target GraphTask to append final callbacks.
 C10_DEFINE_TLS_static(std::shared_ptr<GraphTask>, tls_current_graph_task);
 #define current_graph_task (tls_current_graph_task.get())
-
-C10_DEFINE_TLS_static(
-    std::optional<c10::Stream>,
-    tls_current_node_execution_stream);
-#define current_node_execution_stream (tls_current_node_execution_stream.get())
 
 // Every autograd worker thread is associated with a ready queue, which
 // specifies the stream of work of this thread to do. This shared_ptr is a
@@ -444,8 +438,13 @@ variable_list get_current_input_grad_buffers(Node* node) {
       "input_grad_buffers does not support hooks registered on the producing "
       "autograd node");
 
+  TORCH_CHECK(
+      !at::globalContext().overrideStaleCaptureStream(),
+      "input_grad_buffers does not support "
+      "set_override_stale_capture_stream(True)");
+
   const auto producer_device = node->device();
-  const auto opt_producer_stream = current_node_execution_stream;
+  const auto opt_producer_stream = node->stream();
 
   variable_list result(node->next_edges().size());
   std::lock_guard<std::mutex> lock(graph_task->mutex_);
@@ -1181,11 +1180,6 @@ void Engine::evaluate_function(
       ? inputs.opt_overridden_consumer_stream
       : func->stream();
 
-  auto previous_execution_stream =
-      std::exchange(current_node_execution_stream, opt_parent_stream);
-  auto execution_stream_guard = c10::make_scope_exit([&] {
-    current_node_execution_stream = std::move(previous_execution_stream);
-  });
   c10::OptionalStreamGuard parent_stream_guard{opt_parent_stream};
 
   // Ensure that the incoming gradients are ready

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -434,11 +434,6 @@ variable_list get_current_input_grad_buffers(Node* node) {
       !AnomalyMode::is_enabled(),
       "input_grad_buffers does not support anomaly detection");
   TORCH_CHECK(
-      node->post_hooks().empty(),
-      "input_grad_buffers does not support hooks registered on the producing "
-      "autograd node");
-
-  TORCH_CHECK(
       !at::globalContext().overrideStaleCaptureStream(),
       "input_grad_buffers does not support "
       "set_override_stale_capture_stream(True)");

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -23,6 +23,7 @@
 #include <c10/core/StreamGuard.h>
 #include <c10/util/AbortHandler.h>
 #include <c10/util/Exception.h>
+#include <c10/util/ScopeExit.h>
 #include <c10/util/ThreadLocal.h>
 #include <c10/util/irange.h>
 #include <c10/util/thread_name.h>
@@ -119,6 +120,11 @@ static thread_local int total_depth = 0;
 // queue_callback() to find the target GraphTask to append final callbacks.
 C10_DEFINE_TLS_static(std::shared_ptr<GraphTask>, tls_current_graph_task);
 #define current_graph_task (tls_current_graph_task.get())
+
+C10_DEFINE_TLS_static(
+    std::optional<c10::Stream>,
+    tls_current_node_execution_stream);
+#define current_node_execution_stream (tls_current_node_execution_stream.get())
 
 // Every autograd worker thread is associated with a ready queue, which
 // specifies the stream of work of this thread to do. This shared_ptr is a
@@ -439,11 +445,7 @@ variable_list get_current_input_grad_buffers(Node* node) {
       "autograd node");
 
   const auto producer_device = node->device();
-  auto opt_producer_stream = node->stream();
-  if (opt_producer_stream.has_value()) {
-    opt_producer_stream =
-        at::accelerator::getCurrentStream(producer_device.index());
-  }
+  const auto opt_producer_stream = current_node_execution_stream;
 
   variable_list result(node->next_edges().size());
   std::lock_guard<std::mutex> lock(graph_task->mutex_);
@@ -1179,6 +1181,11 @@ void Engine::evaluate_function(
       ? inputs.opt_overridden_consumer_stream
       : func->stream();
 
+  auto previous_execution_stream =
+      std::exchange(current_node_execution_stream, opt_parent_stream);
+  auto execution_stream_guard = c10::make_scope_exit([&] {
+    current_node_execution_stream = std::move(previous_execution_stream);
+  });
   c10::OptionalStreamGuard parent_stream_guard{opt_parent_stream};
 
   // Ensure that the incoming gradients are ready

--- a/torch/csrc/autograd/graph_task.h
+++ b/torch/csrc/autograd/graph_task.h
@@ -226,6 +226,7 @@ get_current_graph_task_nodes_in_graph();
 TORCH_API bool get_current_graph_task_keep_graph();
 TORCH_API std::vector<Node*> get_current_graph_task_execution_order();
 TORCH_API int get_current_graph_task_id();
+TORCH_API variable_list get_current_input_grad_buffers(Node* node);
 void add_node_to_current_graph_task_exec_info(Node* fn);
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -172,6 +172,20 @@ static void accumulate(
   }
 }
 
+// Note [Direct accumulation thread and stream safety]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Buffers exposed here live in GraphTask::not_ready_. The engine calls add()
+// on those buffers and get_for_direct_accumulation() with the GraphTask mutex
+// held. This serializes ordinary additions with exposing a buffer and makes the
+// recorded thread visible to subsequent producers. The mutex is released
+// before user backward code mutates the returned Tensor, so later producers
+// must run on the same engine thread; a producer on another thread is rejected
+// before it can touch the buffer.
+//
+// Accelerator writes are asynchronous, so thread serialization is not enough.
+// The producer, accumulation, ready, and consumer streams must all match. This
+// orders prior writes, the direct mutation, later additions, and the consumer
+// without recording a new completion event when backward returns None.
 void InputBuffer::validate_direct_accumulation(
     size_t pos,
     const at::Device& device,
@@ -222,6 +236,7 @@ Variable InputBuffer::get_for_direct_accumulation(
   }
   auto& thread = direct_accumulation_threads_[pos];
   const auto current_thread = std::this_thread::get_id();
+  // See Note [Direct accumulation thread and stream safety].
   validate_direct_accumulation(
       pos,
       var.device(),
@@ -311,6 +326,7 @@ void InputBuffer::add(
     if (C10_UNLIKELY(
             direct_accumulation_threads_ != nullptr &&
             direct_accumulation_threads_[pos].has_value())) {
+      // See Note [Direct accumulation thread and stream safety].
       validate_direct_accumulation(
           pos,
           device,
@@ -355,6 +371,7 @@ void InputBuffer::add(
   if (C10_UNLIKELY(
           direct_accumulation_threads_ != nullptr &&
           direct_accumulation_threads_[pos].has_value())) {
+    // See Note [Direct accumulation thread and stream safety].
     validate_direct_accumulation(
         pos,
         device,

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -176,35 +176,30 @@ void InputBuffer::validate_direct_accumulation(
     size_t pos,
     const at::Device& device,
     const std::optional<c10::Stream>& opt_producer_stream,
-    const std::optional<c10::Stream>& opt_consumer_stream) const {
-  if (!direct_accumulation_threads_ ||
-      !direct_accumulation_threads_[pos].has_value()) {
-    return;
-  }
-
+    const std::optional<c10::Stream>& opt_consumer_stream,
+    std::thread::id expected_thread) const {
   TORCH_INTERNAL_ASSERT(buffer[pos].defined());
   TORCH_CHECK(
       buffer[pos].device() == device,
-      "After an InputBuffer is exposed for direct accumulation, all producers "
-      "must use the same engine thread, device, and stream");
+      "Direct InputBuffer accumulation requires the same stream, device, and "
+      "engine thread");
 
   bool same_stream = false;
   if (at::accelerator::isAccelerator(device.type())) {
     TORCH_INTERNAL_ASSERT(
-        opt_producer_stream && opt_consumer_stream &&
         pos < opt_accum_streams.size() && opt_accum_streams[pos] &&
         pos < ready_streams.size() && ready_streams[pos]);
-    same_stream = *opt_producer_stream == *opt_consumer_stream &&
+    same_stream = opt_producer_stream && opt_consumer_stream &&
+        *opt_producer_stream == *opt_consumer_stream &&
         *opt_producer_stream == *opt_accum_streams[pos] &&
         *opt_producer_stream == *ready_streams[pos];
   } else {
     same_stream = !opt_producer_stream && !opt_consumer_stream;
   }
   TORCH_CHECK(
-      *direct_accumulation_threads_[pos] == std::this_thread::get_id() &&
-          same_stream,
-      "After an InputBuffer is exposed for direct accumulation, all producers "
-      "must use the same engine thread, device, and stream");
+      expected_thread == std::this_thread::get_id() && same_stream,
+      "Direct InputBuffer accumulation requires the same stream, device, and "
+      "engine thread");
 }
 
 Variable InputBuffer::get_for_direct_accumulation(
@@ -221,35 +216,20 @@ Variable InputBuffer::get_for_direct_accumulation(
     return {};
   }
 
-  const auto device = var.device();
-  if (at::accelerator::isAccelerator(device.type())) {
-    TORCH_INTERNAL_ASSERT(
-        pos < opt_accum_streams.size() && opt_accum_streams[pos] &&
-        pos < ready_streams.size() && ready_streams[pos]);
-    TORCH_CHECK(
-        opt_producer_stream && opt_consumer_stream &&
-            *opt_producer_stream == *opt_consumer_stream &&
-            *opt_producer_stream == *opt_accum_streams[pos] &&
-            *opt_producer_stream == *ready_streams[pos],
-        "Direct InputBuffer accumulation requires the producer, buffer, and "
-        "consumer to use the same stream");
-  } else {
-    TORCH_CHECK(
-        !opt_producer_stream && !opt_consumer_stream,
-        "Direct InputBuffer accumulation does not support an accelerator "
-        "producer or consumer for a CPU buffer");
-  }
-
   if (!direct_accumulation_threads_) {
     direct_accumulation_threads_ =
         std::make_unique<std::optional<std::thread::id>[]>(buffer.size());
   }
   auto& thread = direct_accumulation_threads_[pos];
-  if (thread.has_value()) {
-    validate_direct_accumulation(
-        pos, device, opt_producer_stream, opt_consumer_stream);
-  } else {
-    thread.emplace(std::this_thread::get_id());
+  const auto current_thread = std::this_thread::get_id();
+  validate_direct_accumulation(
+      pos,
+      var.device(),
+      opt_producer_stream,
+      opt_consumer_stream,
+      thread.value_or(current_thread));
+  if (!thread.has_value()) {
+    thread.emplace(current_thread);
   }
   return var;
 }
@@ -328,9 +308,15 @@ void InputBuffer::add(
   // Non-accelerator case
   //
   if (!is_accelerator) {
-    if (C10_UNLIKELY(direct_accumulation_threads_ != nullptr)) {
+    if (C10_UNLIKELY(
+            direct_accumulation_threads_ != nullptr &&
+            direct_accumulation_threads_[pos].has_value())) {
       validate_direct_accumulation(
-          pos, device, opt_producer_stream_, opt_consumer_stream_);
+          pos,
+          device,
+          opt_producer_stream_,
+          opt_consumer_stream_,
+          *direct_accumulation_threads_[pos]);
     }
     if (!buffer[pos].defined()) {
       buffer[pos] = std::move(var);
@@ -366,9 +352,15 @@ void InputBuffer::add(
   }
 
   TORCH_INTERNAL_ASSERT(opt_consumer_stream && opt_producer_stream);
-  if (C10_UNLIKELY(direct_accumulation_threads_ != nullptr)) {
+  if (C10_UNLIKELY(
+          direct_accumulation_threads_ != nullptr &&
+          direct_accumulation_threads_[pos].has_value())) {
     validate_direct_accumulation(
-        pos, device, opt_producer_stream, opt_consumer_stream);
+        pos,
+        device,
+        opt_producer_stream,
+        opt_consumer_stream,
+        *direct_accumulation_threads_[pos]);
   }
 
   // Handle producer/consumer stream mismatch. Two independent cases:

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -209,9 +209,7 @@ void InputBuffer::validate_direct_accumulation(
 
 Variable InputBuffer::get_for_direct_accumulation(
     size_t pos,
-    const at::Device& producer_device,
     const std::optional<c10::Stream>& opt_producer_stream,
-    const at::Device& consumer_device,
     const std::optional<c10::Stream>& opt_consumer_stream) {
   TORCH_INTERNAL_ASSERT(pos < buffer.size());
   auto& var = buffer[pos];
@@ -224,18 +222,13 @@ Variable InputBuffer::get_for_direct_accumulation(
   }
 
   const auto device = var.device();
-  TORCH_CHECK(
-      device == producer_device && device == consumer_device,
-      "Direct InputBuffer accumulation requires the producer, buffer, and "
-      "consumer to use the same device");
-
   if (at::accelerator::isAccelerator(device.type())) {
     TORCH_INTERNAL_ASSERT(
-        opt_producer_stream && opt_consumer_stream &&
         pos < opt_accum_streams.size() && opt_accum_streams[pos] &&
         pos < ready_streams.size() && ready_streams[pos]);
     TORCH_CHECK(
-        *opt_producer_stream == *opt_consumer_stream &&
+        opt_producer_stream && opt_consumer_stream &&
+            *opt_producer_stream == *opt_consumer_stream &&
             *opt_producer_stream == *opt_accum_streams[pos] &&
             *opt_producer_stream == *ready_streams[pos],
         "Direct InputBuffer accumulation requires the producer, buffer, and "

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -176,16 +176,32 @@ void InputBuffer::validate_direct_accumulation(
     const at::Device& device,
     const std::optional<c10::Stream>& opt_producer_stream,
     const std::optional<c10::Stream>& opt_consumer_stream) const {
-  if (!direct_accumulation_info_ ||
-      !direct_accumulation_info_[pos].has_value()) {
+  if (!direct_accumulation_threads_ ||
+      !direct_accumulation_threads_[pos].has_value()) {
     return;
   }
 
-  const auto& info = *direct_accumulation_info_[pos];
+  TORCH_INTERNAL_ASSERT(buffer[pos].defined());
   TORCH_CHECK(
-      info.thread_id == std::this_thread::get_id() && info.device == device &&
-          info.stream == opt_producer_stream &&
-          info.stream == opt_consumer_stream,
+      buffer[pos].device() == device,
+      "After an InputBuffer is exposed for direct accumulation, all producers "
+      "must use the same engine thread, device, and stream");
+
+  bool same_stream = false;
+  if (at::accelerator::isAccelerator(device.type())) {
+    TORCH_INTERNAL_ASSERT(
+        opt_producer_stream && opt_consumer_stream &&
+        pos < opt_accum_streams.size() && opt_accum_streams[pos] &&
+        pos < ready_streams.size() && ready_streams[pos]);
+    same_stream = *opt_producer_stream == *opt_consumer_stream &&
+        *opt_producer_stream == *opt_accum_streams[pos] &&
+        *opt_producer_stream == *ready_streams[pos];
+  } else {
+    same_stream = !opt_producer_stream && !opt_consumer_stream;
+  }
+  TORCH_CHECK(
+      *direct_accumulation_threads_[pos] == std::this_thread::get_id() &&
+          same_stream,
       "After an InputBuffer is exposed for direct accumulation, all producers "
       "must use the same engine thread, device, and stream");
 }
@@ -202,9 +218,7 @@ Variable InputBuffer::get_for_direct_accumulation(
     return {};
   }
 
-  if ((!direct_accumulation_info_ ||
-       !direct_accumulation_info_[pos].has_value()) &&
-      !can_accumulate_inplace(var)) {
+  if (!can_accumulate_inplace(var)) {
     return {};
   }
 
@@ -215,12 +229,10 @@ Variable InputBuffer::get_for_direct_accumulation(
       "consumer to use the same device");
 
   if (at::accelerator::isAccelerator(device.type())) {
-    TORCH_CHECK(
+    TORCH_INTERNAL_ASSERT(
         opt_producer_stream && opt_consumer_stream &&
-            pos < opt_accum_streams.size() && opt_accum_streams[pos] &&
-            pos < ready_streams.size() && ready_streams[pos],
-        "Direct InputBuffer accumulation requires a known execution, "
-        "accumulation, and readiness stream");
+        pos < opt_accum_streams.size() && opt_accum_streams[pos] &&
+        pos < ready_streams.size() && ready_streams[pos]);
     TORCH_CHECK(
         *opt_producer_stream == *opt_consumer_stream &&
             *opt_producer_stream == *opt_accum_streams[pos] &&
@@ -234,22 +246,16 @@ Variable InputBuffer::get_for_direct_accumulation(
         "producer or consumer for a CPU buffer");
   }
 
-  if (!direct_accumulation_info_) {
-    direct_accumulation_info_ =
-        std::make_unique<std::optional<DirectAccumulationInfo>[]>(
-            buffer.size());
+  if (!direct_accumulation_threads_) {
+    direct_accumulation_threads_ =
+        std::make_unique<std::optional<std::thread::id>[]>(buffer.size());
   }
-  auto& info = direct_accumulation_info_[pos];
-  if (info.has_value()) {
+  auto& thread = direct_accumulation_threads_[pos];
+  if (thread.has_value()) {
     validate_direct_accumulation(
         pos, device, opt_producer_stream, opt_consumer_stream);
-    TORCH_CHECK(
-        is_direct_accumulation_compatible(var),
-        "An InputBuffer exposed for direct accumulation is no longer safely "
-        "mutable");
   } else {
-    info.emplace(DirectAccumulationInfo{
-        std::this_thread::get_id(), device, opt_producer_stream});
+    thread.emplace(std::this_thread::get_id());
   }
   return var;
 }
@@ -328,7 +334,7 @@ void InputBuffer::add(
   // Non-accelerator case
   //
   if (!is_accelerator) {
-    if (C10_UNLIKELY(direct_accumulation_info_ != nullptr)) {
+    if (C10_UNLIKELY(direct_accumulation_threads_ != nullptr)) {
       validate_direct_accumulation(
           pos, device, opt_producer_stream_, opt_consumer_stream_);
     }
@@ -366,7 +372,7 @@ void InputBuffer::add(
   }
 
   TORCH_INTERNAL_ASSERT(opt_consumer_stream && opt_producer_stream);
-  if (C10_UNLIKELY(direct_accumulation_info_ != nullptr)) {
+  if (C10_UNLIKELY(direct_accumulation_threads_ != nullptr)) {
     validate_direct_accumulation(
         pos, device, opt_producer_stream, opt_consumer_stream);
   }

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -116,14 +116,10 @@ void record_stream_any_impl(Variable& var, const c10::Stream& stream) {
   }
 }
 
-bool is_direct_accumulation_compatible(const Variable& v) {
+bool can_accumulate_inplace(const Variable& v) {
   return !(at::isTensorSubclassLike(v) || v._is_zerotensor() ||
            v.is_nested()) &&
-      v.is_non_overlapping_and_dense() && v.has_storage();
-}
-
-bool can_accumulate_inplace(const Variable& v) {
-  return is_direct_accumulation_compatible(v) &&
+      v.is_non_overlapping_and_dense() && v.has_storage() &&
       impl::is_tensor_stealable(v, 1 + at::caching::is_cached_tensor(v)) &&
       v.storage().use_count() == 1;
 }

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -116,17 +116,16 @@ void record_stream_any_impl(Variable& var, const c10::Stream& stream) {
   }
 }
 
+bool is_direct_accumulation_compatible(const Variable& v) {
+  return !(at::isTensorSubclassLike(v) || v._is_zerotensor() ||
+           v.is_nested()) &&
+      v.is_non_overlapping_and_dense() && v.has_storage();
+}
+
 bool can_accumulate_inplace(const Variable& v) {
-  return (
-      // `v` is a "vanilla" Tensor
-      !(at::isTensorSubclassLike(v) || v._is_zerotensor() || v.is_nested()) &&
-
-      // with a favorable memory layout
-      v.is_non_overlapping_and_dense() &&
-
-      // and we hold the last reference
+  return is_direct_accumulation_compatible(v) &&
       impl::is_tensor_stealable(v, 1 + at::caching::is_cached_tensor(v)) &&
-      v.has_storage() && v.storage().use_count() == 1);
+      v.storage().use_count() == 1;
 }
 } // anonymous namespace
 
@@ -170,6 +169,89 @@ static void accumulate(
   } else {
     buffer[pos] = old_var + var;
   }
+}
+
+void InputBuffer::validate_direct_accumulation(
+    size_t pos,
+    const at::Device& device,
+    const std::optional<c10::Stream>& opt_producer_stream,
+    const std::optional<c10::Stream>& opt_consumer_stream) const {
+  if (!direct_accumulation_info_ ||
+      !direct_accumulation_info_[pos].has_value()) {
+    return;
+  }
+
+  const auto& info = *direct_accumulation_info_[pos];
+  TORCH_CHECK(
+      info.thread_id == std::this_thread::get_id() && info.device == device &&
+          info.stream == opt_producer_stream &&
+          info.stream == opt_consumer_stream,
+      "After an InputBuffer is exposed for direct accumulation, all producers "
+      "must use the same engine thread, device, and stream");
+}
+
+Variable InputBuffer::get_for_direct_accumulation(
+    size_t pos,
+    const at::Device& producer_device,
+    const std::optional<c10::Stream>& opt_producer_stream,
+    const at::Device& consumer_device,
+    const std::optional<c10::Stream>& opt_consumer_stream) {
+  TORCH_INTERNAL_ASSERT(pos < buffer.size());
+  auto& var = buffer[pos];
+  if (!var.defined()) {
+    return {};
+  }
+
+  if ((!direct_accumulation_info_ ||
+       !direct_accumulation_info_[pos].has_value()) &&
+      !can_accumulate_inplace(var)) {
+    return {};
+  }
+
+  const auto device = var.device();
+  TORCH_CHECK(
+      device == producer_device && device == consumer_device,
+      "Direct InputBuffer accumulation requires the producer, buffer, and "
+      "consumer to use the same device");
+
+  if (at::accelerator::isAccelerator(device.type())) {
+    TORCH_CHECK(
+        opt_producer_stream && opt_consumer_stream &&
+            pos < opt_accum_streams.size() && opt_accum_streams[pos] &&
+            pos < ready_streams.size() && ready_streams[pos],
+        "Direct InputBuffer accumulation requires a known execution, "
+        "accumulation, and readiness stream");
+    TORCH_CHECK(
+        *opt_producer_stream == *opt_consumer_stream &&
+            *opt_producer_stream == *opt_accum_streams[pos] &&
+            *opt_producer_stream == *ready_streams[pos],
+        "Direct InputBuffer accumulation requires the producer, buffer, and "
+        "consumer to use the same stream");
+  } else {
+    TORCH_CHECK(
+        !opt_producer_stream && !opt_consumer_stream,
+        "Direct InputBuffer accumulation does not support an accelerator "
+        "producer or consumer for a CPU buffer");
+  }
+
+  if (!direct_accumulation_info_) {
+    direct_accumulation_info_ =
+        std::make_unique<std::optional<DirectAccumulationInfo>[]>(
+            buffer.size());
+  }
+  auto& info = direct_accumulation_info_[pos];
+  if (info.has_value()) {
+    validate_direct_accumulation(
+        pos, device, opt_producer_stream, opt_consumer_stream);
+    TORCH_CHECK(
+        is_direct_accumulation_compatible(var),
+        "An InputBuffer exposed for direct accumulation is no longer safely "
+        "mutable");
+  } else {
+    info.emplace(DirectAccumulationInfo{
+        std::this_thread::get_id(), device, opt_producer_stream});
+  }
+  return var;
 }
 
 // Note: [Stream sync contract when dealing with multi-deviced-ness]
@@ -246,6 +328,10 @@ void InputBuffer::add(
   // Non-accelerator case
   //
   if (!is_accelerator) {
+    if (C10_UNLIKELY(direct_accumulation_info_ != nullptr)) {
+      validate_direct_accumulation(
+          pos, device, opt_producer_stream_, opt_consumer_stream_);
+    }
     if (!buffer[pos].defined()) {
       buffer[pos] = std::move(var);
     } else {
@@ -280,6 +366,10 @@ void InputBuffer::add(
   }
 
   TORCH_INTERNAL_ASSERT(opt_consumer_stream && opt_producer_stream);
+  if (C10_UNLIKELY(direct_accumulation_info_ != nullptr)) {
+    validate_direct_accumulation(
+        pos, device, opt_producer_stream, opt_consumer_stream);
+  }
 
   // Handle producer/consumer stream mismatch. Two independent cases:
   //   1. Producer is capturing but the consumer holds a stale non-capturing

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -117,11 +117,16 @@ void record_stream_any_impl(Variable& var, const c10::Stream& stream) {
 }
 
 bool can_accumulate_inplace(const Variable& v) {
-  return !(at::isTensorSubclassLike(v) || v._is_zerotensor() ||
-           v.is_nested()) &&
-      v.is_non_overlapping_and_dense() && v.has_storage() &&
+  return (
+      // `v` is a "vanilla" Tensor
+      !(at::isTensorSubclassLike(v) || v._is_zerotensor() || v.is_nested()) &&
+
+      // with a favorable memory layout
+      v.is_non_overlapping_and_dense() &&
+
+      // and we hold the last reference
       impl::is_tensor_stealable(v, 1 + at::caching::is_cached_tensor(v)) &&
-      v.storage().use_count() == 1;
+      v.has_storage() && v.storage().use_count() == 1);
 }
 } // anonymous namespace
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -98,7 +98,8 @@ struct InputBuffer {
       size_t pos,
       const at::Device& device,
       const std::optional<c10::Stream>& opt_producer_stream,
-      const std::optional<c10::Stream>& opt_consumer_stream) const;
+      const std::optional<c10::Stream>& opt_consumer_stream,
+      std::thread::id expected_thread) const;
 
   // add() validates later producers before they touch an exposed buffer.
   // Keep the per-slot state out of the common allocation path.

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -45,9 +45,11 @@ struct InputBuffer {
         ready_events(size),
         ready_streams(size) {}
   InputBuffer(const InputBuffer& other) = delete;
+  InputBuffer& operator=(const InputBuffer&) = delete;
   InputBuffer(InputBuffer&& other) = default;
   explicit InputBuffer(variable_list&& inputs) : buffer(std::move(inputs)) {}
   InputBuffer& operator=(InputBuffer&& other) = default;
+  ~InputBuffer() = default;
 
   // Accumulates the variable at a specified index.
   // The optional CUDA streams determine which stream the accumulation
@@ -94,12 +96,6 @@ struct InputBuffer {
   std::optional<c10::Stream> opt_overridden_consumer_stream;
 
  private:
-  struct DirectAccumulationInfo {
-    std::thread::id thread_id;
-    at::Device device;
-    std::optional<c10::Stream> stream;
-  };
-
   void validate_direct_accumulation(
       size_t pos,
       const at::Device& device,
@@ -108,8 +104,8 @@ struct InputBuffer {
 
   // add() validates later producers before they touch an exposed buffer.
   // Keep the per-slot state out of the common allocation path.
-  std::unique_ptr<std::optional<DirectAccumulationInfo>[]>
-      direct_accumulation_info_;
+  std::unique_ptr<std::optional<std::thread::id>[]>
+      direct_accumulation_threads_ = nullptr;
 };
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -63,9 +63,7 @@ struct InputBuffer {
 
   TORCH_API Variable get_for_direct_accumulation(
       size_t pos,
-      const at::Device& producer_device,
       const std::optional<c10::Stream>& opt_producer_stream,
-      const at::Device& consumer_device,
       const std::optional<c10::Stream>& opt_consumer_stream);
 
   Variable operator[](size_t pos) {

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -5,12 +5,14 @@
 // values in-place (adding an input twice will accumulate the result).
 // This behaviour is needed and used only in backward graphs.
 
+#include <memory>
+#include <optional>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include <c10/core/Stream.h>
 #include <torch/csrc/autograd/variable.h>
-#include <optional>
 
 namespace torch::autograd {
 
@@ -57,6 +59,13 @@ struct InputBuffer {
       const std::optional<c10::Stream>& opt_consumer_stream,
       Node* fn);
 
+  TORCH_API Variable get_for_direct_accumulation(
+      size_t pos,
+      const at::Device& producer_device,
+      const std::optional<c10::Stream>& opt_producer_stream,
+      const at::Device& consumer_device,
+      const std::optional<c10::Stream>& opt_consumer_stream);
+
   Variable operator[](size_t pos) {
     return buffer[pos];
   }
@@ -83,6 +92,24 @@ struct InputBuffer {
   // is nullopt and Engine::evaluate_function falls back to the node's
   // func->stream().
   std::optional<c10::Stream> opt_overridden_consumer_stream;
+
+ private:
+  struct DirectAccumulationInfo {
+    std::thread::id thread_id;
+    at::Device device;
+    std::optional<c10::Stream> stream;
+  };
+
+  void validate_direct_accumulation(
+      size_t pos,
+      const at::Device& device,
+      const std::optional<c10::Stream>& opt_producer_stream,
+      const std::optional<c10::Stream>& opt_consumer_stream) const;
+
+  // add() validates later producers before they touch an exposed buffer.
+  // Keep the per-slot state out of the common allocation path.
+  std::unique_ptr<std::optional<DirectAccumulationInfo>[]>
+      direct_accumulation_info_;
 };
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -2315,7 +2315,7 @@ static struct PyGetSetDef THPFunction_properties[] = {
      nullptr,
      nullptr,
      nullptr},
-    {"input_grad_buffers",
+    {"_input_grad_buffers",
      (getter)THPFunction_input_grad_buffers,
      nullptr,
      nullptr,

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1392,8 +1392,18 @@ PyObject* THPFunction_input_metadata(PyObject* self, void* unused) {
 PyObject* THPFunction_input_grad_buffers(PyObject* self, void* unused) {
   HANDLE_TH_ERRORS
   auto* py_fn = reinterpret_cast<THPFunction*>(self);
-  check_legacy_fn_attr_access(py_fn->cdata, "input_grad_buffers");
-  auto buffers = get_current_input_grad_buffers(py_fn->cdata.get());
+  auto node = py_fn->cdata;
+  check_legacy_fn_attr_access(node, "input_grad_buffers");
+  TORCH_CHECK(
+      node->post_hooks().empty(),
+      "input_grad_buffers does not support hooks registered on the producing "
+      "autograd node");
+
+  variable_list buffers;
+  {
+    pybind11::gil_scoped_release no_gil;
+    buffers = get_current_input_grad_buffers(node.get());
+  }
 
   THPObjectPtr result(
       PyTuple_New(static_cast<Py_ssize_t>(py_fn->is_variable_input.size())));

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1389,6 +1389,39 @@ PyObject* THPFunction_input_metadata(PyObject* self, void* unused) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPFunction_input_grad_buffers(PyObject* self, void* unused) {
+  HANDLE_TH_ERRORS
+  auto* py_fn = reinterpret_cast<THPFunction*>(self);
+  check_legacy_fn_attr_access(py_fn->cdata, "input_grad_buffers");
+  auto buffers = get_current_input_grad_buffers(py_fn->cdata.get());
+
+  THPObjectPtr result(
+      PyTuple_New(static_cast<Py_ssize_t>(py_fn->is_variable_input.size())));
+  if (!result) {
+    return nullptr;
+  }
+
+  size_t variable_idx = 0;
+  for (const auto i : c10::irange(py_fn->is_variable_input.size())) {
+    PyObject* item = nullptr;
+    if (!py_fn->is_variable_input[i] || !buffers[variable_idx].defined()) {
+      item = Py_NewRef(Py_None);
+    } else {
+      item = THPVariable_Wrap(buffers[variable_idx]);
+      if (!item) {
+        return nullptr;
+      }
+    }
+    if (py_fn->is_variable_input[i]) {
+      ++variable_idx;
+    }
+    PyTuple_SET_ITEM(result.get(), i, item);
+  }
+  TORCH_INTERNAL_ASSERT(variable_idx == buffers.size());
+  return result.release();
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THPFunction_maybe_clear_saved_tensors(
     PyObject* self,
     PyObject* noargs) {
@@ -2269,6 +2302,11 @@ static struct PyGetSetDef THPFunction_properties[] = {
     {"metadata", (getter)THPFunction_metadata, nullptr, nullptr, nullptr},
     {"_input_metadata",
      (getter)THPFunction_input_metadata,
+     nullptr,
+     nullptr,
+     nullptr},
+    {"input_grad_buffers",
+     (getter)THPFunction_input_grad_buffers,
      nullptr,
      nullptr,
      nullptr},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #196491

Custom autograd Functions currently have to return a separate tensor for every
input gradient, even when the engine has already allocated an InputBuffer for
that edge. This prevents fused backward kernels from accumulating directly into
an existing partial gradient.

Expose ctx.input_grad_buffers during Python Function backward execution. Each
entry corresponds to a forward argument, and an eligible buffer can be mutated
synchronously when the Function returns None for that input. Buffer availability
is dynamic, so kernels still need an out-of-place fallback and mixed producers
continue through the normal InputBuffer path.

Look up the execution-local buffer under the GraphTask mutex and record when a
slot is exposed. Later producers are validated to use the same engine thread,
device, and stream. Support eager first-order backward execution, including
backward(inputs=...), and torch.autograd.grad; continue to reject create_graph,
anomaly detection, and producer post-hooks. This keeps the API scoped to
InputBuffer accumulation rather than conflating it with the longer-lived leaf
.grad field. The dynamic lookup avoids a graph traversal or priming phase.

Test Plan:

```
source /home/jw3468/local/miniconda3/etc/profile.d/conda.sh && conda activate /home/jw3468/local/a/pytorch-env && CUDACXX=/usr/local/cuda-12.2/bin/nvcc PATH=/usr/local/cuda-12.2/bin:$PATH USE_FLASH_ATTENTION=1 USE_MEM_EFF_ATTENTION=1 USE_CUDA=1 CUDA_HOME=/usr/local/cuda-12.2 USE_GOLD_LINKER=1 CMAKE_PREFIX_PATH="$CONDA_PREFIX" pip install -e . -v --no-build-isolation
```

```
source /home/jw3468/local/miniconda3/etc/profile.d/conda.sh && conda activate /home/jw3468/local/a/pytorch-env && python test/test_autograd.py TestInputGradBuffersCPU TestInputGradBuffersCUDA TestAutogradStreamSynchronizationCPU TestAutogradStreamSynchronizationCUDA
```

```
source /home/jw3468/local/miniconda3/etc/profile.d/conda.sh && conda activate /home/jw3468/local/a/pytorch-env && python test/test_autograd.py TestAutogradDeviceTypeCUDA.test_inputbuffer_add_multidevice_cuda
```

```
git diff --check
```

Authored with assistance from an AI coding agent.