### PR TITLE
Add annotation_config["key_by"], and annotate nested graph bodies with it

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -2388,6 +2388,28 @@ class TestCuptiAnnotationBackend(TestCase):
         self.assertEqual(seen, ["edge_walk"])
         self.assertEqual(len(self._annotations()), 1)
 
+    def test_source_keying_needs_a_new_enough_cupti(self):
+        # A 13.4 driver with an older CUPTI is the quiet failure: the driver would report
+        # source node ids but the consumer's CUPTI has no field to carry them, so
+        # annotations kept on the capture graph resolve to nothing. Both ends are checked.
+        import torch.cuda._graph_annotations as _ga
+
+        with unittest.mock.patch.object(
+            _ga, "_loaded_cupti_version", return_value=130301
+        ):
+            self.assertFalse(_ga.source_node_ids_available())
+        # No CUPTI in the process yet: nothing to be wrong about, so the driver alone
+        # decides -- the same answer a new-enough CUPTI gives.
+        with unittest.mock.patch.object(
+            _ga, "_loaded_cupti_version", return_value=None
+        ):
+            absent = _ga.source_node_ids_available()
+        with unittest.mock.patch.object(
+            _ga, "_loaded_cupti_version", return_value=130400
+        ):
+            new_enough = _ga.source_node_ids_available()
+        self.assertEqual(absent, new_enough)
+
     def test_invalid_backend_rejected(self):
         with self.assertRaisesRegex(ValueError, r"annotation_config\['backend'\]"):
             torch.cuda.graph(

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -1281,8 +1281,10 @@ class TestMarkKernels(TestCase):
         """A scope containing a nested graph node warns; the rest is annotated.
 
         The dependent-edge walk stops at such a node, so the work in its body is
-        left unannotated (and its ids, being in the body graph's id space, would
-        never be rekeyed by remap_to_exec_graph). What is recorded stays correct.
+        left unannotated: its ids are in the body graph's id space, which
+        remap_to_exec_graph does not rekey. (The CUPTI backend can annotate that
+        work under key_by="source", where nothing is rekeyed.) What is recorded
+        stays correct.
         """
         from cuda.bindings import runtime as cuda_runtime
 
@@ -2231,6 +2233,48 @@ class TestCuptiAnnotationBackend(TestCase):
         exec_graph_id = g.get_graph_data()["exec_graph_id"]
         for tools_id in annotations:
             self.assertEqual(tools_id >> 32, exec_graph_id)
+
+    @unittest.skipIf(
+        not source_node_ids_available(),
+        "annotation_config={'key_by': 'source'} needs a CUDA driver >= 13.4",
+    )
+    def test_conditional_body_annotated_under_source_keying(self):
+        # Body nodes are dropped only because their ids cannot be rekeyed to the exec
+        # graph. Under key_by="source" nothing is rekeyed and CUPTI reports the body work
+        # with a sourceGraphNodeId equal to the body node as built, so the handler keeps
+        # them -- silently, and with the body graph id carried to the destroy hooks, which
+        # would otherwise never see an id that is neither the capture nor an exec graph's.
+        import warnings as _warnings
+
+        from torch._higher_order_ops.cudagraph_conditional_nodes import _if_body
+
+        x = torch.ones([2048], device="cuda")
+        pred = torch.tensor(True, device="cuda")
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            with torch.cuda.graph(
+                g,
+                enable_annotations=True,
+                annotation_config={"backend": "cupti", "key_by": "source"},
+            ):
+                with mark_kernels("region"):
+                    z = x + 1
+                    with _if_body(pred):
+                        _ = torch.sqrt(z)
+        self.assertEqual(
+            [w for w in caught if "were not annotated" in str(w.message)], []
+        )
+
+        capture_id = g._capture_graph_id
+        graph_ids = {tools_id >> 32 for tools_id in self._annotations()}
+        self.assertIn(capture_id, graph_ids)
+        body_ids = graph_ids - {capture_id}
+        self.assertTrue(body_ids, "the conditional body's nodes were not annotated")
+        self.assertEqual(g._annotated_body_graph_ids, body_ids)
+
+        g.instantiate()
+        self.assertTrue(body_ids <= g._recorded_exec_ids)
 
     def test_no_warning_without_body_work(self):
         # The counter must not leak across captures: a plain capture right after one that

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -16,6 +16,7 @@ from torch.cuda._graph_annotations import (
     mark_stream,
     resolve_and_remap,
     resolve_pending_annotations,
+    source_node_ids_available,
 )
 from torch.cuda._utils import _check_cuda_bindings, _check_cuda_bindings_driver
 from torch.cuda.graph_annotations import (
@@ -218,6 +219,52 @@ class TestMarkKernels(TestCase):
                 lambda msg: f"{msg}\nmemset toolsId {hex(tools_id)} was not annotated",
             )
             self.assertEqual(annotations[tools_id], [{"name": "reduction"}])
+
+    @unittest.skipIf(
+        not source_node_ids_available(),
+        "annotation_config={'key_by': 'source'} needs a CUDA driver >= 13.4",
+    )
+    def test_key_by_source_keeps_capture_keys(self):
+        """``key_by="source"`` leaves annotations on the capture graph, for a consumer
+        reading CUPTI's sourceGraphNodeId. Nothing is rekeyed -- not on the first
+        instantiate, and not on a re-instantiate, which mints a fresh exec id the default
+        keying would have chased. The capture id is still handed to the destroy hooks, so
+        the entries are purged with the graph."""
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(
+            graph, enable_annotations=True, annotation_config={"key_by": "source"}
+        ):
+            with mark_kernels("phase_a"):
+                _ = x + 1
+
+        capture_id = graph._capture_graph_id
+        keys = set(get_kernel_annotations())
+        self.assertEqual({k >> 32 for k in keys}, {capture_id})
+
+        for _ in range(2):
+            graph.instantiate()
+            self.assertIsNone(graph._remapped_exec_id)
+            self.assertEqual(set(get_kernel_annotations()), keys)
+        self.assertIn(capture_id, graph._recorded_exec_ids)
+
+    def test_key_by_exec_is_the_default(self):
+        """The default rekeys to the exec graph, which is what a consumer reading CUPTI's
+        (exec) graphNodeId needs. Guards the default against key_by's introduction."""
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph, enable_annotations=True):
+            with mark_kernels("phase_a"):
+                _ = x + 1
+        graph.instantiate()
+
+        self.assertIsNotNone(graph._remapped_exec_id)
+        self.assertNotEqual(graph._remapped_exec_id, graph._capture_graph_id)
+        self.assertEqual(
+            {k >> 32 for k in get_kernel_annotations()}, {graph._remapped_exec_id}
+        )
 
     def test_single_scope_at_capture_start_uses_root_fallback(self):
         graph = torch.cuda.CUDAGraph()
