### PR TITLE
[ROCm] Re-enable static Triton launcher and autotuner plugin tests

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -84,7 +84,6 @@ from torch.testing._internal.common_utils import (
     IS_FBCODE,
     IS_SANDCASTLE,
     parametrize,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -817,8 +816,6 @@ class TestFxGraphCache(TestCase):
             raise unittest.SkipTest(
                 "Static triton launcher requires cuda/xpu and triton bundling"
             )
-        if use_static_triton_launcher and TEST_WITH_ROCM:
-            raise unittest.SkipTest("Static cuda launcher doesn't work with ROCM")
 
         grad_multiplier = 2 if grad else 1
 
@@ -2274,9 +2271,6 @@ class TestFxGraphCache(TestCase):
     @parametrize("bundle_triton", (False, True))
     @parametrize("use_static_triton_launcher", (False, True))
     def test_triton_op(self, bundle_triton, use_static_triton_launcher):
-        if use_static_triton_launcher and TEST_WITH_ROCM:
-            raise unittest.SkipTest("Static cuda launcher doesn't work with ROCM")
-
         libname = "my_cool_namespace"
         opname = "my_triton_operator"
 

--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -921,8 +921,6 @@ class TestStaticTritonCompileResult(TestCase):
 
 
 @requires_gpu_and_triton
-# _FastCudaLauncher hipModuleLaunchKernel path segfaults on ROCm
-@skipIfRocm
 @skipIfXpu
 class TestFastCudaLauncher(TestCase):
     """Tests for _FastCudaLauncher vectorcall C extension."""
@@ -1119,7 +1117,6 @@ class TestFastCudaLauncher(TestCase):
         "use_fast_triton_launcher": True,
     }
 )
-@skipIfRocm  # see TestFastCudaLauncher
 class TestFastCudaLauncherCompileResult(TestCase):
     """E2E tests verifying _FastCudaLauncher handling in torch.compile.
 

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -408,7 +408,12 @@ class TestTritonHeuristics(TestCase):
             tl.store(out_ptr0 + (x0), tmp1, xmask)
 
         triton_meta = {
-            "signature": {"in_ptr0": "*fp32", "out_ptr0": "*fp32", "xnumel": "i32"},
+            "signature": {
+                "in_ptr0": "*fp32",
+                "out_ptr0": "*fp32",
+                "xnumel": "i32",
+                "XBLOCK": "constexpr",
+            },
             "device": DeviceProperties.create(torch.device(GPU_TYPE)),
             "constants": {},
             "configs": [
@@ -727,10 +732,6 @@ class TestCachingAutotunerPrecompileDriverSetup(TestCase):
         self.assertEqual(len(autotuner.compile_results), num_configs)
 
 
-# Triton's HIP MLIR pipeline raises AttributeError("'NoneType' object has no
-# attribute '_unflatten_ir'") inside ast_to_ttir for the trivial cos kernel
-# used by these tests. CUDA paths are unaffected.
-@skipIfRocm
 @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
 class TestCachingAutotunerPlugin(TestCase):
     device_type = GPU_TYPE


### PR DESCRIPTION
Three related re-enables in the inductor test suite, each with the original failure explained:

TestFastCudaLauncher and TestFastCudaLauncherCompileResult were skipped in #183245 (2026-05-11) because _FastCudaLauncher segfaulted at the first hipModuleLaunchKernel; #183926 ([ROCm][inductor] Use hipModuleLoadData in StaticCudaLauncher) landed eight days later and fixed that launch path, but the skip was never revisited. The static launcher has been production-enabled for device_type "hip" since #166492, and both classes now pass (9 tests plus a TMA-guard skip), 25 consecutive isolated runs clean.

TestCachingAutotunerPlugin's skip attributed an AttributeError ("'NoneType' object has no attribute '_unflatten_ir'" inside ast_to_ttir) to Triton's HIP MLIR pipeline. The actual cause is in the shared test fixture: _get_cos_kernel_caching_autotuner_args omits the XBLOCK constexpr from its hand-written signature dict; the CUDA lowering tolerates the omission while the HIP lowering resolves the undeclared constexpr's type to None. Declaring it (the form inductor-generated kernels always use) fixes all 7 tests on ROCm, 25 consecutive runs clean, and the file's full 63 tests still pass with the fixture change.

test_codecache's two "Static cuda launcher doesn't work with ROCM" guards are removed for the same #183926 reason; the 8 static-launcher-with-bundling variants they gated now pass (the bundle_triton=False variants keep their platform-neutral bundling skip), 10 consecutive runs of the 64-variant selection clean.

Test plan and per-selection evidence are in the commit message. gfx942/gfx90a validation via the ciflow labels below.

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben