### PR TITLE
[dynamo] Prebuild pybind enum fixture in fbcode (#196545)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -114,6 +114,10 @@ from torch.testing._internal.jit_utils import JitTestCase
 from torch.utils._sympy.numbers import int_oo
 
 
+if IS_FBCODE:
+    from caffe2.test.dynamo import _pybind11_enum_test
+
+
 pytree_modules = {
     "python": python_pytree,
 }
@@ -238,18 +242,23 @@ class MiscTests(torch._inductor.test_case.TestCase):
 
     @torch.testing._internal.common_utils.scoped_load_inline
     def test_pybind11_enum_conversion(self, load_inline):
-        cpp_source = """
-        #include <torch/extension.h>
+        if IS_FBCODE:
+            # fbcode's Python runtime lacks the shared libs load_inline needs, so
+            # we use the Buck-prebuilt fixture instead of the load_inline argument.
+            mod = _pybind11_enum_test
+        else:
+            cpp_source = """
+            #include <torch/extension.h>
 
-        enum class E { A = 0, B = 1 };
+            enum class E { A = 0, B = 1 };
 
-        PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-            py::enum_<E>(m, "E")
-                .value("A", E::A)
-                .value("B", E::B);
-        }
-        """
-        mod = load_inline(name="pybind11_enum_test", cpp_sources=cpp_source)
+            PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+                py::enum_<E>(m, "E")
+                    .value("A", E::A)
+                    .value("B", E::B);
+            }
+            """
+            mod = load_inline(name="pybind11_enum_test", cpp_sources=cpp_source)
         e = mod.E.A
         self.assertEqual(
             torch.compile(lambda x: int(x), backend="eager", fullgraph=True)(e), 0


### PR DESCRIPTION
Summary:

Build the pybind11 enum fixture with Buck when running `test_pybind11_enum_conversion` internally. The fbcode Python runtime does not ship the shared libraries required by `load_inline()`, while OSS continues using the existing JIT-built fixture.

Test Plan: `buck2 test fbcode//mode/opt fbcode//caffe2/test/dynamo:test_dynamo -- --run-disabled test_misc.py::MiscTests::test_pybind11_enum_conversion test_misc.py::DynamicShapesMiscTests::test_pybind11_enum_conversion_dynamic_shapes test_misc.py::NestedGraphBreaksMiscTests::test_pybind11_enum_conversion_nested_graph_breaks` (3 passed)

Reviewed By: stashuk-olek

Differential Revision: D119370787




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98