### PR TITLE
[xpu][test] Port 5 distributed  tests cases on Intel GPUs

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -46,7 +46,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import implicit_replication
-from torch.testing._internal.common_cuda import SM90OrLater, TEST_CUDA, TEST_MULTIGPU
+from torch.testing._internal.common_cuda import SM90OrLater, TEST_MULTIGPU
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     PLATFORM_SUPPORTS_SYMM_MEM,
@@ -1793,13 +1793,13 @@ class TestFullyShardAllocFromPG(FSDPTest):
         fully_shard(model)
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             self.assertNotRegex(f.read(), self.MEMORY_REGISTER_RE)
@@ -1813,7 +1813,7 @@ class TestFullyShardAllocFromPG(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             self.assertRegex(f.read(), self.MEMORY_REGISTER_RE)
@@ -1921,11 +1921,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         super()._run(*args, **kwargs)
 
     # Test reduce-scatter only on plain FSDP on 2 GPUs
-    # This test verifies NCCL debug logs and is CUDA-specific.
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(
-        not TEST_CUDA, "This test verifies NCCL debug logs and is CUDA-specific"
-    )
     def test_fully_shard_force_sum_reduce_scatter(self):
         torch.manual_seed(42)
         model_args = ModelArgs()
@@ -1946,13 +1942,13 @@ class TestFullyShardForceSumReduction(FSDPTest):
         )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -1969,7 +1965,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -1977,11 +1973,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         self.assertRegex(logs, reduce_scatter_sum_re)
 
     # Test both reduce-scatter and all-reduce on HSDP (DDP+FSDP) on 4 GPUs
-    # This test verifies NCCL debug logs and is CUDA-specific.
     @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(
-        not TEST_CUDA, "This test verifies NCCL debug logs and is CUDA-specific"
-    )
     def test_fully_shard_force_sum_both_reductions(self):
         mesh = init_device_mesh(
             device_type.type, (2, self.world_size // 2), mesh_dim_names=("ddp", "fsdp")
@@ -2012,13 +2004,13 @@ class TestFullyShardForceSumReduction(FSDPTest):
         )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -2037,7 +2029,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -106,7 +106,7 @@ class TestFullyShardOverlap(FSDPTest):
             )
             with torch.get_device_module(device_type).stream(comm_stream):
                 torch.get_device_module(device_type)._sleep(
-                    int(comm_sleep_ms * get_cycles_per_ms())
+                    int(comm_sleep_ms * get_cycles_per_ms(device_type.type))
                 )
             torch.get_device_module(device_type).current_stream().wait_stream(
                 comm_stream
@@ -343,7 +343,7 @@ class TestFullyShardOverlap(FSDPTest):
 
         def delayed_all_gather(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
-                int(comm_sleep_ms * get_cycles_per_ms())
+                int(comm_sleep_ms * get_cycles_per_ms(device_type.type))
             )
             return orig_all_gather_into_tensor(*args, **kwargs)
 
@@ -397,14 +397,14 @@ class Matmul(torch.autograd.Function):
     def forward(ctx, input: torch.Tensor, weight: torch.Tensor, sleep_ms: int):
         ctx.save_for_backward(input, weight)
         ctx.sleep_ms = sleep_ms
-        torch.get_device_module(device_type)._sleep(int(sleep_ms * get_cycles_per_ms()))
+        torch.get_device_module(device_type)._sleep(int(sleep_ms * get_cycles_per_ms(device_type.type)))
         return input @ weight
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (input, weight) = ctx.saved_tensors
         torch.get_device_module(device_type)._sleep(
-            int(2 * ctx.sleep_ms * get_cycles_per_ms())
+            int(2 * ctx.sleep_ms * get_cycles_per_ms(device_type.type))
         )
         grad_input = grad_output @ weight.T
         grad_weight = input.T @ grad_output
@@ -473,7 +473,7 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
             ds = delay_streams[reduce_scatter_group]
             ds.wait_event(rs_event)
             with device_module.stream(ds):
-                device_module._sleep(int(sleep_ms * get_cycles_per_ms()))
+                device_module._sleep(int(sleep_ms * get_cycles_per_ms(device_type.type)))
                 delayed_event = ds.record_event()
             return (rs_input, delayed_event, post_reduce_stream, *rest)
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -397,7 +397,9 @@ class Matmul(torch.autograd.Function):
     def forward(ctx, input: torch.Tensor, weight: torch.Tensor, sleep_ms: int):
         ctx.save_for_backward(input, weight)
         ctx.sleep_ms = sleep_ms
-        torch.get_device_module(device_type)._sleep(int(sleep_ms * get_cycles_per_ms(device_type.type)))
+        torch.get_device_module(device_type)._sleep(
+            int(sleep_ms * get_cycles_per_ms(device_type.type))
+        )
         return input @ weight
 
     @staticmethod
@@ -473,7 +475,9 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
             ds = delay_streams[reduce_scatter_group]
             ds.wait_event(rs_event)
             with device_module.stream(ds):
-                device_module._sleep(int(sleep_ms * get_cycles_per_ms(device_type.type)))
+                device_module._sleep(
+                    int(sleep_ms * get_cycles_per_ms(device_type.type))
+                )
                 delayed_event = ds.record_event()
             return (rs_input, delayed_event, post_reduce_stream, *rest)
 

--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -53,8 +53,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_WITH_ROCM,
-    TEST_XPU,
-    xfailIf,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
@@ -177,7 +175,6 @@ class TestFullyShard2DTraining(FSDPTestContinuous):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(4)
-    @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1881
     def test_train_parity_2d_transformer(self):
         self.run_subtests(
             {"use_shard_placement_fn": [False, True]},
@@ -259,7 +256,6 @@ class TestFullyShard2DTraining(FSDPTestContinuous):
             self.assertEqual(full_param, ref_param)
 
     @skip_if_lt_x_gpu(4)
-    @xfailIf(TEST_XPU)  # https://github.com/pytorch/pytorch/issues/156782
     def test_tp_with_fsdp_offloading(self):
         global_mesh = init_device_mesh(
             device_type, (1, self.world_size), mesh_dim_names=("dp", "tp")
@@ -318,7 +314,6 @@ class TestFullyShard2DTraining(FSDPTestContinuous):
         IS_LINUX or TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/125644"
     )
     @skip_if_lt_x_gpu(4)
-    @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1881
     @with_temp_dir
     def test_train_parity_2d_transformer_checkpoint_resume(self):
         """

--- a/test/distributed/_composable/test_replicate_mixed_precision.py
+++ b/test/distributed/_composable/test_replicate_mixed_precision.py
@@ -708,7 +708,7 @@ class TestReplicateMixedPrecisionCasts(FSDPTestMultiThread):
             torch.bfloat16, torch.bfloat16, torch.bfloat16, True
         )
         model = Model()
-        inp = Input(torch.randn(2, 10).cuda())
+        inp = Input(torch.randn(2, 10).to(device_type))
 
         replicate(model, mp_policy=mp_policy)
         loss = model(inp).sum()

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -406,13 +406,13 @@ class TestReplicate1DTrainingCore(FSDPTest):
 
         def delayed_all_gather(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
-                int(delay_in_ms * get_cycles_per_ms())
+                int(delay_in_ms * get_cycles_per_ms(device_type.type))
             )
             return orig_all_gather(*args, **kwargs)
 
         def delayed_reduce_scatter(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
-                int(delay_in_ms * get_cycles_per_ms())
+                int(delay_in_ms * get_cycles_per_ms(device_type.type))
             )
             return orig_reduce_scatter(*args, **kwargs)
 
@@ -435,12 +435,12 @@ class TestReplicate1DTrainingCore(FSDPTest):
                     losses.append(_model(inp).sum())
                     if _model is model and delay_after_forward:
                         torch.get_device_module(device_type)._sleep(
-                            int(delay_in_ms * get_cycles_per_ms())
+                            int(delay_in_ms * get_cycles_per_ms(device_type.type))
                         )
                     losses[-1].backward()
                     if _model is model and delay_before_optim:
                         torch.get_device_module(device_type)._sleep(
-                            int(delay_in_ms * get_cycles_per_ms())
+                            int(delay_in_ms * get_cycles_per_ms(device_type.type))
                         )
 
                 for param in ref_model.parameters():
@@ -488,7 +488,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
 
         root_loss = model(inp).sum()
         root_loss.backward()
-        torch.get_device_module(device_type)._sleep(int(100 * get_cycles_per_ms()))
+        torch.get_device_module(device_type)._sleep(
+            int(100 * get_cycles_per_ms(device_type.type))
+        )
         optim.step()
         optim.zero_grad()
         nonroot_loss = model[0](inp).sum()
@@ -642,7 +644,9 @@ class TestReplicate1DTrainingCore(FSDPTest):
             optim.step()
             # Sleep after the optimizer step to allow CPU to run ahead into the
             # next iteration's forward, exercising the post-optim stream sync
-            torch.get_device_module(device_type)._sleep(int(25 * get_cycles_per_ms()))
+            torch.get_device_module(device_type)._sleep(
+                int(25 * get_cycles_per_ms(device_type.type))
+            )
         for ref_loss, loss in zip(ref_losses, losses):
             self.assertEqual(ref_loss, loss)
 

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -32,6 +32,11 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 )
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 class Net(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -48,11 +53,11 @@ class ReplicateTest(MultiProcContinuousTest):
 
     @classmethod
     def backend_str(cls) -> str:
-        return "nccl"
+        return dist.get_default_backend_for_device(device_type)
 
     @classmethod
     def device_type(cls) -> str:
-        return "cuda"
+        return device_type
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
@@ -66,7 +71,7 @@ class ReplicateTest(MultiProcContinuousTest):
         # Prefer to test with >=4 GPUs, but for 2 GPUs, use 2-way TP
         replicate_size = 2
         return init_device_mesh(
-            "cuda",
+            device_type,
             (replicate_size, 1, self.world_size // replicate_size),
             mesh_dim_names=("replicate", "shard", "tp"),
         )
@@ -195,7 +200,7 @@ class ReplicateTest(MultiProcContinuousTest):
         This tests that a user can pass in a device mesh to replicate a module
         """
 
-        device = torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")
+        device = torch.device(device_type, self.rank % torch.accelerator.device_count())
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -221,7 +226,7 @@ class ReplicateTest(MultiProcContinuousTest):
         Tests that replicate_model has the same behavior as original model when training
         """
 
-        device = torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")
+        device = torch.device(device_type, self.rank % torch.accelerator.device_count())
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -291,7 +296,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
         torch.manual_seed(42)
         model = MLPStack(mlp_dim)
-        ref_model = copy.deepcopy(model).cuda()
+        ref_model = copy.deepcopy(model).to(device_type)
         replicate(ref_model, mesh=replicate_mesh)
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
         model.parallelize(
@@ -302,7 +307,7 @@ class ReplicateTest(MultiProcContinuousTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
 
         torch.manual_seed(42 + replicate_pg.rank() + 1)
-        device = torch.device("cuda")
+        device = torch.device(device_type)
         for iter_idx in range(10):
             inp = torch.randn((8, mlp_dim), device=device)
             losses: list[torch.Tensor] = []


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU.
We will enable Intel GPU with following methods and keep the original code styles:

Example: "torch.accelerator.current_accelerator()" to determine the accelerator backend

enabled XPU for the following files:

1.  test/distributed/_composable/fsdp/test_fully_shard_comm.py
2.  test/distributed/_composable/fsdp/test_fully_shard_overlap.py
3.  test/distributed/_composable/test_composability/test_2d_composability.py
4.  test/distributed/_composable/test_replicate_mixed_precision.py
5.  test/distributed/_composable/test_replicate_training.py
6.  test/distributed/_composable/test_replicate_with_fsdp.py


cc @newtdms, @guangyey, @etaf, @CuiYifeng, @liangan1, @astachowiczhabana, @pbielak.