### PR TITLE
[ROCm] Enable UVM tests via hip-python's cuda.bindings interop

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -10275,7 +10275,6 @@ class TestMemPool(TestCase):
                 f"expandable_segments:{EXPANDABLE_SEGMENTS}"
             )
 
-    @skipIfRocm(msg="cudaMallocManaged (UVM) is not supported on ROCm")
     @requires_cuda_python_bindings
     def test_use_uvm(self):
         with torch.cuda._use_uvm():
@@ -10285,7 +10284,6 @@ class TestMemPool(TestCase):
         self.assertEqual(z.shape, (256, 256))
         self.assertTrue(z.is_cuda)
 
-    @skipIfRocm(msg="cudaMallocManaged (UVM) is not supported on ROCm")
     @requires_cuda_python_bindings
     def test_use_uvm_numerics(self):
         torch.manual_seed(42)
@@ -10295,7 +10293,6 @@ class TestMemPool(TestCase):
         a_reg = torch.randn(128, 128, device="cuda")
         self.assertEqual(a_uvm, a_reg)
 
-    @skipIfRocm(msg="cudaMallocManaged (UVM) is not supported on ROCm")
     @requires_cuda_python_bindings
     def test_use_uvm_backward(self):
         with torch.cuda._use_uvm():
@@ -10306,7 +10303,6 @@ class TestMemPool(TestCase):
         self.assertIsNotNone(model.weight.grad)
         self.assertEqual(model.weight.grad.shape, (512, 512))
 
-    @skipIfRocm(msg="cudaMallocManaged (UVM) is not supported on ROCm")
     @requires_cuda_python_bindings
     def test_use_uvm_tensor_outlives_context(self):
         # Regression test: a tensor allocated inside _use_uvm() can outlive the

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1918,7 +1918,23 @@ TEST_CUDA_GRAPH = TEST_CUDA and (not TEST_SKIP_CUDAGRAPH) and (
 TEST_CUDA_CUDSS = TEST_CUDA and torch.version.cuda is not None
 TEST_CUDA_GRAPH_CONDITIONAL_NODES = TEST_CUDA_GRAPH and torch.version.cuda is not None
 
-TEST_CUDA_PYTHON_BINDINGS = _check_module_exists("cuda.bindings") and torch.version.cuda is not None
+def _cuda_python_bindings_usable() -> bool:
+    if not _check_module_exists("cuda.bindings"):
+        return False
+    if torch.version.cuda is not None:
+        return True
+    if torch.version.hip is not None:
+        # NVIDIA's cuda-bindings installs and imports fine on a ROCm box but
+        # fails at the first call. hip-python's interop package (PyPI:
+        # hip-python-interop) provides a HIP-backed cuda.bindings and marks
+        # itself with HIP_PYTHON = True; only that flavor is usable here.
+        import cuda.bindings.runtime  # type: ignore[import]
+
+        return bool(getattr(cuda.bindings.runtime, "HIP_PYTHON", False))
+    return False
+
+
+TEST_CUDA_PYTHON_BINDINGS = _cuda_python_bindings_usable()
 TEST_NVMATH = _check_module_exists("nvmath.bindings") and torch.version.cuda is not None
 skipIfNoNvmath = unittest.skipIf(not TEST_NVMATH, "nvmath-python not available")
 


### PR DESCRIPTION
torch.cuda._use_uvm() already works on ROCm: it imports cuda.bindings.runtime directly, and hip-python's interop package (PyPI: hip-python-interop) provides a HIP-backed cuda.bindings with the cuda-python 12+ module layout, verified live against HIP 7.15 (cudaMallocManaged / cudaMemAdvise / cudaFree behave with the (err, *outs) convention, and its error enums compare equal across the cuda/hip enum classes so cuda_python_error_check works unchanged). The only blockers were test-infra: TEST_CUDA_PYTHON_BINDINGS required torch.version.cuda, and the four TestMemPool UVM tests carried a blanket "UVM is not supported on ROCm" skip.

TEST_CUDA_PYTHON_BINDINGS now accepts cuda.bindings on ROCm only when it is the HIP-backed flavor, detected via hip-python's HIP_PYTHON marker attribute (import-safe, no driver call; NVIDIA's cuda-bindings on a ROCm box remains excluded). The four skipIfRocm lines are removed; on machines without hip-python-interop, including current ROCm CI images, the tests skip via requires_cuda_python_bindings exactly as CUDA machines without cuda-python do. Adding hip-python/hip-python-interop to the ROCm CI images is deferred until wheels matching the CI ROCm version publish (ROCm 10.0.0 bindings are in progress per ROCm/hip-python#109).

Test plan, on gfx950 (ROCm 10.0, HIP 7.15): with hip-python-interop + hip-python installed, all four test_use_uvm* tests pass, 25 consecutive runs clean; without them, all four skip with "requires cuda-python (cuda.bindings)".

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang