### PR TITLE
 [Feature Refactoring] Route MM TF32 heuristics through DeviceInterface.allow_tf32.

### DIFF
--- a/test/inductor/test_allow_tf32.py
+++ b/test/inductor/test_allow_tf32.py
@@ -1,34 +1,161 @@
 # Owner(s): ["module: inductor"]
 
+import unittest
+from unittest import mock
+
 import torch
 from torch._dynamo.device_interface import (
     CudaInterface,
+    device_interfaces,
     DeviceInterface,
+    register_interface_for_device,
     XpuInterface,
 )
+from torch._inductor.graph import GraphLowering
+from torch._inductor.heuristics.template.triton import MMTemplateConfigMixin
+from torch._inductor.ir import Buffer, FixedLayout
+from torch._inductor.kernel_inputs import MMKernelInputs
 from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.virtualized import V
+from torch.fx.experimental.proxy_tensor import make_fx
 
 
-class TestAllowTf32(TestCase):
+class _TensorNode:
+    def __init__(self, device: torch.device, size: tuple[int, ...] = (2, 2)) -> None:
+        self._device = device
+        self._size = size
+
+    def get_device(self) -> torch.device:
+        return self._device
+
+    def get_dtype(self) -> torch.dtype:
+        return torch.float32
+
+    def get_size(self) -> tuple[int, ...]:
+        return self._size
+
+    def get_stride(self) -> tuple[int, ...]:
+        return (self._size[-1], 1)
+
+
+class _AllowTf32Interface(DeviceInterface):
+    @staticmethod
+    def allow_tf32() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class TestAllowTf32Interface(TestCase):
     def test_device_interface_default_false(self):
         self.assertFalse(DeviceInterface.allow_tf32())
-        self.assertFalse(DeviceInterface.allow_tf32(size_threshold=True))
 
-    def test_cuda_allow_tf32_respects_threshold(self):
+    def test_cuda_allow_tf32_follows_fp32_precision(self):
         orig = torch.backends.cuda.matmul.fp32_precision
         try:
             torch.backends.cuda.matmul.fp32_precision = "tf32"
-            self.assertTrue(CudaInterface.allow_tf32(size_threshold=True))
-            self.assertFalse(CudaInterface.allow_tf32(size_threshold=False))
+            self.assertTrue(CudaInterface.allow_tf32())
             torch.backends.cuda.matmul.fp32_precision = "ieee"
-            self.assertFalse(CudaInterface.allow_tf32(size_threshold=True))
+            self.assertFalse(CudaInterface.allow_tf32())
         finally:
             torch.backends.cuda.matmul.fp32_precision = orig
 
     def test_xpu_allow_tf32_matches_mkldnn(self):
-        expected = torch.backends.mkldnn.allow_tf32
-        self.assertEqual(XpuInterface.allow_tf32(size_threshold=False), expected)
-        self.assertEqual(XpuInterface.allow_tf32(size_threshold=True), expected)
+        self.assertEqual(XpuInterface.allow_tf32(), torch.backends.mkldnn.allow_tf32)
+
+
+class TestAllowTf32ExtraKwargs(TestCase):
+    mixin = MMTemplateConfigMixin()
+
+    def setUp(self):
+        super().setUp()
+        self._prev_pua = device_interfaces.get("privateuseone")
+        gm = make_fx(lambda: torch.zeros(2, 2))()
+        self.graph = GraphLowering(gm)
+        self._graph_ctx = V.set_graph_handler(self.graph)
+        self._graph_ctx.__enter__()
+        self.addCleanup(self._graph_ctx.__exit__, None, None, None)
+
+    def tearDown(self):
+        if self._prev_pua is None:
+            device_interfaces.pop("privateuseone", None)
+        else:
+            device_interfaces["privateuseone"] = self._prev_pua
+        super().tearDown()
+
+    def _mm_kernel_inputs(
+        self, device_type: str, m: int = 2, n: int = 2, k: int = 2
+    ) -> MMKernelInputs:
+        device = torch.device(device_type)
+        mat1 = Buffer(
+            name="mat1",
+            layout=FixedLayout(device, torch.float32, (m, k)),
+        )
+        mat2 = Buffer(
+            name="mat2",
+            layout=FixedLayout(device, torch.float32, (k, n)),
+        )
+        return MMKernelInputs([mat1, mat2])
+
+    def test_registered_privateuse1_allow_tf32_true(self):
+        register_interface_for_device("privateuseone", _AllowTf32Interface)
+        kernel_inputs = self._mm_kernel_inputs("privateuseone")
+        extra = self.mixin.get_extra_kwargs(kernel_inputs, "mm")
+        self.assertTrue(extra["ALLOW_TF32"])
+
+    def test_unregistered_device_allow_tf32_false(self):
+        kernel_inputs = self._mm_kernel_inputs("cpu")
+        with mock.patch(
+            "torch._inductor.heuristics.template.triton.get_interface_for_device",
+            side_effect=NotImplementedError,
+        ):
+            extra = self.mixin.get_extra_kwargs(kernel_inputs, "mm")
+        self.assertFalse(extra["ALLOW_TF32"])
+
+    @mock.patch(
+        "torch._inductor.heuristics.template.triton.get_interface_for_device",
+        return_value=DeviceInterface,
+    )
+    def test_default_device_interface_allow_tf32_false(self, _mock_get_iface):
+        kernel_inputs = self._mm_kernel_inputs("privateuseone")
+        extra = self.mixin.get_extra_kwargs(kernel_inputs, "mm")
+        self.assertFalse(extra["ALLOW_TF32"])
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_cuda_small_shapes_disable_allow_tf32(self):
+        orig = torch.backends.cuda.matmul.fp32_precision
+        try:
+            torch.backends.cuda.matmul.fp32_precision = "tf32"
+            kernel_inputs = self._mm_kernel_inputs("cuda", m=2, n=2, k=2)
+            extra = self.mixin.get_extra_kwargs(kernel_inputs, "mm")
+            self.assertFalse(extra["ALLOW_TF32"])
+        finally:
+            torch.backends.cuda.matmul.fp32_precision = orig
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_cuda_large_shapes_enable_allow_tf32(self):
+        orig = torch.backends.cuda.matmul.fp32_precision
+        try:
+            torch.backends.cuda.matmul.fp32_precision = "tf32"
+            kernel_inputs = self._mm_kernel_inputs("cuda", m=64, n=1024, k=1024)
+            extra = self.mixin.get_extra_kwargs(kernel_inputs, "mm")
+            self.assertTrue(extra["ALLOW_TF32"])
+        finally:
+            torch.backends.cuda.matmul.fp32_precision = orig
+
+    def test_xpu_unaffected_by_cuda_shape_threshold(self):
+        kernel_inputs = self._mm_kernel_inputs("xpu", m=2, n=2, k=2)
+        with (
+            mock.patch.object(XpuInterface, "allow_tf32", return_value=True),
+            mock.patch(
+                "torch._inductor.heuristics.template.triton.get_interface_for_device",
+                return_value=XpuInterface,
+            ),
+        ):
+            extra = self.mixin.get_extra_kwargs(kernel_inputs, "mm")
+        self.assertTrue(extra["ALLOW_TF32"])
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_allow_tf32.py
+++ b/test/inductor/test_allow_tf32.py
@@ -1,0 +1,35 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch._dynamo.device_interface import (
+    CudaInterface,
+    DeviceInterface,
+    XpuInterface,
+)
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestAllowTf32(TestCase):
+    def test_device_interface_default_false(self):
+        self.assertFalse(DeviceInterface.allow_tf32())
+        self.assertFalse(DeviceInterface.allow_tf32(size_threshold=True))
+
+    def test_cuda_allow_tf32_respects_threshold(self):
+        orig = torch.backends.cuda.matmul.fp32_precision
+        try:
+            torch.backends.cuda.matmul.fp32_precision = "tf32"
+            self.assertTrue(CudaInterface.allow_tf32(size_threshold=True))
+            self.assertFalse(CudaInterface.allow_tf32(size_threshold=False))
+            torch.backends.cuda.matmul.fp32_precision = "ieee"
+            self.assertFalse(CudaInterface.allow_tf32(size_threshold=True))
+        finally:
+            torch.backends.cuda.matmul.fp32_precision = orig
+
+    def test_xpu_allow_tf32_matches_mkldnn(self):
+        expected = torch.backends.mkldnn.allow_tf32
+        self.assertEqual(XpuInterface.allow_tf32(size_threshold=False), expected)
+        self.assertEqual(XpuInterface.allow_tf32(size_threshold=True), expected)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -217,6 +217,10 @@ class DeviceInterface:
         """
         return cls.Stream is not DeviceInterface.Stream
 
+    @staticmethod
+    def allow_tf32(*, size_threshold: bool = True) -> bool:
+        return False
+
     @classmethod
     def get_multi_processor_count(cls, device: torch.types.Device = None) -> int:
         """Return the number of compute units, used for occupancy /
@@ -367,6 +371,12 @@ class CudaInterface(DeviceInterface):
         return (
             torch.version.hip is not None
             or CudaInterface.Worker.get_device_properties(device).major >= 7
+        )
+
+    @staticmethod
+    def allow_tf32(*, size_threshold: bool = True) -> bool:
+        return (
+            torch.backends.cuda.matmul.fp32_precision == "tf32" and size_threshold
         )
 
     @staticmethod
@@ -585,6 +595,10 @@ class XpuInterface(DeviceInterface):
     @staticmethod
     def is_triton_capable(device: torch.types.Device = None) -> bool:
         return True
+
+    @staticmethod
+    def allow_tf32(*, size_threshold: bool = True) -> bool:
+        return torch.backends.mkldnn.allow_tf32
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -218,7 +218,13 @@ class DeviceInterface:
         return cls.Stream is not DeviceInterface.Stream
 
     @staticmethod
-    def allow_tf32(*, size_threshold: bool = True) -> bool:
+    def allow_tf32() -> bool:
+        """Whether the backend permits reduced-precision FP32 matmul in Triton.
+
+        For third-party Triton backends this reflects the backend-specific
+        reduced-precision FP32 mode (not necessarily NVIDIA TF32). Inductor
+        may apply additional shape heuristics at the call site.
+        """
         return False
 
     @classmethod
@@ -374,10 +380,8 @@ class CudaInterface(DeviceInterface):
         )
 
     @staticmethod
-    def allow_tf32(*, size_threshold: bool = True) -> bool:
-        return (
-            torch.backends.cuda.matmul.fp32_precision == "tf32" and size_threshold
-        )
+    def allow_tf32() -> bool:
+        return torch.backends.cuda.matmul.fp32_precision == "tf32"
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
@@ -597,7 +601,7 @@ class XpuInterface(DeviceInterface):
         return True
 
     @staticmethod
-    def allow_tf32(*, size_threshold: bool = True) -> bool:
+    def allow_tf32() -> bool:
         return torch.backends.mkldnn.allow_tf32
 
     @staticmethod

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -2412,20 +2412,21 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
     ) -> dict[str, Any]:
         if not isinstance(kernel_inputs, MMKernelInputs):
             raise AssertionError(f"Expected MMKernelInputs, got {type(kernel_inputs)}")
-        m, n, k = kernel_inputs.mnk_symbolic()
         device_type = kernel_inputs.device_type
-        size_threshold = True
+        try:
+            iface = get_interface_for_device(device_type)
+            allow_tf32 = iface.allow_tf32()
+        except NotImplementedError:
+            allow_tf32 = False
+
         if device_type == "cuda":
+            m, n, k = kernel_inputs.mnk_symbolic()
             # allow_tf32 alignment heuristics based on reverse engineering
             # H100 CUDA 12.8 behavior
             size_threshold = V.graph.sizevars.statically_known_true(
                 sympy.And(sympy.Ge(m, 16), sympy.Ge(Min(n, k), 512))
             )
-        try:
-            iface = get_interface_for_device(device_type)
-            allow_tf32 = iface.allow_tf32(size_threshold=size_threshold)
-        except NotImplementedError:
-            allow_tf32 = False
+            allow_tf32 = allow_tf32 and size_threshold
 
         extra_kwargs = {
             "ALLOW_TF32": allow_tf32,

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -12,6 +12,7 @@ from typing import Any, TYPE_CHECKING
 import sympy
 
 import torch
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.heuristics.registry import register_template_heuristic
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import Min, Mod
@@ -2413,19 +2414,17 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
             raise AssertionError(f"Expected MMKernelInputs, got {type(kernel_inputs)}")
         m, n, k = kernel_inputs.mnk_symbolic()
         device_type = kernel_inputs.device_type
-        if device_type == "xpu":
-            # XPU eager matmul takes TF32 from the oneDNN flag, not the CUDA one.
-            allow_tf32 = torch.backends.mkldnn.allow_tf32
-        elif device_type == "cuda":
+        size_threshold = True
+        if device_type == "cuda":
             # allow_tf32 alignment heuristics based on reverse engineering
             # H100 CUDA 12.8 behavior
             size_threshold = V.graph.sizevars.statically_known_true(
                 sympy.And(sympy.Ge(m, 16), sympy.Ge(Min(n, k), 512))
             )
-            allow_tf32 = (
-                torch.backends.cuda.matmul.fp32_precision == "tf32" and size_threshold
-            )
-        else:
+        try:
+            iface = get_interface_for_device(device_type)
+            allow_tf32 = iface.allow_tf32(size_threshold=size_threshold)
+        except NotImplementedError:
             allow_tf32 = False
 
         extra_kwargs = {


### PR DESCRIPTION
## Summary

MM template heuristics directly read CUDA and XPU backend flags, so an
out-of-tree backend cannot provide its reduced-precision FP32 matmul policy.

Add `DeviceInterface.allow_tf32()` so registered backends can opt in.
Inductor keeps CUDA's existing shape threshold at the call site; the interface
only reflects backend/user FP32 precision policy.

For third-party Triton backends, `allow_tf32` means whether the MM template may
use the backend's reduced-precision FP32 matmul mode (HF32, TF32, etc.); the
actual format is backend-defined. The Triton template kwarg remains `ALLOW_TF32`.

## Changes

- Add a conservative `DeviceInterface.allow_tf32()` capability (default `False`).
- `CudaInterface`: `torch.backends.cuda.matmul.fp32_precision == "tf32"`.
- `XpuInterface`: `torch.backends.mkldnn.allow_tf32`.
- `MMTemplateConfigMixin.get_extra_kwargs`: resolve policy via
  `get_interface_for_device`, then apply CUDA-only shape heuristic
  (`m >= 16 and min(n, k) >= 512`) in Inductor.
- Unsupported/unregistered devices stay disabled.

## Test Plan

```
python test/inductor/test_allow_tf32.py -v
```

Covers:
- Base/CUDA/XPU interface policy
- Registered PrivateUse1 interface -> `ALLOW_TF32=True` via `get_extra_kwargs`
- Unregistered device and default interface -> `False`
- CUDA small shapes disable TF32 even when policy is on
- CUDA large shapes enable TF32 when policy is on
- XPU unaffected by CUDA shape threshold



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98