### PR TITLE
[ROCm] Enforce signed short for __builtin_amdgcn_flat_atomic_fadd_v2bf16

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -128,7 +128,7 @@ __device__ __forceinline__ void opportunistic_fastAtomicAdd(
   if constexpr (
       std::is_same<scalar_t, c10::BFloat16>::value ||
       std::is_same<scalar_t, c10::Half>::value) {
-    typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
+    typedef short __attribute__((ext_vector_type(2))) vec_short2;
     union ill {
       unsigned int i[2];
       int64_t il;

--- a/torch/headeronly/cuda/KernelUtils.h
+++ b/torch/headeronly/cuda/KernelUtils.h
@@ -22,7 +22,7 @@ __device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(
     __hip_bfloat162* address,
     __hip_bfloat162 value) {
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2bf16)) {
-    typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
+    typedef short __attribute__((ext_vector_type(2))) vec_short2;
     static_assert(sizeof(vec_short2) == sizeof(__hip_bfloat162_raw));
     union {
       __hip_bfloat162_raw bf162_raw;


### PR DESCRIPTION
This fix initially is required to fix internal branch torch vision build failures and should be put in upstream as well. The [API](https://clang.llvm.org/docs/AMDGPUBuiltinReference.html#builtin-amdgcn-flat-atomic-fadd-v2bf16) expects an ext_vector_type of signed short; an unsigned element type only compiles on toolchains where the builtin is declared with a GCC-style vector. Changing the typedef to a signed element type matches the builtin exactly.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang