### PR TITLE
[inductor] Type custom-op lowering payloads as object

### DIFF
--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -15,7 +15,9 @@ from torch._inductor.ir import (
     Buffer,
     FixedLayout,
     ir_node_to_tensor,
+    IRNode,
     Layout,
+    Operation,
     StorageBox,
     TensorBox,
 )
@@ -254,13 +256,13 @@ def _extract_tensor_inputs(
     ]
 
     for i, arg in enumerate(args):
-        if isinstance(arg, (TensorBox, Buffer, StorageBox)):
+        if isinstance(arg, _TensorInput):
             tensor_inputs.append(arg)
         else:
             non_tensor_kwargs[param_names[i]] = arg
 
     for key, value in kwargs.items():
-        if isinstance(value, (TensorBox, Buffer, StorageBox)):
+        if isinstance(value, _TensorInput):
             tensor_inputs.append(value)
         else:
             non_tensor_kwargs[key] = value
@@ -291,7 +293,7 @@ def _adapt_user_input_gen_fns(
     inputs: Sequence[object],
     op_overload: torch._ops.OpOverload,
     user_input_gen_fns: Mapping[str, Callable[[torch.Tensor], torch.Tensor]],
-) -> dict[int, Callable[[Buffer], torch.Tensor]]:
+) -> dict[int, Callable[[IRNode], torch.Tensor]]:
     """Convert user input generators from name-based to index-based format.
     Inductor autotune's input_gen_fns expects index of arg_names as key.
     """
@@ -310,11 +312,11 @@ def _adapt_user_input_gen_fns(
 
     def create_internal_input_gen_fn(
         user_function: Callable[[torch.Tensor], torch.Tensor], arg_name: str
-    ) -> Callable[[Buffer], torch.Tensor]:
-        """Create internal input generator that converts IR buffer to user's fake tensor."""
+    ) -> Callable[[IRNode], torch.Tensor]:
+        """Create internal input generator that converts an IR node to a fake tensor."""
 
-        def internal_input_gen_fn(ir_buffer: Buffer) -> torch.Tensor:
-            fake_tensor = ir_node_to_tensor(ir_buffer, replace_symbols_with_hints=True)
+        def internal_input_gen_fn(ir_node: IRNode) -> torch.Tensor:
+            fake_tensor = ir_node_to_tensor(ir_node, replace_symbols_with_hints=True)
             if fake_tensor is None:
                 raise AssertionError("ir_node_to_tensor returned None")
             return user_function(fake_tensor)
@@ -516,7 +518,7 @@ def autotune_custom_op(
         )
 
     # Convert user input generation functions BEFORE creating choices
