### PR TITLE
Resolve Cuspy annotations by source graph node id in both observers

### DIFF
--- a/test/profiler/test_cuspy.py
+++ b/test/profiler/test_cuspy.py
@@ -150,6 +150,29 @@ class TestCuspyRecords(TestCase):
         self.assertEqual(fields[memcpy], all_memcpy)
 
     @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires the cupti python bindings")
+    def test_annotation_column_resolves_source_node_first(self):
+        # A graph's annotations sit under its capture node ids or its exec ones depending on
+        # that capture's annotation_config["key_by"], and one trace can carry both, so the
+        # lookup tries the source (capture) id first and falls back to the exec id. Rows
+        # whose CUPTI ABI reports no source id pass the exec id as both.
+        import numpy as np
+
+        from torch.profiler._cuspy.observers.profiler import _resolve_annotation_column
+
+        registry = {10: {"name": "capture_keyed"}, 21: {"name": "exec_keyed"}}
+        gnid = np.array([20, 21, 22], dtype=np.int64)
+        src_gnid = np.array([10, 11, 12], dtype=np.int64)
+
+        out = _resolve_annotation_column(registry.get, gnid, src_gnid)
+        self.assertEqual(
+            list(out), [{"name": "capture_keyed"}, {"name": "exec_keyed"}, None]
+        )
+        # No resolver installed -> no lookups at all.
+        self.assertEqual(
+            list(_resolve_annotation_column(None, gnid, src_gnid)), [None] * 3
+        )
+
+    @unittest.skipIf(not TEST_CUPTI_PYTHON, "requires the cupti python bindings")
     def test_configure_and_get_config(self):
         # configure() sets the process-wide config get_config() reports; it is first-come-
         # first-serve. Pure config -- no session, only the cupti python bindings (not

--- a/test/profiler/test_cuspy_node_timer.py
+++ b/test/profiler/test_cuspy_node_timer.py
@@ -235,6 +235,64 @@ class TestCuspyNodeTimerCUDA(TestCase):
             self.assertGreaterEqual(end_ns, start_ns)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
+    def test_node_timer_names_source_keyed_graph(self):
+        # A graph captured with annotation_config={"key_by": "source"} keeps its
+        # annotations on the capture graph, so the exec node id CUPTI reports for a
+        # replayed node resolves to nothing; naming has to go through the node's source
+        # id. Registering the source field is all-or-nothing, so this also covers that
+        # the default (kernel-only) selection gets it.
+        from torch.cuda._graph_annotations import source_node_ids_available
+        from torch.cuda.graph_annotations import get_kernel_annotations, mark_kernels
+        from torch.profiler._cuspy.observers.base import ObserverAnnotationSettings
+        from torch.profiler._cuspy.observers.node_timer import NodeTimerObserver
+
+        if not source_node_ids_available():
+            self.skipTest("sourceGraphNodeId needs a CUDA driver >= 13.4")
+
+        x = torch.randn(512, 512, device="cuda")
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            torch.relu_(x)
+        torch.cuda.current_stream().wait_stream(s)
+
+        g = torch.cuda.CUDAGraph(keep_graph=True)
+        with torch.cuda.graph(
+            g, enable_annotations=True, annotation_config={"key_by": "source"}
+        ):
+            with mark_kernels("sourceregion"):
+                for _ in range(4):
+                    torch.relu_(x)
+        g.instantiate()
+        capture_ids = set(get_kernel_annotations())
+        self.assertTrue(capture_ids, "capture recorded no annotations")
+
+        obs = NodeTimerObserver(
+            annotations=ObserverAnnotationSettings(
+                graph_annotation_resolver=lambda nid: (
+                    {"name": "sourceregion"} if nid in capture_ids else None
+                )
+            )
+        )
+        if not obs.available:
+            self.skipTest("Cuspy unavailable (v2 subscribe failed)")
+        try:
+            self.assertTrue(obs._source_fields, "source node field was not selected")
+            obs._cuspy.flush(sync=True)
+            obs.drain_annotated()  # discard warmup spans
+            for _ in range(3):
+                g.replay()
+            torch.cuda.synchronize()
+            obs._cuspy.flush(sync=True)
+            spans = obs.drain_annotated()
+        finally:
+            obs.close()
+
+        if not any(spans.values()):
+            self.skipTest("driver delivered no graph spans")
+        self.assertGreater(len(spans.get("sourceregion", [])), 0)
+
+    @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
     def test_node_timer_collects_memcpy2_spans(self):
         # Peer-to-peer / cross-device copies surface under MEMCPY2 (not MEMCPY). CUPTI

