### PR TITLE
[Feature Refactoring]Replace torch.cuda.synchronize with torch.accelerator in powerSGD_hook

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import torch
 import torch.distributed as dist
+from torch._dynamo.device_interface import get_interface_for_device
 from torch.distributed import distributed_c10d
 from torch.utils._typing_utils import not_none
 
@@ -627,8 +628,12 @@ def powerSGD_hook(
                 for i, original_tensor in enumerate(original_tensors):
                     original_tensor.copy_(tensor[i])
 
-        if torch.cuda.is_available():
-            torch.cuda.synchronize(device)
+        try:
+            device_interface = get_interface_for_device(device.type)
+            if device_interface.is_available():
+                device_interface.synchronize(device)
+        except NotImplementedError:
+            pass
 
         if state.use_error_feedback:
             # Memorize the local errors.
@@ -851,8 +856,12 @@ def batched_powerSGD_hook(
             state.error_dict[bucket_index] = input_tensor_cp - input_tensor
         # Removing this seemingly unnecessary sync somehow may cause failures.
         # See: https://github.com/pytorch/pytorch/pull/54838
-        if torch.cuda.is_available():
-            torch.cuda.synchronize(device)
+        try:
+            device_interface = get_interface_for_device(device.type)
+            if device_interface.is_available():
+                device_interface.synchronize(device)
+        except NotImplementedError:
+            pass
         if not state.warm_start:
             state.p_memory_dict.clear()
             state.q_memory_dict.clear()

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 import torch
 import torch.distributed as dist
-from torch._dynamo.device_interface import get_interface_for_device
 from torch.distributed import distributed_c10d
 from torch.utils._typing_utils import not_none
 
@@ -628,12 +627,8 @@ def powerSGD_hook(
                 for i, original_tensor in enumerate(original_tensors):
                     original_tensor.copy_(tensor[i])
 
-        try:
-            device_interface = get_interface_for_device(device.type)
-            if device_interface.is_available():
-                device_interface.synchronize(device)
-        except NotImplementedError:
-            pass
+        if torch.accelerator.is_available():
+            torch.accelerator.synchronize(device)
 
         if state.use_error_feedback:
             # Memorize the local errors.
@@ -856,12 +851,8 @@ def batched_powerSGD_hook(
             state.error_dict[bucket_index] = input_tensor_cp - input_tensor
         # Removing this seemingly unnecessary sync somehow may cause failures.
         # See: https://github.com/pytorch/pytorch/pull/54838
-        try:
-            device_interface = get_interface_for_device(device.type)
-            if device_interface.is_available():
-                device_interface.synchronize(device)
-        except NotImplementedError:
-            pass
+        if torch.accelerator.is_available():
+            torch.accelerator.synchronize(device)
         if not state.warm_start:
             state.p_memory_dict.clear()
             state.q_memory_dict.clear()


### PR DESCRIPTION
## Summary

Replace the hard-coded `torch.cuda.is_available()` + `torch.cuda.synchronize(device)` calls in both `powerSGD_hook` and `batched_powerSGD_hook` with `torch.accelerator.is_available()` + `torch.accelerator.synchronize(device)`, allowing any registered accelerator backend to get proper device synchronization.

## Changes

- **`torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py`**: In `powerSGD_hook` decompress closure, replace `torch.cuda.is_available()` + `torch.cuda.synchronize(device)` with `torch.accelerator.is_available()` + `torch.accelerator.synchronize(device)`.
- **`torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py`**: Apply the same replacement in `batched_powerSGD_hook` decompress closure.

## Motivation

The PowerSGD compression/decompression path calls `torch.cuda.synchronize(device)` guarded by `torch.cuda.is_available()`, which silently skips synchronization on non-CUDA accelerator backends even when those backends support device synchronization. Using `torch.accelerator` resolves the correct accelerator for the tensor's device, so any registered backend gets proper synchronization. In DDP scenarios the gradient bucket device type always matches the current accelerator type, so the semantics are strictly equivalent to the original CUDA-only path.

## Test Plan

- `python test/distributed/test_c10d_nccl.py DistributedDataParallelTest.test_powerSGD_ddp_comm_hook_nccl`
- `python test/distributed/test_c10d_nccl.py DistributedDataParallelTest.test_powerSGD_ddp_comm_hook_nccl_grad_is_view`