### PR TITLE
add kernel shared memory get_graph_data()

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -1333,6 +1333,7 @@ class TestGetGraphData(TestCase):
             self.assertIn("kernel_name", node)
             self.assertIn("grid_dim", node)
             self.assertIn("block_dim", node)
+            self.assertIn("shared_mem_bytes", node)
             self.assertIn("dependencies", node)
             self.assertIn("dependents", node)
             self.assertEqual(node["graph_id"], exec_graph_id)
@@ -1344,9 +1345,13 @@ class TestGetGraphData(TestCase):
                     for d in dims:
                         self.assertIsInstance(d, int)
                         self.assertGreater(d, 0)
+                # Dynamic shared memory may legitimately be 0.
+                self.assertIsInstance(node["shared_mem_bytes"], int)
+                self.assertGreaterEqual(node["shared_mem_bytes"], 0)
             else:
                 self.assertIsNone(node["grid_dim"])
                 self.assertIsNone(node["block_dim"])
+                self.assertIsNone(node["shared_mem_bytes"])
 
         kernel_nodes = [n for n in data["nodes"] if n["node_type"] == "kernel"]
         self.assertGreater(len(kernel_nodes), 0)

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -818,6 +818,7 @@ class CUDAGraph(_CUDAGraph):
                         "kernel_name": str or None,
                         "grid_dim": tuple(int, int, int) or None,
                         "block_dim": tuple(int, int, int) or None,
+                        "shared_mem_bytes": int or None,
                         "event_ptr": int,
                         "host_fn_addr": int,
                         "host_fn_name": str or None,
@@ -851,8 +852,9 @@ class CUDAGraph(_CUDAGraph):
 
         ``grid_dim`` / ``block_dim`` are the kernel launch dimensions
         ``(x, y, z)`` read from the kernel node's params, populated for kernel
-        nodes (``None`` when the params query fails). They are ``None`` for
-        other node types.
+        nodes (``None`` when the params query fails). ``shared_mem_bytes`` is
+        that launch's *dynamic* shared memory, read from the same params. All
+        three are ``None`` for other node types.
 
         Each node's ``graph_id`` is remapped to the exec graph id so that
         ``tools_id`` values match those reported by CUPTI-based profilers.
@@ -948,6 +950,7 @@ class CUDAGraph(_CUDAGraph):
             kernel_name = None
             grid_dim = None
             block_dim = None
+            shared_mem_bytes = None
             if ntype == node_types.CU_GRAPH_NODE_TYPE_KERNEL:
                 err, params = _cuda_driver.cuGraphKernelNodeGetParams(node)
                 if err == _cuda_driver.CUresult.CUDA_SUCCESS:
@@ -961,6 +964,7 @@ class CUDAGraph(_CUDAGraph):
                         int(params.blockDimY),
                         int(params.blockDimZ),
                     )
+                    shared_mem_bytes = int(params.sharedMemBytes)
                     if params.func:
                         err, name = _cuda_driver.cuFuncGetName(params.func)
                         if err == _cuda_driver.CUresult.CUDA_SUCCESS:
@@ -1009,6 +1013,7 @@ class CUDAGraph(_CUDAGraph):
                     "kernel_name": kernel_name,
                     "grid_dim": grid_dim,
                     "block_dim": block_dim,
+                    "shared_mem_bytes": shared_mem_bytes,
                     "event_ptr": event_ptr,
                     "host_fn_addr": host_fn_addr,
                     "host_fn_name": host_fn_name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196530
* #196529
* #196528
* __->__ #196527

add kernel shared memory get_graph_data()
shared_mem_bytes is the launch's dynamic shared memory and comes from the node
params, right next to the dimensions already read there. It stays best-effort
like the kernel-name lookup beside it: a failed params query reports None rather
than raising, since a dump is a diagnostic and a missing number should not cost
the caller the whole graph.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.4/compat python test/test_cuda_graph_utils.py
```
118 tests pass on a GB200, including test_basic_structure extended to assert the
field is present, is an int on kernel nodes, and is None on every other node
type. Spot-checked against a profile of the same capture: get_graph_data reports
12672 for a cutlass sgemm and 0 for an elementwise kernel, matching the "shared
memory" those kernels carry in their trace args.

This commit was authored with the assistance of an AI coding agent (Claude Code).