### PR TITLE
[Test][XPU] Refactor `functorch/test_vmap.py` and enable on XPU

### DIFF
--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -1151,6 +1151,93 @@ class TestVmapAPI(TestCase):
                 o = torch.vmap(torch.square)(t)
         self.assertEqual(o, torch.square(t))
 
+    def test_restore_vmap_pytree_input_output(self):
+        def f(x, y):
+            output0 = x[0] + x[1]
+            output1 = y
+            return {"a": output0, "b": output1}
+
+        B = 2
+        x0 = torch.randn(B, 3)
+        x1 = torch.randn(B)
+        y = torch.randn(4, B)
+
+        out, out_dims = restore_vmap(f, ((0, 0), 1), B, "error")((x0, x1), y)
+        expected = vmap(f, in_dims=((0, 0), 1), out_dims={"a": 0, "b": 1})((x0, x1), y)
+        self.assertEqual(out, expected)
+        self.assertEqual(out_dims, {"a": 0, "b": 1})
+
+    def test_restore_vmap_no_vmapped_inputs(self):
+        def f(x, y, z):
+            return x, y * z, z
+
+        B = 2
+        # Mix of tensor and non-tensor inputs
+        x = torch.randn(3)
+        y = torch.randn(4)
+        z = 5
+        out, out_dims = restore_vmap(f, (None, None, None), B, "error")(x, y, z)
+        self.assertEqual(out, f(x, y, z))
+        self.assertEqual(out_dims, (None, None, None))
+
+    def test_restore_vmap_unexpanded_outputs(self):
+        def f(x, y):
+            # Mix of tensor and non-tensor outputs
+            return 3 * y, y.sum(), None
+
+        B = 2
+        x = torch.randn(B, 3)
+        y = torch.randn(4)
+        out, out_dims = restore_vmap(f, (0, None), B, "error")(x, y)
+        self.assertEqual(out, f(None, y))
+        self.assertEqual(out_dims, (None, None, None))
+
+    def test_data_attribute(self):
+        def foo(x):
+            y = x.data  # noqa: F841
+            return x
+
+        with self.assertRaisesRegex(
+            RuntimeError, "accessing `data` under vmap transform"
+        ):
+            torch.func.vmap(foo)(torch.randn(3, 3))
+
+        def foo(x):
+            x.data = torch.ones(3, 3)
+            return x
+
+        with self.assertRaisesRegex(
+            RuntimeError, "mutating directly with `.data` under vmap"
+        ):
+            torch.func.vmap(foo)(torch.randn(3, 3))
+
+    def test_vmap_out_dims_negative_one_independent_output(self):
+        t = torch.randn(2, 3)
+        t_scalar = torch.randn([])
+
+        def f_dep(x):
+            return x
+
+        def f_ind(x):
+            return t
+
+        def f_ind_scalar(x):
+            return t_scalar
+
+        res_dep_neg1 = vmap(f_dep, in_dims=0, out_dims=-1)(t)
+        self.assertEqual(res_dep_neg1.shape, torch.Size([3, 2]))
+
+        res_ind_neg1 = vmap(f_ind, in_dims=0, out_dims=-1)(torch.zeros(1))
+        self.assertEqual(res_ind_neg1.shape, torch.Size([2, 3, 1]))
+
+        res_ind_scalar_neg1 = vmap(f_ind_scalar, in_dims=0, out_dims=-1)(torch.zeros(5))
+        self.assertEqual(res_ind_scalar_neg1.shape, torch.Size([5]))
+
+
+@markDynamoStrictTest
+class TestVmapAPIDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_vmap_autocast(self, device):
         if torch.device(device).type == "cpu":
             amp_dtype = torch.bfloat16
@@ -1233,88 +1320,6 @@ class TestVmapAPI(TestCase):
     @unittest.skipIf(not TEST_MPS, "MPS is unavailable")
     def test_vmap_autocast_mps(self):
         self._test_vmap_autocast("mps")
