### PR TITLE
[Elastic] Close mkstemp FD and fix find_free_port UnboundLocalError

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,47 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
+    )
+    def test_create_backend_closes_mkstemp_fd_when_endpoint_missing(
+        self, filestore_mock, mkstemp_mock, close_mock
+    ) -> None:
+        # Regression for pytorch/pytorch#191394: mkstemp's FD must be closed
+        # because FileStore opens the path on its own.
+        fd = 42
+        path = "/tmp/pytorch-rendezvous-test-file"
+        mkstemp_mock.return_value = (fd, path)
+        filestore_mock.return_value = mock.MagicMock()
+        self._params_filestore.endpoint = ""
+
+        create_backend(self._params_filestore)
+
+        close_mock.assert_called_once_with(fd)
+        filestore_mock.assert_called_once_with(path)
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
+    )
+    def test_create_backend_closes_mkstemp_fd_if_filestore_fails(
+        self, filestore_mock, mkstemp_mock, close_mock
+    ) -> None:
+        fd = 43
+        path = "/tmp/pytorch-rendezvous-test-file-fail"
+        mkstemp_mock.return_value = (fd, path)
+        filestore_mock.side_effect = RuntimeError("test error")
+        self._params_filestore.endpoint = ""
+
+        with self.assertRaisesRegex(
+            RendezvousConnectionError,
+            r"^The connection to the C10d store has failed. See inner exception for "
+            r"details.$",
+        ):
+            create_backend(self._params_filestore)
+
+        close_mock.assert_called_once_with(fd)

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,19 +6,55 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
-if os.getenv("CIRCLECI"):
-    print("T85992919 temporarily disabling in circle ci", file=sys.stderr)
-    sys.exit(0)
+_CIRCLECI = bool(os.getenv("CIRCLECI"))
+if _CIRCLECI:
+    print("T85992919 temporarily disabling etcd server tests in circle ci", file=sys.stderr)
 
 
+class FindFreePortTest(unittest.TestCase):
+    def test_find_free_port_retries_when_socket_constructor_fails(self) -> None:
+        # Regression for pytorch/pytorch#191395: socket() failure must not raise
+        # UnboundLocalError from s.close() in the except block.
+        good_sock = mock.MagicMock()
+        addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+        ]
+
+        with mock.patch("socket.getaddrinfo", return_value=addrs), mock.patch(
+            "socket.socket", side_effect=[OSError("socket failed"), good_sock]
+        ) as socket_mock:
+            result = find_free_port()
+
+        self.assertIs(result, good_sock)
+        self.assertEqual(2, socket_mock.call_count)
+        good_sock.bind.assert_called_once_with(("localhost", 0))
+        good_sock.listen.assert_called_once_with(0)
+        good_sock.close.assert_not_called()
+
+    def test_find_free_port_raises_runtime_error_without_unbound_local(self) -> None:
+        addrs = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+        ]
+
+        with mock.patch("socket.getaddrinfo", return_value=addrs), mock.patch(
+            "socket.socket", side_effect=OSError("socket failed")
+        ):
+            with self.assertRaisesRegex(RuntimeError, r"^Failed to create a socket$"):
+                find_free_port()
+
+
+@unittest.skipIf(_CIRCLECI, "T85992919 temporarily disabling in circle ci")
 class EtcdServerTest(unittest.TestCase):
     def test_etcd_server_start_stop(self):
         server = EtcdServer()

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -191,12 +191,15 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
     else:
         try:
             # The temporary file is readable and writable only by the user of
-            # this process.
-            _, path = tempfile.mkstemp()
+            # this process. Close the descriptor immediately; FileStore opens
+            # the path independently and would otherwise leak this FD.
+            fd, path = tempfile.mkstemp()
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."
             ) from exc
+        else:
+            os.close(fd)
 
     try:
         store = FileStore(path)

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -55,11 +55,15 @@ def find_free_port():
         family, type, proto, _, _ = addr
         try:
             s = socket.socket(family, type, proto)
+        except OSError as e:
+            print(f"Socket creation attempt failed: {e}")
+            continue
+        try:
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Summary
- Fix FileStore rendezvous leaking the `tempfile.mkstemp()` file descriptor when no endpoint is supplied (`Fixes #191394`). `FileStore` opens the path on its own, so the mkstemp FD is now closed immediately after the path is retained (including when FileStore construction later fails).
- Fix `find_free_port()` masking socket construction failures with `UnboundLocalError` from `s.close()` when `socket.socket()` itself raises (`Fixes #191395`). Only a successfully created socket is closed on bind/listen failure; remaining addresses are still tried before `RuntimeError`.

## Test plan
- [x] Added regression tests in `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py` asserting the exact mkstemp FD is closed once (success and FileStore-failure paths).
- [x] Added `FindFreePortTest` in `test/distributed/elastic/rendezvous/etcd_server_test.py` covering retry after constructor failure and clean `RuntimeError` (no `UnboundLocalError`).
- [x] Ran isolated unit checks for both behaviors locally (full PyTorch build not available in this environment).
- [ ] CI / relevant elastic rendezvous tests on this PR.