### PR TITLE
Widen FSDP param group stream type annotations to torch.Stream

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -205,7 +205,7 @@ class FSDPParamGroup:
         # Optional stream to run the user-defined all-reduce hook in
         # Saved here and not in the comm. context because we allow the user to
         # specify it, possibly at construction time before lazy init
-        self._all_reduce_hook_stream: torch.cuda.Stream | None = None
+        self._all_reduce_hook_stream: torch.Stream | None = None
 
         # - Communication and communication/computation overlap
         self.comm_ctx = FSDPCommContext()
@@ -688,7 +688,7 @@ class FSDPParamGroup:
                     if isinstance(self.mesh_info, DDPMeshInfo)
                     else None
                 )
-                all_reduce_stream: torch.cuda.Stream
+                all_reduce_stream: torch.Stream
                 if all_reduce_pg is None and self._all_reduce_hook_stream is not None:
                     # this means the native HSDP is not enabled,
                     # but user may want to have a custom HSDP setup


### PR DESCRIPTION
## Summary

Widen the type annotations of `_all_reduce_hook_stream` and `all_reduce_stream` in `FSDPParamGroup` from `torch.cuda.Stream` to `torch.Stream`, allowing out-of-tree accelerator backends to pass their own `Stream` subtypes through FSDP's all-reduce hook path.

## Changes

- **`torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py`**: L208 `self._all_reduce_hook_stream: torch.cuda.Stream | None` → `torch.Stream | None`
- **`torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py`**: L691 `all_reduce_stream: torch.cuda.Stream` → `torch.Stream`

## Motivation

`torch.cuda.Stream` in the type annotations restricts the all-reduce hook stream to CUDA only, even though all device-specific Stream classes inherit from the base `torch.Stream`. Non-CUDA accelerator backends that provide their own Stream subtype would hit a type annotation mismatch. Widening to `torch.Stream` is strictly compatible — CUDA Stream is a subclass — and lets any backend's Stream flow through the hook path unchanged.

## Test Plan

- `python test/distributed/fsdp/test_fsdp_hybrid_shard.py TestFSDPHybridShard`
- `python test/distributed/fsdp/test_fsdp_core.py TestHooks`