### PR TITLE
[SymmMem] Fix signal pad zeroing race in NVSHMEM allocator

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -457,8 +457,14 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     auto alloc_base = nvshmem_malloc(total_size);
     TORCH_CHECK(alloc_base != nullptr, "nvshmem_malloc failed");
     // Zero the signal pad (at the front, [0, buffer_offset)) for the signaling
-    // protocol.
-    AT_CUDA_CHECK(cudaMemset(alloc_base, 0, buffer_offset));
+    // protocol. Sync the memset, then barrier: nvshmem_malloc publishes the
+    // allocation before any rank has zeroed its pad, so peers must not signal
+    // into it until every rank's zeroing has landed.
+    auto stream = at::cuda::getCurrentCUDAStream(
+        static_cast<c10::DeviceIndex>(device_idx));
+    AT_CUDA_CHECK(cudaMemsetAsync(alloc_base, 0, buffer_offset, stream));
+    AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+    nvshmem_barrier_all();
     // Hand back the data buffer pointer, not alloc_base; the signal pad stays
     // hidden in front. Returning the data ptr is safe for free(): the whole
     // block is owned by the NVSHMEMAllocation keyed below, which nvshmem_free's

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -167,9 +167,13 @@ struct GroupInfo {
 C10_EXPORT GroupInfo& get_group_info(const std::string& group_name);
 
 // Identical to empty_strided, but allows symmetric memory access to be
-// established for the allocated tensor via SymmetricMemory::rendezvous(). This
-// function itself is not a collective operation. It invokes
-// SymmetricMemoryAllocator::alloc() for the requested device under the hood.
+// established for the allocated tensor via SymmetricMemory::rendezvous(). It
+// invokes SymmetricMemoryAllocator::alloc() for the requested device under the
+// hood.
+//
+// Whether this is a collective operation is backend-dependent. The NVSHMEM
+// allocator calls nvshmem_malloc and barriers inside alloc(), so with that
+// backend every rank must call this the same number of times in the same order.
 //
 // NOTE [symmetric memory persistent allocation]
 // If an `alloc_id` is supplied, empty_strided_p2p will perform persistent

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3442,6 +3442,7 @@ PYTORCH_SPECIFIC_MAPPINGS = collections.OrderedDict([
     ("nvshmem_malloc", "rocshmem::rocshmem_malloc"),
     ("nvshmem_free", "rocshmem::rocshmem_free"),
     ("nvshmem_ptr", "rocshmem::rocshmem_ptr"),
+    ("nvshmem_barrier_all", "rocshmem::rocshmem_barrier_all"),
     ("nvshmem_team_t", "rocshmem::rocshmem_team_t"),
     ("nvshmem_team_split_strided", "rocshmem::rocshmem_team_split_strided"),
 


### PR DESCRIPTION
Example: https://github.com/pytorch/pytorch/actions/runs/33694747324/job/100468832029 (job succeeded after retry, search for `test_nvshmem_put` for failure logs)

Synchronizes the signal-pad zeroing in [`NVSHMEMSymmetricMemoryAllocator::alloc()`](https://github.com/pytorch/pytorch/blob/8dafa769c46ef9408db00adc4c8d7cdca085ec66/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp#L437-L476) so the pad is provably zero on every rank before any peer can signal into it.

[`nvshmem_malloc`](https://github.com/pytorch/pytorch/blob/8dafa769c46ef9408db00adc4c8d7cdca085ec66/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp#L457) is collective: the moment it returns, every peer may address the new allocation and issue one-sided signal stores into its pad. But each rank zeroes its own pad with a local [`cudaMemset`](https://github.com/pytorch/pytorch/blob/8dafa769c46ef9408db00adc4c8d7cdca085ec66/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp#L461) issued **after** that collective, and nothing orders those two writes against each other. They are independent agents writing the same eight bytes: the peer's store arrives over the fabric without involving the target's CPU or GPU, while the target's zeroing is ordinary local work. If the zeroing lands second it overwrites the delivered signal, and the waiting rank spins forever — [`nvshmem_wait_for_signal`](https://github.com/pytorch/pytorch/blob/8dafa769c46ef9408db00adc4c8d7cdca085ec66/torch/csrc/distributed/c10d/symm_mem/rocshmem_extension.cu#L134-L138) takes no timeout, and a one-sided store fires once with no acknowledgement or retransmit, so an erased signal is unrecoverable rather than merely delayed.

The allocator's postcondition — the pad reads zero, as its own comment and the note at [`:146`](https://github.com/pytorch/pytorch/blob/8dafa769c46ef9408db00adc4c8d7cdca085ec66/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp#L146) both claim — is established locally but published globally. `nvshmem_malloc` guarantees every rank has *allocated*; nothing guarantees every rank has *zeroed* before a peer may write.

[`test_nvshmem_put`](https://github.com/pytorch/pytorch/blob/8dafa769c46ef9408db00adc4c8d7cdca085ec66/test/distributed/test_nvshmem.py#L254-L273) shows the failure in its simplest form. Both ranks allocate, then rank 0 puts its buffer into rank 1 and sets rank 1's pad slot to `5`, and rank 1 waits for that `5`. `nvshmem_malloc` returns on both ranks, which makes rank 1's allocation addressable by rank 0 — but rank 1's own zeroing has not necessarily run yet, since it is queued behind whatever that rank already had in flight. Rank 0 races ahead through `fill_`, `rendezvous` and `nvshmem_put_with_signal`, and its `5` lands in rank 1's pad. Rank 1's zeroing then runs and overwrites it with `0`. Rank 1 issues `nvshmem_wait_for_signal` and spins on a slot whose signal has already come and gone, so it never returns. Rank 0 completes the test body and then blocks in `~NVSHMEMAllocation` on `nvshmem_free`, itself a collective, so both ranks wedge and the harness charges its timeout twice.

The window is small, so the symptom is an intermittent hang rather than a consistent one: `distributed/test_nvshmem` occasionally times out at 600 s on gfx950 and passes on rerun, which is why the job still reports success and the failure is easy to miss in check-run status.

The barrier closes it by holding every peer back until all ranks have zeroed. For that to mean anything the local zeroing must have completed when a rank enters the barrier, which a bare `cudaMemset` does not guarantee, hence the explicit stream synchronize before it. This is the same sequence the sibling allocator already uses at [`CUDASymmetricMemory.cu:426-428`](https://github.com/pytorch/pytorch/blob/8dafa769c46ef9408db00adc4c8d7cdca085ec66/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu#L426-L428), cast included.

Coauthored with Claude

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang