### PR TITLE
[pytorch] Add private `dispatchless_custom_op`

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/dispatchless_custom_op.py
+++ b/benchmarks/dynamo/microbenchmarks/dispatchless_custom_op.py
@@ -1,0 +1,137 @@
+"""Compare steady-state CPU forward-call overhead using the same clone body.
+
+Empty/tiny tensors emphasize wrapper overhead, while larger sizes include more
+tensor work. Registration, warmup, correctness checks, and backward are not timed.
+The requires_grad case includes forward autograd graph construction. Results are
+medians and IQRs of pooled per-call block timings, not confidence intervals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import timeit
+from collections.abc import Callable
+
+import torch
+from torch._library.dispatchless import dispatchless_custom_op
+from torch.utils.benchmark import Timer
+
+
+def clone(x: torch.Tensor) -> torch.Tensor:
+    return x.clone()
+
+
+def clone_backward(ctx: object, grad_output: torch.Tensor) -> torch.Tensor:
+    return grad_output
+
+
+def benchmark_case(
+    variants: dict[str, Callable[[torch.Tensor], torch.Tensor]],
+    size: int,
+    mode: str,
+    min_run_time: float,
+    repeats: int,
+) -> list[dict[str, str | int | float]]:
+    requires_grad = mode == "requires_grad"
+    x = torch.ones(size, dtype=torch.float32, device="cpu", requires_grad=requires_grad)
+    samples: dict[str, list[float]] = {name: [] for name in variants}
+    with torch.set_grad_enabled(mode != "no_grad"):
+        expected = clone(x)
+        for fn in variants.values():
+            actual = fn(x)
+            torch.testing.assert_close(actual, expected)
+            if requires_grad:
+                (grad,) = torch.autograd.grad(actual.sum(), x)
+                torch.testing.assert_close(grad, torch.ones_like(x))
+            for _ in range(10):
+                fn(x)
+
+        names = list(variants)
+        for repeat in range(repeats):
+            offset = repeat % len(names)
+            for name in names[offset:] + names[:offset]:
+                measurement = Timer(
+                    stmt="fn(x)",
+                    globals={"fn": variants[name], "x": x},
+                    num_threads=1,
+                    timer=timeit.default_timer,
+                ).blocked_autorange(min_run_time=min_run_time)
+                samples[name].extend(measurement.times)
+
+    return summarize(samples, size, mode)
+
+
+def summarize(
+    samples: dict[str, list[float]], size: int, mode: str
+) -> list[dict[str, str | int | float]]:
+    medians = {name: statistics.median(times) * 1e6 for name, times in samples.items()}
+    rows: list[dict[str, str | int | float]] = []
+    for name, times in samples.items():
+        quartiles = (
+            statistics.quantiles(times, n=4, method="inclusive")
+            if len(times) > 1
+            else [times[0]] * 3
+        )
+        rows.append(
+            {
+                "mode": mode,
+                "numel": size,
+                "variant": name,
+                "median_us": medians[name],
+                "iqr_us": (quartiles[2] - quartiles[0]) * 1e6,
+                "overhead_vs_plain_us": medians[name] - medians["plain"],
+                "speedup_vs_custom_op": medians["custom_op"] / medians[name],
+                "blocks": len(times),
+            }
+        )
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-run-time", type=float, default=1.0)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--sizes", type=int, nargs="+", default=[0, 1, 1024])
+    args = parser.parse_args()
+    if args.min_run_time <= 0 or args.repeats < 1 or any(size < 0 for size in args.sizes):
+        parser.error("run time and repeats must be positive; sizes must be nonnegative")
+
+    torch.set_num_threads(1)
+    custom = torch.library.custom_op(
+        "dispatchless_benchmark::clone", clone, mutates_args=()
+    )
+    custom.register_autograd(clone_backward)
+    variants = {
+        "plain": clone,
+        "custom_op": custom,
+        "dispatchless_custom_op": dispatchless_custom_op(clone),
+    }
+    rows = []
+    for mode in ("no_grad", "grad_enabled", "requires_grad"):
+        for size in args.sizes:
+            rows.extend(
+                benchmark_case(variants, size, mode, args.min_run_time, args.repeats)
+            )
+    report = {
+        "environment": {
+            "torch": torch.__version__,
+            "python": platform.python_version(),
+            "host": platform.node(),
+            "platform": platform.platform(),
+            "cpu_capability": torch.backends.cpu.get_cpu_capability(),
+            "threads": torch.get_num_threads(),
+            "device": "cpu",
+            "dtype": "float32",
+            "min_run_time": args.min_run_time,
+            "repeats": args.repeats,
+        },
+        "results": rows,
+    }
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/dynamo/test_dispatchless.py
+++ b/test/dynamo/test_dispatchless.py
@@ -1,0 +1,234 @@
+# Owner(s): ["module: dynamo", "module: custom-operators"]
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch._dynamo.testing import EagerAndRecordGraphs
+from torch._library.dispatchless import (
+    _flat_call,
+    dispatchless_custom_op,
+    flat_dispatchless_call,
+)
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+from torch.testing._internal.dynamo_pytree_test_utils import PytreeRegisteringTestCase
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+@dataclass
+class Payload:
+    value: torch.Tensor
+    scale: int
+
+
+class DispatchlessTest(PytreeRegisteringTestCase):
+    def test_eager_direct_call(self):
+        class Unregistered:
+            def __init__(self, value):
+                self.value = value
+
+        x = torch.randn(4, requires_grad=True)
+        payload = Unregistered(x)
+        calls = []
+
+        class RecordMode(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                calls.append(func)
+                return func(*args, **(kwargs or {}))
+
+        @dispatchless_custom_op
+        def op(arg):
+            self.assertIs(arg, payload)
+            return arg.value.sin()
+
+        with RecordMode():
+            result = op(payload)
+        self.assertEqual(calls, [torch.ops.aten.sin.default])
+        self.assertEqual(result, x.sin())
+        self.assertEqual(torch.autograd.grad(result.sum(), x)[0], x.cos())
+
+    @parametrize("tracing_mode", ["real", "fake", "symbolic"])
+    @parametrize("pre_dispatch", [False, True])
+    def test_make_fx_preserves_call(self, tracing_mode, pre_dispatch):
+        @dispatchless_custom_op
+        def op(payload, *, scale=2):
+            return {"result": payload["x"][0].sin() * scale, "metadata": (None, scale)}
+
+        def fn(x):
+            return op({"x": [x]}, scale=3)
+
+        x = torch.randn(4)
+        gm = make_fx(fn, tracing_mode=tracing_mode, pre_dispatch=pre_dispatch)(x)
+        gm.graph.lint()
+        targets = [node.target for node in gm.graph.nodes if node.op == "call_function"]
+        self.assertEqual(targets.count(flat_dispatchless_call), 1)
+        self.assertNotIn(torch.ops.aten.sin.default, targets)
+        self.assertEqual(gm(x + 1), fn(x + 1))
+
+    def test_make_fx_decomposition(self):
+        @dispatchless_custom_op
+        def op(x):
+            return {"value": x.sin() + 1}
+
+        x = torch.randn(4)
+        gm = make_fx(op, decomposition_table={flat_dispatchless_call: _flat_call})(x)
+        targets = [node.target for node in gm.graph.nodes if node.op == "call_function"]
+        self.assertNotIn(flat_dispatchless_call, targets)
+        self.assertIn(torch.ops.aten.sin.default, targets)
+        self.assertEqual(gm(x), op(x))
+
+    def test_dynamo_pytree_inputs_outputs(self):
+        self.register_pytree_node(
+            Payload,
+            lambda p: ((p.value, p.scale), None),
+            lambda values, _: Payload(*values),
+        )
+
+        @dispatchless_custom_op
+        def op(payload, *, bias):
+            result = Payload(payload.value.sin() + bias, payload.scale)
+            return {"output": result, "none": None}
+
+        def fn(x, bias):
+            result = op(Payload(x, 2), bias=bias)
+            return result["output"].value * result["output"].scale, result["none"]
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        for _ in range(2):
+            x, bias = torch.randn(4), torch.randn(4)
+            self.assertEqual(compiled(x, bias), fn(x, bias))
+        self.assertEqual(len(backend.graphs), 1)
+        gm = backend.graphs[0]
+        gm.graph.lint()
+        targets = [node.target for node in gm.graph.nodes if node.op == "call_function"]
+        self.assertEqual(targets.count(flat_dispatchless_call), 1)
+        self.assertNotIn(torch.sin, targets)
+
+    def test_dynamo_dynamic_shapes(self):
+        @dispatchless_custom_op
+        def op(x):
+            return {"result": x.sin(), "size": x.shape[0]}
+
+        def fn(x):
+            result = op(x)
+            return result["result"] + result["size"]
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True, dynamic=True)
+        for size in (4, 7):
+            x = torch.randn(size)
+            self.assertEqual(compiled(x), fn(x))
+        self.assertEqual(len(backend.graphs), 1)
+
+    def test_dynamo_operator_identity(self):
+        def make_op(offset):
+            @dispatchless_custom_op
+            def op(x):
+                return x + offset
+
+            return op
+
+        def fn(op, x):
+            return op(x)
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        x = torch.randn(4)
+        first, second = make_op(1), make_op(2)
+        self.assertEqual(compiled(first, x), x + 1)
+        self.assertEqual(compiled(second, x), x + 2)
+        self.assertEqual(compiled(first, x), x + 1)
+        self.assertEqual(len(backend.graphs), 2)
+
+    def test_output_specs_are_per_call(self):
+        @dispatchless_custom_op
+        def op(x, *, as_dict):
+            result = x.sin()
+            return {"value": result} if as_dict else [result]
+
+        def fn(x):
+            return op(x, as_dict=True)["value"] + op(x, as_dict=False)[0]
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        x = torch.randn(4)
+        self.assertEqual(compiled(x), fn(x))
+        targets = [node.target for node in backend.graphs[0].graph.nodes]
+        self.assertEqual(targets.count(flat_dispatchless_call), 2)
+
+    def test_nested_operators_and_repeated_inputs(self):
+        @dispatchless_custom_op
+        def inner(x, y):
+            return x * y
+
+        @dispatchless_custom_op
+        def outer(values):
+            return inner(values[0], values[1]).sin()
+
+        def fn(x):
+            return outer([x, x])
+
+        x = torch.randn(4)
+        gm = make_fx(fn)(x)
+        self.assertEqual(gm(x), fn(x))
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertEqual(targets.count(flat_dispatchless_call), 1)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn(x))
+
+    def test_registered_constant(self):
+        @dataclass(frozen=True)
+        class Config:
+            scale: int
+
+        self.register_constant(Config)
+
+        @dispatchless_custom_op
+        def op(x, config):
+            return x * config.scale
+
+        def fn(x, config):
+            return op(x, config)
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        x = torch.randn(4)
+        for scale in (2, 3, 2):
+            self.assertEqual(compiled(x, Config(scale)), x * scale)
+        self.assertEqual(len(backend.graphs), 2)
+
+    @parametrize("output", [False, True])
+    def test_unsupported_pytree_leaf(self, output):
+        class Unregistered:
+            pass
+
+        @dispatchless_custom_op
+        def op(x):
+            return Unregistered() if output else x
+
+        x = torch.randn(4)
+        with self.assertRaisesRegex(RuntimeError, "non-fx-graphable type"):
+            make_fx(op)(x if output else Unregistered())
+
+    def test_output_spec_mismatch(self):
+        @dispatchless_custom_op
+        def op(x):
+            return [x.sin()] if x.shape[0] == 4 else {"value": x.sin()}
+
+        gm = make_fx(op)(torch.randn(4))
+        with self.assertRaisesRegex(RuntimeError, "same output pytree structure"):
+            gm(torch.randn(7))
+
+
+instantiate_parametrized_tests(DispatchlessTest)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_dispatchless.py
+++ b/test/inductor/test_dispatchless.py
@@ -1,0 +1,92 @@
+# Owner(s): ["module: inductor", "module: custom-operators"]
+
+from __future__ import annotations
+
+import torch
+from torch._dynamo.testing import InductorAndRecordGraphs
+from torch._inductor import metrics
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
+from torch._library.dispatchless import dispatchless_custom_op, flat_dispatchless_call
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize
+
+
+class DispatchlessTest(TestCase):
+    @parametrize("requires_grad", [False, True])
+    def test_values_gradients_and_decomposition(self, device, requires_grad):
+        @dispatchless_custom_op
+        def op(payload, *, scale):
+            result = payload[0].sin() * scale
+            return {"result": result, "other": (payload[1].cos(), None)}
+
+        def fn(x, y):
+            result = op([x, y], scale=2)
+            return result["result"] + result["other"][0]
+
+        backend = InductorAndRecordGraphs()
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        x = torch.randn(16, device=device, requires_grad=requires_grad)
+        y = torch.randn(16, device=device, requires_grad=requires_grad)
+        expected = fn(x, y)
+        actual = compiled(x, y)
+        self.assertEqual(actual, expected)
+        if requires_grad:
+            self.assertEqual(
+                torch.autograd.grad(actual.sum(), (x, y)),
+                torch.autograd.grad(expected.sum(), (x, y)),
+            )
+        self.assertTrue(backend.inductor_graphs)
+        self.assertIn(
+            flat_dispatchless_call,
+            [node.target for node in backend.graphs[0].graph.nodes],
+        )
+        for gm in backend.inductor_graphs:
+            self.assertNotIn(
+                flat_dispatchless_call, [node.target for node in gm.graph.nodes]
+            )
+
+    def test_fuses_across_operator(self, device):
+        @dispatchless_custom_op
+        def op(x):
+            return x.sin() * 2
+
+        def fn(x):
+            return op(x + 1).cos() + 3
+
+        x = torch.randn(256, device=device)
+        metrics.reset()
+        actual, code = run_and_get_code(torch.compile(fn, fullgraph=True), x)
+        self.assertEqual(actual, fn(x))
+        self.assertEqual(metrics.generated_kernel_count, 1)
+        self.assertTrue(code)
+        self.assertNotIn("flat_dispatchless_call(", "\n".join(code))
+
+    def test_dynamic_shapes_and_nested_calls(self, device):
+        @dispatchless_custom_op
+        def inner(x, y):
+            return x * y
+
+        @dispatchless_custom_op
+        def outer(payload):
+            return {"value": inner(payload[0], payload[1]).sin()}
+
+        def fn(x):
+            return outer([x, x])["value"] + x.shape[0]
+
+        compiled = torch.compile(fn, fullgraph=True, dynamic=True)
+        for size in (4, 7):
+            x = torch.randn(size, device=device, requires_grad=True)
+            actual, expected = compiled(x), fn(x)
+            self.assertEqual(actual, expected)
+            self.assertEqual(
+                torch.autograd.grad(actual.sum(), x),
+                torch.autograd.grad(expected.sum(), x),
+            )
+
+
+instantiate_device_type_tests(DispatchlessTest, globals(), only_for=("cpu", "cuda"))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -65,6 +65,7 @@ from torch._functorch._aot_autograd.utils import is_async_collective_tensor_type
 from torch._guards import TracingContext
 from torch._higher_order_ops.flat_apply import flat_apply
 from torch._higher_order_ops.torchbind import call_torchbind
+from torch._library.dispatchless import _DispatchlessCustomOp
 from torch._library.opaque_object import (
     is_custom_class,
     is_opaque_constant_type,
@@ -1581,6 +1582,11 @@ class VariableBuilder:
             return ErrorOnGraphBreakVariable(value.error_on_graph_break)
         elif isinstance(value, CudagraphOverrideContextManager):
             return CudagraphOverrideVariable(value.fwd, value.bwd)
+        elif isinstance(value, _DispatchlessCustomOp):
+            from .torch import DispatchlessCustomOpVariable
+
+            self.install_guards(GuardBuilder.ID_MATCH)
+            return DispatchlessCustomOpVariable(value, source=self.source)
         elif callable(value) and trace_rules.lookup_callable(value) is not None:
             if trace_rules.is_callable_allowed(value):
                 self.tx.output.has_user_defined_allowed_in_graph = True
@@ -5336,6 +5342,10 @@ class SourcelessBuilder:
             return UserDefinedObjectVariable(value)
         elif ConstantVariable.is_literal(value):
             return ConstantVariable.create(value)
+        elif isinstance(value, _DispatchlessCustomOp):
+            from .torch import DispatchlessCustomOpVariable
+
+            return DispatchlessCustomOpVariable(value)
         elif callable(value) and trace_rules.lookup_callable(value) is not None:
             if trace_rules.is_callable_allowed(value):
                 tx.output.has_user_defined_allowed_in_graph = True

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -135,6 +135,7 @@ except ModuleNotFoundError:
 if TYPE_CHECKING:
     from torch._custom_class_base import CustomClassBase
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
+    from torch._library.dispatchless import _DispatchlessCustomOp
     from torch.utils._pytree import TreeSpec
 
 
@@ -142,6 +143,84 @@ V = TypeVar("V")
 T = TypeVar("T")
 
 log = logging.getLogger(__name__)
+
+
+class DispatchlessCustomOpVariable(VariableTracker):
+    def __init__(self, value: "_DispatchlessCustomOp", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.value = value
+
+    def as_python_constant(self) -> "_DispatchlessCustomOp":
+        return self.value
+
+    def python_type(self) -> type:
+        return type(self.value)
+
+    def call_function(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from torch._dynamo.utils import _make_inlined, get_fake_value
+        from torch._higher_order_ops.flat_apply import (
+            func_to_graphable,
+            is_graphable_type,
+            to_graphable,
+        )
+        from torch._library.dispatchless import flat_dispatchless_call
+
+        from .builder import SourcelessBuilder, wrap_fx_proxy
+
+        flat_args_vt, input_spec_vt = unpack_iterable(
+            tx,
+            _make_inlined(tx, _pytree.tree_flatten)(
+                VariableTracker.build(tx, (args, kwargs))
+            ),
+        )
+        flat_args = unpack_iterable(tx, flat_args_vt)
+        for arg in flat_args:
+            if not is_graphable_type(arg.python_type()):
+                unimplemented(
+                    gb_type="Unsupported dispatchless custom operator input",
+                    context=f"Input type: {arg.python_type()}",
+                    explanation="Dispatchless custom operators require graphable pytree leaves.",
+                    hints=["Register container types with torch.utils._pytree."],
+                )
+        input_spec = input_spec_vt.as_python_constant()
+        fn = self.value.__wrapped__
+        proxy_args = tuple(arg.as_proxy() for arg in flat_args)
+        fake_args = _pytree.tree_map_only(
+            torch.fx.Proxy, lambda proxy: get_fake_value(proxy.node, tx), proxy_args
+        )
+        if tx.fake_mode is None:
+            raise AssertionError("Dispatchless tracing requires a fake tensor mode")
+        with tx.fake_mode:
+            fake_args, fake_kwargs = _pytree.tree_unflatten(fake_args, input_spec)
+            flat_outputs, output_spec = to_graphable(fn(*fake_args, **fake_kwargs))
+
+        _, func_spec = func_to_graphable(fn)
+        func_proxy = tx.output.register_static_attr_and_return_proxy(
+            "dispatchless_callable", func_spec
+        )
+        input_spec_proxy = tx.output.register_static_attr_and_return_proxy(
+            "dispatchless_input_spec", input_spec
+        )
+        output_spec_proxy = tx.output.register_static_attr_and_return_proxy(
+            "dispatchless_output_spec", output_spec
+        )
+        proxy = tx.output.create_proxy(
+            "call_function",
+            flat_dispatchless_call,
+            (func_proxy, input_spec_proxy, output_spec_proxy, *proxy_args),
+            {},
+        )
+        flat_output_vt = wrap_fx_proxy(tx, proxy, example_value=flat_outputs)
+        return SourcelessBuilder.create(tx, _pytree.tree_unflatten).call_function(
+            tx,
+            [flat_output_vt, VariableTracker.build(tx, output_spec)],
+            {},
+        )
 
 
 def _is_supported_out_tensor_layout(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -4243,6 +4243,9 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
 
         import torch.utils._pytree as pytree
 
+        if self.is_pytree_constant_class and self.source:
+            return super().as_python_constant()
+
         if not istype(
             self.value, (pytree.TreeSpec, pytree.LeafSpec, pytree.ConstantNode)
         ):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -29,6 +29,7 @@ from torch._dynamo.utils import counters
 from torch._environment import is_fbcode
 from torch._higher_order_ops.out_dtype import out_dtype
 from torch._inductor.utils import pad_listlike
+from torch._library.dispatchless import _flat_call, flat_dispatchless_call
 from torch._prims_common import (
     elementwise_dtypes,
     ELEMENTWISE_TYPE_PROMOTION_KIND,
@@ -160,6 +161,9 @@ def register_decomposition(
         if op in decompositions:
             log.warning("duplicate decomp: %s", ops)
     return decomp.register_decomposition(ops, decompositions)
+
+
+register_decomposition(flat_dispatchless_call)(_flat_call)
 
 
 @register_decomposition([aten.special_log_ndtr])

--- a/torch/_library/dispatchless.py
+++ b/torch/_library/dispatchless.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+from typing_extensions import ParamSpec
+
+from torch._ops import HigherOrderOperator
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+@dataclass(frozen=True, eq=False)
+class _DispatchlessCustomOp(Generic[_P, _R]):
+    __wrapped__: Callable[_P, _R]
+
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        from torch.fx.experimental.proxy_tensor import (
+            disable_proxy_modes_tracing,
+            get_proxy_mode,
+        )
+
+        mode = get_proxy_mode()
+        if mode is None:
+            return self.__wrapped__(*args, **kwargs)
+
+        import torch.utils._pytree as pytree
+        from torch._higher_order_ops.flat_apply import func_to_graphable, to_graphable
+
+        # Dispatch normally removes the active mode before invoking its handler.
+        with disable_proxy_modes_tracing():
+            flat_args, input_spec = to_graphable((args, kwargs))
+            _, func_spec = func_to_graphable(self.__wrapped__)
+            flat_out, output_spec = to_graphable(self.__wrapped__(*args, **kwargs))
+            flat_out = _trace_flat_call(
+                mode, func_spec, input_spec, output_spec, flat_args, flat_out
+            )
+        return pytree.tree_unflatten(flat_out, output_spec)
+
+
+def dispatchless_custom_op(fn: Callable[_P, _R]) -> _DispatchlessCustomOp[_P, _R]:
+    """Wrap a functional Python function as an experimental dispatchless operator.
+
+    Eager calls invoke ``fn`` directly. ``make_fx`` and Dynamo preserve a flat
+    operator call with pytree inputs and outputs; Inductor traces through its
+    implementation. Tensor dependencies must be explicit arguments, and ``fn``
+    must work with FakeTensor inputs. Registered pytree containers and constants
+    are supported, with a stable output structure for each captured call.
+
+    The function must not mutate inputs or Python state, or return tensor aliases.
+    These purity requirements are preconditions, not eager runtime checks.
+    Autograd follows the backing function eagerly and with Inductor. Other AOT
+    backends must decompose the operator before differentiating it. Custom
+    gradient registration and export serialization are not supported.
+    """
+    if not callable(fn):
+        raise TypeError("dispatchless_custom_op expects a callable")
+    return _DispatchlessCustomOp(fn)
+
+
+def _flat_call(func_spec, input_spec, output_spec, *flat_args):
+    import torch.utils._pytree as pytree
+    from torch._higher_order_ops.flat_apply import to_graphable
+
+    fn = pytree._retrieve_constant(func_spec)
+    args, kwargs = pytree.tree_unflatten(flat_args, input_spec)
+    flat_out, actual_spec = to_graphable(fn(*args, **kwargs))
+    if actual_spec != output_spec:
+        raise RuntimeError(
+            "Dispatchless custom operators must return the same output pytree "
+            f"structure for each captured call: expected {output_spec}, "
+            f"got {actual_spec}"
+        )
+    return flat_out
+
+
+def _trace_flat_call(
+    mode, func_spec, input_spec, output_spec, flat_args, flat_out=None
+):
+    import torch.utils._pytree as pytree
+    from torch.fx.experimental.proxy_tensor import (
+        maybe_handle_decomp,
+        track_tensor_tree,
+    )
+
+    node_args = (func_spec, input_spec, output_spec, *flat_args)
+    result = maybe_handle_decomp(mode, flat_dispatchless_call, node_args, {})
+    if result is not NotImplemented:
+        return result
+    if flat_out is None:
+        flat_out = _flat_call(*node_args)
+    proxy_args = pytree.tree_map(mode.tracer.unwrap_proxy, node_args)
+    proxy = mode.tracer.create_proxy(
+        "call_function", flat_dispatchless_call, proxy_args, {}
+    )
+    return track_tensor_tree(flat_out, proxy, constant=None, tracer=mode.tracer)
+
+
+class _FlatDispatchlessCall(HigherOrderOperator):
+    def __init__(self) -> None:
+        super().__init__("flat_dispatchless_call")
+
+    def __call__(self, func_spec, input_spec, output_spec, *flat_args):
+        from torch.fx.experimental.proxy_tensor import (
+            disable_proxy_modes_tracing,
+            get_proxy_mode,
+        )
+
+        mode = get_proxy_mode()
+        if mode is None:
+            return _flat_call(func_spec, input_spec, output_spec, *flat_args)
+        with disable_proxy_modes_tracing():
+            return _trace_flat_call(mode, func_spec, input_spec, output_spec, flat_args)
+
+
+flat_dispatchless_call = _FlatDispatchlessCall()


### PR DESCRIPTION
Summary:
Implement the functional, private-API scope of https://github.com/pytorch/pytorch/issues/193056 in fbcode PyTorch. Eager calls invoke the backing Python function without custom-op dispatch or pytree flattening. `make_fx` and Dynamo preserve an opaque `flat_dispatchless_call` with per-call pytree specifications. Inductor decomposes the call into its backing implementation, enabling fusion and ordinary autograd.

The direct-call higher-order operator reuses existing pytree/flat-apply helpers without changing dispatcher registration or the global decomposition table. Functions must be functional, FakeTensor-compatible, and receive tensor dependencies explicitly. Mutation, output aliases, custom gradient registration, and export serialization are out of scope; other AOT backends must provide decomposition before differentiation.

Registered frozen-dataclass constants exposed an existing Dynamo gap: `FrozenDataClassVariable.as_python_constant` bypassed the base class's registered-constant path. Preserve that path and its existing equality guards without allowing arbitrary frozen-dataclass reconstruction. Regression coverage checks changed constants recompile and equal constants reuse a graph.

Authored with assistance from OpenAI Codex. Submitted as a draft for human review.

Test Plan:
36 tests passed with no failures or skips, covering eager execution, tracing modes, pytree inputs/outputs, guarding, dynamic shapes, CPU/CUDA values and gradients, Inductor decomposition/fusion, and existing `flat_apply` regressions:
```
buck2 test mode/opt fbcode//caffe2/test/dynamo:test_dynamo fbcode//caffe2/test/inductor:dispatchless fbcode//caffe2/test/inductor:dispatchless_cpu -- --regex 'test_(dispatchless|flat_apply)'
```
https://www.internalfb.com/intern/testinfra/testrun/31525197424747472

9 additional frozen-dataclass and registered-constant regression tests passed with no failures or skips:
```
buck2 test mode/opt fbcode//caffe2/test/dynamo:test_dynamo -- test_proxy_frozen_dataclass test_frozen_dataclass_default_value test_pytree_register_constant_with_side_effect test_frozen_dataclass_as_dict_key
```
https://www.internalfb.com/intern/testinfra/testrun/15199648939438376

Lint passed:
```
arc lint -a --only-changed caffe2/torch/_library/dispatchless.py caffe2/torch/_dynamo/variables/torch.py caffe2/torch/_dynamo/variables/builder.py caffe2/torch/_dynamo/variables/user_defined.py caffe2/torch/_inductor/decomposition.py caffe2/test/dynamo/test_dispatchless.py caffe2/test/inductor/test_dispatchless.py caffe2/test/inductor/BUCK
```
`arc f` and the extra `CITRINEAGENT` lint invocation reported no configured linters. `arc pyre check-owning-targets` found six owning targets, but type checking is disabled for all six, so no type checks ran. Tests use `mode/opt`; the default dev mode encountered unrelated Dynamo collection errors and an ASAN/CUDA initialization incompatibility.

Benchmark-only follow-up (2026-09-09): implementation and functional test sources are unchanged; the earlier 45 passing tests remain the functional validation evidence. Added a runnable benchmark in `caffe2/benchmarks/dynamo/microbenchmarks/dispatchless_custom_op.py`.

```
buck2 run mode/opt fbcode//caffe2/benchmarks/dynamo/microbenchmarks:dispatchless_custom_op -- --min-run-time 1 --repeats 3
```
Buck run: https://www.internalfb.com/buck2/3a763aeb-8475-4a47-a6c6-3e06f1765872

Exit 0. Output equality checks passed in all 27 variant/case combinations; gradient checks passed in all requires-grad cases. All three variants execute the same non-aliasing `x.clone()` body. The standard `custom_op` has the matching clone backward registered. This measures warmed-up CPU forward calls, with registration, explicit warmup, correctness checks, and backward excluded. The requires-grad case includes forward autograd graph construction. There are no timing assertions.

Environment: AMD EPYC 9654 96-Core Processor, host `devgpu007.eag6.facebook.com`, PyTorch `2.15.0a0+fb`, Python `3.12.14+meta`, CPU float32, one intra-op thread, `AVX2` capability. `Timer.blocked_autorange` ran at least 1 second per variant per round, for 3 rounds with rotated variant order. The CPU timer does not synchronize accelerators.

All latency columns are microseconds per call. Cells show median (IQR), pooled over per-call block timings. Delta columns subtract the corresponding plain-function median; speedup is total custom-op latency divided by dispatchless latency.

| Mode | Elements | Plain us (IQR) | custom_op us (IQR) | Dispatchless us (IQR) | custom_op delta us | Dispatchless delta us | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| no_grad | 0 | 0.748 (0.020) | 6.955 (0.071) | 2.285 (0.012) | 6.208 | 1.537 | 3.04x |
| no_grad | 1 | 0.893 (0.004) | 7.125 (0.026) | 2.463 (0.016) | 6.233 | 1.570 | 2.89x |
| no_grad | 1024 | 0.945 (0.005) | 7.224 (0.038) | 2.588 (0.032) | 6.279 | 1.643 | 2.79x |
| grad_enabled | 0 | 0.749 (0.003) | 7.077 (0.044) | 2.278 (0.011) | 6.328 | 1.528 | 3.11x |
| grad_enabled | 1 | 0.912 (0.005) | 7.468 (0.092) | 2.517 (0.031) | 6.556 | 1.605 | 2.97x |
| grad_enabled | 1024 | 0.968 (0.005) | 7.489 (0.119) | 2.642 (0.028) | 6.520 | 1.674 | 2.83x |
| requires_grad | 0 | 1.020 (0.015) | 9.793 (0.052) | 2.623 (0.051) | 8.773 | 1.602 | 3.73x |
| requires_grad | 1 | 1.169 (0.012) | 9.921 (0.072) | 2.775 (0.019) | 8.752 | 1.606 | 3.58x |
| requires_grad | 1024 | 1.224 (0.025) | 10.092 (0.102) | 2.906 (0.032) | 8.868 | 1.681 | 3.47x |

`no_grad` disables grad mode; `grad_enabled` enables grad mode but inputs do not require gradients; `requires_grad` enables grad mode and input gradients.

Observed total-call speedup was 2.79-3.73x. Dispatchless still adds approximately 1.53-1.68 us above plain Python, compared with 6.21-8.87 us for `custom_op`. These are shared-devserver CPU microbenchmark measurements, not GPU, compilation, backward, or end-to-end workload speedups; IQRs describe variability, not confidence intervals.

Follow-up lint:
```
arc lint -a --only-changed caffe2/benchmarks/dynamo/microbenchmarks/dispatchless_custom_op.py caffe2/benchmarks/dynamo/microbenchmarks/BUCK
arc lint -a --rev '.^' --only-changed
```
No lint issues. `arc f` and `CITRINEAGENT` reported no configured linters. `arc pyre check-owning-targets --reuse-current-config --report-unchecked-targets caffe2/benchmarks/dynamo/microbenchmarks/dispatchless_custom_op.py` found two owning targets with typing disabled, so no type checks ran.

Differential Revision: D119414357




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98