### PR TITLE
[Feature Refactoring] Replace torch.cuda.current_device() in ShardedTensor.device fallback

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -51,7 +51,7 @@ def tensor_device(types, args=(), kwargs=None, pg=None):
     elif pg and pg._get_backend_name() == "gloo":
         dev = torch.device("cpu")
     else:
-        dev = torch.device(torch.cuda.current_device())
+        dev = self_st._get_preferred_device()
     return dev
 
 


### PR DESCRIPTION
## Summary

Replace the hard-coded `torch.cuda.current_device()` call in the `ShardedTensor.device` fallback path with `self_st._get_preferred_device()`, allowing out-of-tree accelerator backends to resolve the correct device.

## Changes

- **`torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py`**: In the `tensor_device` function (line 54), replaced `torch.device(torch.cuda.current_device())` with `self_st._get_preferred_device()`.

## Motivation

The `tensor_device` function returns the device of a `ShardedTensor`. When the tensor has no local shards and the process group is non-gloo, the code previously fell back to `torch.cuda.current_device()`, which crashes on non-CUDA accelerator backends. The existing method `ShardedTensor._get_preferred_device()` (defined at `api.py:371`) already handles NCCL/CUDA, GLOO/CPU, and custom backends — the same method is used by `ShardedTensor.to()` and `ShardedTensor._get_preferred_device()` in `api.py`. This change simply reuses that logic in the fallback path, keeping the NCCL path strictly equivalent.

## Test Plan

- `python test/distributed/_shard/sharded_tensor/test_sharded_tensor.py TestShardTensor TestLocalTensor`