### PR TITLE
[profiler][cuspy] Use the documented forced flush when a field selection changes

### DIFF
--- a/torch/profiler/_cuspy/core.py
+++ b/torch/profiler/_cuspy/core.py
@@ -727,15 +727,14 @@ class Cuspy:
     def flush(self, *, sync: bool = False, timeout_s: float = 5.0) -> None:
         """Flush CUPTI's activity buffers to the processing worker.
 
-        Both paths issue ``cuptiActivityFlushAll(0)`` -- which hands over COMPLETED
-        records, never in-progress ones -- and end by draining the native decoder's
-        accumulated columns and dispatching them to the observers. Cuspy never
-        FORCE-flushes (``CUPTI_ACTIVITY_FLAG_FLUSH_FORCED``): a forced flush hands back
-        a still-running kernel's record with a zero end timestamp and consumes it, so
-        CUPTI never re-delivers the real completion (it would strand a slow-but-healthy
-        collective as a false hang in the comm watchdog), and forcing in-progress
-        buffers over concurrent host activity is the flush race that corrupts the HES
-        heap and freezes the decode worker.
+        Both paths issue ``cuptiActivityFlushAll(0)`` -- which hands over buffers whose
+        records are all complete, never a buffer holding an in-progress record -- and
+        end by draining the native decoder's accumulated columns and dispatching them to
+        the observers. Neither path FORCE-flushes: a forced flush hands back a
+        still-running kernel's record with a zero end timestamp and consumes it, so CUPTI
+        never re-delivers the real completion (it would strand a slow-but-healthy
+        collective as a false hang in the comm watchdog). The one forced flush Cuspy
+        issues is in _reconfigure, behind a device sync, where CUPTI requires it.
 
         Plain (``sync=False``) flushes then drains -- the background flush loop and the
         per-step foreground driver. With ``sync=True`` it first blocks until the native
@@ -1107,18 +1106,24 @@ class Cuspy:
         added = [k for k in target if k not in self._enabled]
         for kind in (*removed, *changed):
             self._cupti.activity_disable(sub, kind)
-        # FENCE between disabling and (re-)enabling a kind with a new field selection.
-        # A completed buffer carries one layout per kind (ppRecordLayouts), so a buffer
-        # that spans the switch has one of its two record shapes read at the other's
-        # offsets -- field 24 (the kernel name) is the schema's only const char*, so it
-        # is the only field whose misparse faults; every misparsed numeric field is
-        # silently wrong. activity_flush_all() hands over COMPLETED buffers only and
-        # leaves the partially-filled one to refill under the new selection, so it must
-        # be the fence. Placement matters as much as the fence: the disable above is
-        # what stops the kind producing, so by here nothing is refilling the buffer the
-        # fence evacuates. No forced flush is involved.
+        # CUPTI requires cuptiActivityFlushAll(FORCED) between disabling a kind and
+        # re-enabling it with a different field selection (usage guide, User-Defined
+        # Activity Records). A completed buffer carries one layout per kind
+        # (ppRecordLayouts), so a buffer still filling at the switch would otherwise mix
+        # two record shapes under one layout: the kernel-name const char* misparses into
+        # a wild pointer and every numeric field is silently wrong. A plain flush cannot
+        # evacuate that buffer while any record in it is in progress, and under a
+        # concurrent launch load there always is one, so the flush must be forced. The
+        # device sync first completes every kernel in flight at the disable, so the
+        # forced flush hands back no zero-end record for them. Kernels of a kind that
+        # stays enabled and is launched by another thread between the sync and the flush
+        # can still come back with a zero end timestamp and lose their completion; that
+        # is a few records per reconfigure and is dwarfed by the kernels the disable
+        # itself leaves unrecorded. The disable above stops the changed kind producing,
+        # so nothing refills the buffer between the flush and the enable.
         if removed or changed:
-            self.flush(sync=True)
+            torch.cuda.synchronize()
+            self._cupti.activity_flush_all(forced=True)
         for kind in (*added, *changed):
             self._cupti.activity_enable(sub, kind, target[kind])
 

--- a/torch/profiler/_cuspy/cupti_python.py
+++ b/torch/profiler/_cuspy/cupti_python.py
@@ -56,6 +56,7 @@ LIBCUPTI_SONAME = "libcupti.so.13"
 # CUPTI C-API result/flag constants (cupti_result.h / cupti_activity.h). These
 # are stable ABI values, so they are spelled out rather than resolved.
 CUPTI_SUCCESS = 0
+CUPTI_ACTIVITY_FLAG_FLUSH_FORCED = 1
 
 # CUpti_ActivityAttribute selectors Cuspy sets on its subscription
 # (ActivityAttr.USER_DEFINED_RECORDS / .ENABLE_KERNEL_LATENCY_TIMESTAMPS /
@@ -407,13 +408,17 @@ class _PyLibCupti:
             ctypes.byref(val),
         )
 
-    def activity_flush_all(self) -> None:
-        """Hand over COMPLETED buffers only (``cuptiActivityFlushAll(0)``). Cuspy
-        never forces in-progress buffers (``CUPTI_ACTIVITY_FLAG_FLUSH_FORCED``): a
-        forced flush consumes a still-running kernel's record (its real completion is
-        then never re-delivered) and racing it against concurrent host activity is the
-        flush race that corrupts the HES heap and freezes the decode worker."""
-        self._check(self._lib.cuptiActivityFlushAll(0), "cuptiActivityFlushAll")
+    def activity_flush_all(self, *, forced: bool = False) -> None:
+        """``cuptiActivityFlushAll``. Plain (``forced=False``, flag 0) hands over buffers
+        whose records are all complete and leaves a buffer holding an in-progress record
+        with CUPTI. ``forced=True`` (``CUPTI_ACTIVITY_FLAG_FLUSH_FORCED``) hands over every
+        buffer, in-progress records included: a still-running kernel comes back with a
+        zero end timestamp and its completion is never re-delivered, so callers must
+        device-sync first. The CUPTI usage guide (User-Defined Activity Records, Usage)
+        makes the forced flush mandatory between disabling a kind and re-enabling it with
+        a different field selection; that is Cuspy's only forced flush."""
+        flag = CUPTI_ACTIVITY_FLAG_FLUSH_FORCED if forced else 0
+        self._check(self._lib.cuptiActivityFlushAll(flag), "cuptiActivityFlushAll")
 
     def activity_get_num_dropped_records(
         self, sub_handle: int, ctx: int, stream_id: int


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196548

CUPTI's usage guide (User-Defined Activity Records, Usage) requires
cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED) between disabling an
activity kind and re-enabling it with a different field selection. The monitor
has never issued that call. #186439 used a plain flush there, and #195172
replaced it with the flush(sync=True) fence, both on the grounds that forced
flushes were the dangerous option. _reconfigure now follows the documented
sequence: disable, device sync, forced flush, re-enable.

Root cause of the deviation: the monitor's docstrings attribute two hazards to
forced flushes. The first, a still-running kernel handed back with a zero end
timestamp and never re-delivered, is real. The second, host heap corruption
and a frozen decode worker, was carried over from the pre-multiplexer design
and matches the HW-trace bug later bisected on GB200 (NV6274883), which does
not depend on the flush flag. Meanwhile a plain flush cannot do what the
protocol needs: flag 0 withholds any buffer holding an in-progress record, and
under a concurrent launch load the buffer that straddles the selection change
always holds one. The fence's device sync does not fix that because other
threads keep launching, so its poll loop waits on the in-progress buffer,
which is where its cost comes from.

The device sync in front of the forced flush completes every kernel that was
in flight at the disable, so those come back with real end timestamps. Kernels
of a kind that stays enabled and is launched by another thread in the
microseconds between the sync and the flush can still come back with END=0
and lose their completion; that is a few records per reconfigure and is
smaller than what the disable itself leaves unrecorded. It is zero when the
kernel kind is among the changed kinds, which is the node-timer plus profiler
case.

Alternatives considered: keeping the fence and adding a forced flush after it
works but keeps the fence's cost; disabling every enabled kind around the
flush would remove the END=0 residue but toggling RUNTIME/DRIVER breaks
CUPTI's CUDA-graph kernel tracing, as noted in _reconfigure.

Test Plan:

A fuzz harness (2 threads launching tiny kernels plus a CUDA graph replay
thread, observers registered/unregistered every 20-200 ms, every decoded
kernel record validated, kernel-name pointers checked through /proc/self/mem
so a bad pointer counts instead of faulting) on 2x GB200, driver 580.126.20,
libcupti 13.3.75, HES off. The fence strategy below is the #195172 code; the
tree strategy is this commit's _reconfigure unmodified.

```
source agent_space/cupti_fuzz/env.sh
python agent_space/cupti_fuzz/run_matrix.py --seeds 3 --strategies tree,fence -- --prod 1 --threads 2 --graph 1 --duration 20 --toggle-min-ms 20 --toggle-max-ms 200
python agent_space/cupti_fuzz/run_matrix.py --seeds 6 --strategies tree -- --threads 2 --graph 1 --duration 8
python agent_space/cupti_fuzz/det2.py fence "+wide,-wide"
python agent_space/cupti_fuzz/det2.py tree "+wide,-wide"
```

Node-timer selection with the profiler selection toggling: fence 0 crashes,
0 bad names, 147 ms median / 1.6 s max per reconfigure, 7.4M kernel records
over 3x20 s; this commit 0 crashes, 0 bad names, 7.5 ms median / 18 ms max,
18.7M records. Five-field base toggled to the full 47-field kernel selection:
fence segfaults inside libcupti's worker thread in every run (11/11), this
commit 0 crashes and 0 bad names in 10 runs. A no-toggle baseline records
every launch with no bad names and no END=0 records, so all deficits come from
the reconfigure path.

```
python test/profiler/test_cuspy.py
```

has the same 30 environment failures at HEAD and with this commit on this
box (kineto in the CUDA 12.8 build holds the CUPTI subscriber). lintrunner is
clean on both files.

Ported from Edward Z. Yang's https://github.com/pytorch/pytorch/pull/195844,
rebased onto main for the _cupti -> _cuspy / CuptiMonitor -> Cuspy rename
(#195881). One change from the original: the torch.cuda.synchronize() is no
longer guarded by torch.cuda.is_available(). Reaching _reconfigure with kinds
to remove or change means a live CUPTI subscription over a real context, so
the guard cannot be false.

This commit was authored with the assistance of an AI coding assistant.