### PR TITLE
[Feature Refactoring] Use torch.accelerator in AOTI repro synchronize

### DIFF
--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -329,8 +329,6 @@ def repro_run(
 
     gm, args, kwargs = repro_common(options, exported_program)
 
-    from torch.cuda import synchronize
-
     _aoti_compile_and_package_inner(
         gm,
         args,
@@ -340,15 +338,11 @@ def repro_run(
         inductor_configs=config_patches,
     )
 
-    need_sync = False
-
-    for arg in args:
-        if isinstance(arg, torch.Tensor) and arg.is_cuda:
-            need_sync = True
-            break
-
-    if need_sync:
-        synchronize()  # ensure segfaults are surfaced
+    if (
+        any(isinstance(arg, torch.Tensor) and arg.device.type != "cpu" for arg in args)
+        and torch.accelerator.is_available()
+    ):
+        torch.accelerator.synchronize()  # ensure segfaults are surfaced
 
 
 def export_for_aoti_minifier(
@@ -414,14 +408,9 @@ def repro_minify(
     strict = options.minifier_export_mode == "dynamo"
     skip_export_error = options.skip_export_error
 
-    from torch.cuda import synchronize
-
-    need_sync = False
-
-    for arg in args:
-        if isinstance(arg, torch.Tensor) and arg.is_cuda:
-            need_sync = True
-            break
+    need_sync = any(
+        isinstance(arg, torch.Tensor) and arg.device.type != "cpu" for arg in args
+    )
 
     def module_fails(
         gm: torch.fx.GraphModule,
@@ -451,8 +440,9 @@ def repro_minify(
                 check_accuracy=options.accuracy,
                 inductor_configs=inductor_configs,
             )
-            if need_sync:
-                synchronize()  # ensure segfaults are surfaced
+            if need_sync and torch.accelerator.is_available():
+                # Ensures that segfaults are surfaced
+                torch.accelerator.synchronize()
             return False
         except Exception as e:
             if check_str is not None and check_str not in repr(e):


### PR DESCRIPTION
## Summary
This PR replaces the hard-coded `torch.cuda.synchronize()` calls in the AOTI repro/minifier tooling with the accelerator-agnostic `torch.accelerator` API, aligning `torch/_dynamo/repro/aoti.py` with the idiom already landed in `torch/_dynamo/repro/after_aot.py` and `torch/_dynamo/utils.py::timed()`.

## Changes
- **`torch/_dynamo/repro/aoti.py`**:
  - `repro_run`: replaced the `arg.is_cuda`-gated `torch.cuda.synchronize()` with `torch.accelerator.synchronize()`, guarded by "any input tensor is non-CPU" plus `torch.accelerator.is_available()`.
  - `repro_minify`: replaced the duplicated `is_cuda` scan loop with `need_sync = any(isinstance(arg, torch.Tensor) and arg.device.type != "cpu" for arg in args)`, and gated the in-closure synchronize on `need_sync and torch.accelerator.is_available()`.
  - Removed both `from torch.cuda import synchronize` imports.

## Motivation
The repro tool only synchronized when an input tensor lived on CUDA. On any other accelerator (e.g. a PrivateUse1 out-of-tree backend), asynchronous segfaults raised during AOTI compile-and-run were silently swallowed: `module_fails` would not observe the crash, so the minifier could not converge on the faulting subgraph. `torch._dynamo.repro.after_aot` already uses the `torch.accelerator` idiom for the same "ensure segfaults are surfaced" purpose; this PR aligns `aoti.py` with it.

Behavioral note: CUDA and CPU-only inputs behave exactly as before. Non-CUDA, non-CPU input tensors (e.g. meta tensors, or tensors on another accelerator when one is available) now also trigger a synchronize, which matches the semantics already accepted for `after_aot.py` upstream.

## Test Plan
- Ran `lintrunner` on the modified file (clean) and `python -m py_compile torch/_dynamo/repro/aoti.py`.
- `python test/inductor/test_minifier_utils.py` (CPU) as a sanity check that the repro/minifier utilities still import and run.
- Equivalence argument for CUDA: on CUDA inputs the new guard (`device.type != "cpu"` + `torch.accelerator.is_available()`) is logically equivalent to `is_cuda`, and `torch.accelerator.synchronize()` dispatches to the CUDA synchronize — the same behavior already reviewed and accepted for `after_aot.py`. 

## Notes
- Follow-up (out of scope for this PR): `_cuda_system_info_comment()` in `torch/_dynamo/debug_utils.py` is still CUDA-only, so repro headers do not collect system info for other accelerators; `torch/_dynamo/repro/after_aot.py` also still has an `a.is_cuda` residual in its SymIntWrapper device selection.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98