-
-    def test_restore_vmap_pytree_input_output(self):
-        def f(x, y):
-            output0 = x[0] + x[1]
-            output1 = y
-            return {"a": output0, "b": output1}
-
-        B = 2
-        x0 = torch.randn(B, 3)
-        x1 = torch.randn(B)
-        y = torch.randn(4, B)
-
-        out, out_dims = restore_vmap(f, ((0, 0), 1), B, "error")((x0, x1), y)
-        expected = vmap(f, in_dims=((0, 0), 1), out_dims={"a": 0, "b": 1})((x0, x1), y)
-        self.assertEqual(out, expected)
-        self.assertEqual(out_dims, {"a": 0, "b": 1})
-
-    def test_restore_vmap_no_vmapped_inputs(self):
-        def f(x, y, z):
-            return x, y * z, z
-
-        B = 2
-        # Mix of tensor and non-tensor inputs
-        x = torch.randn(3)
-        y = torch.randn(4)
-        z = 5
-        out, out_dims = restore_vmap(f, (None, None, None), B, "error")(x, y, z)
-        self.assertEqual(out, f(x, y, z))
-        self.assertEqual(out_dims, (None, None, None))
-
-    def test_restore_vmap_unexpanded_outputs(self):
-        def f(x, y):
-            # Mix of tensor and non-tensor outputs
-            return 3 * y, y.sum(), None
-
-        B = 2
-        x = torch.randn(B, 3)
-        y = torch.randn(4)
-        out, out_dims = restore_vmap(f, (0, None), B, "error")(x, y)
-        self.assertEqual(out, f(None, y))
-        self.assertEqual(out_dims, (None, None, None))
-
-    def test_data_attribute(self):
-        def foo(x):
-            y = x.data  # noqa: F841
-            return x
-
-        with self.assertRaisesRegex(
-            RuntimeError, "accessing `data` under vmap transform"
-        ):
-            torch.func.vmap(foo)(torch.randn(3, 3))
-
-        def foo(x):
-            x.data = torch.ones(3, 3)
-            return x
-
-        with self.assertRaisesRegex(
-            RuntimeError, "mutating directly with `.data` under vmap"
-        ):
-            torch.func.vmap(foo)(torch.randn(3, 3))
-
-    def test_vmap_out_dims_negative_one_independent_output(self):
-        t = torch.randn(2, 3)
-        t_scalar = torch.randn([])
-
-        def f_dep(x):
-            return x
-
-        def f_ind(x):
-            return t
-
-        def f_ind_scalar(x):
-            return t_scalar
-
-        res_dep_neg1 = vmap(f_dep, in_dims=0, out_dims=-1)(t)
-        self.assertEqual(res_dep_neg1.shape, torch.Size([3, 2]))
-
-        res_ind_neg1 = vmap(f_ind, in_dims=0, out_dims=-1)(torch.zeros(1))
-        self.assertEqual(res_ind_neg1.shape, torch.Size([2, 3, 1]))
-
-        res_ind_scalar_neg1 = vmap(f_ind_scalar, in_dims=0, out_dims=-1)(torch.zeros(5))
-        self.assertEqual(res_ind_scalar_neg1.shape, torch.Size([5]))
 
 
 def slice_inputs(inputs, bdims, i):

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -6475,7 +6475,9 @@ class TestRandomnessDevice(TestCase):
 
 
 @markDynamoStrictTest
-class TestTransformFailure(TestCase):
+class TestTransformFailureDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skipIfTorchDynamo()
     @parametrize(
         "transform",
@@ -6820,8 +6822,10 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestRandomnessDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
 )
+instantiate_device_type_tests(
+    TestTransformFailureDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+)
 