--- a/tools/gen_cupti_stubs.py
+++ b/tools/gen_cupti_stubs.py
@@ -46,7 +46,8 @@ _ATTR_PREFIX = "CUPTI_ACTIVITY_ATTR_"
 # Ctype (decode interpretation); the byte width comes from CUPTI's captured layout, not here.
 _CHAR_PTR_DECL_RE = re.compile(r"(?:const\s+)?char\s*\*")
 # Trailing count sentinel each field enum ends with (``*_FIELD_MAX``); not a real field.
-_SENTINEL_SUFFIXES = ("MAX", "FORCE_INT")
+# CUPTI 13.4 added ``CUPTI_ACTIVITY_ATTR_COUNT`` as the attribute enum's sentinel.
+_SENTINEL_SUFFIXES = ("MAX", "FORCE_INT", "COUNT")
 # CUPTI_API_VERSION lives in the sibling cupti_version.h; stamped into the generated
 # module (with the header's sha256) so its provenance -- which CUPTI ABI it came from
 # -- is self-evident.

--- a/torch/profiler/_cuspy/observers/base.py
+++ b/torch/profiler/_cuspy/observers/base.py
@@ -307,9 +307,14 @@ class CuspyObserver:
     @staticmethod
     def _with_graph_fields(activities: Any) -> dict[int, set[int]]:
         """Augment a field map so the graph resolver can name nodes: add each GPU-op kind's
-        GRAPH_NODE_ID. Collection-free (it's a normal record field, no extra kinds, stays on
-        the vectorized path). Expects a ``{kind: fields}`` map."""
-        from torch.profiler._cuspy.records import GRAPH_NODE_FIELD
+        GRAPH_NODE_ID, plus its SOURCE_GRAPH_NODE_ID where the CUPTI ABI has one (the key an
+        annotation kept on its capture graph is under). Collection-free (normal record
+        fields, no extra kinds, stays on the vectorized path). Expects a ``{kind: fields}``
+        map."""
+        from torch.profiler._cuspy.records import (
+            GRAPH_NODE_FIELD,
+            SOURCE_GRAPH_NODE_FIELD,
+        )
 
         aug: dict[int, set[int]] = {}
         for kind, sel in dict(activities).items():
@@ -317,6 +322,8 @@ class CuspyObserver:
             fields = {int(f) for f in sel}
             if k in GRAPH_NODE_FIELD:
                 fields.add(GRAPH_NODE_FIELD[k])
+            if k in SOURCE_GRAPH_NODE_FIELD:
+                fields.add(SOURCE_GRAPH_NODE_FIELD[k])
             aug[k] = fields
         return aug
 

--- a/torch/profiler/_cuspy/observers/node_timer.py
+++ b/torch/profiler/_cuspy/observers/node_timer.py
@@ -13,8 +13,9 @@ By default only CONCURRENT_KERNEL is timed -- the common case. Opt into MEMCPY /
 MEMCPY2 (peer-to-peer) / MEMSET via ``kinds`` to time those nodes too. Requesting
 MEMCPY2 also enables MEMCPY implicitly (CUPTI emits no MEMCPY2 records unless
 MEMCPY is on too). Every kind here times the same 4
-fields (START, END, GRAPH_NODE_ID, STREAM_ID), so all records are one size and
-Cuspy decodes them via its vectorized stride + kind-dispatch path; this observer
+fields (START, END, GRAPH_NODE_ID, STREAM_ID) -- plus SOURCE_GRAPH_NODE_ID when every
+selected kind has one (``records.SOURCE_GRAPH_NODE_FIELD``) -- so all records are one size
+and Cuspy decodes them via its vectorized stride + kind-dispatch path; this observer
 just buffers the raw columns (the cost is in Cuspy's decode, not here).
 
 Durations are keyed by graph_node_id alone, kind-agnostic: each CUDA-graph node
@@ -26,7 +27,9 @@ base); :meth:`drain_annotated` then returns ``{name: [(start_ns, end_ns), ...]}`
 resolving each span graph-first then eager-fallback:
 
   * **Graph** (``graph_annotation_resolver``) -- ``graph_node_id -> name`` via the resolver
-    (a custom one or the default registry). Needs no extra record kinds, so it stays on
+    (a custom one or the default registry), tried on the node's source (capture) id before
+    its exec id, since a graph captured with ``annotation_config["key_by"] == "source"``
+    keeps its annotations under the former. Needs no extra record kinds, so it stays on
     Cuspy's **vectorized** decode path. On by default; ``None`` disables it.
   * **Eager** (``support_eager_annotations``) -- ``record_function``-style regions bracketed
     with :meth:`push_annotation`/:meth:`annotate` (inherited from the base) become
@@ -57,6 +60,7 @@ from torch.profiler._cuspy.records import (
     Memcpy,
     Memcpy2,
     Memset,
+    SOURCE_GRAPH_NODE_FIELD,
 )
 
 
@@ -113,6 +117,19 @@ def _bucket_name(annotation: Any) -> str:
     return str(annotation) if annotation else ""
 
 
+def _graph_names(resolver: Any, nodes: Any) -> Any:
+    """Per-span bucket name from a graph annotation resolver. Resolves each *unique* node
+    id once (a small set) and gathers back to per-span; node 0 (eager) never resolves."""
+    import numpy as np
+
+    uniq, inv = np.unique(nodes, return_inverse=True)
+    names = np.array(
+        [_bucket_name(resolver(int(g))) if g else "" for g in uniq.tolist()],
+        dtype=object,
+    )
+    return names[inv]
+
+
 class NodeTimerObserver(CuspyObserver):
     """Buffers raw per-activity ``(graph_node_id, start_ns, end_ns, stream_id)`` spans
     Cuspy delivers; :meth:`drain` returns them as flat numpy columns. Construct with
