### PR TITLE
[DCP]Resolve default device_type from current accelerator in optimizer.py helpers

### DIFF
--- a/test/distributed/checkpoint/test_optimizer.py
+++ b/test/distributed/checkpoint/test_optimizer.py
@@ -1,0 +1,62 @@
+# Owner(s): ["oncall: distributed checkpoint"]
+
+from unittest import mock
+
+import torch
+import torch.distributed.checkpoint.optimizer as dcp_optimizer
+from torch.distributed.checkpoint.metadata import TensorProperties
+from torch.distributed.checkpoint.optimizer import _alloc_tensor, _gen_rank_device
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
+
+
+class TestOptimizerDeviceDefaults(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
+    # All default-path tests patch torch.accelerator.current_accelerator:
+    # on a GPU CI machine it would resolve to cuda and break determinism.
+
+    def test_gen_rank_device_explicit_cpu(self):
+        self.assertEqual(_gen_rank_device(3, "cpu"), "cpu")
+
+    def test_infer_default_device_type_falls_back_to_cpu(self):
+        with mock.patch.object(
+            torch.accelerator, "current_accelerator", return_value=None
+        ):
+            self.assertEqual(dcp_optimizer._infer_default_device_type(), "cpu")
+            self.assertEqual(_gen_rank_device(5), "cpu")
+
+    def test_gen_rank_device_default_follows_accelerator(self):
+        with mock.patch.object(
+            torch.accelerator,
+            "current_accelerator",
+            return_value=torch.device("xpu"),
+        ):
+            with mock.patch.object(torch.xpu, "is_available", return_value=True):
+                with mock.patch.object(torch.xpu, "device_count", return_value=2):
+                    self.assertEqual(
+                        dcp_optimizer._infer_default_device_type(), "xpu"
+                    )
+                    # rank 3 with 2 devices -> "xpu:1", same modulo rule as before
+                    self.assertEqual(_gen_rank_device(3), "xpu:1")
+
+    def test_alloc_tensor_default_falls_back_to_cpu(self):
+        props = TensorProperties(dtype=torch.float32)
+        with mock.patch.object(
+            torch.accelerator, "current_accelerator", return_value=None
+        ):
+            t = _alloc_tensor(props, (2, 3))
+        self.assertEqual(t.device.type, "cpu")
+        self.assertEqual(t.shape, torch.Size((2, 3)))
+
+    def test_alloc_tensor_explicit_device_unchanged(self):
+        props = TensorProperties(dtype=torch.float32)
+        t = _alloc_tensor(props, (2, 3), "cpu")
+        self.assertEqual(t.device.type, "cpu")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -53,7 +53,14 @@ __all__ = [
 ]
 
 
-def _gen_rank_device(global_rank: int, device_type: str = "cuda") -> str:
+def _infer_default_device_type() -> str:
+    accelerator = torch.accelerator.current_accelerator(check_available=True)
+    return accelerator.type if accelerator is not None else "cpu"
+
+
+def _gen_rank_device(global_rank: int, device_type: str | None = None) -> str:
+    if device_type is None:
+        device_type = _infer_default_device_type()
     if device_type == "cpu":
         return "cpu"
     device_module = _get_device_module(device_type)
@@ -100,8 +107,10 @@ def _is_nested_tensor(val: torch.Tensor) -> bool:
 
 
 def _alloc_tensor(
-    props: TensorProperties, size: Sequence[int], device_type: str = "cuda"
+    props: TensorProperties, size: Sequence[int], device_type: str | None = None
 ) -> torch.Tensor:
+    if device_type is None:
+        device_type = _infer_default_device_type()
     if device_type == "cpu":
         device = cast(torch.device, _get_device_module(device_type).current_device())
     else:


### PR DESCRIPTION
## Summary

`_gen_rank_device` and `_alloc_tensor` in
`torch/distributed/checkpoint/optimizer.py` hardcode
`device_type: str = "cuda"` as their default. Every in-repo call site
passes the device type explicitly (derived from the process group's
default device via `_get_pg_default_device`), so the defaults are dead
code in-tree — but for out-of-tree accelerators the fallback is wrong:

- `_gen_rank_device` silently produces `"cpu"` placements on a non-CUDA
  box (cuda-unavailable fallback),
- `_alloc_tensor` raises `RuntimeError: No CUDA GPUs are available`.

This was reported for third-party backends in #129110. This PR changes
both defaults to `None` and resolves them at call time via
`torch.accelerator.current_accelerator(check_available=True)`, falling
back to `"cpu"` when no accelerator is available. Probing happens only at
call time — no import-time side effects. No new API or registry is
introduced.

## Changes

- Added a 4-line module-private helper `_infer_default_device_type()`
  that resolves the default device type from
  `torch.accelerator.current_accelerator(check_available=True)` and
  falls back to `"cpu"` when it returns `None` (+11/-2 across the file).
- Changed both `device_type: str = "cuda"` defaults to
  `str | None = None` and resolved inside the function bodies.
- Added `test/distributed/checkpoint/test_optimizer.py` (new, CPU-only,
  5 tests) calling the production symbols directly; all default-path
  tests patch `torch.accelerator.current_accelerator` for determinism on
  GPU machines, and one test patches an in-tree accelerator module
  (`torch.xpu`) to exercise the resolution. Labeled
  `hw_classification = HardwareClassification.GENERIC` (pure framework
  logic, no device variants).

| backend | `_gen_rank_device(0)` old -> new | `_alloc_tensor(props, size)` old -> new |
|---|---|---|
| cuda | `"cuda:0"` -> `"cuda:0"` | cuda tensor -> cuda tensor |
| cpu-only | `"cpu"` -> `"cpu"` | RuntimeError -> cpu tensor |
| npu (no patching) | `"cpu"` (silent) -> `"npu:0"` | RuntimeError -> npu tensor |
| xpu / mps / mtia | `"cpu"` -> own accelerator | same as above |

The failure-mode change on the default path (RuntimeError -> correct
allocation for non-CUDA machines) is the intended fix and is unreachable
from any in-tree caller.

## Depends on

- **#190991** (`HardwareClassification` enum) — used by the new test
  file's `hw_classification` label. Already merged; present in trunk.

## Not changed

- All 5 in-tree call sites keep passing `device_type` explicitly —
  byte-identical behavior for every in-tree backend (CUDA regression
  included in the test plan).
- No public API, no registry; the module's public entry
  `load_sharded_optimizer_state_dict` and its call chain
  (`torch/distributed/fsdp/_shard_utils.py`) are untouched.
- `torch_npu` requires no changes: the helpers only use standard
  `torch.npu.is_available/device_count/current_device` and
  `current_accelerator` already supports PrivateUse1.
- The distributed test-infra per-rank device binding guard fix is a
  separate PR (test infrastructure, not this module).

## Test plan

- [x] CUDA (A100, fad7424):
      `python -m pytest test/distributed/checkpoint/test_fsdp_optim_state.py -q`
      -> 2 passed in 44.41s (no regression);
      `python test/distributed/checkpoint/test_optimizer.py` -> OK (5 tests).
- [x] NPU (torch_npu 2.13.0+git45fbeae, Ascend 910B3 x8):
      probe `python -c "...print(_gen_rank_device(3))"` prints `cpu`
      before this PR and `npu:3` after (3 % 8 devices);
      new UT -> OK (5 tests); regression -> 2/2 OK (same-generation test
      file, with the companion test-infra PR (#XXXX, backfilled on
      submit) and `HCCL_NPU_SOCKET_PORT_RANGE`).
- [x] CPU (no accelerator): new UT -> OK (5 tests).
- [ ] CI (lint / unittest / distributed shards).