-instantiate_device_type_tests(TestTransformFailure, globals(), only_for=only_for)
 instantiate_device_type_tests(TestVmapDeviceType, globals(), only_for=only_for)
 instantiate_device_type_tests(TestVmapNestedTensor, globals(), only_for=only_for)
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4544,7 +4544,7 @@ class TestVmapOperatorsOpInfoDevice(TestCase):
         dtypes=OpDTypes.any_one,
     )
     @opsToleranceOverride(
-        "TestVmapOperatorsOpInfo",
+        "TestVmapOperatorsOpInfoDevice",
         "test_vmap_exhaustive",
         (
             tol1(
@@ -4615,7 +4615,7 @@ class TestVmapOperatorsOpInfoDevice(TestCase):
         dtypes=OpDTypes.any_one,
     )
     @opsToleranceOverride(
-        "TestVmapOperatorsOpInfo",
+        "TestVmapOperatorsOpInfoDevice",
         "test_op_has_batch_rule",
         (
             tol1(

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4759,6 +4759,11 @@ class TestVmapOperatorsOpInfoDevice(TestCase):
                 # One or more of the overload doesn't have a Batch rule.
                 xfail("bincount"),
                 xfail("torch.ops.aten._scaled_dot_product_flash_attention_for_cpu"),
+                # The vectorized CPU kernels return NaN when the divisor is
+                # FLT_MIN, since Sleef_fmodf8 is only valid for |a / b| <= 2**24.
+                # The scalar CPU path and other backends return the correct value.
+                xfail("fmod", device_type="cpu"),
+                xfail("remainder", device_type="cpu"),
             }
         ),
     )

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -6779,7 +6779,11 @@ class TestVmapNestedTensor(Namespace.TestVmapBase):
 
 
 instantiate_device_type_tests(
-    TestVmapAPIDevice, globals(), only_for=("cpu", "cuda", "mps"), allow_mps=True
+    TestVmapAPIDevice,
+    globals(),
+    only_for=("cpu", "cuda", "mps", "xpu"),
+    allow_mps=True,
+    allow_xpu=True,
 )
 
 only_for = ("cpu", "cuda")

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3680,9 +3680,6 @@ class TestVmapOperators(Namespace.TestVmapBase):
                 self.assertEqual(actual, expected)
 
 
-instantiate_parametrized_tests(TestVmapOperators)
-
-
 def construct_v(output, batch_size, contig=False):
     if contig:
         return torch.randn(
@@ -6802,38 +6799,40 @@ class TestVmapNestedTensorDevice(Namespace.TestVmapBase):
             vmap(vmap(vmap(f)))(x)
 
 
+instantiate_parametrized_tests(TestVmapOperators)
+
+
+only_for = ("cpu", "cuda", "xpu")
 instantiate_device_type_tests(
     TestVmapAPIDevice,
     globals(),
-    only_for=("cpu", "cuda", "mps", "xpu"),
+    only_for=only_for + ("mps",),
     allow_mps=True,
     allow_xpu=True,
 )
-
-only_for = ("cpu", "cuda")
 instantiate_device_type_tests(
     TestVmapBatchedGradientDevice,
     globals(),
-    only_for=only_for + ("xpu",),
+    only_for=only_for,
     allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestVmapOperatorsOpInfoDevice,
     globals(),
-    only_for=only_for + ("xpu",),
+    only_for=only_for,
     allow_xpu=True,
 )
 instantiate_device_type_tests(
-    TestRandomnessDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+    TestRandomnessDevice, globals(), only_for=only_for, allow_xpu=True
 )
 instantiate_device_type_tests(
-    TestTransformFailureDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+    TestTransformFailureDevice, globals(), only_for=only_for, allow_xpu=True
 )
 instantiate_device_type_tests(
-    TestVmapDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+    TestVmapDevice, globals(), only_for=only_for, allow_xpu=True
 )
 instantiate_device_type_tests(
-    TestVmapNestedTensorDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+    TestVmapNestedTensorDevice, globals(), only_for=only_for, allow_xpu=True
 )
 
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -6528,7 +6528,9 @@ class TestTransformFailureDevice(TestCase):
 
 
 @markDynamoStrictTest
-class TestVmapDeviceType(Namespace.TestVmapBase):
+class TestVmapDevice(Namespace.TestVmapBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _vmap_test(self, *args, **kwargs):
         return _vmap_test(self, *args, **kwargs)
 
@@ -6825,8 +6827,10 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestTransformFailureDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
 )
+instantiate_device_type_tests(
+    TestVmapDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+)
 
-instantiate_device_type_tests(TestVmapDeviceType, globals(), only_for=only_for)
 instantiate_device_type_tests(TestVmapNestedTensor, globals(), only_for=only_for)
 
 if __name__ == "__main__":

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -6628,7 +6628,9 @@ class TestVmapDevice(Namespace.TestVmapBase):
 
 
 @markDynamoStrictTest
-class TestVmapNestedTensor(Namespace.TestVmapBase):
+class TestVmapNestedTensorDevice(Namespace.TestVmapBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _vmap_test(self, *args, **kwargs):
         return _vmap_test(self, *args, **kwargs)
 
@@ -6830,8 +6832,10 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestVmapDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
 )
+instantiate_device_type_tests(
+    TestVmapNestedTensorDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+)
 
-instantiate_device_type_tests(TestVmapNestedTensor, globals(), only_for=only_for)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -57,7 +57,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
     onlyCPU,
-    onlyCUDA,
     OpDTypes,
     ops,
     skipOps,
@@ -4267,7 +4266,9 @@ def discover_variants(opinfo):
 # TODO: enable this when we get a bit closer to getting torch.vmap x torch.compile working.
 # @markDynamoStrictTest
 @unMarkDynamoStrictTest
-class TestVmapOperatorsOpInfo(TestCase):
+class TestVmapOperatorsOpInfoDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def vmap_outplace_test(
         self,
         func,
@@ -4504,22 +4505,22 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail("cdouble"),
         xfail("cfloat"),
         xfail(
-            "jiterator_binary", device_type="cuda"
+            "jiterator_binary", device_type=("cuda", "xpu")
         ),  # NYI: querying is_contiguous inside of vmap
         xfail(
-            "jiterator_binary_return_by_ref", device_type="cuda"
+            "jiterator_binary_return_by_ref", device_type=("cuda", "xpu")
         ),  # NYI: querying is_contiguous inside of vmap
         xfail(
-            "jiterator_4inputs_with_extra_args", device_type="cuda"
+            "jiterator_4inputs_with_extra_args", device_type=("cuda", "xpu")
         ),  # NYI: querying is_contiguous inside of vmap
         xfail(
             "equal", ""
         ),  # TypeError: object of type 'bool' has no len(); likely testrunner problem
         xfail(
-            "jiterator_unary", device_type="cuda"
+            "jiterator_unary", device_type=("cuda", "xpu")
         ),  # NYI: querying is_contiguous inside of vmap
         xfail(
-            "jiterator_2inputs_2outputs", device_type="cuda"
+            "jiterator_2inputs_2outputs", device_type=("cuda", "xpu")
         ),  # NYI: querying is_contiguous inside of vmap
         # ---------------------------------------------------------------------
         # TypeError: expected Tensor as element 0 in argument 0, but got NotImplementedType
@@ -4552,14 +4553,14 @@ class TestVmapOperatorsOpInfo(TestCase):
             tol1(
                 "linalg.det",
                 {torch.float32: tol(atol=1e-04, rtol=1e-04)},
-                device_type="cuda",
+                device_type=("cuda", "xpu"),
             ),
             # The following is often flaky, but just on windows.
             # We should investigate if it's actually a problem or not.
             tol1(
                 "nn.functional.conv_transpose3d",
                 {torch.float32: tol(atol=1e-04, rtol=1e-02)},
-                device_type="cuda",
+                device_type=("cuda", "xpu"),
             ),
         ),
     )
@@ -4724,9 +4725,9 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("linalg.ldl_solve", "", device_type="cpu"),
                 xfail("chalf", ""),
                 xfail("clamp_max", ""),
-                xfail("jiterator_binary_return_by_ref", device_type="cuda"),
-                xfail("jiterator_unary", device_type="cuda"),
-                xfail("jiterator_2inputs_2outputs", device_type="cuda"),
+                xfail("jiterator_binary_return_by_ref", device_type=("cuda", "xpu")),
+                xfail("jiterator_unary", device_type=("cuda", "xpu")),
+                xfail("jiterator_2inputs_2outputs", device_type=("cuda", "xpu")),
                 xfail("special.airy_ai"),
                 xfail("clamp_min", ""),
                 xfail("sparse.sampled_addmm"),
@@ -4747,8 +4748,8 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("special.laguerre_polynomial_l"),
                 xfail("special.legendre_polynomial_p"),
                 xfail("special.hermite_polynomial_h"),
-                xfail("jiterator_binary", device_type="cuda"),
-                xfail("jiterator_4inputs_with_extra_args", device_type="cuda"),
+                xfail("jiterator_binary", device_type=("cuda", "xpu")),
+                xfail("jiterator_4inputs_with_extra_args", device_type=("cuda", "xpu")),
                 xfail("_segment_reduce", "lengths"),
                 xfail("lu_solve", ""),
                 xfail("special.hermite_polynomial_he"),
@@ -5140,7 +5141,9 @@ class TestVmapOperatorsOpInfo(TestCase):
         is_cuda_sm86 = device.startswith("cuda") and torch.cuda.get_device_capability(
             0
         ) == (8, 6)
-        atol, rtol = (1e-3, 1e-3) if is_cuda_sm86 else (1e-4, 1e-4)
+        atol, rtol = (
+            (1e-3, 1e-3) if is_cuda_sm86 or device.startswith("xpu") else (1e-4, 1e-4)
+        )
 
         def test():
             for loop_out, batched_out in generator:
@@ -5316,7 +5319,7 @@ class TestVmapOperatorsOpInfo(TestCase):
 
         self.vmap_outplace_test(f, (x, gy), {}, in_dims=(None, 0))
 
-    @onlyCUDA
+    @onlyAccelerator
     @parametrize("inplace", [True, False])
     def test_0d_tensor_index_put(self, device, inplace):
         def f(t, idx, v):
@@ -5324,7 +5327,7 @@ class TestVmapOperatorsOpInfo(TestCase):
             return fn(t, idx, v)
 
         N = 2
-        t = torch.zeros((N, 5), device="cuda")
+        t = torch.zeros((N, 5), device=device)
         idx = torch.tensor([1, 3])
         v = torch.tensor(1, dtype=t.dtype, device="cpu")
 
@@ -6806,7 +6809,12 @@ instantiate_device_type_tests(
     only_for=only_for + ("xpu",),
     allow_xpu=True,
 )
-instantiate_device_type_tests(TestVmapOperatorsOpInfo, globals(), only_for=only_for)
+instantiate_device_type_tests(
+    TestVmapOperatorsOpInfoDevice,
+    globals(),
+    only_for=only_for + ("xpu",),
+    allow_xpu=True,
+)
 
 instantiate_device_type_tests(TestTransformFailure, globals(), only_for=only_for)
 instantiate_device_type_tests(TestRandomness, globals(), only_for=only_for)

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -64,6 +64,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_WINDOWS,
     markDynamoStrictTest,
@@ -109,6 +110,8 @@ class EnableVmapFallbackWarnings:
 
 @markDynamoStrictTest
 class TestVmapAPI(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_non_tensor_output_raises(self):
         with self.assertRaisesRegex(ValueError, "got type <class 'float'>"):
             vmap(lambda x: 3.14)(torch.ones(3))

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -6021,7 +6021,7 @@ class TestRandomnessDevice(TestCase):
                 expected = op(passed, 0)
 
                 self._assert_all_slices_unique(vmap_result)
-                # RNG differs between eager and via dynamo trace on CUDA/XPI
+                # RNG differs between eager and via dynamo trace on CUDA/XPU
                 if not (TEST_WITH_TORCHDYNAMO and torch.device(device).type != "cpu"):
                     self.assertEqual(expected, vmap_result)
                 return

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -1518,6 +1518,8 @@ def _make_case(op, input_getter=TensorFactory.randn):
 
 @markDynamoStrictTest
 class TestVmapOperators(Namespace.TestVmapBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _vmap_test(self, *args, **kwargs):
         return _vmap_test(self, *args, **kwargs)
 
@@ -1841,7 +1843,7 @@ class TestVmapOperators(Namespace.TestVmapBase):
         test(op, (getter([B0, 2], device), getter([B0], device, torch.double)))
         test(op, (getter([B0], device, torch.double), getter([B0, 2], device)))
 
-        if not torch.cuda.is_available():
+        if not torch.accelerator.is_available():
             return
 
         # TODO(rzou): fix the following

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -5645,7 +5645,9 @@ class TestVmapOperatorsOpInfoDevice(TestCase):
 
 
 @markDynamoStrictTest
-class TestRandomness(TestCase):
+class TestRandomnessDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _reset_random(self, generator, orig_state, use_generator, seed):
         return (
             generator.set_state(orig_state)
@@ -5796,15 +5798,15 @@ class TestRandomness(TestCase):
         if randomness == "different":
             for i in range(B0):
                 expected = torch.randperm(10, **kwargs)
-                # RNG differs between eager and via dynamo trace on CUDA
-                if TEST_WITH_TORCHDYNAMO and torch.device(device).type == "cuda":
+                # RNG differs between eager and via dynamo trace on CUDA/XPU
+                if TEST_WITH_TORCHDYNAMO and torch.device(device).type != "cpu":
                     self._assert_all_slices_unique(vmap_result)
                 else:
                     self.assertEqual(vmap_result[i], expected)
         else:
             expected = torch.randperm(10, **kwargs)
-            # RNG differs between eager and via dynamo trace on CUDA
-            if TEST_WITH_TORCHDYNAMO and torch.device(device).type == "cuda":
+            # RNG differs between eager and via dynamo trace on CUDA/XPU
+            if TEST_WITH_TORCHDYNAMO and torch.device(device).type != "cpu":
                 self._assert_all_slices_equal(vmap_result)
             else:
                 for i in range(B0):
@@ -6022,8 +6024,8 @@ class TestRandomness(TestCase):
                 expected = op(passed, 0)
 
                 self._assert_all_slices_unique(vmap_result)
-                # RNG differs between eager and via dynamo trace on CUDA
-                if not (TEST_WITH_TORCHDYNAMO and torch.device(device).type == "cuda"):
+                # RNG differs between eager and via dynamo trace on CUDA/XPI
+                if not (TEST_WITH_TORCHDYNAMO and torch.device(device).type != "cpu"):
                     self.assertEqual(expected, vmap_result)
                 return
 
@@ -6035,8 +6037,8 @@ class TestRandomness(TestCase):
                 passed = passed[0]
             expected = op(passed, 0)
             self._assert_all_slices_equal(vmap_result)
-            # RNG differs between eager and via dynamo trace on CUDA
-            if not (TEST_WITH_TORCHDYNAMO and torch.device(device).type == "cuda"):
+            # RNG differs between eager and via dynamo trace on CUDA/XPU
+            if not (TEST_WITH_TORCHDYNAMO and torch.device(device).type != "cpu"):
                 for i in range(B0):
                     self.assertEqual(expected, vmap_result[i])
 
@@ -6815,9 +6817,11 @@ instantiate_device_type_tests(
     only_for=only_for + ("xpu",),
     allow_xpu=True,
 )
+instantiate_device_type_tests(
+    TestRandomnessDevice, globals(), only_for=only_for + ("xpu",), allow_xpu=True
+)
 
 instantiate_device_type_tests(TestTransformFailure, globals(), only_for=only_for)
-instantiate_device_type_tests(TestRandomness, globals(), only_for=only_for)
 instantiate_device_type_tests(TestVmapDeviceType, globals(), only_for=only_for)
 instantiate_device_type_tests(TestVmapNestedTensor, globals(), only_for=only_for)
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -72,7 +72,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfTorchDynamo,
     subtest,
-    TEST_MPS,
     TEST_WITH_ROCM,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
@@ -1238,7 +1237,7 @@ class TestVmapAPI(TestCase):
 class TestVmapAPIDevice(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def _test_vmap_autocast(self, device):
+    def test_vmap_autocast(self, device):
         if torch.device(device).type == "cpu":
             amp_dtype = torch.bfloat16
         else:
@@ -1309,17 +1308,6 @@ class TestVmapAPIDevice(TestCase):
 
         if not expected.allclose(out):
             raise AssertionError("Expected func3 output to be close to vmap output")
-
-    def test_vmap_autocast_cpu(self):
-        self._test_vmap_autocast("cpu")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
-    def test_vmap_autocast_cuda(self):
-        self._test_vmap_autocast("cuda")
-
-    @unittest.skipIf(not TEST_MPS, "MPS is unavailable")
-    def test_vmap_autocast_mps(self):
-        self._test_vmap_autocast("mps")
 
 
 def slice_inputs(inputs, bdims, i):
@@ -6789,6 +6777,10 @@ class TestVmapNestedTensor(Namespace.TestVmapBase):
         ):
             vmap(vmap(vmap(f)))(x)
 
+
+instantiate_device_type_tests(
+    TestVmapAPIDevice, globals(), only_for=("cpu", "cuda", "mps"), allow_mps=True
+)
 
 only_for = ("cpu", "cuda")
 instantiate_device_type_tests(TestVmapOperatorsOpInfo, globals(), only_for=only_for)

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -55,6 +55,8 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
+    onlyAccelerator,
+    onlyCPU,
     onlyCUDA,
     OpDTypes,
     ops,
@@ -3719,7 +3721,9 @@ def _get_rand_no_zeros(*args, **kwargs):
 
 
 @markDynamoStrictTest
-class TestVmapBatchedGradient(Namespace.TestVmapBase):
+class TestVmapBatchedGradientDevice(Namespace.TestVmapBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _vmap_test(self, *args, **kwargs):
         return _vmap_test(self, *args, **kwargs)
 
@@ -3982,11 +3986,9 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
         x = torch.randn(2, 3, device=device, requires_grad=True)
         self._batched_grad_test(lambda x: F.threshold(x, 0.5, 0.0), (x,))
 
+    @onlyAccelerator
     @parametrize("backend", PLATFORM_SPECIFIC_SDPA)
     def test_sdpa(self, device, backend):
-        if device == "cpu":
-            raise unittest.SkipTest("This test is only for CUDA for now")
-
         def T(*args):
             return torch.randn(*args, dtype=torch.float16, device=device)
 
@@ -4036,11 +4038,9 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
                 in_dims=(2, 1, None),
             )
 
+    @onlyAccelerator
     @parametrize("backend", PLATFORM_SPECIFIC_SDPA)
     def test_sdpa_unbatched_inputs(self, device, backend):
-        if device == "cpu":
-            raise unittest.SkipTest("This test is only for CUDA for now")
-
         query = torch.randn(
             3, 4, 32, 64, dtype=torch.float16, device=device, requires_grad=True
         )
@@ -4068,10 +4068,8 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
         self.assertEqual(actual_backward_grads, expected_backward_grads)
         self.assertEqual(actual_grads, expected_grads)
 
+    @onlyCPU
     def test_sdpa_unbatched_inputs_cpu(self, device):
-        if device != "cpu":
-            raise unittest.SkipTest("This test is only for CPU")
-
         query = torch.randn(3, 4, 32, 64, device=device, requires_grad=True)
         key = torch.randn_like(query, requires_grad=True)
         value = torch.randn_like(query, requires_grad=True)
@@ -4099,6 +4097,7 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
         self.assertEqual(actual_backward_grads, expected_backward_grads)
         self.assertEqual(actual_grads, expected_grads)
 
+    @onlyAccelerator
     @parametrize(
         "backend",
         [
@@ -4108,9 +4107,6 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
         ],
     )
     def test_sdpa_unbatched_inputs_with_mask(self, device, backend):
-        if device == "cpu":
-            raise unittest.SkipTest("This test is only for CUDA for now")
-
         query = torch.randn(3, 4, 32, 64, dtype=torch.float16, device=device)
         key = torch.randn_like(query)
         value = torch.randn_like(query)
@@ -4124,14 +4120,17 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
 
         self.assertEqual(actual, expected)
 
+    @onlyAccelerator
     @parametrize("backend", PLATFORM_SPECIFIC_SDPA)
     @parametrize("randomness", ["error", "same", "different"])
     def test_randomness(self, device, randomness, backend):
-        if device == "cpu":
-            raise unittest.SkipTest("This test is only for CUDA for now")
-
+        device_type = torch.device(device).type
         # xfail for cuDNN version between 9.10 and 9.13
-        if backend == SDPBackend.CUDNN_ATTENTION and randomness == "different":
+        if (
+            backend == SDPBackend.CUDNN_ATTENTION
+            and randomness == "different"
+            and device_type == "cuda"
+        ):
             if 91100 <= TEST_CUDNN_VERSION <= 91300:
                 raise unittest.SkipTest(
                     "xfail on cuDNN 9.10-9.13 with CUDNN backend and randomness='different'"
@@ -4157,6 +4156,18 @@ class TestVmapBatchedGradient(Namespace.TestVmapBase):
             fail_with_randomness = randomness == "error"
             if backend != SDPBackend.MATH:
                 fail_with_randomness |= randomness == "same"
+
+            if device_type == "xpu":
+                # On XPU, EFFICIENT_ATTENTION currently maps/falls back to the
+                # MATH implementation, so randomness="same" is allowed here.
+                if backend == SDPBackend.EFFICIENT_ATTENTION and randomness == "same":
+                    fail_with_randomness = False
+
+                # On XPU, FLASH_ATTENTION with dropout and randomness="different"
+                # currently has no available kernel, so this path is expected to raise.
+                if backend == SDPBackend.FLASH_ATTENTION and randomness == "different":
+                    fail_with_randomness = True
+
             context = (
                 self.assertRaises(RuntimeError)
                 # We currently don't support randomness == "same", and "error" should always error with randomness
@@ -6789,13 +6800,14 @@ instantiate_device_type_tests(
 )
 
 only_for = ("cpu", "cuda")
+instantiate_device_type_tests(
+    TestVmapBatchedGradientDevice,
+    globals(),
+    only_for=only_for + ("xpu",),
+    allow_xpu=True,
+)
 instantiate_device_type_tests(TestVmapOperatorsOpInfo, globals(), only_for=only_for)
 
-instantiate_device_type_tests(
-    TestVmapBatchedGradient,
-    globals(),
-    only_for=only_for,
-)
 instantiate_device_type_tests(TestTransformFailure, globals(), only_for=only_for)
 instantiate_device_type_tests(TestRandomness, globals(), only_for=only_for)
 instantiate_device_type_tests(TestVmapDeviceType, globals(), only_for=only_for)

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -195,7 +195,10 @@ def evaluate_platform_supports_flash_attention():
     if TEST_CUDA:
         return not IS_WINDOWS and SM80OrLater
     if TEST_XPU:
-        return True
+        from torch.testing._internal.common_xpu import (
+            evaluate_platform_supports_flash_attention as xpu_supports_flash_attention,
+        )
+        return xpu_supports_flash_attention()
     return False
 
 def evaluate_platform_supports_ck_sdpa():

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12132,8 +12132,8 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
 
                # vmap: calling random operator not supported
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
 
                DecorateInfo(unittest.skip("make_traced() doesn't set seed properly!"), 'TestCommon', 'test_python_ref_executor'),
 
@@ -12164,8 +12164,8 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
 
                # vmap: calling random operator not supported
-               DecorateInfo(unittest.expectedFailure, "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.expectedFailure, "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.expectedFailure, "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.expectedFailure, "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
 
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick'),
                DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_compare_cpu'),
@@ -12195,8 +12195,8 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
 
                # vmap: calling random operator not supported
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
 
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick'),
            )),
@@ -12224,8 +12224,8 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
 
                # vmap: calling random operator not supported
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick'),
            )),
     OpInfo('normal',
@@ -12256,8 +12256,8 @@ op_db: list[OpInfo] = [
                # FX failed to normalize op - add the op to the op_skip list.
                DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
                # vmap: calling random operator not supported
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
            )),
     OpInfo('uniform',
            op=lambda inp, *args, **kwargs: wrapper_set_seed(torch.Tensor.uniform_, inp, *args, **kwargs),
@@ -16418,7 +16418,7 @@ op_db: list[OpInfo] = [
                # RuntimeError: aten::_upsample_nearest_exact*d hit the vmap fallback which is currently disabled
                DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapjvpall_has_batch_rule'),
                DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapvjp_has_batch_rule'),
-               DecorateInfo(unittest.expectedFailure, 'TestVmapOperatorsOpInfo', 'test_op_has_batch_rule'),
+               DecorateInfo(unittest.expectedFailure, 'TestVmapOperatorsOpInfoDevice', 'test_op_has_batch_rule'),
            ),
            supports_out=False),
     OpInfo('nn.functional.interpolate',
@@ -17192,8 +17192,8 @@ op_db: list[OpInfo] = [
             # https://github.com/pytorch/pytorch/issues/107256
             DecorateInfo(unittest.skip("Skipped!"), 'TestSchemaCheckModeOpInfo', 'test_schema_correctness'),
             # aten::_scaled_mm hit the vmap fallback which is currently disabled
-            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
-            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
+            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
+            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
             DecorateInfo(unittest.expectedFailure, 'TestNNCOpInfo', 'test_nnc_correctness',
                          dtypes=(torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz)),
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_compare_cpu'),
@@ -17221,8 +17221,8 @@ op_db: list[OpInfo] = [
             # https://github.com/pytorch/pytorch/issues/107256
             DecorateInfo(unittest.skip("Skipped!"), 'TestSchemaCheckModeOpInfo', 'test_schema_correctness'),
             # aten::_scaled_mm hit the vmap fallback which is currently disabled
-            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
-            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
+            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
+            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
             DecorateInfo(unittest.expectedFailure, 'TestNNCOpInfo', 'test_nnc_correctness',
                          dtypes=(torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz)),
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_compare_cpu'),
@@ -19886,8 +19886,8 @@ op_db: list[OpInfo] = [
            skips=(
                # Tests that assume input is a tensor or sequence of tensors
                DecorateInfo(unittest.skip("Test expects tensor input"), "TestCommon", "test_noncontiguous_samples"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
                # CPU randn generates different values based on the strides of out tensor
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='cpu'),
                # randn fails to warn when resizing its out tensor
@@ -19949,8 +19949,8 @@ op_db: list[OpInfo] = [
            skips=(
                # Tests that assume input is a tensor or sequence of tensors
                DecorateInfo(unittest.skip("Test expects tensor input"), "TestCommon", "test_noncontiguous_samples"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
                # CPU randint generates different values based on the strides of out tensor
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
                # randint fails to warn when resizing its out tensor
@@ -21403,7 +21403,7 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),
                DecorateInfo(unittest.expectedFailure, 'TestDTensorOps', 'test_dtensor_op_db'),
-               DecorateInfo(unittest.expectedFailure, 'TestVmapOperatorsOpInfo', 'test_op_has_batch_rule'),
+               DecorateInfo(unittest.expectedFailure, 'TestVmapOperatorsOpInfoDevice', 'test_op_has_batch_rule'),
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values',
                             dtypes=[torch.bool], active_if=TEST_WITH_ROCM),
            )),
@@ -22485,8 +22485,8 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             DecorateInfo(unittest.expectedFailure, 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.expectedFailure, 'TestReductions', 'test_dim_empty_keepdim'),
             # aten::hash_tensor hit the vmap fallback which is currently disabled
-            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
-            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
+            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfoDevice", "test_op_has_batch_rule"),
+            DecorateInfo(unittest.skip("Skipped!"), "TestVmapOperatorsOpInfoDevice", "test_vmap_exhaustive"),
             # NYI
             DecorateInfo(unittest.expectedFailure, 'TestInductorOpInfo', 'test_comprehensive'),
             # Sharding strategy NYI


### PR DESCRIPTION
- Use XPU function to determine if flash attention is supported
- Refactor `TestVmapAPI`:
  - Add `hw_classification` 
  - Extract device-dependent tests into `TestVmapAPIDevice`
  - Refactor `TestMapAPIDevice` to use `device` parameter and `instantiate_device_type_tests`
  - Enable XPU for `TestVmapAPIDevice`
- Add `hw_classificiation` to `TestVmapOperators`
- Refactor `TestVmapBatchedGradient`
  - add `Device` suffix
  - use `onlyAccelerator`
  - apply XPU specific changes
  - enable on XPU
- Refactor `TestVmapOperatorsOpInfoDevice`
  - apply XPU specific changes
  - enable on XPU
  - update decorators
  - rename class
  - rename entries in `common_method_invocations.py`
- Refactor `TestRandomness`
  - add `Device` suffix
  - add XPU specific changes
  - enable on XPU
- Refactor `TestTransformFailure`
  - add `Device` suffix
  - enable for XPU
- Refactor `TestVmapDeviceType`
  - remove the `Type` suffix
  - enable on XPU
- Refactor `TestVmapNestedTensor`
  - add `Device` suffix
  - enable on XPU
- Refactor the `instantiate_...` calls and group them at the end of the file