### PR TITLE
[ROCm][UT] Re-enable test_2d_reductions_mixed_indexing on RDNA

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1050,7 +1050,6 @@ class CommonTemplate:
         # Check the code for multiple Rn_BLOCK's
         self._assert_reduction_ndims(code, 2)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/158328")
     @parametrize("reduction_op", [torch.sum, torch.argmax])
     def test_2d_reductions_mixed_indexing(
         self,

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -27,9 +27,10 @@ from torch.testing._internal.common_utils import (
     decorateIf,
     instantiate_parametrized_tests,
     MI200_ARCH,
+    MI300_ARCH,
+    MI350_ARCH,
     NAVI_ARCH,
     parametrize,
-    skipIfRocm,
     skipIfRocmArch,
     subtest,
 )
@@ -1050,6 +1051,7 @@ class CommonTemplate:
         # Check the code for multiple Rn_BLOCK's
         self._assert_reduction_ndims(code, 2)
 
+    @skipIfRocmArch(MI200_ARCH + MI300_ARCH + MI350_ARCH)
     @parametrize("reduction_op", [torch.sum, torch.argmax])
     def test_2d_reductions_mixed_indexing(
         self,


### PR DESCRIPTION
Part of #196583

## Summary

`test_2d_reductions_mixed_indexing` is skipped on ROCm by

```python
@skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/158328")
```

The decorator was added by #185013, a bulk pass that inlined CI bot disable
entries as decorators. The auto-disable behind it, #158328, was raised for
`reduction_op0` only, which is the `torch.sum` parametrization. Because the
decorator sits on the method it covers every parametrize case, so
`torch.argmax` was disabled without ever having been reported as failing.

The test is not architecture specific: it asserts only that the generated
Triton code contains two reduction dimensions, with numerical correctness
covered by the usual `_run_and_compare` check against eager.

To stay conservative on untested hardware, this PR narrows the skip to CDNA
(MI200/MI300/MI350) rather than removing it, so RDNA runs while MI stays skipped.

## Validation

Both parametrize cases pass with `PYTORCH_TEST_WITH_ROCM=1` on gfx1100
(RDNA3), gfx1151 (RDNA3.5) and gfx1200 (RDNA4), each reporting `2 passed`.
gfx1151 was run three times consecutively with identical results.

Environment: `torch 2.12.0+rocm10.1.0a20260810`, HIP `7.16.26314`, Triton
`3.8.0`.

MI200/MI300/MI350 remain skipped via `@skipIfRocmArch(MI200_ARCH + MI300_ARCH + MI350_ARCH)` since that hardware was unavailable for validation; a follow-up can drop those arches once confirmed on MI. Upstream ROCm CI runs on MI, where this test stays skipped, so the RDNA evidence above is local.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben