### PR TITLE
[Auto] Fix #194062: [inductor] [silent incorrectness] torch.full ignores dtype when fill_value is sy

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -991,13 +991,10 @@ class TestPatternMatcher(TestCase):
         def unbacked(x):
             return torch.full((2,), x.item(), dtype=dtype).cumsum(0).sum()
 
-        x = torch.tensor(3)
+        x = torch.tensor(0)
         result, (code,) = run_and_get_code(torch.compile(unbacked, fullgraph=True), x)
         self.assertEqual(result, unbacked(x))
-        if dtype == torch.bool:
-            self.assertNotIn("aten.cumsum", code)  # exempt, so this one still folds
-        else:
-            self.assertIn("aten.cumsum", code)
+        self.assertIn("aten.cumsum", code)
 
         def make(fill):
             def fn():

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -496,6 +496,15 @@ class TestInductorDynamic(DynamicShapesTestCase):
         opt_r = opt_f(splits)
         self.assertEqual(r, opt_r)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    @parametrize("fill_value", (0, 3))
+    def test_full_symbolic_fill_respects_dtype(self, device, fill_value):
+        def f(x):
+            return torch.full((2,), x.item(), dtype=torch.bool, device=device).sum()
+
+        x = torch.tensor(fill_value, device=device)
+        self.assertEqual(torch.compile(f, fullgraph=True)(x), f(x))
+
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
     def test_nonzero_size_factory_nobreak(self, device):
         def f(x, b):

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -45,8 +45,9 @@ from torch.utils._sympy.reference import (
 from torch.utils._sympy.singleton_int import SingletonInt
 from torch.utils._sympy.solve import INEQUALITY_TYPES, mirror_rel_op, try_solve
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
+from torch._inductor.analyze_preserves_zero_mask import PreservesZeros
 from torch._inductor.bounds import ValueRangeAnalysis
-from torch._inductor.index_propagation import TypedExpr
+from torch._inductor.index_propagation import SymPyOps, TypedExpr
 
 
 UNARY_OPS = [
@@ -1269,6 +1270,27 @@ class TestTypedExpr(TestCase):
         I = Identity(1)
         typed_I = TypedExpr(I, torch.int32)
         self.assertEqual(typed_I.expr, 1)
+
+    def test_symbolic_to_dtype_requires_fallback(self):
+        value = TypedExpr(sympy.Symbol("x", integer=True), torch.int64)
+        self.assertIs(SymPyOps.to_dtype(value, torch.bool), NotImplemented)
+        self.assertEqual(SymPyOps.to_dtype(value, torch.int64), value)
+        self.assertEqual(
+            SymPyOps.to_dtype(TypedExpr(3, torch.int64), torch.bool),
+            TypedExpr(True, torch.bool),
+        )
+
+    def test_preserves_zeros_to_dtype(self):
+        analysis = PreservesZeros()
+        value = analysis.to_dtype(TypedExpr(0, torch.int64), torch.bool)
+        analysis.store("output", sympy.S.Zero, value)
+        self.assertTrue(analysis.store_preserves_zeros)
+
+        analysis = PreservesZeros()
+        symbol = sympy.Symbol("x", integer=True)
+        value = analysis.to_dtype(TypedExpr(symbol, torch.int64), torch.bool)
+        analysis.store("output", sympy.S.Zero, value)
+        self.assertFalse(analysis.store_preserves_zeros)
 
 
 class TestCCodePrinting(TestCase):

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -41,13 +41,13 @@ class PreservesZeros(SymPyOps, DefaultHandler):
 
     @staticmethod
     def to_dtype(
-        value: TypedExpr,
+        x: TypedExpr,
         dtype: torch.dtype,
         src_dtype: torch.dtype | None = None,
-        use_compute_types: bool = False,
+        use_compute_types: bool = True,
     ) -> TypedExpr:
         # Casts preserve zero, while unknown values remain unknown to this analysis.
-        return TypedExpr(value.expr, dtype)
+        return TypedExpr(x.expr, dtype)
 
     def store(
         self, name: str, index: sympy.Expr, value: TypedExpr, mode: "StoreMode" = None

--- a/torch/_inductor/analyze_preserves_zero_mask.py
+++ b/torch/_inductor/analyze_preserves_zero_mask.py
@@ -39,6 +39,16 @@ class PreservesZeros(SymPyOps, DefaultHandler):
             sympy.Float(0) if dtype.is_floating_point else sympy.Integer(0), dtype
         )
 
+    @staticmethod
+    def to_dtype(
+        value: TypedExpr,
+        dtype: torch.dtype,
+        src_dtype: torch.dtype | None = None,
+        use_compute_types: bool = False,
+    ) -> TypedExpr:
+        # Casts preserve zero, while unknown values remain unknown to this analysis.
+        return TypedExpr(value.expr, dtype)
+
     def store(
         self, name: str, index: sympy.Expr, value: TypedExpr, mode: "StoreMode" = None
     ) -> None:

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1037,14 +1037,8 @@ def pointless_cumsum_check(match: Match) -> bool:
     if len(match.kwargs["shape"]) == 0:
         return False
     # A symbolic fill_value arrives as an fx Node, which the replacement's int() and
-    # * both reject. A boolean full stays folded: bool(Node) is True, the right
-    # saturation for every nonzero fill and the wrong one for a zero fill, but
-    # declining is worse today - inductor's own full(..., dtype=bool) lowering drops
-    # the bool cast for a symbolic int fill (#194062). Drop the exemption when that
-    # lands.
-    return is_boolean_dtype(match.kwargs["dtype"]) or not isinstance(
-        match.kwargs["fill_value"], torch.fx.Node
-    )
+    # * both reject.
+    return not isinstance(match.kwargs["fill_value"], torch.fx.Node)
 
 
 @register_graph_pattern(

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -108,6 +108,9 @@ class SymPyOps:
         src_dtype: torch.dtype | None = None,
         use_compute_types: bool = False,
     ) -> TypedExpr:
+        # Retagging a symbolic expression would erase a value-changing cast.
+        if not value.is_constant() and value.dtype != dtype:
+            return NotImplemented
         return TypedExpr(value.expr, dtype)
 
     @staticmethod


### PR DESCRIPTION
## Automated draft for #194062

Issue: #194062 - [inductor] [silent incorrectness] torch.full ignores dtype when fill_value is symbolic

> @mlazos, please review this Codex-generated draft. It has not yet received human review and must not be marked ready or merged until you have validated it.

Fixes #194062


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo