### PR TITLE
Keep an exec-keyed alias for nodes CUPTI reports without a source node id

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -13,6 +13,7 @@ from torch.cuda._graph_annotations import (
     _is_tools_id_unavailable,
     _rekey_annotations,
     _reset_kernel_annotations,
+    _sourceless_nodes,
     mark_stream,
     resolve_and_remap,
     resolve_pending_annotations,
@@ -248,6 +249,65 @@ class TestMarkKernels(TestCase):
             self.assertIsNone(graph._remapped_exec_id)
             self.assertEqual(set(get_kernel_annotations()), keys)
         self.assertIn(capture_id, graph._recorded_exec_ids)
+
+    @unittest.skipIf(
+        not source_node_ids_available(),
+        "annotation_config={'key_by': 'source'} needs a CUDA driver >= 13.4",
+    )
+    def test_key_by_source_aliases_nodes_without_a_source_id(self):
+        """Host and memcpy nodes keep an exec-keyed copy even under source keying.
+
+        CUPTI reports no sourceGraphNodeId for those kinds (a graph memcpy node surfaces
+        as the peer-to-peer MEMCPY2 activity kind when its endpoints are on different
+        devices, and that record has no such field), so the capture key alone would never
+        be looked up for them. Every other node stays capture-keyed only, and a
+        re-instantiate moves the alias to the new exec graph instead of leaving the old
+        one behind."""
+        pinned = torch.ones(1024, pin_memory=True)
+        dst = torch.zeros(1024, device="cuda")
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        warm = torch.cuda.Stream()
+        warm.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warm):
+            dst.copy_(pinned, non_blocking=True)
+            dst.mul_(2)
+        torch.cuda.current_stream().wait_stream(warm)
+
+        with torch.cuda.graph(
+            graph, enable_annotations=True, annotation_config={"key_by": "source"}
+        ):
+            with mark_kernels("phase_a"):
+                dst.copy_(pinned, non_blocking=True)
+                dst.mul_(2)
+
+        capture_id = graph._capture_graph_id
+        captured = set(get_kernel_annotations())
+        # The copy is a memcpy node (the multiply is a kernel), so exactly one entry needs
+        # the alias -- if the capture stops producing one, this test proves nothing.
+        sourceless = {t for t in captured if t in _sourceless_nodes}
+        self.assertEqual(len(sourceless), 1)
+
+        graph.instantiate()
+        first_exec = graph._remapped_exec_id
+        self.assertIsNotNone(first_exec)
+        aliases = {(first_exec << 32) | (t & 0xFFFFFFFF) for t in sourceless}
+        annotations = get_kernel_annotations()
+        self.assertEqual(set(annotations), captured | aliases)
+        # The alias shares the entry, so both keys resolve to the same annotation.
+        for tools_id in sourceless:
+            alias = (first_exec << 32) | (tools_id & 0xFFFFFFFF)
+            self.assertEqual(annotations[alias], annotations[tools_id])
+        self.assertIn(capture_id, graph._recorded_exec_ids)
+        self.assertIn(first_exec, graph._recorded_exec_ids)
+
+        graph.instantiate()
+        second_exec = graph._remapped_exec_id
+        self.assertNotEqual(second_exec, first_exec)
+        keys = set(get_kernel_annotations())
+        self.assertEqual(
+            keys,
+            captured | {(second_exec << 32) | (t & 0xFFFFFFFF) for t in sourceless},
+        )
 
     def test_key_by_exec_is_the_default(self):
         """The default rekeys to the exec graph, which is what a consumer reading CUPTI's

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -409,6 +409,18 @@ def _collect_descendants(
 # on it, which is precisely what the merge resolves.
 _kernel_annotations: dict[int, dict[str, Any]] = {}
 
+# Annotated toolsIds whose node type CUPTI reports without a source node id
+# (_SOURCELESS_NODE_TYPES). Under key_by="source" these are the only entries that still
+# need an exec-keyed copy, which alias_sourceless_to_exec_graph adds at instantiate.
+_sourceless_nodes: set[int] = set()
+
+
+def note_sourceless_node(tools_id: int) -> None:
+    """Record that this node's type carries no source node id, so a source-keyed capture
+    still aliases it into exec space. Called by whichever backend discovered the node (it
+    has the node type in hand; the registry does not). Not a public API."""
+    _sourceless_nodes.add(tools_id)
+
 
 def _merge_annotation(tools_id: int, annotation: Any) -> None:
     """Merge one scope's annotation into a node's entry; the first write wins per key.
@@ -484,6 +496,45 @@ def _get_annotatable_type_values() -> frozenset[int]:
 # lazily, like _ANNOTATABLE_TYPES above: _cuda_driver is None when cuda.bindings is
 # absent, so reading the enum at import time would break `import torch`.
 _NESTED_GRAPH_TYPES: set[Any] | None = None
+
+# Node types CUPTI reports with no sourceGraphNodeId, so a consumer can only ever name them
+# by their exec node id (see records.SOURCE_GRAPH_NODE_FIELD). MEMCPY is here because a
+# graph memcpy node surfaces as either the MEMCPY or the MEMCPY2 (peer-to-peer) activity
+# kind depending on where its endpoints live, and only MEMCPY2 lacks the field -- the graph
+# node type cannot tell the two apart, so both get the alias and the non-P2P case just
+# carries a duplicate key. Lazily initialized like the sets above.
+_SOURCELESS_NODE_TYPES: set[Any] | None = None
+
+
+def _get_sourceless_node_types() -> set[Any]:
+    global _SOURCELESS_NODE_TYPES
+    if _SOURCELESS_NODE_TYPES is None:
+        node_types = _cuda_driver.CUgraphNodeType  # pyrefly: ignore[missing-attribute]
+        _SOURCELESS_NODE_TYPES = {
+            node_types.CU_GRAPH_NODE_TYPE_HOST,
+            node_types.CU_GRAPH_NODE_TYPE_MEMCPY,
+        }
+    return _SOURCELESS_NODE_TYPES
+
+
+_SOURCELESS_TYPE_VALUES: frozenset[int] | None = None
+
+
+def _get_sourceless_type_values() -> frozenset[int]:
+    """:func:`_get_sourceless_node_types` as raw driver enum values."""
+    global _SOURCELESS_TYPE_VALUES
+    if _SOURCELESS_TYPE_VALUES is None:
+        _SOURCELESS_TYPE_VALUES = frozenset(
+            int(t) for t in _get_sourceless_node_types()
+        )
+    return _SOURCELESS_TYPE_VALUES
+
+
+def node_type_has_source_id(node_type: Any) -> bool:
+    """Whether CUPTI reports a source (capture-graph) node id for this node type, i.e.
+    whether an annotation kept on the capture graph can name it. Takes the driver enum or
+    its raw value. Not a public API."""
+    return int(node_type) not in _get_sourceless_type_values()
 
 
 def _get_nested_graph_types() -> set[Any]:
@@ -615,13 +666,14 @@ def _end_kernel_scope(scope: _KernelScope) -> list[int]:
             nested_seen.add(node_type.name)
         if node_type not in annotatable:
             continue
-        tools_ids.append(
-            _check_cuda_bindings(
-                _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
-                    node
-                )
+        tools_id = _check_cuda_bindings(
+            _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
+                node
             )
         )
+        if not node_type_has_source_id(node_type):
+            note_sourceless_node(tools_id)
+        tools_ids.append(tools_id)
 
     if nested_seen:
         # The annotations recorded above are still correct -- the exec graph preserves
@@ -1032,6 +1084,51 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     torch_cuda_graph._remapped_exec_id = exec_graph_id
 
 
+def alias_sourceless_to_exec_graph(
+    torch_cuda_graph: torch.cuda.CUDAGraph,
+) -> int | None:
+    """Give this graph's source-id-less nodes an exec-keyed copy of their annotation.
+
+    The counterpart of :func:`remap_to_exec_graph` for a capture that chose
+    ``annotation_config={"key_by": "source"}``: its annotations stay on the capture graph,
+    but host and (peer-to-peer) memcpy nodes are reported by CUPTI without a source node
+    id, so a consumer can only name them by their exec node id. Those entries -- and only
+    those -- are copied to the exec key, leaving the capture key in place: the two keys
+    share one annotation dict, so a later merge into either is seen through both.
+
+    Each instantiate() mints a fresh exec id, so the previous instantiate's aliases are
+    dropped first rather than left behind. Returns the exec graph id the aliases are under
+    (for the caller's destroy bookkeeping), or None when there was nothing to alias.
+    """
+    capture_graph_id = torch_cuda_graph._capture_graph_id
+    if capture_graph_id is None or not _sourceless_nodes:
+        return None
+    aliased = [
+        tools_id
+        for tools_id in _sourceless_nodes
+        if tools_id >> 32 == capture_graph_id and tools_id in _kernel_annotations
+    ]
+    if not aliased:
+        return None
+
+    exec_graph_id = _check_cuda_bindings(
+        _cuda_runtime.cudaGraphExecGetId(  # pyrefly: ignore[missing-attribute]
+            torch_cuda_graph.raw_cuda_graph_exec()
+        )
+    )
+    previous = torch_cuda_graph._remapped_exec_id
+    if previous == exec_graph_id:
+        return exec_graph_id
+    if previous is not None:
+        for tools_id in aliased:
+            _kernel_annotations.pop((previous << 32) | (tools_id & 0xFFFFFFFF), None)
+    for tools_id in aliased:
+        alias = (exec_graph_id << 32) | (tools_id & 0xFFFFFFFF)
+        _kernel_annotations[alias] = _kernel_annotations[tools_id]
+    torch_cuda_graph._remapped_exec_id = exec_graph_id
+    return exec_graph_id
+
+
 def _rekey_annotations(
     annotations: dict[int, dict[str, Any]],
     capture_graph_id: int,
@@ -1133,6 +1230,7 @@ def _reset_kernel_annotations() -> None:
     use to isolate themselves without tripping its deprecation warning. Not a public
     API."""
     _kernel_annotations.clear()
+    _sourceless_nodes.clear()
     _pending_scopes.clear()
 
 
@@ -1177,6 +1275,9 @@ def remove_kernel_annotations(exec_graph_ids: Iterable[int]) -> None:
         return
     for key in [k for k in _kernel_annotations if k >> 32 in ids]:
         del _kernel_annotations[key]
+    _sourceless_nodes.difference_update(
+        [k for k in _sourceless_nodes if k >> 32 in ids]
+    )
 
 
 # Counter-based stream ID registry. IDs start at 60 (above the highest

--- a/torch/cuda/_graph_node_callbacks.py
+++ b/torch/cuda/_graph_node_callbacks.py
@@ -55,6 +55,8 @@ def _on_graph_node_created(_domain: int, _cbid: int, cbdata: int) -> None:
         _get_annotatable_type_values,
         capture_root_graph_id,
         current_annotation,
+        node_type_has_source_id,
+        note_sourceless_node,
         record_node_annotation,
     )
     from torch.cuda._utils import _check_cuda_bindings
@@ -83,6 +85,11 @@ def _on_graph_node_created(_domain: int, _cbid: int, cbdata: int) -> None:
         global _dropped_body_nodes
         _dropped_body_nodes += 1
         return
+    # The node type is only in hand here, and the registry needs it to know which entries
+    # a source-keyed capture must still alias into exec space (see
+    # _graph_annotations.note_sourceless_node).
+    if not node_type_has_source_id(graph_data.node_type):
+        note_sourceless_node(tools_id)
     record_node_annotation(tools_id, annotation)
 
 

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -562,10 +562,17 @@ class CUDAGraph(_CUDAGraph):
             return
         if self._annotation_key_by == "source":
             # Annotations stay keyed to the capture graph: the consumer reads CUPTI's
-            # sourceGraphNodeId, which reports the node each exec node came from, so no
-            # exec id ever has to be tracked. The capture id still goes to the destroy
-            # hooks, which is what purges these entries when the graph dies.
+            # sourceGraphNodeId, which reports the node each exec node came from. Host and
+            # memcpy nodes are the exception -- CUPTI reports no source id for those, so
+            # they still need an exec-keyed copy (see alias_sourceless_to_exec_graph). The
+            # capture id, and any exec id an alias landed under, go to the destroy hooks,
+            # which is what purges these entries when the graph dies.
+            from torch.cuda._graph_annotations import alias_sourceless_to_exec_graph
+
             self._recorded_exec_ids.add(self._capture_graph_id)
+            aliased_exec_id = alias_sourceless_to_exec_graph(self)
+            if aliased_exec_id is not None:
+                self._recorded_exec_ids.add(aliased_exec_id)
             return
         from torch.cuda._graph_annotations import remap_to_exec_graph
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #197131
* __->__ #196530
* #196529

Human note:

Due to nvidia's incomplete support, MEMCPY2 (Memcpy PtoP) and host nodes don't report src graph node id via cupti, so to correlate annotations for those nodes with profiles we still need to 
1) have allocations keyed by exec graph, even if users selected src graph
2) report both src ids and exec ids in profiles 
3) correlate using exec graph 

Source keying (annotation_config={"key_by": "source"}) assumed every replayed
node carries a sourceGraphNodeId back to the capture node its annotation is
under. Two kinds do not: CUPTI's peer-to-peer copy record (MEMCPY2) and the
graph-host-node record have a graph node id but no source counterpart in the
13.4 ABI, so a source-keyed graph silently lost the annotations on its host
nodes and on any graphed cross-device copy -- exactly the NVLink traffic worth
naming.

Those entries, and only those, now get an exec-keyed copy at instantiate, so the
per-instantiate bookkeeping this option exists to avoid stays proportional to
the handful of nodes that need it. The alias shares the annotation dict with the
capture-keyed entry (a later merge into one is seen through both), and a
re-instantiate moves it to the new exec graph rather than leaving the old key
behind. Which nodes need it is decided where the node type is in hand -- the
edge walk and the CUPTI creation callback both already have it -- rather than by
walking the graph again at instantiate. MEMCPY is aliased alongside HOST because
the graph node type cannot tell a peer-to-peer copy from an ordinary one (where
the endpoints live is what decides whether CUPTI reports MEMCPY or MEMCPY2); a
same-device copy just carries a duplicate key.

No consumer change: Cuspy already resolves source-then-exec, so a P2P copy falls
through to the alias while everything else still hits its capture key.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.4/compat python test/test_cuda_graph_utils.py
LD_LIBRARY_PATH=/usr/local/cuda-13.4/compat python test/profiler/test_cuspy_node_timer.py
```

121 and 9 tests pass on a GB200 with CUDA driver 615.71.09. The added test
captures a pinned host-to-device copy next to a kernel, then asserts the memcpy
node is the one that gets an exec-keyed alias, that both keys resolve to the
same annotation, and that a second instantiate moves the alias rather than
accumulating one per exec graph. Neither suite covers the CUPTI backend, so that
path was checked by hand with a capture under
annotation_config={"backend": "cupti", "key_by": "source"}.

This commit was authored with the assistance of an AI coding agent (Claude Code).