### PR TITLE
Do not leak check_mutable_operations when TestFX.setUp fails

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -268,16 +268,19 @@ def _parse_profiler_trace_lines(traces: str) -> list[tuple[str, str, str]]:
 class TestFX(JitTestCase):
     def setUp(self):
         super().setUp()
+        if not (IS_FBCODE or IS_WINDOWS or IS_MACOS):
+            lib_file_path = find_library_location("libtorchbind_test.so")
+            torch.ops.load_library(str(lib_file_path))
+
         # Checking for mutable operations while tracing is feature flagged
-        # Enable it in testing but not by default
+        # Enable it in testing but not by default. check_mutable_operations is
+        # process-global and is only restored in tearDown, which unittest skips
+        # when setUp raises -- so this must stay the last statement of setUp, or
+        # a failure above would leak it into every later test in the process.
         self.orig_tracer_mutable_flag = (
             torch.fx.proxy.TracerBase.check_mutable_operations
         )
         torch.fx.proxy.TracerBase.check_mutable_operations = True
-
-        if not (IS_FBCODE or IS_WINDOWS or IS_MACOS):
-            lib_file_path = find_library_location("libtorchbind_test.so")
-            torch.ops.load_library(str(lib_file_path))
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
`TestFX.setUp` flips the process-global `torch.fx.proxy.TracerBase.check_mutable_operations` to `True` and restores it only in `tearDown`, but it does that *before* loading `libtorchbind_test.so`. That load raises `OSError` on installs that do not ship the test-only library (wheels, since 2.13), and unittest skips `tearDown` when `setUp` raises — so the flag stays `True` for the rest of the process and every later test tracing an in-place op fails with `RuntimeError: Tried to trace mutable operation ...`.

Moving the load above the flip makes the flip the last statement of `setUp`, matching the four other classes in this file. The `TestFX` failures from the missing library are unchanged and out of scope.

## Test plan

On a wheel without `libtorchbind_test.so`, with the poisoning case ahead of `TestCommonPass` in the same process:

```
python -m pytest -q -p no:randomly \
    test/test_fx.py::TestFX::test_all_input_nodes \
    test/fx/test_common_passes.py -k "all_input_nodes or Mutation"
```

before: `6 failed` — after: `1 failed, 5 passed`

The remaining failure is `TestFX::test_all_input_nodes` on the missing library, before and after. The five newly passing cases are all `_cpu`.


Fixes https://github.com/intel/torch-xpu-ops/issues/4455

Authored with an AI assistant.
