### PR TITLE
[autograd] Refresh view grad_fn before registering hooks

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2554,13 +2554,19 @@ class TestAutograd(TestCase):
         view.register_hook(fn0)
         view2.register_hook(fn1)
         view.mul_(2)
-        # We need to explicitly trigger an update to view to update its grad_fn
-        view2.grad_fn
         view2.register_hook(fn2)
         (view + view2).sum().backward()
-        # The hooks originally registered to view are not fired, one must explicitly
-        # trigger an update to the view's grad_fn, and then register a new hook
+        # Hooks registered before the inplace operation are not fired, but registering
+        # a new hook refreshes the view's grad_fn and attaches it to the new node.
         self.assertEqual(count[0], 1)
+
+    def test_tensor_hooks_inplace_through_view_alias(self):
+        leaf = torch.ones(2, requires_grad=True)
+        view = leaf.clone().view(2)
+        view[:].add_(1)
+        view.register_hook(lambda grad: grad * 2)
+        view.sum().backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 2))
 
     def test_retain_grad_cycle(self):
         x = torch.ones(5, 5, requires_grad=True)

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -691,6 +691,8 @@ class Tensor(torch._C.TensorBase):
             raise RuntimeError(
                 "cannot register a hook on a tensor that doesn't require gradient"
             )
+        # Accessing grad_fn refreshes a stale view before creating its hook dict.
+        _ = self.grad_fn
         if self._backward_hooks is None:
             self._backward_hooks = OrderedDict()
             if self.grad_fn is not None:


### PR DESCRIPTION
## Issue

Fixes #196459

## Summary

Refresh a view's `grad_fn` before inspecting or creating its backward-hook dictionary. This prevents a lazy view-history refresh from clearing a newly created dictionary before `_register_hook_dict` uses it, and ensures hooks registered after an alias mutation attach to the current autograd node.

## Testing

- Added coverage for first hook registration after an in-place alias update.
- Updated existing coverage to verify registration itself refreshes stale view history.
- `lintrunner -a`

The focused tests loaded the exact patched method and test bodies against the existing compiled extension, avoiding a second build while another build was active.

## Checklist

- [x] Passes lint (`spin quicklint -a` and `lintrunner -a`)
- [x] Added/updated tests
- [x] Documentation not applicable
- [x] Benchmark results not applicable

## BC-breaking?

No.

> AI disclosure: Codex assisted with root-cause analysis, implementation, and test preparation. The author directed the minimal fix and regression coverage after reviewing the root-cause explanation.
