### PR TITLE
Skip WeakKeyDictionaryScriptObjectTestCase when torchbind lib is missing

### DIFF
--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -588,7 +588,14 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
         # Raises SkipTest when libtorchbind_test.so is absent, as on a wheel
         # install. It must run here: unittest ignores SkipTest from __init__.
         load_torchbind_test_lib()
+        self._build_fixtures()
 
+    # Under PYTORCH_TEST_WITH_DYNAMO the whole of `run()`, `setUp()` included,
+    # is compiled, and tracing the ScriptObject construction below fails with
+    # "haven't registered a fake class". Keep the fixtures out of the graph;
+    # they used to live in `__init__`, outside the compiled region.
+    @torch._dynamo.disable
+    def _build_fixtures(self):
         self.reference = self._reference().copy()
 
         # A (key, value) pair not in the mapping

--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -585,13 +585,9 @@ class WeakKeyDictionaryScriptObjectTestCase(TestCase):
         super().setUp()
         if IS_MACOS:
             raise unittest.SkipTest("non-portable load_library call used in test")
-
-    def __init__(self, *args, **kw):
-        unittest.TestCase.__init__(self, *args, **kw)
-        try:
-            load_torchbind_test_lib()
-        except unittest.SkipTest:
-            return  # Skip in setup
+        # Raises SkipTest when libtorchbind_test.so is absent, as on a wheel
+        # install. It must run here: unittest ignores SkipTest from __init__.
+        load_torchbind_test_lib()
 
         self.reference = self._reference().copy()
 


### PR DESCRIPTION
On a wheel install `libtorchbind_test.so` is absent, and
`WeakKeyDictionaryScriptObjectTestCase` neither passes nor skips: 8 of its 14
tests fail with `AttributeError: ... has no attribute 'reference'`.

The class already tries to skip, from `__init__`:

```python
try:
    load_torchbind_test_lib()
except unittest.SkipTest:
    return  # Skip in setup
```

unittest ignores `SkipTest` raised in `__init__`. The `return` skips nothing, it
just leaves the fixtures unbuilt. (The clause was dead until #193122 changed the
loader from `OSError` to `SkipTest`.)

Fix: load in `setUp`, where unittest acts on it. The fixtures can't follow --
`PYTORCH_TEST_WITH_DYNAMO` compiles `setUp` and tracing the
`_TorchScriptTesting._Foo` construction fails on the unregistered fake class --
so they move into a `torch._dynamo.disable`'d helper.

Verified on `2.15.0.dev20260909+xpu` (has #193122, no library): 8 failed 6 passed
-> 14 skipped, both eager and `PYTORCH_TEST_WITH_DYNAMO=1`. The library-present
path is covered by this PR's CI, which builds the test binaries -- `dynamo_wrapped`
runs `test_weak.py` and all 14 pass.

Fixes intel/torch-xpu-ops#5127

Authored with an AI assistant.