@@ -2307,6 +2354,10 @@ class TestCuptiAnnotationBackend(TestCase):
         with self.assertRaisesRegex(ValueError, "unrecognized annotation_config key"):
             torch.cuda.graph(
                 torch.cuda.CUDAGraph(), annotation_config={"backend_name": "cupti"}
+            )
+        with self.assertRaisesRegex(ValueError, r"annotation_config\['key_by'\]"):
+            torch.cuda.graph(
+                torch.cuda.CUDAGraph(), annotation_config={"key_by": "capture"}
             )
 
 

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -43,7 +43,9 @@ control (e.g. resolving once before remapping several graphs).
 
 from __future__ import annotations
 
+import ctypes
 import importlib.metadata
+import os
 import threading
 import warnings
 from collections.abc import Mapping
@@ -146,14 +148,12 @@ def _set_annotations_enabled(enabled: bool) -> None:
     to scope annotations to a capture; not a public API."""
     global _annotations_enabled, _capture_root_graph_id
     _annotations_enabled = enabled
-    if enabled:
-        # A previous capture that raised before its ids were taken must not leak them
-        # into this one.
-        _body_graph_ids.clear()
     if not enabled:
         _capture_root_graph_id = None
         # A capture that raised mid-scope would otherwise leak its scopes into the next one.
         _active_scopes.clear()
+        # Likewise the body ids, though capture end normally takes them first.
+        _body_graph_ids.clear()
 
 
 def _set_annotation_backend(backend: str) -> None:
@@ -307,18 +307,50 @@ def _probe_tools_id() -> bool:
     return True
 
 
+# The CUPTI ABI that first reports sourceGraphNodeId, and the driver that first populates
+# it. Both ends have to be new enough: the field is only in 13.4 headers, and an older
+# user-mode driver leaves it unset.
+_MIN_SOURCE_NODE_CUPTI_VERSION = 130400
+_MIN_SOURCE_NODE_DRIVER_VERSION = 13040
+
+
+def _loaded_cupti_version() -> int | None:
+    """CUPTI's version if libcupti is already in this process, else ``None``.
+
+    RTLD_NOLOAD so the probe never pulls CUPTI in: loading it is a side effect a capture
+    should not have, and a process that has not loaded it has no consumer of source node
+    ids to be wrong about yet. ``torch`` front-loads the CUPTI wheel at import (see
+    ``_preload_cuda_deps``), so in practice the check does run. Not a public API."""
+    try:
+        lib = ctypes.CDLL("libcupti.so.13", mode=os.RTLD_NOLOAD)
+    except OSError:
+        return None
+    try:
+        version = ctypes.c_uint32()
+        lib.cuptiGetVersion.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+        if lib.cuptiGetVersion(ctypes.byref(version)) != 0:  # CUPTI_SUCCESS
+            return None
+    except AttributeError:
+        return None
+    return version.value
+
+
 def source_node_ids_available() -> bool:
-    """Whether the driver reports a node's source (capture-time) graph node on replayed
-    work, which is what lets annotations stay keyed to the capture graph instead of being
-    rekeyed to each exec graph. CUPTI surfaces it as ``sourceGraphNodeId``, added in the
-    13.4 ABI and only populated by a 13.4 user-mode driver, so the driver version is the
-    gate. Not a public API."""
+    """Whether a node's source (capture-time) graph node is reported on replayed work,
+    which is what lets annotations stay keyed to the capture graph instead of being rekeyed
+    to each exec graph. CUPTI surfaces it as ``sourceGraphNodeId``: the field arrived in the
+    13.4 ABI and only a 13.4 user-mode driver fills it in, so both are checked. A CUPTI too
+    old to have the field is the quiet failure worth catching -- a 13.4 driver with a 13.3
+    CUPTI reports nothing and the annotations resolve to nothing. Not a public API."""
     if not _HAS_CUDA_BINDINGS:
+        return False
+    cupti_version = _loaded_cupti_version()
+    if cupti_version is not None and cupti_version < _MIN_SOURCE_NODE_CUPTI_VERSION:
         return False
     rt = _cuda_runtime
     ok = rt.cudaError_t.cudaSuccess  # pyrefly: ignore[missing-attribute]
     err, version = rt.cudaDriverGetVersion()  # pyrefly: ignore[missing-attribute]
-    return err == ok and version >= 13040
+    return err == ok and version >= _MIN_SOURCE_NODE_DRIVER_VERSION
 
 
 def _is_tools_id_unavailable() -> bool:

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -146,6 +146,10 @@ def _set_annotations_enabled(enabled: bool) -> None:
     to scope annotations to a capture; not a public API."""
     global _annotations_enabled, _capture_root_graph_id
     _annotations_enabled = enabled
+    if enabled:
+        # A previous capture that raised before its ids were taken must not leak them
+        # into this one.
+        _body_graph_ids.clear()
     if not enabled:
         _capture_root_graph_id = None
         # A capture that raised mid-scope would otherwise leak its scopes into the next one.
@@ -161,6 +165,43 @@ def _set_annotation_backend(backend: str) -> None:
     armed, which needs the capture live. Not a public API."""
     global _annotation_backend
     _annotation_backend = backend
+
+
+# Key space this capture's annotations stay in ("exec" | "source"), from
+# annotation_config. Published like _annotation_backend so the node-creation handler can
+# see it; the graph object carries the same choice for the instantiate-time paths.
+_annotation_key_by: str = "exec"
+
+# Body graph ids (child-graph / conditional bodies) this capture recorded annotations
+# under. Their ids are neither the capture nor the exec graph's, so the graph-destroy
+# purge would miss them; torch.cuda.graph takes the set at capture end and hands it to the
+# graph, which passes it to the destroy hooks like any other id it recorded under.
+_body_graph_ids: set[int] = set()
+
+
+def _set_annotation_key_by(key_by: str) -> None:
+    """Publish this capture's key space. Set by ``torch.cuda.graph`` alongside
+    :func:`_set_annotations_enabled`. Not a public API."""
+    global _annotation_key_by
+    _annotation_key_by = key_by
+
+
+def source_keyed() -> bool:
+    """Whether the active capture keeps its annotations on the capture graph, i.e. whether
+    a body node's own id is a key a consumer can resolve. Not a public API."""
+    return _annotation_key_by == "source"
+
+
+def note_body_graph_id(graph_id: int) -> None:
+    """Record that this capture annotated into a nested body graph. Not a public API."""
+    _body_graph_ids.add(graph_id)
+
+
+def take_body_graph_ids() -> set[int]:
+    """The body graph ids annotated since the last call, and reset. Not a public API."""
+    global _body_graph_ids
+    ids, _body_graph_ids = _body_graph_ids, set()
+    return ids
 
 
 def current_annotation() -> dict[str, Any] | None:
@@ -474,13 +515,11 @@ def _get_annotatable_type_values() -> frozenset[int]:
 
 
 # Node types whose work lives in a separate cudaGraph_t (child graphs, conditional
-# bodies). The dependent-edge walk does not descend into such a node, so annotations
-# there would be silently lost. Descending is not enough on its own, and neither is
-# annotation_config["key_by"] == "source" (which otherwise removes the exec-graph
-# renumbering as an obstacle): cudaGraphAddChildGraphNode *clones* the body, so CUPTI
-# reports the clone's node as sourceGraphNodeId rather than the body the caller built and
-# annotated, and work inside a conditional body produces no CUPTI activity record at all
-# (even with CUPTI_ACTIVITY_ATTR_ENABLE_DEVICE_GRAPH_TRACE set). See mark_kernels. Initialized
+# bodies). The edge walk does not descend into a body, so it can only warn that the work
+# is unannotated; the CUPTI backend is told about body nodes as they are created and
+# annotates them when the ids hold up, i.e. under key_by="source" (a body node's id is in
+# its own graph's space, which remap_to_exec_graph does not rekey). See mark_kernels.
+# Initialized
 # lazily, like _ANNOTATABLE_TYPES above: _cuda_driver is None when cuda.bindings is
 # absent, so reading the enum at import time would break `import torch`.
 _NESTED_GRAPH_TYPES: set[Any] | None = None
@@ -866,19 +905,11 @@ def mark_kernels(annotation: str | dict[str, Any], *, backward: bool = True):
     .. note::
         Child-graph and conditional nodes have bodies in a separate
         ``cudaGraph_t`` that this walk does not descend into, so their work is
-        left unannotated and a warning is issued. Descending is possible
-        (``cudaGraphNodeGetParams`` exposes the body graphs), but would not be
-        enough on its own. With the default ``annotation_config["key_by"]``
-        (``"exec"``) a body's nodes are renumbered when the exec graph inlines
-        them and nothing exposes that renumbering, so
-        :func:`remap_to_exec_graph` could not key the annotations to what a
-        profiler reports. ``"source"`` keying removes that obstacle but not the
-        other two: ``cudaGraphAddChildGraphNode`` clones the body, so CUPTI
-        reports a node of the clone -- an id the caller never saw -- as the
-        source, and work inside a conditional body
-        (``torch.cond`` / ``torch.while_loop``) yields no CUPTI activity record
-        to attribute in the first place. A scope *inside* a conditional body
-        therefore records nothing at all.
+        left unannotated and a warning is issued. A scope *inside* a conditional
+        body (``torch.cond`` / ``torch.while_loop``) records nothing for the same
+        reason: with the default ``annotation_config["key_by"]`` a body node's id
+        is not rekeyed to the exec graph, so the annotation would match nothing in
+        a trace.
 
     .. warning::
         This API is in prototype and may change in future releases.
@@ -927,15 +958,14 @@ def mark_kernels(annotation: str | dict[str, Any], *, backward: bool = True):
         and _graph_id(scope.graph) != _capture_root_graph_id
     ):
         # Inside a conditional node's body: torch.cond / torch.while_loop capture into a
-        # separate cudaGraph_t, and the work in it produces no CUPTI activity record --
-        # so anything recorded here would be a key nothing in a trace can match. Record
-        # nothing rather than dead keys. Unaffected by key_by="source": there is no
-        # record to carry a source node id.
+        # separate cudaGraph_t whose node ids the exec-graph remap does not cover, so
+        # anything recorded here would be a key nothing matches. Record nothing rather
+        # than dead keys.
         warnings.warn(
             "mark_kernels: this scope is inside a CUDA graph conditional-node body "
             "(torch.cond / torch.while_loop), which is captured into a separate "
-            "cudaGraph_t whose work a profiler does not report; nothing is annotated "
-            "for it",
+            "cudaGraph_t whose node ids are not remapped to the exec graph; nothing is "
+            "annotated for it",
             stacklevel=3,
         )
         yield