@@ -143,8 +160,9 @@ class NodeTimerObserver(CuspyObserver):
         self._lock = threading.Lock()
         # Raw span column chunks as the worker thread delivers them: each is
         # (graph_node_id, start, end, stream, correlation_id|None -- the id only when
-        # eager). Kept raw (not pre-aggregated) so consumers build per-kernel timing on top.
-        self._chunks: list[tuple[Any, Any, Any, Any, Any]] = []
+        # eager, source_graph_node_id). Kept raw (not pre-aggregated) so consumers build
+        # per-kernel timing on top.
+        self._chunks: list[tuple[Any, Any, Any, Any, Any, Any]] = []
         # EXTERNAL_CORRELATION chunks (external_id, correlation_id) for the eager name
         # join; only populated when eager naming is on.
         self._ext_chunks: list[tuple[Any, Any]] = []
@@ -152,12 +170,24 @@ class NodeTimerObserver(CuspyObserver):
         # (CORRELATION_ID + EXTERNAL_CORRELATION + RUNTIME) and sets up the resolver
         # from `annotations`. Register last so the buffers are ready before delivery.
         fields = {int(k): set(_TIMED_FIELDS[int(k)]) for k in self._kinds}
+        # Source (capture-graph) node ids where the CUPTI ABI has them: a graph's
+        # annotations sit under those instead of the exec node ids when it was captured
+        # with annotation_config["key_by"] == "source". All-or-nothing across the selected
+        # kinds (MEMCPY2 has no such field) so every record stays one size and the decode
+        # stays on the vectorized path.
+        self._source_fields: dict[int, int] = (
+            {k: SOURCE_GRAPH_NODE_FIELD[k] for k in fields}
+            if all(k in SOURCE_GRAPH_NODE_FIELD for k in fields)
+            else {}
+        )
+        for kind, field in self._source_fields.items():
+            fields[kind].add(field)
         super().__init__(fields, annotations=annotations)
 
     def _on_activities(self, columns: dict[Any, dict[int, Any]]) -> None:
         # Worker thread: just stash the columns (cheap append); grouping/joining
         # happens after drain, off this hot path.
-        spans: list[tuple[Any, Any, Any, Any, Any]] = []
+        spans: list[tuple[Any, Any, Any, Any, Any, Any]] = []
         exts: list[tuple[Any, Any]] = []
         for kind, cols in columns.items():
             k = int(kind)
@@ -182,7 +212,10 @@ class NodeTimerObserver(CuspyObserver):
             if start is None or end is None or gnode is None or stream is None:
                 continue
             corr = cols.get(CORRELATION_FIELD[k]) if self._eager else None
-            spans.append((gnode, start, end, stream, corr))
+            source_field = self._source_fields.get(k)
+            src = None if source_field is None else cols.get(source_field)
+            src = gnode if src is None else src
+            spans.append((gnode, start, end, stream, corr, src))
         if spans or exts:
             with self._lock:
                 self._chunks.extend(spans)
@@ -275,12 +308,16 @@ class NodeTimerObserver(CuspyObserver):
 
         resolver = self._annotation_resolver
         if resolver is not None:
-            uniq_g, inv_g = np.unique(gnode, return_inverse=True)
-            g_names = np.array(
-                [_bucket_name(resolver(int(g))) if g else "" for g in uniq_g.tolist()],
-                dtype=object,
-            )
-            span_names = g_names[inv_g]
+            # Source (capture) node ids first, then the exec ids: a graph's annotations are
+            # under one or the other depending on its annotation_config["key_by"], and a run
+            # can mix graphs that chose differently. The two key spaces hold different graph
+            # ids, so a hit is never ambiguous.
+            source = np.concatenate([c[5] for c in chunks]).astype("<u8", copy=False)
+            span_names = _graph_names(resolver, source)
+            if self._source_fields:
+                unnamed = span_names == ""
+                if unnamed.any():
+                    span_names[unnamed] = _graph_names(resolver, gnode)[unnamed]
 
         # Eager fallback for spans the graph resolver didn't name: correlation_id ->
         # external_id -> name. The external ids were resolved at dispatch through