-    input_gen_fns: dict[int, Callable[[Buffer], torch.Tensor]] = {}
+    input_gen_fns: dict[int, Callable[[IRNode], torch.Tensor]] = {}
     if user_input_gen_fns:
         input_gen_fns = _adapt_user_input_gen_fns(
             inputs, op_overload, user_input_gen_fns
@@ -668,7 +670,7 @@ def _generate_dynamic_configs(
 def _prepare_configs_and_decompositions(
     processed_configs: list[CustomOpConfig] | None,
     config_generator: Callable[[dict[str, torch.Tensor]], list[CustomOpConfig]] | None,
-    tensor_inputs: list[_TensorInput],
+    tensor_inputs: Sequence[_TensorInput],
     default_impl: Callable[..., Any],
     op_overload: torch._ops.OpOverload,
     runtime_kwargs: Mapping[str, object],
@@ -714,7 +716,7 @@ def _standard_lowering_fn(
     name: str,
     op_overload: torch._ops.OpOverload,
     input_gen_fns: dict[str, Callable[[torch.Tensor], torch.Tensor]] | None,
-    tensor_inputs: list[_TensorInput],
+    tensor_inputs: Sequence[_TensorInput],
     runtime_kwargs: Mapping[str, object],
     config_generator: Callable[[dict[str, torch.Tensor]], list[CustomOpConfig]]
     | None = None,
@@ -745,8 +747,7 @@ def _standard_lowering_fn(
     result, _ = autotune_custom_op(
         name=name,
         decompositions=decompositions,
-        # pyrefly: ignore[bad-argument-type]  # TODO: Fix the public input type.
-        inputs=tensor_inputs,
+        inputs=cast(list[torch.fx.Node], list(tensor_inputs)),
         non_tensor_args=non_tensor_args,
         config_patches_list=config_patches_list,
         op_overload=op_overload,
@@ -760,11 +761,13 @@ def _standard_lowering_fn(
 
 
 def _apply_config_patches_recursive(
-    operations: list,
+    operations: Sequence[Operation],
     config_patches: Mapping[str, object],
 ) -> None:
     """Apply config_patches to operations, including those inside subgraphs."""
     for op in operations:
+        if not isinstance(op, IRNode):
+            raise AssertionError(f"Expected IRNode operation, got {type(op)}")
         if hasattr(op, "set_config_patches"):
             op.set_config_patches(dict(config_patches))
 
@@ -780,7 +783,7 @@ def _lower_single_impl(
     impl: Callable[..., Any],
     impl_kwargs: Mapping[str, object],
     runtime_kwargs: Mapping[str, object],
-    tensor_inputs: list[_TensorInput],
+    tensor_inputs: Sequence[_TensorInput],
     name: str,
     config_patches: Mapping[str, object] | None = None,
 ) -> TensorBox | None:
@@ -834,7 +837,9 @@ def _lower_single_impl(
 
     log.info("Inlining implementation: %s", impl.__name__)
     ops_before = len(V.graph.operations)
-    result = cast(TensorBox, inline_subgraph_to_ir_nodes(impl_gm, tensor_inputs, name))
+    result = inline_subgraph_to_ir_nodes(impl_gm, list(tensor_inputs), name)
+    if not isinstance(result, TensorBox):
+        raise AssertionError(f"Expected TensorBox, got {type(result)}")
 
     if config_patches:
         _apply_config_patches_recursive(V.graph.operations[ops_before:], config_patches)
@@ -852,7 +857,7 @@ def _range_based_lowering_fn(
     tensor_name: str,
     dim_index: int,
     ranges: list[tuple[int, int | float]],
-    tensor_inputs: list[_TensorInput],
+    tensor_inputs: Sequence[_TensorInput],
     runtime_kwargs: Mapping[str, object],
     range_upper_bound: int,
     config_generator: Callable[[dict[str, torch.Tensor]], list[CustomOpConfig]]
@@ -901,8 +906,7 @@ def _range_based_lowering_fn(
         autotuned_result, winning_choice = autotune_custom_op(
             name=range_name,
             decompositions=decompositions,
-            # pyrefly: ignore[bad-argument-type]  # TODO: Fix the public input type.
-            inputs=tensor_inputs,
+            inputs=cast(list[torch.fx.Node], list(tensor_inputs)),
             non_tensor_args=non_tensor_args,
             op_overload=op_overload,
             user_input_gen_fns=range_input_gen_fns,
@@ -1060,10 +1064,11 @@ def _range_based_lowering_fn(
             raise
 
     ops_before = len(V.graph.operations)
-    result = cast(
-        TensorBox,
-        inline_subgraph_to_ir_nodes(dispatch_gm, tensor_inputs, f"{name}_dispatch"),
+    result = inline_subgraph_to_ir_nodes(
+        dispatch_gm, list(tensor_inputs), f"{name}_dispatch"
     )
+    if not isinstance(result, TensorBox):
+        raise AssertionError(f"Expected TensorBox, got {type(result)}")
 
     # Apply config_patches from all impl groups to inlined operations
     # TODO - consider conflicting patches

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -3,9 +3,9 @@
 import contextlib
 import functools
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, cast, Protocol
+from typing import Any, cast, Protocol, TypeAlias
 from typing_extensions import NotRequired, TypedDict
 
 import torch
@@ -31,6 +31,8 @@ from torch._inductor.virtualized import V
 log = logging.getLogger(__name__)
 
 DEFAULT_RANGE_UPPER_BOUND = 65536
+
+_TensorInput: TypeAlias = TensorBox | Buffer | StorageBox
 
 
 class DispatchOnConfig(TypedDict):
@@ -227,10 +229,10 @@ __all__ = [
 
 
 def _extract_tensor_inputs(
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
+    args: tuple[object, ...],
+    kwargs: Mapping[str, object],
     op_overload: torch._ops.OpOverload,
-) -> tuple[list[Any], dict[str, Any]]:
+) -> tuple[list[_TensorInput], dict[str, object]]:
     """Extract tensor inputs from mixed args/kwargs.
     Separates tensors (for autotuning input_nodes) from non-tensor parameters.
 
@@ -242,8 +244,8 @@ def _extract_tensor_inputs(
     Returns:
         Tuple of (tensor_inputs_list, non_tensor_kwargs)
     """
-    tensor_inputs = []
-    non_tensor_kwargs = {}
+    tensor_inputs: list[_TensorInput] = []
+    non_tensor_kwargs: dict[str, object] = {}
 
     # Get schema names and extend with fallback names for any extra args
     schema_names = [arg.name for arg in op_overload._schema.arguments]
@@ -267,9 +269,9 @@ def _extract_tensor_inputs(
 
 
 def _merge_config_and_runtime_kwargs(
-    config_params: dict[str, Any],
-    runtime_kwargs: dict[str, Any],
-) -> dict[str, Any]:
+    config_params: Mapping[str, object],
+    runtime_kwargs: Mapping[str, object],
+) -> dict[str, object]:
     """Merge config parameters with runtime kwargs. Config params take precedence,
     since they represent the values being autotuned.
 
@@ -280,16 +282,16 @@ def _merge_config_and_runtime_kwargs(
     Returns:
         Merged kwargs dictionary with config values taking precedence
     """
-    merged_kwargs = runtime_kwargs.copy()
+    merged_kwargs = dict(runtime_kwargs)
     merged_kwargs.update(config_params)
     return merged_kwargs
 
 
 def _adapt_user_input_gen_fns(
-    inputs: list[Any],
+    inputs: Sequence[object],
     op_overload: torch._ops.OpOverload,
-    user_input_gen_fns: dict[str, Callable[[torch.Tensor], torch.Tensor]],
-) -> dict[int, Callable[[Any], torch.Tensor]]:
+    user_input_gen_fns: Mapping[str, Callable[[torch.Tensor], torch.Tensor]],
+) -> dict[int, Callable[[Buffer], torch.Tensor]]:
     """Convert user input generators from name-based to index-based format.
     Inductor autotune's input_gen_fns expects index of arg_names as key.
     """
@@ -308,10 +310,10 @@ def _adapt_user_input_gen_fns(
 
     def create_internal_input_gen_fn(
         user_function: Callable[[torch.Tensor], torch.Tensor], arg_name: str
-    ) -> Callable[[Any], torch.Tensor]:
+    ) -> Callable[[Buffer], torch.Tensor]:
         """Create internal input generator that converts IR buffer to user's fake tensor."""
 
-        def internal_input_gen_fn(ir_buffer: Any) -> torch.Tensor:
+        def internal_input_gen_fn(ir_buffer: Buffer) -> torch.Tensor:
             fake_tensor = ir_node_to_tensor(ir_buffer, replace_symbols_with_hints=True)
             if fake_tensor is None:
                 raise AssertionError("ir_node_to_tensor returned None")
@@ -514,7 +516,7 @@ def autotune_custom_op(
         )
 
     # Convert user input generation functions BEFORE creating choices
-    input_gen_fns: dict[int, Callable[[Any], torch.Tensor]] = {}
+    input_gen_fns: dict[int, Callable[[Buffer], torch.Tensor]] = {}
     if user_input_gen_fns:
         input_gen_fns = _adapt_user_input_gen_fns(
             inputs, op_overload, user_input_gen_fns
@@ -631,7 +633,7 @@ def autotune_custom_op(
 
 
 def _generate_dynamic_configs(
-    tensor_inputs: list[Buffer],
+    tensor_inputs: Sequence[_TensorInput],
     config_generator: Callable[[dict[str, torch.Tensor]], list[CustomOpConfig]],
     op_overload: torch._ops.OpOverload,
     operation_name: str,
@@ -666,12 +668,12 @@ def _generate_dynamic_configs(
 def _prepare_configs_and_decompositions(
     processed_configs: list[CustomOpConfig] | None,
     config_generator: Callable[[dict[str, torch.Tensor]], list[CustomOpConfig]] | None,
-    tensor_inputs: list[Any],
+    tensor_inputs: list[_TensorInput],
     default_impl: Callable[..., Any],
     op_overload: torch._ops.OpOverload,
-    runtime_kwargs: dict[str, Any],
+    runtime_kwargs: Mapping[str, object],
     name: str,
-) -> tuple[list[Callable], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[Callable[..., Any]], list[dict[str, object]], list[dict[str, object]]]:
     """Prepare decompositions and merged kwargs from configs.
 
     Handles both static configs and dynamic config generation.
@@ -690,7 +692,7 @@ def _prepare_configs_and_decompositions(
     # Prepare decompositions and kwargs for autotuning
     decompositions = []
     non_tensor_args = []
-    config_patches_list = []
+    config_patches_list: list[dict[str, object]] = []
 
     for cfg in configs_to_use:
         decomp = cfg.get_decomposition(default_impl=default_impl)
@@ -712,13 +714,13 @@ def _standard_lowering_fn(
     name: str,
     op_overload: torch._ops.OpOverload,
     input_gen_fns: dict[str, Callable[[torch.Tensor], torch.Tensor]] | None,
-    tensor_inputs: list[Any],
-    runtime_kwargs: dict[str, Any],
+    tensor_inputs: list[_TensorInput],
+    runtime_kwargs: Mapping[str, object],
     config_generator: Callable[[dict[str, torch.Tensor]], list[CustomOpConfig]]
     | None = None,
     min_speedup_threshold: float = 1.0,
     benchmark_with_cudagraphs: bool = False,
-) -> Any:
+) -> TensorBox | None:
     """Standard autotuning lowering function.
 
     Returns None if no configs/decompositions available, signaling caller to
@@ -743,6 +745,7 @@ def _standard_lowering_fn(
     result, _ = autotune_custom_op(
         name=name,
         decompositions=decompositions,
+        # pyrefly: ignore[bad-argument-type]  # TODO: Fix the public input type.
         inputs=tensor_inputs,
         non_tensor_args=non_tensor_args,
         config_patches_list=config_patches_list,
@@ -758,12 +761,12 @@ def _standard_lowering_fn(
 
 def _apply_config_patches_recursive(
     operations: list,
-    config_patches: dict[str, Any],
+    config_patches: Mapping[str, object],
 ) -> None:
     """Apply config_patches to operations, including those inside subgraphs."""
     for op in operations:
         if hasattr(op, "set_config_patches"):
-            op.set_config_patches(config_patches.copy())
+            op.set_config_patches(dict(config_patches))
 
         # Recurse into any subgraphs (Switch, WhileLoop, InvokeSubgraph, etc.)
         for subgraph in op.get_subgraphs():
@@ -775,12 +778,12 @@ def _apply_config_patches_recursive(
 
 def _lower_single_impl(
     impl: Callable[..., Any],
-    impl_kwargs: dict[str, Any],
-    runtime_kwargs: dict[str, Any],
-    tensor_inputs: list[Any],
+    impl_kwargs: Mapping[str, object],
+    runtime_kwargs: Mapping[str, object],
+    tensor_inputs: list[_TensorInput],
     name: str,
-    config_patches: dict[str, Any] | None = None,
-) -> Any:
+    config_patches: Mapping[str, object] | None = None,
+) -> TensorBox | None:
     """Lower a single implementation by tracing and inlining it.
 
     Uses error_on_new_guards() during tracing to detect if the impl adds guards.
@@ -794,7 +797,7 @@ def _lower_single_impl(
 
     merged_kwargs = _merge_config_and_runtime_kwargs(impl_kwargs, runtime_kwargs)
 
-    def impl_wrapper(*tensors):
+    def impl_wrapper(*tensors: torch.Tensor) -> Any:
         return impl(*tensors, **merged_kwargs)
 
     shape_env = V.fake_mode.shape_env
@@ -831,7 +834,7 @@ def _lower_single_impl(
 
     log.info("Inlining implementation: %s", impl.__name__)
     ops_before = len(V.graph.operations)
-    result = inline_subgraph_to_ir_nodes(impl_gm, tensor_inputs, name)
+    result = cast(TensorBox, inline_subgraph_to_ir_nodes(impl_gm, tensor_inputs, name))
 
     if config_patches:
         _apply_config_patches_recursive(V.graph.operations[ops_before:], config_patches)
@@ -849,14 +852,14 @@ def _range_based_lowering_fn(
     tensor_name: str,
     dim_index: int,
     ranges: list[tuple[int, int | float]],
-    tensor_inputs: list[Any],
-    runtime_kwargs: dict[str, Any],
+    tensor_inputs: list[_TensorInput],
+    runtime_kwargs: Mapping[str, object],
     range_upper_bound: int,
     config_generator: Callable[[dict[str, torch.Tensor]], list[CustomOpConfig]]
     | None = None,
     min_speedup_threshold: float = 1.0,
     benchmark_with_cudagraphs: bool = False,
-) -> Any:
+) -> TensorBox | None:
     """Range-based autotuning lowering function."""
     from torch._inductor.codegen.subgraph import inline_subgraph_to_ir_nodes
     from torch.fx.experimental.proxy_tensor import make_fx
@@ -898,6 +901,7 @@ def _range_based_lowering_fn(
         autotuned_result, winning_choice = autotune_custom_op(
             name=range_name,
             decompositions=decompositions,
+            # pyrefly: ignore[bad-argument-type]  # TODO: Fix the public input type.
             inputs=tensor_inputs,
             non_tensor_args=non_tensor_args,
             op_overload=op_overload,
@@ -960,7 +964,7 @@ def _range_based_lowering_fn(
             config_patches=group.config_patches,
         )
 
-    def dispatch_fn(*fake_tensors):
+    def dispatch_fn(*fake_tensors: torch.Tensor) -> Any:
         """Build nested torch.cond dispatch: cond(pred1, impl1, cond(pred2, impl2, ...))."""
         num_impl_groups = len(impl_groups)
         if num_impl_groups < 2:
@@ -984,7 +988,7 @@ def _range_based_lowering_fn(
                 result = result | pred
             return result  # pyrefly: ignore [bad-return]
 
-        def build_nested_cond(idx: int):
+        def build_nested_cond(idx: int) -> Callable[..., Any]:
             if idx >= num_impl_groups:
                 raise RuntimeError(f"Invalid impl group index: {idx}")
 
@@ -994,7 +998,7 @@ def _range_based_lowering_fn(
             )
 
             @torch._dynamo.dont_skip_tracing
-            def group_fn(*ops):
+            def group_fn(*ops: torch.Tensor) -> Any:
                 return group.impl_func(*ops, **merged_kwargs)
 
             if idx == num_impl_groups - 1:
@@ -1003,7 +1007,9 @@ def _range_based_lowering_fn(
             next_fn = build_nested_cond(idx + 1)
 
             @torch._dynamo.dont_skip_tracing
-            def cond_wrapper(*ops, _ranges=group.ranges):
+            def cond_wrapper(
+                *ops: torch.Tensor, _ranges: list[RangeBounds] = group.ranges
+            ) -> Any:
                 return torch.cond(
                     pred=build_range_predicate(_ranges),
                     true_fn=group_fn,
@@ -1054,11 +1060,14 @@ def _range_based_lowering_fn(
             raise
 
     ops_before = len(V.graph.operations)
-    result = inline_subgraph_to_ir_nodes(dispatch_gm, tensor_inputs, f"{name}_dispatch")
+    result = cast(
+        TensorBox,
+        inline_subgraph_to_ir_nodes(dispatch_gm, tensor_inputs, f"{name}_dispatch"),
+    )
 
     # Apply config_patches from all impl groups to inlined operations
     # TODO - consider conflicting patches
-    merged_patches: dict[str, Any] = {}
+    merged_patches: dict[str, object] = {}
     for group in impl_groups:
         merged_patches.update(group.config_patches)
     if merged_patches:


### PR DESCRIPTION
## Summary

- distinguish Inductor tensor inputs from opaque non-tensor custom-op payloads
- use read-only `Mapping[str, object]` boundaries for runtime kwargs and config patches
- give private lowering helpers concrete result types while retaining `Any` at dynamic implementation calls
- leave `CustomOpConfig`, `register_custom_op_autotuning`, and `autotune_custom_op` signatures unchanged

## Test plan

```bash
pyrefly check torch/_inductor/kernel/custom_op.py
```

This reports only the same two pre-existing `bad-return` diagnostics in the input-generator helpers as the untouched base.

```bash
UV_NO_CONFIG=1 UV_OFFLINE=1 lintrunner -a --skip PYREFLY torch/_inductor/kernel/custom_op.py
```

```bash
python agent_space/run_with_custom_op.py test/inductor/test_custom_op_out_lowering.py
python agent_space/run_with_custom_op.py test/inductor/test_custom_op_autotune.py
```

The runtime tests used a local module overlay because the editable install points at another compatible worktree. They passed 9 and 23 tests, respectively.

Authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo