### PR TITLE
[ROCm] Fix multi_kernel_hints template generation and re-enable its tests

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -5094,7 +5094,6 @@ class TestPrologueFusion(TestCase):
             "tl.full([1], 1.1, tl.float32)", 3, exactly=True
         ).check("tl.store").run(code[0])
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/152221")
     @config.patch(
         {
             "max_autotune_gemm_backends": "Triton",

--- a/test/inductor/test_multi_kernel.py
+++ b/test/inductor/test_multi_kernel.py
@@ -19,8 +19,8 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
-    skipIfRocm,
     skipIfXpu,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -197,8 +197,6 @@ class MultiKernelTest(TestCase):
             self.assertFalse(_contains_multi_kernel_code(wrapper_code))
 
     @requires_triton()
-    # TODO: bobrenjc93 to fix multi-kernel for ROCM
-    @skipIfRocm
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
     @skipIfXpu(msg="driver issue, torch-xpu-ops: 2295")
     def test_triton_gemm(self):
@@ -222,13 +220,14 @@ class MultiKernelTest(TestCase):
         # One for the first pass and one for the second pass.
         # We mainly care about the wrapper for the final pass here.
         wrapper_code = wrapper_code[-1]
-        self.assertEqual(ref, act)
+        # fp32 accumulation-order divergence between the triton template and
+        # hipblasLt at K=4096; measured and derived in issue #196494.
+        rocm_tol = {"atol": 2e-3, "rtol": 1e-3} if TEST_WITH_ROCM else {}
+        self.assertEqual(ref, act, **rocm_tol)
         self.assertTrue(_contains_size_hint_multi_kernel_code(wrapper_code))
 
     @skipIfXpu(msg="driver issue, torch-xpu-ops: 2295")
     @requires_triton()
-    # TODO: bobrenjc93 to fix multi-kernel for ROCM
-    @skipIfRocm
     @unittest.skipIf(not IS_BIG_GPU, "templates require big gpu")
     def test_triton_relu_fused_gemm(self):
         def fn(x, y):
@@ -251,7 +250,10 @@ class MultiKernelTest(TestCase):
         # One for the first pass and one for the second pass.
         # We mainly care about the wrapper for the final pass here.
         wrapper_code = wrapper_code[-1]
-        self.assertEqual(ref, act)
+        # fp32 accumulation-order divergence between the triton template and
+        # hipblasLt at K=4096; measured and derived in issue #196494.
+        rocm_tol = {"atol": 2e-3, "rtol": 1e-3} if TEST_WITH_ROCM else {}
+        self.assertEqual(ref, act, **rocm_tol)
         self.assertTrue(_contains_size_hint_multi_kernel_code(wrapper_code))
 
     @parametrize("force_kernel", (0, 1))

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -1895,7 +1895,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 continue
 
             # Construct key for finding duplicate configs
-            key: tuple[int, ...] = (
+            key: tuple[int | None, ...] = (
                 conf.block_m,
                 conf.block_n,
                 conf.block_k,
@@ -1904,6 +1904,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 waves_per_eu,
                 matrix_instr_nonkdim,
                 kpack,
+                conf.hint_override,
             )
 
             # Check if gemm specific arg exists - add to key if does
@@ -1930,6 +1931,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                     "matrix_instr_nonkdim": matrix_instr_nonkdim,
                     "waves_per_eu": waves_per_eu,
                     "kpack": kpack,
+                    "hint_override": conf.hint_override,
                 }
                 if group_m is not None:
                     kwargs["GROUP_M"] = group_m

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -1872,7 +1872,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
         """
         Finalizes configs after scaling, applying additional constraints.
         """
-        used: OrderedSet[tuple[int, ...]] = OrderedSet()
+        used: OrderedSet[tuple[int | None, ...]] = OrderedSet()
 
         max_mm_configs = config.test_configs.max_mm_configs
 


### PR DESCRIPTION
Setting inductor's multi_kernel_hints on ROCm broke every Triton GEMM template choice: the ROCm override of _finalize_mm_configs drops hint_override from both its dedup key and its yielded template kwargs, while the base implementation carries both. The size-hint multi-kernel machinery then selects choices per hint, finds none, and autotuning fails with NoValidChoicesError whose message ("All choices failed to compile") is misleading because zero choices were ever generated. The fix mirrors the base class: hint_override joins the dedup key and the yielded kwargs.

This re-enables test_pending_fusions_multiple and the two multi-kernel gemm tests (test_triton_gemm, test_triton_relu_fused_gemm). The gemm tests additionally get a TEST_WITH_ROCM-conditional tolerance (atol 2e-3, rtol 1e-3): with the crash fixed they fail only the strict fp32 default (observed 3.3e-4 max abs at K=4096), and an fp64-reference experiment shows both hipblasLt and the Triton template are equally accurate at every K in 512..8192 with their mutual difference growing exactly as fp32 accumulation-order rounding predicts; the derivation and table are in #196494, cited at the assertion site. The epilogue-fusion static-analysis tests stay skipped: their occupancy-model rejection cases are a separate, genuinely unported area on ROCm.

Test plan, on gfx950 (ROCm 10.0, HIP 7.15): all three selections pass; test_pending_fusions_multiple and the gemm pair each ran 25 consecutive times with zero failures; a standalone repro of the config bug (max_autotune + TRITON-only backends + multi_kernel_hints=[64,256,4096]) fails before this change and passes after. gfx942/gfx90a validation via the ciflow labels below.

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben