### PR TITLE
[CI] Raise @claude job timeout to 2 hours

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,6 +17,8 @@ jobs:
       id-token: write
     secrets: inherit
     with:
+      # Large reviews were hitting the reusable workflow's 60-minute default.
+      timeout_minutes: 120
       # Commenters opt into Fable by including "fable" in the comment (e.g.
       # "@claude fable review"); default stays Opus. Branch on event_name so an
       # issue/PR body mentioning "fable" doesn't affect an unrelated @claude comment.
@@ -34,7 +36,7 @@ jobs:
            (github.event_name == 'issues' && contains(github.event.issue.body, 'effort=low'))) && 'low' ||
           'medium'
         }}
-      # Surface stalled Bedrock requests before the one-hour job timeout.
+      # Surface stalled Bedrock requests before the job timeout above.
       settings: '{"outputStyle":"Concise","alwaysThinkingEnabled":true,"env":{"API_TIMEOUT_MS":"180000","CLAUDE_CODE_MAX_RETRIES":"2","CLAUDE_ENABLE_STREAM_WATCHDOG":"1"}}'
       # These logs are public and may include assistant messages and tool output.
       show_full_output: true


### PR DESCRIPTION
✴️ iz2: Requested by @jansel — `@claude` reviews on large PRs were being killed at the 60-minute cap.

The caller was inheriting `timeout_minutes: 60` from the reusable workflow's default; this sets it to 120 for pytorch/pytorch only, leaving the other 11 callers of `_claude-code.yml` unchanged.

Measured on pytorch/pytorch over the last 21 days: 108 of 958 non-skipped `claude-code` jobs (11%) ended `cancelled`, and 106 of those 108 had run ≥ 59 minutes — i.e. they hit the cap rather than being cancelled for another reason. On 2026-09-09 it was 15 of 111 (14%). A killed run posts no review and discards the model spend it already incurred.

This raises the ceiling; it does not make reviews faster. Note the budget covers the whole job, including checkout and the log-upload steps, and it only takes effect once merged, since `issue_comment` workflows run from the default branch.

Test plan: config-only change to a `workflow_call` input; the next `@claude` comment on the default branch exercises it.