--- a/torch/profiler/_cuspy/observers/profiler.py
+++ b/torch/profiler/_cuspy/observers/profiler.py
@@ -748,7 +748,10 @@ def _attach_event_node_ids(
     # an installed one may merge a node's annotation list into a single dict). Resolving it
     # here rather than reading the store directly is what lets _annotation_to_args spread the
     # fields into args -- a raw list is re-serialized to an opaque "annotation" string instead.
-    ce["annotation"] = _resolve_annotation_column(resolver, gnid)
+    # These ids come from the recorder's instantiate-time walk, so they are exec ids with no
+    # source counterpart: a graph whose annotations stayed on the capture graph
+    # (annotation_config["key_by"] == "source") resolves its kernels but not its event nodes.
+    ce["annotation"] = _resolve_annotation_column(resolver, gnid, gnid)
 
 
 def _add_graph_event_node_spans(
@@ -853,9 +856,28 @@ def _demangle_column(names: Any) -> Any:
     return out
 
 
-def _resolve_annotation_column(resolver, gnid: Any) -> Any:
+def _source_gnid(cols, cat, gnid: Any) -> Any:
+    """Per-row source (capture-graph) node id, or the exec node ids when this CUPTI ABI has
+    no such field. See _resolve_annotation_column for what the two are used for."""
+    field = getattr(cat, "SOURCE_GRAPH_NODE_ID", None)
+    col = None if field is None else cols.get(field.id)
+    return gnid if col is None else col.astype(np.int64)
+
+
+def _resolve_node_id(resolver, src: int, exec_id: int) -> Any:
+    """Resolve one node against the registry, source node first. Which key a graph's entries
+    are under is that capture's choice (annotation_config["key_by"]: rekeyed to each exec
+    graph, or left on the capture graph for CUPTI's sourceGraphNodeId), and a trace can mix
+    graphs that chose differently, so both are tried. The two key spaces hold different graph
+    ids, so a hit is never ambiguous."""
+    if resolver is None:
+        return None
+    return resolver(src) or (resolver(exec_id) if exec_id != src else None)
+
+
+def _resolve_annotation_column(resolver, gnid: Any, src_gnid: Any) -> Any:
     """Per-row graph annotation as an object column. None resolver -> all-None column, no
-    calls. The resolver is memoized per graph_node_id by the observer (see
+    calls. The resolver is memoized per node id by the observer (see
     CuspyObserver._annotation_resolver), so distinct nodes resolve once for its
     lifetime."""
     n = len(gnid)
@@ -863,8 +885,8 @@ def _resolve_annotation_column(resolver, gnid: Any) -> Any:
     if resolver is None:
         out[:] = None
         return out
-    for i, g in enumerate(gnid.tolist()):
-        out[i] = resolver(g)
+    for i, (g, s) in enumerate(zip(gnid.tolist(), src_gnid.tolist())):
+        out[i] = _resolve_node_id(resolver, s, g)
     return out
 
 
@@ -904,15 +926,20 @@ def _resolve_lane_columns(lane_resolver, frame: dict[str, Any]) -> Any:
     Returning the op's own stream number is therefore still a distinct logical lane; None is how
     a resolver says "leave it on its CUDA stream"."""
     gnid = frame["graph_node_id"]
+    src_gnid = frame.get("source_graph_node_id")
+    if src_gnid is None:
+        src_gnid = gnid
     n = len(gnid)
     logical = np.array(
         frame["stream_id"], dtype=np.int64
     )  # default: the op's CUDA stream
     names = np.full(n, None, dtype=object)
-    for i, g in enumerate(gnid.tolist()):
+    for i, (g, s) in enumerate(zip(gnid.tolist(), src_gnid.tolist())):
         if not g:
             continue
-        res = lane_resolver(g)
+        # A lane is read off the node's annotation, so it resolves in whichever key space
+        # that graph kept its annotations in (see _resolve_node_id).
+        res = _resolve_node_id(lane_resolver, s, g)
         if res is not None:
             lane, names[i] = res
             logical[i] = lane + (0 if lane >= LOGICAL_LANE_BASE else LOGICAL_LANE_BASE)
@@ -921,6 +948,7 @@ def _resolve_lane_columns(lane_resolver, frame: dict[str, Any]) -> Any:
 
 def _kernel_columns(cols, convert, resolver):
     gnid = cols[Kernel.GRAPH_NODE_ID.id].astype(np.int64)
+    src_gnid = _source_gnid(cols, Kernel, gnid)
     corr = cols[Kernel.CORRELATION_ID.id].astype(np.int64)
     return {
         "start_ns": convert(cols[Kernel.START.id]),
@@ -930,9 +958,10 @@ def _kernel_columns(cols, convert, resolver):
         "stream_id": cols[Kernel.STREAM_ID.id].astype(np.int64),
         "correlation_id": corr,
         "graph_node_id": gnid,
+        "source_graph_node_id": src_gnid,
         "graph_id": cols[Kernel.GRAPH_ID.id].astype(np.int64),
         "name": _demangle_column(cols[Kernel.NAME.id]),
-        "annotation": _resolve_annotation_column(resolver, gnid),
+        "annotation": _resolve_annotation_column(resolver, gnid, src_gnid),
         "grid_x": cols[Kernel.GRID_X.id].astype(np.int64),
         "grid_y": cols[Kernel.GRID_Y.id].astype(np.int64),
         "grid_z": cols[Kernel.GRID_Z.id].astype(np.int64),
@@ -951,6 +980,7 @@ def _kernel_columns(cols, convert, resolver):
 
 def _memcpy_columns(cols, convert, resolver):
     gnid = cols[Memcpy.GRAPH_NODE_ID.id].astype(np.int64)
+    src_gnid = _source_gnid(cols, Memcpy, gnid)
     corr = cols[Memcpy.CORRELATION_ID.id].astype(np.int64)
     return {
         "start_ns": convert(cols[Memcpy.START.id]),
@@ -960,8 +990,9 @@ def _memcpy_columns(cols, convert, resolver):
         "stream_id": cols[Memcpy.STREAM_ID.id].astype(np.int64),
         "correlation_id": corr,
         "graph_node_id": gnid,
+        "source_graph_node_id": src_gnid,
         "graph_id": cols[Memcpy.GRAPH_ID.id].astype(np.int64),
-        "annotation": _resolve_annotation_column(resolver, gnid),
+        "annotation": _resolve_annotation_column(resolver, gnid, src_gnid),
         "bytes": cols[Memcpy.BYTES.id].astype(np.int64),
         "copy_kind": cols[Memcpy.COPY_KIND.id].astype(np.int64),
         "src_kind": cols[Memcpy.SRC_KIND.id].astype(np.int64),
@@ -978,6 +1009,7 @@ def _memcpy2_columns(cols, convert, resolver):
     # correlation/graph ids). src/dst device aren't surfaced (the span on the issuing device's
     # lane is what's wanted), but they're available on Memcpy2 if needed later.
     gnid = cols[Memcpy2.GRAPH_NODE_ID.id].astype(np.int64)
+    src_gnid = _source_gnid(cols, Memcpy2, gnid)
     corr = cols[Memcpy2.CORRELATION_ID.id].astype(np.int64)
     return {
         "start_ns": convert(cols[Memcpy2.START.id]),
@@ -987,8 +1019,9 @@ def _memcpy2_columns(cols, convert, resolver):
         "stream_id": cols[Memcpy2.STREAM_ID.id].astype(np.int64),
         "correlation_id": corr,
         "graph_node_id": gnid,
+        "source_graph_node_id": src_gnid,
         "graph_id": cols[Memcpy2.GRAPH_ID.id].astype(np.int64),
-        "annotation": _resolve_annotation_column(resolver, gnid),
+        "annotation": _resolve_annotation_column(resolver, gnid, src_gnid),
         "bytes": cols[Memcpy2.BYTES.id].astype(np.int64),
         "copy_kind": cols[Memcpy2.COPY_KIND.id].astype(np.int64),
         "src_kind": cols[Memcpy2.SRC_KIND.id].astype(np.int64),
@@ -1001,6 +1034,7 @@ def _memcpy2_columns(cols, convert, resolver):
 
 def _memset_columns(cols, convert, resolver):
     gnid = cols[Memset.GRAPH_NODE_ID.id].astype(np.int64)
+    src_gnid = _source_gnid(cols, Memset, gnid)
     corr = cols[Memset.CORRELATION_ID.id].astype(np.int64)
     return {
         "start_ns": convert(cols[Memset.START.id]),
@@ -1010,8 +1044,9 @@ def _memset_columns(cols, convert, resolver):
         "stream_id": cols[Memset.STREAM_ID.id].astype(np.int64),
         "correlation_id": corr,
         "graph_node_id": gnid,
+        "source_graph_node_id": src_gnid,
         "graph_id": cols[Memset.GRAPH_ID.id].astype(np.int64),
-        "annotation": _resolve_annotation_column(resolver, gnid),
+        "annotation": _resolve_annotation_column(resolver, gnid, src_gnid),
         "bytes": cols[Memset.BYTES.id].astype(np.int64),
         "value": cols[Memset.VALUE.id].astype(np.int64),
         "memory_kind": cols[Memset.MEMORY_KIND.id].astype(np.int64),
@@ -1023,6 +1058,7 @@ def _memset_columns(cols, convert, resolver):
 
 def _graph_host_node_columns(cols, convert, resolver):
     gnid = cols[GraphHostNode.GRAPH_NODE_ID.id].astype(np.int64)
+    src_gnid = _source_gnid(cols, GraphHostNode, gnid)
     return {
         "start_ns": convert(cols[GraphHostNode.START.id]),
         "end_ns": convert(cols[GraphHostNode.END.id]),
@@ -1031,8 +1067,9 @@ def _graph_host_node_columns(cols, convert, resolver):
         "stream_id": cols[GraphHostNode.STREAM_ID.id].astype(np.int64),
         "correlation_id": cols[GraphHostNode.CORRELATION_ID.id].astype(np.int64),
         "graph_node_id": gnid,
+        "source_graph_node_id": src_gnid,
         "graph_id": cols[GraphHostNode.GRAPH_ID.id].astype(np.int64),
-        "annotation": _resolve_annotation_column(resolver, gnid),
+        "annotation": _resolve_annotation_column(resolver, gnid, src_gnid),
         "process_id": cols[GraphHostNode.PROCESS_ID.id].astype(np.int64),
         "thread_id": cols[GraphHostNode.THREAD_ID.id].astype(np.int64),
     }

--- a/torch/profiler/_cuspy/records.py
+++ b/torch/profiler/_cuspy/records.py
@@ -64,6 +64,7 @@ __all__ = [
     "STRING_FIELDS",
     "CORRELATION_FIELD",
     "GRAPH_NODE_FIELD",
+    "SOURCE_GRAPH_NODE_FIELD",
     "RecordLayouts",
 ]
 
@@ -133,6 +134,16 @@ GRAPH_NODE_FIELD: dict[int, int] = {
     kind: cat.GRAPH_NODE_ID.id
     for kind, cat in _CATALOGS.items()
     if hasattr(cat, "GRAPH_NODE_ID")
+}
+
+
+# Per-kind source-graph-node-id field: the node a replayed node was instantiated from, i.e.
+# the capture-graph node an annotation was recorded against. Empty on a pre-13.4 CUPTI ABI,
+# which has no such field -- consumers fall back to GRAPH_NODE_FIELD.
+SOURCE_GRAPH_NODE_FIELD: dict[int, int] = {
+    kind: cat.SOURCE_GRAPH_NODE_ID.id
+    for kind, cat in _CATALOGS.items()
+    if hasattr(cat, "SOURCE_GRAPH_NODE_ID")
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #197131
* #196530
* __->__ #196529

Follow-up to the previous commit, which let a capture keep its annotations on
the capture graph (annotation_config={"key_by": "source"}). Nothing consumed
that yet: both Cuspy observers looked annotations up by the exec graph node id
CUPTI reports for replayed work, so a source-keyed graph resolved to nothing.

Both now select SOURCE_GRAPH_NODE_ID where the CUPTI ABI has it and try it
before the exec id. The fallback chain, rather than a switch, is what lets one
trace carry graphs that were captured with different key_by values; the two key
spaces hold different graph ids, so a hit is never ambiguous. The profiler
observer carries the id as its own column so lane assignment -- which reads the
same annotations -- resolves the same way.

For the always-on NodeTimerObserver the field is selected all-or-nothing across
the requested kinds, because MEMCPY2 has no source field and a mixed selection
would give the kinds different record sizes and drop Cuspy's decode off its
vectorized stride path. _TIMED_FIELDS deliberately stays a 4-tuple: it is
imported and unpacked by the out-of-tree cuspy-collector wheel, which would
break on a 5th element. An extra delivered column is ignored by that wheel, so
this is safe against the pinned version and leaves it a field to adopt.

gen_cupti_stubs.py is here because the source fields only reach the catalogs
through it: CUPTI 13.4 added CUPTI_ACTIVITY_ATTR_COUNT as the attribute enum's
sentinel, which the generator emitted as a bogus ActivityAttr.COUNT.

Read the profiler observer first (records.py -> observers/base.py ->
observers/profiler.py), then node_timer.py, which repeats the same idea over its
own column buffers.

Graph event-record nodes still resolve by exec id only: their ids come from the
instantiate-time topology walk, and CUPTI reports no source counterpart for
them, so a source-keyed graph names its kernels but not its event nodes.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.4/compat python test/profiler/test_cuspy_node_timer.py
LD_LIBRARY_PATH=/usr/local/cuda-13.4/compat python test/profiler/test_cuspy.py TestCuspyRecords.test_annotation_column_resolves_source_node_first
LD_LIBRARY_PATH=/usr/local/cuda-13.4/compat python test/test_cuda_graph_utils.py
```

9, 1 and 118 tests pass on a GB200 with CUPTI 13.4.58 and CUDA driver 615.71.09.
The added node-timer test names a source-keyed graph's replayed spans through a
resolver that only knows capture ids, so it fails if the source column is not
selected or not preferred; it skips below a 13.4 driver.

End to end, a mark_kernels region on a graph captured either way lands on the
replayed kernels in a chrome trace (2/2 kernels annotated under both "exec" and
"source"), checked with a scratch script driving torch.profiler with
custom_profiler_config='{"backend":"cuspy"}'.

Note: the rest of test_cuspy.py could not be run to completion -- it segfaults
partway through with heap corruption inside cuptiActivitySetAttribute_v2 on a
second subscribe. That reproduces on CUPTI 13.3 without these changes and is
unrelated to them.

This commit was authored with the assistance of an AI coding agent (Claude Code).