### PR TITLE
[inductor] Guard triton CPU test against missing SweepInputsCpuTest (#196515)

### DIFF
--- a/test/inductor/test_triton_cpu_backend.py
+++ b/test/inductor/test_triton_cpu_backend.py
@@ -27,16 +27,19 @@ TRITON_CPU_SLOW_TESTS = (
 )
 
 if HAS_CPU and TRITON_HAS_CPU:
+    # SweepInputsCpuTest is only defined when CPU tests are enabled
+    # (RUN_CPU); otherwise there is nothing to subclass.
+    if hasattr(test_torchinductor, "SweepInputsCpuTest"):
 
-    @config.patch(
-        {
-            "cpu_backend": "triton",
-            "test_configs.runtime_triton_dtype_assert": False,
-            "test_configs.runtime_triton_shape_assert": False,
-        }
-    )
-    class SweepInputsCpuTritonTest(test_torchinductor.SweepInputsCpuTest):
-        pass
+        @config.patch(
+            {
+                "cpu_backend": "triton",
+                "test_configs.runtime_triton_dtype_assert": False,
+                "test_configs.runtime_triton_shape_assert": False,
+            }
+        )
+        class SweepInputsCpuTritonTest(test_torchinductor.SweepInputsCpuTest):
+            pass
 
     @config.patch(
         {


### PR DESCRIPTION
Summary:

`SweepInputsCpuTest` in `test_torchinductor` is only defined under `RUN_CPU`. When CPU tests are excluded (e.g. `PYTORCH_TESTING_DEVICE_ONLY_FOR=cuda`), `test_triton_cpu_backend.py` crashes at import with `AttributeError` and the whole `:triton_cpu_backend` target fails to list.
- Guard the subclass with `hasattr` so the target lists in that configuration; no behavior change where `RUN_CPU` is true.
- CPU failures newly exposed by the listed target (libdevice/TD gaps in the triton CPU backend) are parked as skips in a separate internal-only child diff, not here.

___

Test Plan:
P2495282491 direct-Buck runs on H100 (`-m ovr_config//triton:stable`).

| `:triton_cpu_backend` | Before | After (this diff) |
|---|---|---|
| Listing | Failed, 0 tests ran | Succeeds, target runs |
| `CpuTritonTests` | Never executed | Runs; remaining CPU failures parked separately |
| GPU suites | Candidate-only failures 0 | Unchanged |

```
buck2 --isolation-dir triton_inductor_candidate test fbcode//mode/opt -m ovr_config//triton:stable -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 fbcode//caffe2/test/inductor:triton_cpu_backend -- --jobs 1 --run-mode BundledWithMax --max-tests-per-bundle 8 --retry 1 --return-nonzero-on-failures --env CUDA_VISIBLE_DEVICES=2 --env PYTORCH_TEST_REMOTE_GPU=1 --env PYTORCH_TESTING_DEVICE_ONLY_FOR=cuda
=> Pass 792, Fail 94, Skip 563 (listing fixed; 94 are the parked CPU-backend gaps)
```

Reviewed By: shawnxu26

Differential Revision: D119398217




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo