### PR TITLE
Allow FakeTensorMode KeyedRefs in swap_tensors

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3314,12 +3314,53 @@ class FakeTensorOperatorInvariants(TestCase):
 
         self.assertEqual(mode.count, 0)
 
-    # PropagateRealTensors installs weakrefs
+    def _assert_only_keyedref_weakrefs(self, tensors):
+        keyed_ref = getattr(weakref, "KeyedRef", None)
+        if keyed_ref is None:
+            return
+        for t in tensors:
+            refs = weakref.getweakrefs(t)
+            self.assertTrue(refs)
+            self.assertTrue(all(isinstance(r, keyed_ref) for r in refs))
+
+    @unittest.skipIf(
+        getattr(weakref, "KeyedRef", None) is None,
+        "weakref.KeyedRef is a CPython-only private attribute",
+    )
+    def test_swap_tensors_allows_mode_memo_keyedref(self):
+        # FakeTensorMode memos FakeTensors in a WeakValueDictionary, which
+        # attaches KeyedRef weakrefs. Those must not block swap_tensors, or
+        # Module.to() fails with "_apply(): Couldn't swap Linear.weight".
+        keyed_ref = weakref.KeyedRef
+        with FakeTensorMode():
+            t1 = torch.nn.Parameter(torch.randn(2, 2))
+            t2 = torch.nn.Parameter(torch.randn(3, 3))
+            refs1 = weakref.getweakrefs(t1)
+            refs2 = weakref.getweakrefs(t2)
+            self.assertTrue(refs1)
+            self.assertTrue(refs2)
+            self.assertTrue(all(isinstance(r, keyed_ref) for r in refs1))
+            self.assertTrue(all(isinstance(r, keyed_ref) for r in refs2))
+            wr = weakref.ref(t1)
+            with self.assertRaisesRegex(RuntimeError, "has weakref"):
+                torch.utils.swap_tensors(t1, t2)
+            del wr
+            id1, id2 = id(t1), id(t2)
+            shape1, shape2 = tuple(t1.shape), tuple(t2.shape)
+            torch.utils.swap_tensors(t1, t2)
+            self.assertEqual(id(t1), id1)
+            self.assertEqual(id(t2), id2)
+            self.assertEqual(tuple(t1.shape), shape2)
+            self.assertEqual(tuple(t2.shape), shape1)
+
+    # The PropagateRealTensors clone of this test used to xfail because that
+    # mode also memos tensors (KeyedRef). Those refs are the same kind this
+    # swap_tensors change allows, so the clone is expected to pass. The
+    # KeyedRef asserts below run in both the base test and that clone.
     @unittest.skipIf(
         IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW,
         "https://github.com/pytorch/pytorch/issues/165387",
     )
-    @expectedFailurePropagateRealTensors
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_module_to(self):
         def _check_device(sd, device_type):
@@ -3328,9 +3369,11 @@ class FakeTensorOperatorInvariants(TestCase):
 
         with FakeTensorMode():
             m = torch.nn.Linear(2, 2)
+            self._assert_only_keyedref_weakrefs(m.parameters())
             _check_device(m.state_dict(), "cpu")
             m.to("cuda")
             _check_device(m.state_dict(), "cuda")
+            self._assert_only_keyedref_weakrefs(m.parameters())
 
 
 make_propagate_real_tensors_cls(FakeTensorOperatorInvariants)

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -32,6 +32,18 @@ def set_module(obj, mod):
 cmake_prefix_path = _osp.join(_osp.dirname(_osp.dirname(__file__)), "share", "cmake")
 
 
+def _has_blocking_weakrefs(t):
+    # WeakValueDictionary (FakeTensorMode / MetaConverter tensor_memo) attaches
+    # KeyedRef weakrefs that track Python object identity. swap_tensors keeps
+    # that identity, so those refs stay valid. Other weakrefs still block.
+    keyed_ref = getattr(weakref, "KeyedRef", None)
+    for ref in weakref.getweakrefs(t):
+        if keyed_ref is not None and isinstance(ref, keyed_ref):
+            continue
+        return True
+    return False
+
+
 def swap_tensors(t1, t2):
     """
     This function swaps the content of the two Tensor objects.
@@ -40,10 +52,9 @@ def swap_tensors(t1, t2):
 
     This will not work if t1 and t2 have different slots.
     """
-    # Ensure there are no weakrefs
-    if weakref.getweakrefs(t1):
+    if _has_blocking_weakrefs(t1):
         raise RuntimeError("Cannot swap t1 because it has weakref associated with it")
-    if weakref.getweakrefs(t2):
+    if _has_blocking_weakrefs(t2):
         raise RuntimeError("Cannot swap t2 because it has weakref associated with it")
     t1_slots = set(copyreg._slotnames(t1.__class__))  # type: ignore[attr-defined]
     t2_slots = set(copyreg._slotnames(t2.__class__))  # type: ignore[attr-defined]


### PR DESCRIPTION
# Fixing an Issue

Before submitting, please review:
- [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy

---

## Issue

Tracked by #195996 (do not close that umbrella). Failing test: `test/test_fake_tensor.py::FakeTensorOperatorInvariants::test_module_to`. Related: #170770, Linux skip kept for #165387.

## Summary

Fixes `FakeTensorOperatorInvariants.test_module_to` in NVIDIA Windows-on-Arm CUDA CI.

The failure occurs when `nn.Module.to("cuda")` runs inside `FakeTensorMode`. `Module._apply` uses `swap_tensors` for FakeTensor parameters. `swap_tensors` assumed any Python weakref is unsafe, which causes `_apply(): Couldn't swap Linear.weight` because FakeTensorMode's `WeakValueDictionary` memo attaches `weakref.KeyedRef`.

This PR lets `swap_tensors` ignore `KeyedRef` and still reject every other weakref. The change is correct because a KeyedRef only tracks Python object identity, and `swap_tensors` preserves that identity.

## Failure evidence

- NVIDIA pytorch-windows-ci Actions run: the first-failing public job URL is not available for this node id. The signature was reproduced on Windows ARM64 + CUDA (N1X) with the same `run_test.py` path used by NVIDIA WoA CI.
- Failed Actions job or shard: n/a; NVIDIA internal WoA shards ran `test_fake_tensor.py` including `test_module_to` after this change and the file was successful.
- PyTorch commit or nightly build: reproduced against pytorch-dev main of that night, CUDA 13.4 / CPython 3.13 WoA wheel
- Platform: Windows 11 ARM64 (N1X / RTX Spark), CUDA
- Python and relevant dependencies: CPython 3.13, CUDA 13.4
- Failing test: `test/test_fake_tensor.py::FakeTensorOperatorInvariants::test_module_to`
- Error signature: `RuntimeError: _apply(): Couldn't swap Linear.weight` caused by `Cannot swap t1 because it has weakref associated with it`
- Tracked by https://github.com/pytorch/pytorch/issues/195996
- Dedicated upstream issue, if any: #170770 (same FakeTensor + `swap_tensors` weakref class; this PR only allows `KeyedRef`, not `WeakIdRef` or user `weakref.ref`)

## Root cause

Under FakeTensorMode, parameters live in a `WeakValueDictionary` memo, so CPython attaches `weakref.KeyedRef`. `swap_tensors` treated every weakref as blocking, so `Module._apply` could not swap FakeTensor parameters onto CUDA.

## Changes

- `torch.utils.swap_tensors`: skip `weakref.KeyedRef`; keep blocking `weakref.ref` and other refs
- Tests: KeyedRef swap path, mixed user weakref still raises, `test_module_to` asserts KeyedRefs before/after `.to("cuda")`, drop `expectedFailurePropagateRealTensors` on that test

## Test plan

Before this change:
Command: `python test/test_fake_tensor.py FakeTensorOperatorInvariants.test_module_to -v`
Result: `RuntimeError: _apply(): Couldn't swap Linear.weight` on WoA N1X CUDA

After this change:
Command: `python test/test_fake_tensor.py FakeTensorOperatorInvariants.test_module_to FakeTensorOperatorInvariants.test_swap_tensors_allows_mode_memo_keyedref PropagateRealTensorsFakeTensorOperatorInvariants.test_module_to_propagate_real_tensors PropagateRealTensorsFakeTensorOperatorInvariants.test_swap_tensors_allows_mode_memo_keyedref_propagate_real_tensors`
Result: pass on WoA N1X CUDA

Nearby: `python test/test_torch.py TestTorch.test_swap_basic TestTorch.test_swap_fail_slots` pass.

NVIDIA internal WoA CI (CUDA 13.4, Python 3.13, 5 test shards) was green after this change; shard 1 ran `test_fake_tensor.py` including `test_module_to`.

Lint: `lintrunner -a --skip PYREFLY torch/utils/__init__.py test/test_fake_tensor.py` from WSL2. Only FLAKE8 EXE002 (drvfs marks files executable); no code findings on these two files.

## Checklist

- [x] Passes lint (`lintrunner -a` from WSL2 on the changed files; PYREFLY skipped locally because this WSL tree has no built torch)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. User `weakref.ref` on a tensor still cannot be swapped. Only CPython `KeyedRef` from `WeakValueDictionary` is allowed.

## Reviewer notes

This is not `allow_weakrefs=True` on `Module._apply` (see #187090). Relaxing every weakref has been reverted before. KeyedRef is identity-only and stays valid across swap.

Linux `test_module_to` remains skipped for #165387.

Draft until internal reviewers on winai/pytorch-dev MR 10 sign off if that is still required by the Windows CI fix process.
