### PR TITLE
[Inductor] Clean up references to the removed mix-order ratio gate

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -49,12 +49,8 @@ class SkipPatternTest(TestBase):
     """
 
     @inductor_config.patch(split_reductions=False)
-    def test_dimension_too_close(self):
-        """
-        Skip if the two reduction size are too close.
-        We require one reduction dimension to be much larger so we can split
-        that dimension and make it efficient.
-        """
+    def test_workload_too_small(self):
+        """768x768 is 0.6Mi elements, under the 5Mi strict threshold."""
 
         def f(x):
             out1 = x.sum(dim=1)
@@ -129,9 +125,6 @@ class MixOrderReductionTest(TestBase):
 
     @parametrize("shape", ((4096, 8192), (4096, 16384), (8192, 16384)))
     def test_wide_reduction_fuses_in_strict_mode(self, shape):
-        """Wide reductions (large ncol, nrow < ncol*2) should use mix-order
-        fusion in the default (strict) mode, now that the `nrow >= ncol*2`
-        gate is removed."""
         if not inductor_config.triton.mix_order_reduction:
             self.skipTest("Mix order reduction not enabled")
 
@@ -153,9 +146,6 @@ class MixOrderReductionTest(TestBase):
 
     @parametrize("shape", ((6144, 4000), (8192, 6144)))
     def test_flat_reduction_fuses_in_strict_mode(self, shape):
-        """A relatively flat reduction (nrow >= 4096, nrow < ncol*2) should use
-        mix-order fusion in the default (strict) mode, now that the
-        `nrow >= ncol*2` gate is removed."""
         if not inductor_config.triton.mix_order_reduction:
             self.skipTest("Mix order reduction not enabled")
 
@@ -176,9 +166,6 @@ class MixOrderReductionTest(TestBase):
         )
 
     def test_wide_reduction_respects_row_floor(self):
-        """Strict mode still requires nrow >= 4096: with too few rows there is
-        not enough parallelism to split the other reduction across, so the
-        shape is left unfused (guards against over-fusing 2048x8192)."""
         if not inductor_config.triton.mix_order_reduction:
             self.skipTest("Mix order reduction not enabled")
 
@@ -221,8 +208,8 @@ class MixOrderReductionTest(TestBase):
             "same-order reductions must not be classified as mix-order",
         )
 
-    @inductor_config.patch({"triton.mix_order_reduction_non_strict_mode": True})
-    def test_square_mix_order_reductions_non_strict(self):
+    def test_square_mix_order_reductions(self):
+        """8192x8192 clears both strict checks, so no non-strict override."""
         if not inductor_config.triton.mix_order_reduction:
             self.skipTest("Mix order reduction not enabled")
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -403,10 +403,6 @@ class MixOrderReduction:
             ):
                 return False
 
-            # Don't gate on the nrow/ncol ratio: mix-order reduction can also
-            # be helpful on relatively flat inputs, and a `nrow >= ncol * 2`
-            # gate would reject profitable shapes.
-
             # Need enough rows to split the other reduction across; too few
             # gives insufficient parallelism to justify the fusion overhead.
             if not V.graph.sizevars.evaluate_expr(


### PR DESCRIPTION
Cleanup after #188660, which removed the `nrow >= ncol * 2` gate. 
No behavior change. Relates to issue: https://github.com/pytorch/pytorch/issues/185534

- `test_square_mix_order_reductions_non_strict`: 8192x8192 clears both remaining strict checks (`nrow * ncol >= 5Mi`, `nrow >= 4096`), so the non-strict override no longer affects the outcome. Dropped and renamed (thanks @liqiangxl's nit).
- `test_dimension_too_close`: named and documented after the removed ratio heuristic. 768x768 now skips on the 5Mi threshold, so renamed to `test_workload_too_small`.
- `scheduler.py`: drop the comment describing the deleted gate.

<details>
<summary>Why the other three non-strict overrides stay</summary>

| test | shape | reason |
|---|---|---|
| `test_no_recompile` | 2048x1024 | below both the 4096 row floor and the 5Mi threshold |
| `test_dimension_refactoring_mismatch` | 13x8472 | 13 rows |
| `test_same_order_reductions_with_non_common_strided_read` | 8192x8192 | asserts zero fusions; the override keeps that attributable to the same-order classifier, not to a strict gate |

</details>

Test plan: `test/inductor/test_mix_order_reduction.py` in CI.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo