### PR TITLE
[inductor] decompose_addmm skips non-default alpha and beta

### DIFF
--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -10,12 +10,14 @@ from torch._inductor.fx_passes.decompose_mem_bound_mm import check_device
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
     is_navi3_arch,
     parametrize,
     patch_test_members,
+    subtest,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU_AND_TRITON
 from torch.testing._internal.triton_utils import requires_gpu
@@ -495,6 +497,46 @@ class TestDecomposeMemMM(TestCase):
             1,
         )
         counters.clear()
+
+
+class TestDecomposeAddmmScalars(TestCase):
+    @parametrize(
+        "beta,alpha,should_decompose",
+        [
+            subtest((None, None, True), name="no_kwargs"),
+            (1, 1, True),
+            (0, 1, False),
+            (1, 2.0, False),
+            (0.5, 3.0, False),
+        ],
+    )
+    @torch._inductor.config.patch(
+        post_grad_fusion_options={"decompose_mm_pass": {}},
+    )
+    def test_decompose_addmm_scalars(self, device, beta, alpha, should_decompose):
+        # The pass takes a single-row mat1 on CPU and a tall one on GPU. k, n > 16 keep
+        # Inductor's CPU addmm decomposition, which bumps the same counter, out of the way.
+        m, k, n = (1 if device == "cpu" else 10240), 24, 24
+        bias = torch.full((n,), float("nan") if beta == 0 else 10.0, device=device)
+        mat1 = torch.randn(m, k, device=device)
+        mat2 = torch.randn(k, n, device=device)
+        kwargs = {} if beta is None else {"beta": beta, "alpha": alpha}
+
+        def fn(x, a, b):
+            return torch.addmm(x, a, b, **kwargs)
+
+        args = (bias, mat1, mat2)
+        counters.clear()
+        self.assertEqual(torch.compile(fn)(*args), fn(*args), rtol=1e-3, atol=1e-3)
+        self.assertEqual(counters["inductor"]["decompose_addmm"], int(should_decompose))
+
+
+instantiate_device_type_tests(
+    TestDecomposeAddmmScalars,
+    globals(),
+    only_for=("cpu", "cuda", "xpu"),
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
+++ b/torch/_inductor/fx_passes/decompose_mem_bound_mm.py
@@ -250,7 +250,8 @@ def decompose_bmm(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node):
 
 
 @register_graph_pattern(
-    CallFunction(aten.addmm, Arg(), Arg(), Arg()),
+    # The matcher drops kwargs a pattern doesn't declare; pin beta/alpha to what repl computes
+    CallFunction(aten.addmm, Arg(), Arg(), Arg(), beta=1, alpha=1),
     pass_dict=construct_pattern_matcher_pass("decompose_mm_pass"),
 )
 def decompose_addmm(


### PR DESCRIPTION
## Issue

Fixes #196577

## Summary

`decompose_addmm` was matching `aten.addmm` calls with non-default `alpha` or `beta`, even though its replacement only implements the default `beta=1, alpha=1` behavior. Restrict the pattern to the default coefficients so non-default calls fall back to the regular `addmm` lowering. Add device-generic regression coverage for omitted defaults, explicit defaults, and non-default coefficients.

## Checklist

* [x] Passes lint (`spin fixlint`)
* [x] Added/updated tests
* [ ] Updated documentation (if applicable)
* [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo