### PR TITLE
Fix cudagraph_skip_dynamic_graphs for extern kernels with dynamic inputs

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -739,6 +739,37 @@ if HAS_CUDA_AND_TRITON:
                     "skipping cudagraphs due to graph with symbolic shapes inputs"
                 ).run(utils_log_stream.getvalue())
 
+        @torch._inductor.config.patch("triton.cudagraph_skip_dynamic_graphs", True)
+        @torch._inductor.config.patch("graph_partition", True)
+        def test_skip_extern_with_dynamic_input_static_output(self):
+            """Extern kernels consuming dynamic-shaped inputs but producing
+            static-shaped outputs (e.g. median on a dynamic tensor) must be
+            partitioned out when cudagraph_skip_dynamic_graphs is True."""
+
+            @torch.compile(mode="reduce-overhead", fullgraph=True)
+            def foo(rows, weight):
+                return torch.median(rows) * (weight @ weight).relu()
+
+            scheduler_log_stream, scheduler_ctx = logs_to_string(
+                "torch._inductor.scheduler", "cudagraphs"
+            )
+            weight = torch.randn(64, 64, device="cuda")
+            with scheduler_ctx():
+                for n in (10, 13, 16):
+                    rows = torch.randn(n, 64, device="cuda")
+                    torch._dynamo.mark_dynamic(rows, 0)
+                    result = foo(rows, weight)
+                    expected = torch.median(rows) * (weight @ weight).relu()
+                    self.assertEqual(result, expected)
+
+            log_output = scheduler_log_stream.getvalue()
+            # median should be partitioned out as dynamic
+            FileCheck().check("reason=dynamic shape ops").check(
+                "aten.median"
+            ).run(log_output)
+            # The static mm should be cudagraphable
+            FileCheck().check("cudagraphable").run(log_output)
+
         @parametrize("backend", ("inductor", "cudagraphs"))
         @torch._dynamo.config.patch("cudagraph_backend_keep_input_mutation", True)
         @torch._dynamo.config.patch("cudagraph_backend_support_input_mutation", True)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5538,6 +5538,31 @@ def get_scheduler_node_symbol_uses(
     return free_symbol_uses
 
 
+def _has_dynamic_input_shapes(node: BaseSchedulerNode) -> bool:
+    """
+    Check if a scheduler node reads from any input with dynamic shapes.
+
+    get_scheduler_node_symbol_uses only captures symbols from a node's own
+    operations and output layouts.  ExternKernel / FallbackKernel nodes that
+    consume a dynamically-shaped tensor but produce a statically-shaped output
+    (e.g. median on a dynamic tensor returning a scalar) will report no
+    symbols, even though their execution depends on the dynamic dimension.
+    This helper fills that gap by inspecting the input layouts directly.
+    """
+    if isinstance(node, FusedSchedulerNode):
+        return any(_has_dynamic_input_shapes(snode) for snode in node.snodes)
+    ir_node = node.node
+    if ir_node is None:
+        return False
+    if not isinstance(ir_node, ir.InputsKernel):
+        return False
+    for inp in ir_node.inputs:
+        if isinstance(inp, ir.IRNode):
+            if get_layout_symints(inp):
+                return True
+    return False
+
+
 def _is_epilogue_fusion_enabled(template_node: BaseSchedulerNode) -> bool:
     """Check per-template flag, fall back to global config."""
     tb = template_node.get_template_node()
@@ -11231,6 +11256,8 @@ class Scheduler:
         # Partition around nodes with dynamic shapes when cudagraph_skip_dynamic_graphs is enabled
         if config.triton.cudagraph_skip_dynamic_graphs:
             if get_scheduler_node_symbol_uses(node):
+                return "dynamic shape ops"
+            if _has_dynamic_input_shapes(node):
                 return "dynamic shape ops"
 
         return None


### PR DESCRIPTION
Fixes #196385

`cudagraph_skip_dynamic_graphs=True` is supposed to partition out operations with dynamic shapes so they run eagerly instead of being recorded into a CUDA graph. However, ExternKernel/FallbackKernel nodes (like `aten.median`) that consume a dynamically-shaped input but produce a statically-shaped output were not being detected as dynamic.

The existing check (`get_scheduler_node_symbol_uses`) only inspects a node's own operations and output layouts for dynamic symbols. For extern kernels like `median(dynamic_tensor) -> scalar`, both return empty — the node's code doesn't explicitly reference the input size symbol, and the scalar output has no shape. So the node was incorrectly placed in the cudagraph-eligible partition, causing one cudagraph recording per unique input size.

This adds a fallback check `_has_dynamic_input_shapes()` that inspects input layouts. If any input has dynamic shape symbols, the node is partitioned out. This correctly handles the case where an extern kernel depends on a dynamic dimension through its inputs rather than through its own code or output.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo