### PR TITLE
[dynamo] Validate getattr arguments before dispatch

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5625,6 +5625,32 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         with self.assertRaises(TypeError):
             fn(torch.randn(4))
 
+    @parametrize(
+        "case",
+        [
+            subtest("no_args", name="no_args"),
+            subtest("one_arg", name="one_arg"),
+            subtest("too_many_args", name="too_many_args"),
+            subtest("keyword_arg", name="keyword_arg"),
+        ],
+    )
+    def test_getattr_wrong_args_raises(self, case):
+        def fn(x):
+            try:
+                if case == "no_args":
+                    return getattr()
+                if case == "one_arg":
+                    return getattr(x)
+                if case == "too_many_args":
+                    return getattr(x, "shape", None, None)
+                return getattr(x, name="shape")
+            except TypeError as exc:
+                return x.sin(), str(exc)
+
+        x = torch.randn(4)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(opt_fn(x), fn(x))
+
     def test_user_defined_class_name(self):
         class MyClassFoo:
             pass

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -67,6 +67,7 @@ from ..source import (
 from ..utils import (
     check_constant_args,
     check_numpy_ndarray_args,
+    check_positional,
     check_unspec_or_constant_args,
     check_unspec_python_args,
     dict_methods,
@@ -3507,6 +3508,8 @@ class GetAttrBuiltinVariable(BaseBuiltinVariable):
             args = [
                 a.realize() if isinstance(a, LazyVariableTracker) else a for a in args
             ]
+        no_keywords(tx, "getattr", kwargs)
+        check_positional(tx, "getattr", len(args), 2, 3)
         try:
             return self._call_getattr(tx, args, kwargs)
         except Unsupported:
@@ -3546,6 +3549,9 @@ class GetAttrBuiltinVariable(BaseBuiltinVariable):
             )
 
         name = name_var.as_python_constant()
+        if not isinstance(name, str):
+            type_name = name_var.python_type_name()
+            raise_type_error(tx, f"attribute name must be string, not '{type_name}'")
         return generic_getattr(tx, obj, name, default)
 
 


### PR DESCRIPTION
## Summary

Part of #195901.

`GetAttrBuiltinVariable` accessed positional arguments before validating `getattr()` calls. Too few arguments could raise an internal `IndexError`, excess arguments could be silently ignored, and keyword arguments were not rejected before dispatch. Non-string attribute names could also surface as internal Dynamo errors.

This change uses `no_keywords` and `check_positional` to match CPython’s argument validation, validates attribute names before generic lookup, adds focused regression coverage for invalid calls, and removes the CPython 3.13 expected-failure marker for `BuiltinTest.test_getattr`.

## Test plan

- [x] `test/dynamo/test_misc.py -k wrong_args_raises`: 5 passed
- [x] CPython 3.13 `BuiltinTest.test_getattr` under Dynamo using the installed-nightly/local-source overlay: passed
- [x] `test/dynamo/test_tp_getattro.py -k test_getattr`: 6 passed
- [x] Python formatting checks passed

 Validated with Python 3.13.15 and CPU nightly torch
`2.15.0.dev20260908`. Clang-tidy, source-built, and CI validation remain outstanding.

Prepared with assistance from Codex. I reviewed and approved the changes before submission.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98