@@ -1133,6 +1163,7 @@ def _reset_kernel_annotations() -> None:
     use to isolate themselves without tripping its deprecation warning. Not a public
     API."""
     _kernel_annotations.clear()
+    _body_graph_ids.clear()
     _pending_scopes.clear()
 
 

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -266,6 +266,20 @@ def _probe_tools_id() -> bool:
     return True
 
 
+def source_node_ids_available() -> bool:
+    """Whether the driver reports a node's source (capture-time) graph node on replayed
+    work, which is what lets annotations stay keyed to the capture graph instead of being
+    rekeyed to each exec graph. CUPTI surfaces it as ``sourceGraphNodeId``, added in the
+    13.4 ABI and only populated by a 13.4 user-mode driver, so the driver version is the
+    gate. Not a public API."""
+    if not _HAS_CUDA_BINDINGS:
+        return False
+    rt = _cuda_runtime
+    ok = rt.cudaError_t.cudaSuccess  # pyrefly: ignore[missing-attribute]
+    err, version = rt.cudaDriverGetVersion()  # pyrefly: ignore[missing-attribute]
+    return err == ok and version >= 13040
+
+
 def _is_tools_id_unavailable() -> bool:
     """Return True if cudaGraphNodeGetToolsId is not usable."""
     global _tools_id_available
@@ -460,9 +474,13 @@ def _get_annotatable_type_values() -> frozenset[int]:
 
 
 # Node types whose work lives in a separate cudaGraph_t (child graphs, conditional
-# bodies). The dependent-edge walk does not descend into such a node, and the nodes
-# inside are numbered in the body graph's id space, which remap_to_exec_graph never
-# rekeys -- so annotations there would be silently lost. See mark_kernels. Initialized
+# bodies). The dependent-edge walk does not descend into such a node, so annotations
+# there would be silently lost. Descending is not enough on its own, and neither is
+# annotation_config["key_by"] == "source" (which otherwise removes the exec-graph
+# renumbering as an obstacle): cudaGraphAddChildGraphNode *clones* the body, so CUPTI
+# reports the clone's node as sourceGraphNodeId rather than the body the caller built and
+# annotated, and work inside a conditional body produces no CUPTI activity record at all
+# (even with CUPTI_ACTIVITY_ATTR_ENABLE_DEVICE_GRAPH_TRACE set). See mark_kernels. Initialized
 # lazily, like _ANNOTATABLE_TYPES above: _cuda_driver is None when cuda.bindings is
 # absent, so reading the enum at import time would break `import torch`.
 _NESTED_GRAPH_TYPES: set[Any] | None = None
@@ -850,12 +868,17 @@ def mark_kernels(annotation: str | dict[str, Any], *, backward: bool = True):
         ``cudaGraph_t`` that this walk does not descend into, so their work is
         left unannotated and a warning is issued. Descending is possible
         (``cudaGraphNodeGetParams`` exposes the body graphs), but would not be
-        enough on its own: a body's nodes are numbered in that graph's id space
-        and are renumbered again when the exec graph inlines them, and nothing
-        exposes that renumbering, so :func:`remap_to_exec_graph` could not key
-        the annotations to what a profiler reports. For the same reason a scope
-        *inside* a conditional body (``torch.cond`` / ``torch.while_loop``)
-        records nothing at all.
+        enough on its own. With the default ``annotation_config["key_by"]``
+        (``"exec"``) a body's nodes are renumbered when the exec graph inlines
+        them and nothing exposes that renumbering, so
+        :func:`remap_to_exec_graph` could not key the annotations to what a
+        profiler reports. ``"source"`` keying removes that obstacle but not the
+        other two: ``cudaGraphAddChildGraphNode`` clones the body, so CUPTI
+        reports a node of the clone -- an id the caller never saw -- as the
+        source, and work inside a conditional body
+        (``torch.cond`` / ``torch.while_loop``) yields no CUPTI activity record
+        to attribute in the first place. A scope *inside* a conditional body
+        therefore records nothing at all.
 
     .. warning::
         This API is in prototype and may change in future releases.
@@ -904,14 +927,15 @@ def mark_kernels(annotation: str | dict[str, Any], *, backward: bool = True):
         and _graph_id(scope.graph) != _capture_root_graph_id
     ):
         # Inside a conditional node's body: torch.cond / torch.while_loop capture into a
-        # separate cudaGraph_t. Its node ids are in that graph's id space and are
-        # renumbered again in the exec graph, so anything recorded here would be a key
-        # that matches nothing in a trace. Record nothing rather than dead keys.
+        # separate cudaGraph_t, and the work in it produces no CUPTI activity record --
+        # so anything recorded here would be a key nothing in a trace can match. Record
+        # nothing rather than dead keys. Unaffected by key_by="source": there is no
+        # record to carry a source node id.
         warnings.warn(
             "mark_kernels: this scope is inside a CUDA graph conditional-node body "
             "(torch.cond / torch.while_loop), which is captured into a separate "
-            "cudaGraph_t whose node ids are never remapped to the exec graph; "
-            "nothing is annotated for it",
+            "cudaGraph_t whose work a profiler does not report; nothing is annotated "
+            "for it",
             stacklevel=3,
         )
         yield

--- a/torch/cuda/_graph_node_callbacks.py
+++ b/torch/cuda/_graph_node_callbacks.py
@@ -75,8 +75,10 @@ def _on_graph_node_created(_domain: int, _cbid: int, cbdata: int) -> None:
     # logs it rather than letting it reach CUPTI's C dispatch.
     tools_id = _check_cuda_bindings(runtime.cudaGraphNodeGetToolsId(graph_data.node))
     # Nodes reported for any other graph belong to a child-graph or conditional body, whose
-    # ids live in that body graph's space and are renumbered again in the exec graph -- so
-    # recording them would produce keys matching nothing. disarm() warns about the total.
+    # work a profiler cannot attribute back to the id recorded here -- so recording them
+    # would produce keys matching nothing. Holds under annotation_config["key_by"] ==
+    # "source" too (see _graph_annotations._NESTED_GRAPH_TYPES for why the source node id
+    # does not rescue either body kind). disarm() warns about the total.
     if tools_id >> 32 != capture_root_graph_id():
         global _dropped_body_nodes
         _dropped_body_nodes += 1
@@ -184,8 +186,8 @@ def disarm() -> None:
         warnings.warn(
             f"mark_kernels: {_dropped_body_nodes} node(s) created inside a CUDA graph "
             "child-graph or conditional-node body (torch.cond / torch.while_loop) were "
-            "not annotated -- such a body is captured into a separate cudaGraph_t whose "
-            "node ids are never remapped to the exec graph, so an annotation there would "
-            "match nothing in a profiler trace",
+            "not annotated -- such a body is captured into a separate cudaGraph_t that a "
+            "profiler does not report against the ids recorded here, so an annotation "
+            "there would match nothing in a trace",
             stacklevel=2,
         )

--- a/torch/cuda/_graph_node_callbacks.py
+++ b/torch/cuda/_graph_node_callbacks.py
@@ -55,7 +55,9 @@ def _on_graph_node_created(_domain: int, _cbid: int, cbdata: int) -> None:
         _get_annotatable_type_values,
         capture_root_graph_id,
         current_annotation,
+        note_body_graph_id,
         record_node_annotation,
+        source_keyed,
     )
     from torch.cuda._utils import _check_cuda_bindings
 
@@ -74,15 +76,20 @@ def _on_graph_node_created(_domain: int, _cbid: int, cbdata: int) -> None:
     # returned above -- an error here is genuinely unexpected, and Cuspy's switchboard
     # logs it rather than letting it reach CUPTI's C dispatch.
     tools_id = _check_cuda_bindings(runtime.cudaGraphNodeGetToolsId(graph_data.node))
-    # Nodes reported for any other graph belong to a child-graph or conditional body, whose
-    # work a profiler cannot attribute back to the id recorded here -- so recording them
-    # would produce keys matching nothing. Holds under annotation_config["key_by"] ==
-    # "source" too (see _graph_annotations._NESTED_GRAPH_TYPES for why the source node id
-    # does not rescue either body kind). disarm() warns about the total.
-    if tools_id >> 32 != capture_root_graph_id():
-        global _dropped_body_nodes
-        _dropped_body_nodes += 1
-        return
+    # Nodes reported for any other graph belong to a child-graph or conditional body. Their
+    # ids are in that body graph's own space, which remap_to_exec_graph does not rekey, so
+    # they are only worth recording when the annotations stay on the capture graph: under
+    # key_by="source" CUPTI reports the body work with a sourceGraphNodeId in exactly that
+    # space, and the entry resolves. Otherwise the key would match nothing -- drop it, and
+    # let disarm() warn about the total.
+    body_graph_id = tools_id >> 32
+    if body_graph_id != capture_root_graph_id():
+        if not source_keyed():
+            global _dropped_body_nodes
+            _dropped_body_nodes += 1
+            return
+        # Neither the capture nor the exec graph's id, so the destroy purge needs telling.
+        note_body_graph_id(body_graph_id)
     record_node_annotation(tools_id, annotation)
 
 
@@ -186,8 +193,8 @@ def disarm() -> None:
         warnings.warn(
             f"mark_kernels: {_dropped_body_nodes} node(s) created inside a CUDA graph "
             "child-graph or conditional-node body (torch.cond / torch.while_loop) were "
-            "not annotated -- such a body is captured into a separate cudaGraph_t that a "
-            "profiler does not report against the ids recorded here, so an annotation "
-            "there would match nothing in a trace",
+            "not annotated -- such a body is captured into a separate cudaGraph_t whose "
+            "node ids are not remapped to the exec graph, so an annotation there would "
+            "match nothing in a trace",
             stacklevel=2,
         )

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -331,6 +331,10 @@ class CUDAGraph(_CUDAGraph):
     # before the first remap. Lets a re-instantiate (which produces a fresh exec
     # id) rekey annotations from the previous exec id to the new one.
     _remapped_exec_id: int | None
+    # Key space the recorded annotations stay in: "exec" rekeys them to each exec
+    # graph, "source" leaves them on the capture graph for consumers reading CUPTI's
+    # sourceGraphNodeId. Stamped from annotation_config at capture_begin.
+    _annotation_key_by: str
     # Exec graph ids a consumer has recorded per-graph state under (one per
     # instantiate). Handed to the graph-destroy hooks on destruction so consumers
     # can purge that state and their maps do not grow across the run.
@@ -362,6 +366,7 @@ class CUDAGraph(_CUDAGraph):
         instance._tracker = None
         instance._capture_graph_id = None
         instance._remapped_exec_id = None
+        instance._annotation_key_by = "exec"
         instance._recorded_exec_ids = set()
         instance._keep_graph = keep_graph
         # OrderedDict (not dict): RemovableHandle weak-references the mapping.
@@ -554,6 +559,13 @@ class CUDAGraph(_CUDAGraph):
         # rekeys the annotations; remap_to_exec_graph self-skips when the exec id
         # is unchanged.
         if self._capture_graph_id is None:
+            return
+        if self._annotation_key_by == "source":
+            # Annotations stay keyed to the capture graph: the consumer reads CUPTI's
+            # sourceGraphNodeId, which reports the node each exec node came from, so no
+            # exec id ever has to be tracked. The capture id still goes to the destroy
+            # hooks, which is what purges these entries when the graph dies.
+            self._recorded_exec_ids.add(self._capture_graph_id)
             return
         from torch.cuda._graph_annotations import remap_to_exec_graph
 
@@ -1149,6 +1161,7 @@ def export_graph_data(path: str) -> Callable[[CUDAGraph], None]:
 # Recognized keys of graph()'s annotation_config, each mapped to (default, allowed values).
 _ANNOTATION_CONFIG_KEYS: dict[str, tuple[typing.Any, tuple[typing.Any, ...]]] = {
     "backend": ("auto", ("auto", "cupti", "edge_walk")),
+    "key_by": ("exec", ("exec", "source")),
 }
 
 
@@ -1213,6 +1226,12 @@ class graph:
             :class:`torch.profiler.profile` records no GPU activity; ``"edge_walk"`` forces
             the walk, which cannot see nodes created while the current stream was not yet
             capturing.
+            Also supports ``"key_by"``, which selects the graph the annotations stay keyed
+            to: ``"exec"`` (default) rekeys them to the executable graph at each
+            ``instantiate()``, matching the graph node id CUPTI reports for replayed work;
+            ``"source"`` leaves them on the capture graph, for a consumer that reads CUPTI's
+            ``sourceGraphNodeId`` instead (needs CUPTI >= 13.4 and a CUDA driver >= 13.4,
+            else the capture raises).
         check_input_liveness (bool, optional): If ``True``, tracks external tensor inputs during graph capture and
             raises an error if any are deallocated before replay. This helps debug "use after free" errors
             where input tensors are garbage collected between capture and replay. Default: ``False``.
@@ -1318,6 +1337,23 @@ class graph:
                     "Cuspy able to subscribe; use 'auto' to fall back to the "
                     "dependent-edge walk instead."
                 )
+
+        # Which key space this graph's annotations stay in (see
+        # CUDAGraph._maybe_remap_annotations). Rejected up front rather than at instantiate,
+        # so an unsupported driver surfaces before any annotation is recorded against a key
+        # nothing will ever look up.
+        key_by = self._annotation_config["key_by"]
+        if self._enable_annotations and key_by == "source":
+            from torch.cuda._graph_annotations import source_node_ids_available
+
+            if not source_node_ids_available():
+                raise RuntimeError(
+                    "annotation_config={'key_by': 'source'} keeps annotations keyed to the "
+                    "capture graph, which needs a consumer reading CUPTI's sourceGraphNodeId "
+                    "(CUPTI >= 13.4) and a CUDA driver >= 13.4 or an equivalent cuda-compat. "
+                    "Use 'exec' to have them rekeyed to the exec graph instead."
+                )
+        self.cuda_graph._annotation_key_by = key_by
 
         # Scope annotation recording to this capture: the capture-root stamp and
         # mark_kernels both gate on this flag, and __exit__ always clears it. It has to be

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -335,6 +335,10 @@ class CUDAGraph(_CUDAGraph):
     # graph, "source" leaves them on the capture graph for consumers reading CUPTI's
     # sourceGraphNodeId. Stamped from annotation_config at capture_begin.
     _annotation_key_by: str
+    # Nested body graphs (child-graph / conditional bodies) this capture annotated into,
+    # under key_by="source". Their ids are neither the capture nor an exec graph's, so they
+    # are carried here to reach the destroy hooks like the others.
+    _annotated_body_graph_ids: set[int]
     # Exec graph ids a consumer has recorded per-graph state under (one per
     # instantiate). Handed to the graph-destroy hooks on destruction so consumers
     # can purge that state and their maps do not grow across the run.
@@ -367,6 +371,7 @@ class CUDAGraph(_CUDAGraph):
         instance._capture_graph_id = None
         instance._remapped_exec_id = None
         instance._annotation_key_by = "exec"
+        instance._annotated_body_graph_ids = set()
         instance._recorded_exec_ids = set()
         instance._keep_graph = keep_graph
         # OrderedDict (not dict): RemovableHandle weak-references the mapping.
@@ -566,6 +571,7 @@ class CUDAGraph(_CUDAGraph):
             # exec id ever has to be tracked. The capture id still goes to the destroy
             # hooks, which is what purges these entries when the graph dies.
             self._recorded_exec_ids.add(self._capture_graph_id)
+            self._recorded_exec_ids |= self._annotated_body_graph_ids
             return
         from torch.cuda._graph_annotations import remap_to_exec_graph
 
@@ -1306,6 +1312,7 @@ class graph:
         from torch.cuda import _graph_node_callbacks
         from torch.cuda._graph_annotations import (
             _set_annotation_backend,
+            _set_annotation_key_by,
             _set_annotations_enabled,
             maybe_stamp_capture_root,
         )
@@ -1354,6 +1361,7 @@ class graph:
                     "Use 'exec' to have them rekeyed to the exec graph instead."
                 )
         self.cuda_graph._annotation_key_by = key_by
+        _set_annotation_key_by(key_by)
 
         # Scope annotation recording to this capture: the capture-root stamp and
         # mark_kernels both gate on this flag, and __exit__ always clears it. It has to be
@@ -1408,6 +1416,7 @@ class graph:
             _set_annotations_enabled,
             discard_capture_annotations,
             resolve_pending_annotations,
+            take_body_graph_ids,
         )
 
         try:
@@ -1417,6 +1426,7 @@ class graph:
             _graph_node_callbacks.disarm()
             if self._enable_annotations:
                 resolve_pending_annotations()
+                self.cuda_graph._annotated_body_graph_ids = take_body_graph_ids()
 
             # For keep_graph=False capture_end instantiates, which remaps annotations
             # from the capture id (stamped back at capture_begin) to the exec id. For


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196530
* #196529
* __->__ #196528

Kernel annotations are recorded during capture against capture-graph node
toolsIds, then rekeyed to the exec graph at every instantiate() because that is
the graph node id CUPTI reports for replayed work. The rekey is bookkeeping that
has to chase each fresh exec id (_remapped_exec_id), and it exists only to match
what the consumer can observe.

CUPTI 13.4 reports sourceGraphNodeId -- the node a replayed node was
instantiated from -- alongside the exec node id, so a consumer on a 13.4 stack
can look annotations up where they were recorded. This adds
annotation_config={"key_by": "source"} to opt into that: the remap becomes a
no-op and the capture id, rather than an exec id, is handed to the graph-destroy
hooks so the entries are still purged with the graph. "exec" stays the default,
so nothing changes for kineto or for a pre-13.4 stack.

The gate is per capture rather than global (a process can mix graphs whose
traces are consumed differently) and rejects an unsupported driver at capture
rather than at instantiate, so an unusable choice surfaces before any annotation
is recorded under a key nothing will look up. source_node_ids_available() checks
both ends that have to be new enough: the driver, since only a 13.4 user-mode
driver populates sourceGraphNodeId, and -- when libcupti is already in the
process -- CUPTI, since a 13.3 ABI has no field to carry it. That pairing is the
quiet failure worth catching; the CUPTI probe uses RTLD_NOLOAD so a capture never
loads CUPTI just to ask.

That unblocks work inside a nested graph body (torch.cond / torch.while_loop),
which has never been annotated. The reason was always the keying: a body node's
id lives in its own graph's id space, which remap_to_exec_graph does not rekey,
so an annotation there matched nothing. Under "source" keying nothing is rekeyed
and CUPTI reports the body work with a sourceGraphNodeId equal to the body node
as built -- measured on a 13.4 driver -- so the CUPTI backend now keeps those
nodes instead of counting them as dropped. Only that backend: it is told about
each node as it is created, while the dependent-edge walk cannot see into a body
at all and still warns. Child-graph bodies are left for a follow-up; they need a
hop through the clone cudaGraphAddChildGraphNode makes, which is a separate
problem from the keying.

A body graph id is neither the capture nor an exec graph's, so the destroy hooks
would never have purged those entries; the capture collects the ids it annotated
into and hands them over with the rest.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.4/compat python test/test_cuda_graph_utils.py
```

119 tests pass on a GB200 with CUDA driver 615.71.09 (cuda-compat 13.4). Four are
new: source keying survives a re-instantiate, exec remains the default, an
invalid key_by is rejected, and a torch.cond body captured under
{"backend": "cupti", "key_by": "source"} has its nodes annotated, warns about
nothing, and reaches the destroy hooks with the body graph id. The source-keyed
tests skip on a driver below 13.4.

Checked by hand that the recorded ids are the ones a profiler reports: a capture
with a conditional body annotates 0x100000000, 0x100000002 and 0x200000000, and
replaying it yields kernel records whose sourceGraphNodeIds are exactly those
three (the last being the body node). Resolving them needs the consumer half in
the next commit.

This commit was authored with the assistance of an AI coding agent (Claude Code).