### PR TITLE
Move ascend/pytorch from L2 to L3

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -45,7 +45,6 @@ L1:
 
 L2:
   - TorchedHat/pytorch-redhat-ci
-  - Ascend/pytorch
   - torch-spyre/torch-spyre
   - vllm-project/vllm
 
@@ -53,3 +52,5 @@ L3:
   # Canonical test repos for CRCR.
   crcr-test:
     pytorch/crcr-test: [atalman, can-gaa-hou, fffrog, jewelkm89, KarhouTam, subinz1]
+  npu:
+    Ascend/pytorch: [huangjingwei, kerer-ai, zyw-hw]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #196580

According to the [L3 Upgrade Standard](https://github.com/pytorch/rfcs/blob/master/RFC-0050-Cross-Repository-CI-Relay-for-PyTorch-Out-of-Tree-Backends.md#l3) and the Ascend/PyTorch [dashboard](https://hud.pytorch.org/crcr/Ascend/pytorch?days=14&page=1) in CRCR HUD, the Ascend NPU meets all the requirements for L3. Therefore, we are requesting an upgrade of Ascend/pytorch from L2 to L3.

<img width="1561" height="386" alt="image" src="https://github.com/user-attachments/assets/16c1cf2c-1968-4585-bca0-ef17282361dc" />

Thank you.

cc @albanD @atalman 
