### PR TITLE
[Inductor] freeze buffer references for ReinterpretView loader

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3974,6 +3974,31 @@ class CPUReproTests(TestCase):
             )
         check_metrics_vec_kernel_count(1)
 
+    def test_internal_copy_source_depends_on_destination(self):
+        # When lowering copy_, destination's StorageBox swings to source. A prior
+        # ReinterpretView loader of destination must freeze its buffer reference
+        # to avoid reading source and forming a circular dependency cycle.
+        def fn(x):
+            destination = torch.ops._inductor_test.realize(x + 1)
+            before = torch.as_strided(
+                destination,
+                destination.shape,
+                destination.stride(),
+            ).clone()
+            source = torch.ops._inductor_test.realize(before + 1)
+            destination.copy_(source)
+            after = torch.as_strided(
+                destination,
+                destination.shape,
+                destination.stride(),
+            ).clone()
+            return before, destination, after
+
+        x = torch.randn(16)
+        gm = make_fx(fn)(x)
+        compiled = compile_fx_inner(gm, [x])
+        self.assertEqual(fn(x), compiled([x]))
+
     def test_emulate_precision_casts_explicit_lowp_round_trip(self):
         # An explicit fp32->fp16->fp32 round-trip must keep its intermediate
         # rounding under emulate_precision_casts. The CPU codegen used to collapse

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4221,9 +4221,11 @@ class ReinterpretView(BaseView):
         return list(self.layout.stride)
 
     def make_loader(self) -> Callable[[Sequence[Expr]], OpsValue]:
+        name = self.get_name()
+
         def loader(index: Sequence[Expr]) -> OpsValue:
             indexer = self.layout.make_indexer()
-            tmp_loader = ops.load(self.get_name(), indexer(index))
+            tmp_loader = ops.load(name, indexer(index))
             if self.layout.dtype != self.data.dtype:
                 return ops.to_dtype_bitcast(tmp_loader, self.dtype, self.data.dtype)
             else:


### PR DESCRIPTION
So basically when we do an in-place copy (like copy_), it changes where the data pointer points. The catch is that anything reading the data before that copy happens still needs to see the original, older version

The bug was happening because ReinterpretView.make_loader was looking up the buffer name dynamically while it was running using self.get_name(). Since the pointer got changed later on, the old loader would accidentally look at the new updated buffer instead of the old one. That messed up the order of operations and caused a weird loop error in the graph.

To fix it I made it grab and save the name right away when make_loader() is first called (name = self.get_name()). This locks in the right buffer name early, so changing the pointer later on won't mess up what the view is supposed to read.

Resolves #195742

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo