### PR TITLE
[xpu][fix]Add XPU expected failure for log_sigmoid_forward in test_meta

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -913,6 +913,15 @@ meta_dispatch_device_expected_failures['cuda'] = {
     aten.upsample_nearest3d.vec: {f16},  # aten::upsample_nearest3d.vec
 }
 
+meta_dispatch_device_expected_failures['xpu'] = {
+    # The log_sigmoid_forward buffer output is device dependent: CPU returns
+    # exp(-|x|) for the backward pass while CUDA and XPU recompute it and
+    # return an empty tensor. A meta tensor has no device, so the decomp
+    # cannot pick the right shape. Same divergence as the 'cuda' entry above.
+    aten.log_sigmoid_forward.default: {bf16, f16, f64, f32},
+    aten.log_sigmoid_forward.output : {bf16, f16, f64, f32},  # aten::log_sigmoid_forward.output
+}
+
 meta_dispatch_device_skips['cpu'] = {
     aten._embedding_bag_forward_only.default: {bf16, f16, f32, f64},
 


### PR DESCRIPTION
#188963 turns on XPU for the `test_meta.py` crossref tests (`allow_xpu=True`).
Running that newly enabled `TestMetaXPU` surfaces a failure in
`log_sigmoid_forward`. Nothing regressed -- the divergence has always been
there, XPU just never ran these tests before.

### What the newly enabled test found

`log_sigmoid_forward` returns `(output, buffer)`, and `buffer` has a different
shape on different devices. CPU fills it in for the backward pass; CUDA and XPU
don't need it and return an empty `(0,)` tensor. The decomp picks by asking the
input what device it is on:

```python
if self.is_cuda or self.is_xpu:
    buffer = self.new_zeros((0,))
else:
    buffer = z
```

The crossref test runs the meta path on a plain meta tensor, which has no
device, so both checks are `False` and it takes the CPU branch. Meta says
`(5,)`, the real XPU kernel says `(0,)`, and the test fails:

```
RuntimeError: output 1: meta disagrees with real impl:
for element 1, was torch.Size([5]) but real shape was torch.Size([0])
```

### How CUDA handled it

CUDA has exactly the same divergence, and it was not fixed in the decomp --
a meta tensor has no device to check, and making all backends agree on `buffer`
would break BC. Instead it was declared an expected failure:

```python
meta_dispatch_device_expected_failures['cuda'] = {
    ...
    aten.log_sigmoid_forward.default: {bf16, f16, f64, f32},
    aten.log_sigmoid_forward.output : {bf16, f16, f64, f32},
}
```

### XPU follows

Add the same two entries under `'xpu'`. Dtypes came from
`PYTORCH_COLLECT_EXPECT=1`, not written by hand.

Nothing real is broken either way: a FakeTensor on xpu does report
`is_xpu=True`, so `torch.compile` and `export` get `(0,)` correctly. Only this
test, which uses device-less meta tensors, hits the bad branch.

This is inert on main until #188963 lands. The dict is a `defaultdict` read by
device type, so the new key is never looked up on a CPU or CUDA run.

### Test plan

`TestMetaXPU` doesn't exist yet, so I added `allow_xpu=True` locally (not in this
PR) and ran on an Intel BMG GPU with `2.15.0.dev20260909+xpu`.

```
python -m pytest -q test/test_meta.py -k "xpu and (logsigmoid or multilabel_soft_margin_loss)"
```

before: `16 failed, 8 passed, 28 skipped`
after: `24 passed, 28 skipped`

Then the whole XPU dispatch sweep, to be sure both entries are really hit and
neither turns into an `unexpected success`:

```
python -m pytest -q test/test_meta.py -k "xpu and (test_dispatch_meta_outplace or test_dispatch_symbolic_meta_outplace)"
38 failed, 13024 passed, 978 skipped, 182 xfailed
```

Those 38 were already failing before this change (`narrow_copy`, and
`tensordot` / `__rmatmul__` / `scaled_dot_product_attention` on int8/uint8).

```
lintrunner --skip CLANGTIDY,CLANGFORMAT test/test_meta.py
```

### Related

- Enabling PR that makes this test run on XPU: #188963
- Issue: intel/torch-xpu-ops#5020

Authored with an AI assistant.
