### PR TITLE
[Native DSL] Make topk kernels N-dynamic

### DIFF
--- a/test/python_native/test_topk_cutedsl.py
+++ b/test/python_native/test_topk_cutedsl.py
@@ -20,7 +20,7 @@
 import unittest
 
 import torch
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_cuda import SM90OrLater, TEST_CUDA
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -53,6 +53,7 @@ def _test_n(k: int) -> int:
 
 
 @unittest.skipUnless(TEST_CUDA, "CUDA required")
+@unittest.skipUnless(SM90OrLater, "SM90+ required")
 @skipIfNoCuteDSL
 class TestCuTeDSLTopK(TestCase):
     def _assert_topk_matches_aten(self, x: torch.Tensor, k: int) -> None:
@@ -120,6 +121,25 @@ class TestCuTeDSLTopK(TestCase):
                 self.assertEqual(torch.gather(x, -1, got_i), got_v)
                 if deterministic:
                     self.assertEqual(got_i, ref_i)
+
+    def test_register_dynamic_n_ladder(self) -> None:
+        from torch._native.ops.topk.cutedsl_kernels import (
+            _compile_topk_register_i64,
+            topk_register,
+        )
+
+        torch.manual_seed(14)
+        k = 16
+        ns = (64, 128, 256, 512, 1024)
+        compiled = _compile_topk_register_i64(ns, k)
+        for n in ns:
+            x = torch.randn(4, n, device="cuda")
+            with torch.backends.python_native.cutedsl.disabled():
+                ref_v, _ = torch.topk(x, k, dim=-1)
+            got_v, got_i = topk_register(x, k)
+            self.assertIs(_compile_topk_register_i64(ns, k), compiled)
+            self.assertEqual(got_v, ref_v)
+            self.assertEqual(torch.gather(x, -1, got_i), got_v)
 
     def test_radix_fixed_work_regimes(self) -> None:
         from torch._native.ops.topk.cutedsl_kernels import topk_radix

--- a/test/python_native/test_topk_cutedsl.py
+++ b/test/python_native/test_topk_cutedsl.py
@@ -35,13 +35,10 @@ _REGISTER_KS = (16, 32)
 _SUPPORTED_KS = _REGISTER_KS + _RADIX_KS
 
 
-def _radix_min_n_for_k(k: int) -> int:
-    """Mirror of the radix kernel's per-K N gate; used to size test
-    shapes so the override actually fires rather than falling through
-    to aten."""
-    from torch._native.ops.topk.cutedsl_impl import _RADIX_MIN_N_MULTIPLIER
+def _radix_min_n_for_k(k: int, dtype: str = "float32") -> int:
+    from torch._native.ops.topk.aot import _radix_min_n
 
-    return _RADIX_MIN_N_MULTIPLIER[k] * k
+    return _radix_min_n(dtype, k, torch.cuda.get_device_capability()[0])
 
 
 def _test_n(k: int) -> int:
@@ -73,6 +70,86 @@ class TestCuTeDSLTopK(TestCase):
         if k >= 2:
             diffs = got_v[..., :-1] - got_v[..., 1:]
             self.assertTrue((diffs >= 0).all(), "output is not descending")
+
+    @parametrize("deterministic", (False, True))
+    def test_radix_dynamic_n(self, deterministic: bool) -> None:
+        from torch._native.ops.topk.aot import _specialization
+        from torch._native.ops.topk.cutedsl_kernels import (
+            _compile_topk_radix,
+            topk_radix,
+        )
+
+        torch.manual_seed(11)
+        k = 64
+        pn = torch.backends.python_native
+        compiled_by_work = {}
+        for _tail_iters, ns in (
+            (0, (1024, 2048, 4096)),
+            (1, (128, 132, 1028, 4100, 5124)),
+            (2, (512, 516)),
+            (3, (768, 1540)),
+            (4, (1020, 2044)),
+        ):
+            for n in ns:
+                cache_tail, fixed_vec_iters = _specialization(n, k, deterministic)
+                compiled = _compile_topk_radix(
+                    k,
+                    deterministic,
+                    cache_tail,
+                    fixed_vec_iters,
+                )
+                work_key = (cache_tail, fixed_vec_iters)
+                previous = compiled_by_work.setdefault(work_key, compiled)
+                self.assertIs(compiled, previous)
+
+                x = torch.randn(4, n, device="cuda", dtype=torch.float32)
+                with pn.cutedsl.disabled():
+                    ref_v, ref_i = torch.topk(x, k, dim=-1)
+                got_v, got_i = topk_radix(x, k, deterministic=deterministic)
+
+                self.assertIs(
+                    _compile_topk_radix(
+                        k,
+                        deterministic,
+                        cache_tail,
+                        fixed_vec_iters,
+                    ),
+                    compiled,
+                )
+                self.assertEqual(got_v, ref_v)
+                self.assertEqual(torch.gather(x, -1, got_i), got_v)
+                if deterministic:
+                    self.assertEqual(got_i, ref_i)
+
+    def test_radix_fixed_work_regimes(self) -> None:
+        from torch._native.ops.topk.cutedsl_kernels import topk_radix
+
+        torch.manual_seed(12)
+        pn = torch.backends.python_native
+        for k, n in ((512, 5120), (1024, 35840)):
+            x = torch.randn(4, n, device="cuda", dtype=torch.float32)
+            with pn.cutedsl.disabled():
+                ref_v, ref_i = torch.topk(x, k, dim=-1)
+            got_v, got_i = topk_radix(x, k, deterministic=True)
+            self.assertEqual(got_v, ref_v)
+            self.assertEqual(got_i, ref_i)
+
+    @parametrize("deterministic", (False, True))
+    def test_radix_bfloat16(self, deterministic: bool) -> None:
+        from torch._native.ops.topk.cutedsl_kernels import topk_radix
+
+        torch.manual_seed(13)
+        k = 64
+        n = _radix_min_n_for_k(k, "bfloat16")
+        x = torch.randn(256, n, device="cuda", dtype=torch.bfloat16)
+        with torch.backends.python_native.cutedsl.disabled():
+            ref_v, ref_i = torch.topk(x, k, dim=-1)
+        got_v, got_i = topk_radix(x, k, deterministic=deterministic)
+        self.assertEqual(got_v, ref_v)
+        self.assertEqual(torch.gather(x, -1, got_i), got_v)
+        self.assertEqual(got_i.dtype, torch.int64)
+        if deterministic:
+            self.assertEqual(got_i, ref_i)
 
     @parametrize("k", _SUPPORTED_KS)
     def test_correctness_random_gaussian(self, k: int) -> None:

--- a/test/python_native/test_topk_radix_kernel.py
+++ b/test/python_native/test_topk_radix_kernel.py
@@ -25,22 +25,15 @@ class TestRadixKernelBuilder(TestCase):
     def test_build_contract(self):
         from torch._native.ops.topk.cutedsl_kernels import build
 
-        b = build(
-            {
-                "kernel": "radix",
-                "dtype": "float32",
-                "K": 64,
-                "deterministic": False,
-                "scalar_tail_iters": None,
-                "fixed_vec_iters": None,
-            }
-        )
-        self.assertEqual(b["prefix"], "topk_radix_f32_k64_nondet_vdyn_tdyn")
+        b = build({"dtype": "float32", "N": 4096, "K": 64, "deterministic": False})
+        self.assertEqual(b["prefix"], "topk_radix_f32_n4096_k64_nondet")
         self.assertEqual(len(b["fake_args"]), 4)
         self.assertEqual(
             [t["name"] for t in b["tensor_args"]], ["mX", "mValues", "mIndices"]
         )
-        self.assertEqual(b["tensor_args"][0]["dynamic_sizes"], [0, 1])
+        self.assertEqual(b["tensor_args"][0]["dynamic_sizes"], [0])
+        self.assertIsNone(b["fn"].scalar_tail_iters)
+        self.assertIsNone(b["fn"].fixed_vec_iters)
 
     @skipIfNoCuteDSL
     def test_build_prefixes_unique_across_grid(self):
@@ -49,16 +42,7 @@ class TestRadixKernelBuilder(TestCase):
         prefixes = set()
         for dtype in ("float32", "bfloat16"):
             for det in (False, True):
-                b = build(
-                    {
-                        "kernel": "radix",
-                        "dtype": dtype,
-                        "K": 64,
-                        "deterministic": det,
-                        "scalar_tail_iters": None,
-                        "fixed_vec_iters": None,
-                    }
-                )
+                b = build({"dtype": dtype, "N": 4096, "K": 64, "deterministic": det})
                 prefixes.add(b["prefix"])
         self.assertEqual(len(prefixes), 4)
 
@@ -66,25 +50,33 @@ class TestRadixKernelBuilder(TestCase):
     def test_launch_bounds_compile_without_cuda_device(self):
         import cutlass.cute as cute
         import cutlass.cutlass_dsl.cutlass as cutlass_dsl
+        from cutlass import Float32, Int64
 
-        from torch._native.ops.topk.cutedsl_kernels import build
-
-        b = build(
-            {
-                "kernel": "radix",
-                "dtype": "float32",
-                "K": 1024,
-                "deterministic": True,
-                "scalar_tail_iters": 0,
-                "fixed_vec_iters": None,
-            }
+        from torch._native.ops.topk.cutedsl_kernels import (
+            _make_fake_tensor,
+            _RadixSelectTopK,
         )
+
+        batch = cute.sym_int()
+        k = 1024
         with mock.patch.object(
             cutlass_dsl.cuda_helpers,
             "get_device_attribute",
             side_effect=AssertionError("unexpected CUDA device query"),
         ):
-            cute.compile(b["fn"], *b["fake_args"])
+            cute.compile(
+                _RadixSelectTopK(
+                    k,
+                    deterministic=True,
+                    index_dtype=Int64,
+                    scalar_tail_iters=4,
+                    min_blocks_per_mp=2,
+                ),
+                _make_fake_tensor(Float32, (batch, 32768), 4),
+                _make_fake_tensor(Float32, (batch, k), 4),
+                _make_fake_tensor(Int64, (batch, k), 4),
+                cute.runtime.make_fake_stream(),
+            )
 
 
 @unittest.skipUnless(TEST_CUDA, "CUDA required")

--- a/test/python_native/test_topk_radix_kernel.py
+++ b/test/python_native/test_topk_radix_kernel.py
@@ -7,6 +7,7 @@ contract and the dtype/index-width compile parameters against stock aten.
 """
 
 import unittest
+from unittest import mock
 
 import torch
 from torch.testing._internal.common_cuda import TEST_CUDA
@@ -24,12 +25,22 @@ class TestRadixKernelBuilder(TestCase):
     def test_build_contract(self):
         from torch._native.ops.topk.cutedsl_kernels import build
 
-        b = build({"dtype": "float32", "N": 4096, "K": 64, "deterministic": False})
-        self.assertEqual(b["prefix"], "topk_radix_f32_n4096_k64_nondet")
+        b = build(
+            {
+                "kernel": "radix",
+                "dtype": "float32",
+                "K": 64,
+                "deterministic": False,
+                "scalar_tail_iters": None,
+                "fixed_vec_iters": None,
+            }
+        )
+        self.assertEqual(b["prefix"], "topk_radix_f32_k64_nondet_vdyn_tdyn")
         self.assertEqual(len(b["fake_args"]), 4)
         self.assertEqual(
             [t["name"] for t in b["tensor_args"]], ["mX", "mValues", "mIndices"]
         )
+        self.assertEqual(b["tensor_args"][0]["dynamic_sizes"], [0, 1])
 
     @skipIfNoCuteDSL
     def test_build_prefixes_unique_across_grid(self):
@@ -38,9 +49,42 @@ class TestRadixKernelBuilder(TestCase):
         prefixes = set()
         for dtype in ("float32", "bfloat16"):
             for det in (False, True):
-                b = build({"dtype": dtype, "N": 4096, "K": 64, "deterministic": det})
+                b = build(
+                    {
+                        "kernel": "radix",
+                        "dtype": dtype,
+                        "K": 64,
+                        "deterministic": det,
+                        "scalar_tail_iters": None,
+                        "fixed_vec_iters": None,
+                    }
+                )
                 prefixes.add(b["prefix"])
         self.assertEqual(len(prefixes), 4)
+
+    @skipIfNoCuteDSL
+    def test_launch_bounds_compile_without_cuda_device(self):
+        import cutlass.cute as cute
+        import cutlass.cutlass_dsl.cutlass as cutlass_dsl
+
+        from torch._native.ops.topk.cutedsl_kernels import build
+
+        b = build(
+            {
+                "kernel": "radix",
+                "dtype": "float32",
+                "K": 1024,
+                "deterministic": True,
+                "scalar_tail_iters": 0,
+                "fixed_vec_iters": None,
+            }
+        )
+        with mock.patch.object(
+            cutlass_dsl.cuda_helpers,
+            "get_device_attribute",
+            side_effect=AssertionError("unexpected CUDA device query"),
+        ):
+            cute.compile(b["fn"], *b["fake_args"])
 
 
 @unittest.skipUnless(TEST_CUDA, "CUDA required")
@@ -66,7 +110,7 @@ class TestRadixKernelParams(TestCase):
         i_f = _make_fake_tensor(index_dtype, (batch, k), math.gcd(4, k))
         compiled = cute.compile(
             _RadixSelectTopK(
-                N, k, deterministic=True, in_dtype=in_dtype, index_dtype=index_dtype
+                k, deterministic=True, in_dtype=in_dtype, index_dtype=index_dtype
             ),
             x_f,
             v_f,

--- a/torch/_native/ops/topk/aot.py
+++ b/torch/_native/ops/topk/aot.py
@@ -22,6 +22,54 @@ ARCHS = ("sm_90", "sm_90a", "sm_100", "sm_100a")
 _DTYPES = {"float32": "at::kFloat", "bfloat16": "at::kBFloat16"}
 _NS = [2048, 4096, 8192, 16384]
 _KS = [64, 128, 256]
+_RADIX_KS = (64, 128, 256, 512, 1024)
+_REGISTER_DYNAMIC_NS = (64, 128, 256, 512, 1024)
+_REGISTER_RUNGS = {
+    16: (_REGISTER_DYNAMIC_NS, (2048,)),
+    32: ((256,),),
+}
+_RADIX_MIN_N = {
+    "float32": {
+        9: {64: 2048, 128: 2048, 256: 2048, 512: 4096, 1024: 32768},
+        10: {64: 128, 128: 256, 256: 512, 512: 4096, 1024: 32768},
+    },
+    "bfloat16": {
+        9: {64: 2048, 128: 2048, 256: 2048, 512: 4096, 1024: 32768},
+        10: {64: 2048, 128: 2048, 256: 2048, 512: 4096, 1024: 32768},
+    },
+}
+_MAX_TAIL_ITERS = 4
+
+
+def _radix_min_n(dtype, k, major):
+    if dtype not in _RADIX_MIN_N or k not in _RADIX_KS or major < 9:
+        return None
+    capability = 10 if major >= 10 else 9
+    return _RADIX_MIN_N[dtype][capability][k]
+
+
+def _register_rung(n, k):
+    for rung in _REGISTER_RUNGS.get(k, ()):
+        if n in rung:
+            return "_".join(str(value) for value in rung)
+    return None
+
+
+def _specialization(n, k, deterministic):
+    if k not in _RADIX_KS or n % 4:
+        return None, None
+    num_threads = max(k, 256)
+    tile = num_threads * 4
+    vec_iters = n // tile
+    fixed_vec_iters = None
+    if k <= 256 and vec_iters <= 1:
+        fixed_vec_iters = 1
+    elif deterministic and k == 512 and vec_iters == 2:
+        fixed_vec_iters = vec_iters
+    scalar_tail_iters = (
+        _MAX_TAIL_ITERS if deterministic or fixed_vec_iters is not None else None
+    )
+    return scalar_tail_iters, fixed_vec_iters
 
 
 def kernel_precompile_grid():

--- a/torch/_native/ops/topk/cutedsl_kernels.py
+++ b/torch/_native/ops/topk/cutedsl_kernels.py
@@ -240,6 +240,7 @@ class _RadixSelectTopK:
             grid=[M, 1, 1],
             block=[self.NUM_THREADS, 1, 1],
             min_blocks_per_mp=self.min_blocks_per_mp,
+            preferred_smem_carveout=0 if self.min_blocks_per_mp > 1 else None,
             stream=stream,
         )
 

--- a/torch/_native/ops/topk/cutedsl_kernels.py
+++ b/torch/_native/ops/topk/cutedsl_kernels.py
@@ -321,7 +321,10 @@ class _RadixSelectTopK:
             if byte_pos == 0:
                 # First pass: decided_mask==0, every element participates.
                 for step in cutlass.range(VEC_ITERS):
-                    if step < ACTUAL_VEC_ITERS:
+                    vec_active = True
+                    if const_expr(self.fixed_vec_iters is not None):
+                        vec_active = step < ACTUAL_VEC_ITERS
+                    if vec_active:
                         base = step * NT * VEC + tidx * VEC
                         rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
                         for vi in cutlass.range_constexpr(self.VEC):
@@ -340,7 +343,10 @@ class _RadixSelectTopK:
                         cute.arch.atomic_add(_elem_ptr(s_hist, byte_val), Int32(1))
             else:
                 for step in cutlass.range(VEC_ITERS):
-                    if step < ACTUAL_VEC_ITERS:
+                    vec_active = True
+                    if const_expr(self.fixed_vec_iters is not None):
+                        vec_active = step < ACTUAL_VEC_ITERS
+                    if vec_active:
                         base = step * NT * VEC + tidx * VEC
                         rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
                         for vi in cutlass.range_constexpr(self.VEC):
@@ -427,7 +433,10 @@ class _RadixSelectTopK:
             above_base = Int32(0)
             eq_base = Int32(0)
             for step in cutlass.range(VEC_ITERS):
-                if step < ACTUAL_VEC_ITERS:
+                vec_active = True
+                if const_expr(self.fixed_vec_iters is not None):
+                    vec_active = step < ACTUAL_VEC_ITERS
+                if vec_active:
                     base = step * NT * VEC + tidx * VEC
                     rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
 
@@ -541,7 +550,10 @@ class _RadixSelectTopK:
         else:
             # Non-deterministic atomic-counter gather.
             for step in cutlass.range(VEC_ITERS):
-                if step < ACTUAL_VEC_ITERS:
+                vec_active = True
+                if const_expr(self.fixed_vec_iters is not None):
+                    vec_active = step < ACTUAL_VEC_ITERS
+                if vec_active:
                     base = step * NT * VEC + tidx * VEC
                     rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
                     for vi in cutlass.range_constexpr(self.VEC):
@@ -698,9 +710,6 @@ def build(spec: dict) -> dict:
     dtype = _DTYPES[spec["dtype"]]
     N, K = int(spec["N"]), int(spec["K"])
     deterministic = bool(spec.get("deterministic", False))
-    from .aot import _specialization
-
-    scalar_tail_iters, fixed_vec_iters = _specialization(N, K, deterministic)
     batch_sym = cute.sym_int()
     div_n = math.gcd(4, N)
     div_k = math.gcd(4, K)
@@ -716,11 +725,6 @@ def build(spec: dict) -> dict:
             deterministic=deterministic,
             in_dtype=dtype,
             index_dtype=Int64,
-            scalar_tail_iters=scalar_tail_iters,
-            fixed_vec_iters=fixed_vec_iters,
-            min_blocks_per_mp=_radix_min_blocks_per_mp(
-                K, deterministic, scalar_tail_iters
-            ),
         ),
         "fake_args": [
             x_fake,

--- a/torch/_native/ops/topk/cutedsl_kernels.py
+++ b/torch/_native/ops/topk/cutedsl_kernels.py
@@ -185,37 +185,47 @@ def _block_excl_prefix_i32(
 class _RadixSelectTopK:
     """One-CTA-per-row fused radix-select + bitonic sort.
 
-    See the module docstring for the algorithm. Compile-time parameters:
-    ``N``/``K``/``deterministic`` select the shape specialization;
+    ``K`` and ``deterministic`` are specialised at compile time. ``N`` is
+    dynamic. Bounded vector/tail work rungs avoid occupancy cliffs without
+    returning to exact-N specialisation.
+
     ``in_dtype`` is Float32 or BFloat16 (bf16 widens to fp32 at load --
     exact and monotone -- and narrows back on the phase-4 store);
     ``index_dtype`` is Int32 (JIT path, staged then widened by the
     wrapper) or Int64 (AOT path, writes aten's int64 indices directly).
+
+    When ``deterministic`` is True, phase 2 uses block-wide prefix-sum
+    scans for input-stable gather and phase 3's bitonic comparator uses
+    a lex ``(ord, -idx)`` key. Output matches aten bit-exactly.
+
+    When ``deterministic`` is False, phase 2 uses smem atomic counters
+    for the gather and phase 3 sorts by ord-only. Faster (no extra smem
+    bookkeeping, no per-step block barrier on the gather), but ties at
+    the threshold radix bin are resolved non-deterministically and
+    indices may differ across runs.
     """
 
     VEC: int = 4
 
     def __init__(
         self,
-        N: int,
         K: int,
         deterministic: bool = True,
         in_dtype=Float32,
         index_dtype=Int32,
+        scalar_tail_iters: int | None = None,
+        fixed_vec_iters: int | None = None,
+        min_blocks_per_mp: int = 0,
     ):
-        self.N = N
         self.K = K
         self.deterministic = deterministic
         self.in_dtype = in_dtype
         self.index_dtype = index_dtype
+        self.scalar_tail_iters = scalar_tail_iters
+        self.fixed_vec_iters = fixed_vec_iters
+        self.min_blocks_per_mp = min_blocks_per_mp
         self.NUM_THREADS = _num_threads_for_k(K)
         self.NUM_STAGES = int(math.log2(K))
-        TILE = self.NUM_THREADS * self.VEC
-        self.VEC_ITERS = N // TILE
-        self.VEC_TAIL_START = self.VEC_ITERS * TILE
-        self.SCALAR_TAIL_ITERS = (
-            N - self.VEC_TAIL_START + self.NUM_THREADS - 1
-        ) // self.NUM_THREADS
 
     @cute.jit
     def __call__(
@@ -229,6 +239,7 @@ class _RadixSelectTopK:
         self.kernel(mX, mValues, mIndices).launch(
             grid=[M, 1, 1],
             block=[self.NUM_THREADS, 1, 1],
+            min_blocks_per_mp=self.min_blocks_per_mp,
             stream=stream,
         )
 
@@ -237,13 +248,21 @@ class _RadixSelectTopK:
         tidx, _, _ = cute.arch.thread_idx()
         row, _, _ = cute.arch.block_idx()
 
-        N = const_expr(self.N)
+        N = mX.shape[1]
         K = const_expr(self.K)
         NT = const_expr(self.NUM_THREADS)
         VEC = const_expr(self.VEC)
-        VEC_ITERS = const_expr(self.VEC_ITERS)
-        VEC_TAIL_START = const_expr(self.VEC_TAIL_START)
-        SCALAR_TAIL_ITERS = const_expr(self.SCALAR_TAIL_ITERS)
+        TILE = const_expr(self.NUM_THREADS * self.VEC)
+        ACTUAL_VEC_ITERS = N // TILE
+        if const_expr(self.fixed_vec_iters is None):
+            VEC_ITERS = ACTUAL_VEC_ITERS
+        else:
+            VEC_ITERS = const_expr(self.fixed_vec_iters)
+        VEC_TAIL_START = ACTUAL_VEC_ITERS * TILE
+        if const_expr(self.scalar_tail_iters is None):
+            SCALAR_TAIL_ITERS = (N - VEC_TAIL_START + NT - 1) // NT
+        else:
+            SCALAR_TAIL_ITERS = const_expr(self.scalar_tail_iters)
         N_HIST_BINS = const_expr(_N_HIST_BINS)
         IN_DTYPE = self.in_dtype
         INDEX_DTYPE = self.index_dtype
@@ -301,14 +320,15 @@ class _RadixSelectTopK:
             if byte_pos == 0:
                 # First pass: decided_mask==0, every element participates.
                 for step in cutlass.range(VEC_ITERS):
-                    base = step * NT * VEC + tidx * VEC
-                    rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
-                    for vi in cutlass.range_constexpr(self.VEC):
-                        ords = _f32_to_radix_ord(Float32(rvals[vi]))
-                        byte_val = ((ords >> Int32(shift)) & Int32(255)) ^ Int32(
-                            xor_val
-                        )
-                        cute.arch.atomic_add(_elem_ptr(s_hist, byte_val), Int32(1))
+                    if step < ACTUAL_VEC_ITERS:
+                        base = step * NT * VEC + tidx * VEC
+                        rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
+                        for vi in cutlass.range_constexpr(self.VEC):
+                            ords = _f32_to_radix_ord(Float32(rvals[vi]))
+                            byte_val = ((ords >> Int32(shift)) & Int32(255)) ^ Int32(
+                                xor_val
+                            )
+                            cute.arch.atomic_add(_elem_ptr(s_hist, byte_val), Int32(1))
                 for step in cutlass.range(SCALAR_TAIL_ITERS):
                     idx = VEC_TAIL_START + step * NT + tidx
                     if idx < N:
@@ -319,15 +339,18 @@ class _RadixSelectTopK:
                         cute.arch.atomic_add(_elem_ptr(s_hist, byte_val), Int32(1))
             else:
                 for step in cutlass.range(VEC_ITERS):
-                    base = step * NT * VEC + tidx * VEC
-                    rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
-                    for vi in cutlass.range_constexpr(self.VEC):
-                        ords = _f32_to_radix_ord(Float32(rvals[vi]))
-                        if (ords & decided_mask) == prefix:
-                            byte_val = ((ords >> Int32(shift)) & Int32(255)) ^ Int32(
-                                xor_val
-                            )
-                            cute.arch.atomic_add(_elem_ptr(s_hist, byte_val), Int32(1))
+                    if step < ACTUAL_VEC_ITERS:
+                        base = step * NT * VEC + tidx * VEC
+                        rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
+                        for vi in cutlass.range_constexpr(self.VEC):
+                            ords = _f32_to_radix_ord(Float32(rvals[vi]))
+                            if (ords & decided_mask) == prefix:
+                                byte_val = (
+                                    (ords >> Int32(shift)) & Int32(255)
+                                ) ^ Int32(xor_val)
+                                cute.arch.atomic_add(
+                                    _elem_ptr(s_hist, byte_val), Int32(1)
+                                )
                 for step in cutlass.range(SCALAR_TAIL_ITERS):
                     idx = VEC_TAIL_START + step * NT + tidx
                     if idx < N:
@@ -403,95 +426,100 @@ class _RadixSelectTopK:
             above_base = Int32(0)
             eq_base = Int32(0)
             for step in cutlass.range(VEC_ITERS):
-                base = step * NT * VEC + tidx * VEC
-                rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
+                if step < ACTUAL_VEC_ITERS:
+                    base = step * NT * VEC + tidx * VEC
+                    rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
 
-                # Hoist per-element classification into per-lane registers
-                # so the count pass and write pass don't redo the radix-ord
-                # transform and threshold compare.
-                # Class encoding: 2 = above, 1 = eq, 0 = below.
-                cls_reg = cute.make_rmem_tensor(VEC, Int32)
-                packed_local = Int32(0)
-                for vi in cutlass.range_constexpr(self.VEC):
-                    o = _f32_to_radix_ord(Float32(rvals[vi]))
-                    if o > threshold:
-                        cls_reg[vi] = Int32(2)
-                        packed_local = packed_local + Int32(1 << 16)
-                    elif o == threshold:
-                        cls_reg[vi] = Int32(1)
-                        packed_local = packed_local + Int32(1)
-                    else:
-                        cls_reg[vi] = Int32(0)
+                    # Hoist per-element classification into per-lane registers
+                    # so the count pass and write pass don't redo the radix-ord
+                    # transform and threshold compare.
+                    # Class encoding: 2 = above, 1 = eq, 0 = below.
+                    cls_reg = cute.make_rmem_tensor(VEC, Int32)
+                    packed_local = Int32(0)
+                    for vi in cutlass.range_constexpr(self.VEC):
+                        o = _f32_to_radix_ord(Float32(rvals[vi]))
+                        if o > threshold:
+                            cls_reg[vi] = Int32(2)
+                            packed_local = packed_local + Int32(1 << 16)
+                        elif o == threshold:
+                            cls_reg[vi] = Int32(1)
+                            packed_local = packed_local + Int32(1)
+                        else:
+                            cls_reg[vi] = Int32(0)
 
-                # Block-wide exclusive prefix sum. ``s_hist`` is reused as
-                # scratch for the warp-total scan (Phase 1 is done with it).
-                packed_pfx, packed_step_total = _block_excl_prefix_i32(
-                    packed_local, s_hist, lane_idx, warp_idx, NUM_WARPS
-                )
-                above_pfx = packed_pfx >> Int32(16)
-                eq_pfx = packed_pfx & Int32(0xFFFF)
+                    # Block-wide exclusive prefix sum. ``s_hist`` is reused as
+                    # scratch for the warp-total scan (Phase 1 is done with it).
+                    packed_pfx, packed_step_total = _block_excl_prefix_i32(
+                        packed_local, s_hist, lane_idx, warp_idx, NUM_WARPS
+                    )
+                    above_pfx = packed_pfx >> Int32(16)
+                    eq_pfx = packed_pfx & Int32(0xFFFF)
 
-                # Per-thread write offsets within this step.
-                my_above = above_base + above_pfx
-                my_eq = eq_base + eq_pfx
-                for vi in cutlass.range_constexpr(self.VEC):
-                    val_f32 = Float32(rvals[vi])
-                    cls = cls_reg[vi]
-                    idx = base + Int32(vi)
-                    if cls == Int32(2):
-                        if my_above < Int32(K):
-                            s_vals[my_above] = val_f32
-                            s_idxs[my_above] = Int32(idx)
-                        my_above = my_above + Int32(1)
-                    elif cls == Int32(1):
-                        if my_eq < remaining_k:
-                            s_eq_vals[my_eq] = val_f32
-                            s_eq_idxs[my_eq] = Int32(idx)
-                        my_eq = my_eq + Int32(1)
+                    # Per-thread write offsets within this step.
+                    my_above = above_base + above_pfx
+                    my_eq = eq_base + eq_pfx
+                    for vi in cutlass.range_constexpr(self.VEC):
+                        val_f32 = Float32(rvals[vi])
+                        cls = cls_reg[vi]
+                        idx = base + Int32(vi)
+                        if cls == Int32(2):
+                            if my_above < Int32(K):
+                                s_vals[my_above] = val_f32
+                                s_idxs[my_above] = Int32(idx)
+                            my_above = my_above + Int32(1)
+                        elif cls == Int32(1):
+                            if my_eq < remaining_k:
+                                s_eq_vals[my_eq] = val_f32
+                                s_eq_idxs[my_eq] = Int32(idx)
+                            my_eq = my_eq + Int32(1)
 
-                # Advance running bases. Cap eq at remaining_k - we never
-                # need more. All threads update in registers; no smem.
-                above_base = above_base + (packed_step_total >> Int32(16))
-                eq_base = min(
-                    remaining_k, eq_base + (packed_step_total & Int32(0xFFFF))
-                )
+                    # Advance running bases. Cap eq at remaining_k - we never
+                    # need more. All threads update in registers; no smem.
+                    above_base = above_base + (packed_step_total >> Int32(16))
+                    eq_base = min(
+                        remaining_k, eq_base + (packed_step_total & Int32(0xFFFF))
+                    )
 
             # --- Scalar tail ---
             for step in cutlass.range(SCALAR_TAIL_ITERS):
-                idx = VEC_TAIL_START + step * NT + tidx
-                valid = idx < N
-                packed_local = Int32(0)
-                if valid:
-                    ords = _f32_to_radix_ord(Float32(mX[row, idx]))
-                    if ords > threshold:
-                        packed_local = Int32(1 << 16)
-                    elif ords == threshold:
-                        packed_local = Int32(1)
+                step_start = VEC_TAIL_START + step * NT
+                # A fixed upper bound can cover every tail count. Keep the
+                # block-wide scan out of wholly inactive iterations.
+                if step_start < N:
+                    idx = step_start + tidx
+                    valid = idx < N
+                    packed_local = Int32(0)
+                    if valid:
+                        ords = _f32_to_radix_ord(Float32(mX[row, idx]))
+                        if ords > threshold:
+                            packed_local = Int32(1 << 16)
+                        elif ords == threshold:
+                            packed_local = Int32(1)
 
-                packed_pfx, packed_step_total = _block_excl_prefix_i32(
-                    packed_local, s_hist, lane_idx, warp_idx, NUM_WARPS
-                )
-                above_pfx = packed_pfx >> Int32(16)
-                eq_pfx = packed_pfx & Int32(0xFFFF)
+                    packed_pfx, packed_step_total = _block_excl_prefix_i32(
+                        packed_local, s_hist, lane_idx, warp_idx, NUM_WARPS
+                    )
+                    above_pfx = packed_pfx >> Int32(16)
+                    eq_pfx = packed_pfx & Int32(0xFFFF)
 
-                my_above = above_base + above_pfx
-                my_eq = eq_base + eq_pfx
-                if valid:
-                    val_f32 = Float32(mX[row, idx])
-                    ords = _f32_to_radix_ord(val_f32)
-                    if ords > threshold:
-                        if my_above < Int32(K):
-                            s_vals[my_above] = val_f32
-                            s_idxs[my_above] = Int32(idx)
-                    elif ords == threshold:
-                        if my_eq < remaining_k:
-                            s_eq_vals[my_eq] = val_f32
-                            s_eq_idxs[my_eq] = Int32(idx)
+                    my_above = above_base + above_pfx
+                    my_eq = eq_base + eq_pfx
+                    if valid:
+                        val_f32 = Float32(mX[row, idx])
+                        ords = _f32_to_radix_ord(val_f32)
+                        if ords > threshold:
+                            if my_above < Int32(K):
+                                s_vals[my_above] = val_f32
+                                s_idxs[my_above] = Int32(idx)
+                        elif ords == threshold:
+                            if my_eq < remaining_k:
+                                s_eq_vals[my_eq] = val_f32
+                                s_eq_idxs[my_eq] = Int32(idx)
 
-                above_base = above_base + (packed_step_total >> Int32(16))
-                eq_base = min(
-                    remaining_k, eq_base + (packed_step_total & Int32(0xFFFF))
-                )
+                    above_base = above_base + (packed_step_total >> Int32(16))
+                    eq_base = min(
+                        remaining_k, eq_base + (packed_step_total & Int32(0xFFFF))
+                    )
 
             # The eq-merge below has each thread read s_eq_vals[tidx - n_above],
             # i.e. a slot written by some other thread during the gather above.
@@ -512,26 +540,31 @@ class _RadixSelectTopK:
         else:
             # Non-deterministic atomic-counter gather.
             for step in cutlass.range(VEC_ITERS):
-                base = step * NT * VEC + tidx * VEC
-                rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
-                for vi in cutlass.range_constexpr(self.VEC):
-                    val_f32 = Float32(rvals[vi])
-                    idx = base + Int32(vi)
-                    ords = _f32_to_radix_ord(val_f32)
-                    if ords > threshold:
-                        pos = cute.arch.atomic_add(_elem_ptr(s_write_ctr, 0), Int32(1))
-                        if pos < Int32(K):
-                            s_vals[pos] = val_f32
-                            s_idxs[pos] = Int32(idx)
-                    elif ords == threshold:
-                        eq_pos = cute.arch.atomic_add(_elem_ptr(s_eq_ctr, 0), Int32(1))
-                        if eq_pos < remaining_k:
+                if step < ACTUAL_VEC_ITERS:
+                    base = step * NT * VEC + tidx * VEC
+                    rvals = _load_vec(_elem_ptr(mX, (row, base)), VEC, IN_DTYPE)
+                    for vi in cutlass.range_constexpr(self.VEC):
+                        val_f32 = Float32(rvals[vi])
+                        idx = base + Int32(vi)
+                        ords = _f32_to_radix_ord(val_f32)
+                        if ords > threshold:
                             pos = cute.arch.atomic_add(
                                 _elem_ptr(s_write_ctr, 0), Int32(1)
                             )
                             if pos < Int32(K):
                                 s_vals[pos] = val_f32
                                 s_idxs[pos] = Int32(idx)
+                        elif ords == threshold:
+                            eq_pos = cute.arch.atomic_add(
+                                _elem_ptr(s_eq_ctr, 0), Int32(1)
+                            )
+                            if eq_pos < remaining_k:
+                                pos = cute.arch.atomic_add(
+                                    _elem_ptr(s_write_ctr, 0), Int32(1)
+                                )
+                                if pos < Int32(K):
+                                    s_vals[pos] = val_f32
+                                    s_idxs[pos] = Int32(idx)
             for step in cutlass.range(SCALAR_TAIL_ITERS):
                 idx = VEC_TAIL_START + step * NT + tidx
                 if idx < N:
@@ -644,6 +677,13 @@ _DTYPES = {"float32": Float32, "bfloat16": BFloat16}
 _DTYPE_SHORT = {"float32": "f32", "bfloat16": "bf16"}
 
 
+def _radix_min_blocks_per_mp(
+    k: int, deterministic: bool, scalar_tail_iters: int | None
+) -> int:
+    # These K=1024 tail rungs otherwise exceed the two-CTA register budget.
+    return 2 if deterministic and k == 1024 and scalar_tail_iters in (0, 3, 4) else 0
+
+
 def build(spec: dict) -> dict:
     """AOT builder: one manifest spec point -> compile inputs + sidecar.
 
@@ -652,12 +692,14 @@ def build(spec: dict) -> dict:
      "deterministic": bool}. Returns {"prefix", "fn", "fake_args",
     "tensor_args"}; the export tool runs ``cute.compile(fn, *fake_args)``
     and ``export_to_c`` under ``prefix``, then writes ``tensor_args`` to
-    the marshalling sidecar. AOT kernels always store int64 indices
-    (aten's output dtype), unlike the JIT path's int32-plus-widen.
+    the marshalling sidecar.
     """
     dtype = _DTYPES[spec["dtype"]]
     N, K = int(spec["N"]), int(spec["K"])
     deterministic = bool(spec.get("deterministic", False))
+    from .aot import _specialization
+
+    scalar_tail_iters, fixed_vec_iters = _specialization(N, K, deterministic)
     batch_sym = cute.sym_int()
     div_n = math.gcd(4, N)
     div_k = math.gcd(4, K)
@@ -669,7 +711,15 @@ def build(spec: dict) -> dict:
     return {
         "prefix": prefix,
         "fn": _RadixSelectTopK(
-            N, K, deterministic=deterministic, in_dtype=dtype, index_dtype=Int64
+            K,
+            deterministic=deterministic,
+            in_dtype=dtype,
+            index_dtype=Int64,
+            scalar_tail_iters=scalar_tail_iters,
+            fixed_vec_iters=fixed_vec_iters,
+            min_blocks_per_mp=_radix_min_blocks_per_mp(
+                K, deterministic, scalar_tail_iters
+            ),
         ),
         "fake_args": [
             x_fake,
@@ -692,17 +742,41 @@ def build(spec: dict) -> dict:
 
 @instrumented_cutedsl_cache(
     "aten::topk",
-    key_fn=lambda N, K, deterministic: f"radix N={N} K={K} det={deterministic}",
+    key_fn=lambda K,
+    deterministic,
+    scalar_tail_iters,
+    fixed_vec_iters,
+    dtype="float32": (
+        f"radix dtype={dtype} K={K} det={deterministic} "
+        f"tail={scalar_tail_iters} vec={fixed_vec_iters}"
+    ),
 )
-def _compile_topk_radix(N: int, K: int, deterministic: bool):
+def _compile_topk_radix_fixed_max(
+    K: int,
+    deterministic: bool,
+    scalar_tail_iters: int | None,
+    fixed_vec_iters: int | None,
+    dtype: str = "float32",
+):
     batch_sym = cute.sym_int()
-    div_n = math.gcd(4, N)
+    n_sym = cute.sym_int(divisibility=4)
     div_k = math.gcd(4, K)
-    x_fake = _make_fake_tensor(Float32, (batch_sym, N), div_n)
-    v_fake = _make_fake_tensor(Float32, (batch_sym, K), div_k)
-    i_fake = _make_fake_tensor(Int32, (batch_sym, K), div_k)
+    in_dtype = _DTYPES[dtype]
+    x_fake = _make_fake_tensor(in_dtype, (batch_sym, n_sym), 4)
+    v_fake = _make_fake_tensor(in_dtype, (batch_sym, K), div_k)
+    i_fake = _make_fake_tensor(Int64, (batch_sym, K), div_k)
     return cute.compile(
-        _RadixSelectTopK(N, K, deterministic=deterministic),
+        _RadixSelectTopK(
+            K,
+            deterministic=deterministic,
+            in_dtype=in_dtype,
+            index_dtype=Int64,
+            scalar_tail_iters=scalar_tail_iters,
+            fixed_vec_iters=fixed_vec_iters,
+            min_blocks_per_mp=_radix_min_blocks_per_mp(
+                K, deterministic, scalar_tail_iters
+            ),
+        ),
         x_fake,
         v_fake,
         i_fake,
@@ -711,12 +785,15 @@ def _compile_topk_radix(N: int, K: int, deterministic: bool):
     )
 
 
+_compile_topk_radix = _compile_topk_radix_fixed_max
+
+
 def topk_radix(
     x: torch.Tensor, k: int, *, deterministic: bool = True
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Fused radix-select top-K for fp32 2D contiguous ``x``.
+    """Fused radix-select top-K for fp32/bf16 2D contiguous ``x``.
 
-    Returns ``(values[M, K]: fp32, indices[M, K]: int64)`` with K sorted
+    Returns values in the input dtype and int64 indices with K sorted
     descending per row. Caller must ensure ``k`` is in the supported set
     (see ``cutedsl_impl.py``) and ``N % 4 == 0``.
 
@@ -726,11 +803,20 @@ def topk_radix(
     is faster but indices may differ on ties.
     """
     M, N = x.shape
-    out_v = torch.empty(M, k, dtype=torch.float32, device=x.device)
-    # Kernel writes int32 indices; widen before returning to match aten.
-    out_i_i32 = torch.empty(M, k, dtype=torch.int32, device=x.device)
-    _compile_topk_radix(N, k, deterministic)(x, out_v, out_i_i32)
-    return out_v, out_i_i32.to(torch.int64)
+    from .aot import _specialization
+
+    scalar_tail_iters, fixed_vec_iters = _specialization(N, k, deterministic)
+    dtype = "float32" if x.dtype == torch.float32 else "bfloat16"
+    out_v = torch.empty(M, k, dtype=x.dtype, device=x.device)
+    out_i = torch.empty(M, k, dtype=torch.int64, device=x.device)
+    _compile_topk_radix(
+        k,
+        deterministic,
+        scalar_tail_iters,
+        fixed_vec_iters,
+        dtype,
+    )(x, out_v, out_i)
+    return out_v, out_i
 
 
 # ---------------------------------------------------------------------------
@@ -819,15 +905,59 @@ def _topk_merge_desc(a: cute.Tensor, b: cute.Tensor, K: cutlass.Constexpr) -> No
     _bitonic_merge_desc(a, K)
 
 
+@cute.jit
+def _register_topk_warp(
+    mX: cute.Tensor,
+    mValues: cute.Tensor,
+    mIndices: cute.Tensor,
+    row,
+    row_safe,
+    in_bounds,
+    lane_idx,
+    K: cutlass.Constexpr,
+    VEC: cutlass.Constexpr,
+) -> None:
+    keys = cute.make_rmem_tensor(VEC, Int64)
+    for i in cutlass.range_constexpr(VEC):
+        col = lane_idx * Int32(VEC) + Int32(i)
+        keys[i] = _make_key(mX[row_safe, col], col)
+
+    _bitonic_sort_desc(keys, VEC)
+
+    topk = cute.make_rmem_tensor(K, Int64)
+    if const_expr(VEC >= K):
+        for i in cutlass.range_constexpr(K):
+            topk[i] = keys[i]
+    else:
+        SENTINEL = const_expr(-(1 << 63))
+        for i in cutlass.range_constexpr(VEC):
+            topk[i] = keys[i]
+        for i in cutlass.range_constexpr(K - VEC):
+            topk[VEC + i] = Int64(SENTINEL)
+        _bitonic_sort_desc(topk, K)
+
+    log2_warp = const_expr(int(math.log2(cute.arch.WARP_SIZE)))
+    for s in cutlass.range_constexpr(log2_warp):
+        other = cute.make_rmem_tensor(K, Int64)
+        for i in cutlass.range_constexpr(K):
+            other[i] = cute.arch.shuffle_sync_bfly(topk[i], offset=Int32(1 << s))
+        _topk_merge_desc(topk, other, K)
+
+    if lane_idx == Int32(0) and in_bounds:
+        for i in cutlass.range_constexpr(K):
+            v, idx = _decode_key(topk[i])
+            mValues[row, i] = v
+            mIndices[row, i] = idx
+
+
 class _RegisterTopK:
     """Register-resident top-K. Each warp owns one row; ``ROWS_PER_CTA``
     warps per CTA. K in {16, 32}, N a power of 2 in [K, 2048].
     """
 
-    def __init__(self, N: int, K: int, rows_per_cta: int = 4):
-        self.N = N
+    def __init__(self, N: int | tuple[int, ...], K: int, rows_per_cta: int = 4):
+        self.NS = (N,) if isinstance(N, int) else N
         self.K = K
-        self.VEC = N // 32
         self.ROWS_PER_CTA = rows_per_cta
         self.NUM_THREADS = 32 * rows_per_cta
 
@@ -854,7 +984,6 @@ class _RegisterTopK:
         bidx, _, _ = cute.arch.block_idx()
 
         K = const_expr(self.K)
-        VEC = const_expr(self.VEC)
         ROWS = const_expr(self.ROWS_PER_CTA)
         WARP_SIZE = const_expr(cute.arch.WARP_SIZE)
 
@@ -868,55 +997,39 @@ class _RegisterTopK:
         row_safe = row if row < M else Int32(0)
         in_bounds = row < M
 
-        # Per-thread Int64 keys covering this row's VEC-sized stripe.
-        keys = cute.make_rmem_tensor(VEC, Int64)
-        for i in cutlass.range_constexpr(VEC):
-            col = lane_idx * Int32(VEC) + Int32(i)
-            keys[i] = _make_key(mX[row_safe, col], col)
-
-        _bitonic_sort_desc(keys, VEC)
-
-        # Build per-thread top-K. If VEC < K, pad with INT64_MIN so the
-        # sentinel sorts strictly below any real key; if VEC >= K take the
-        # leading K (already sorted).
-        topk = cute.make_rmem_tensor(K, Int64)
-        if const_expr(VEC >= K):
-            for i in cutlass.range_constexpr(K):
-                topk[i] = keys[i]
-        else:
-            SENTINEL = const_expr(-(1 << 63))
-            for i in cutlass.range_constexpr(VEC):
-                topk[i] = keys[i]
-            for i in cutlass.range_constexpr(K - VEC):
-                topk[VEC + i] = Int64(SENTINEL)
-            _bitonic_sort_desc(topk, K)
-
-        # Warp-cooperative top-K merge via butterfly shuffles.
-        log2_warp = const_expr(int(math.log2(WARP_SIZE)))
-        for s in cutlass.range_constexpr(log2_warp):
-            other = cute.make_rmem_tensor(K, Int64)
-            for i in cutlass.range_constexpr(K):
-                other[i] = cute.arch.shuffle_sync_bfly(topk[i], offset=Int32(1 << s))
-            _topk_merge_desc(topk, other, K)
-
-        # Lane 0 of each warp now holds the row's top-K descending.
-        if lane_idx == Int32(0) and in_bounds:
-            for i in cutlass.range_constexpr(K):
-                v, idx = _decode_key(topk[i])
-                mValues[row, i] = v
-                mIndices[row, i] = idx
+        N = mX.shape[1]
+        for i in cutlass.range_constexpr(len(self.NS)):
+            if N == const_expr(self.NS[i]):
+                _register_topk_warp(
+                    mX,
+                    mValues,
+                    mIndices,
+                    row,
+                    row_safe,
+                    in_bounds,
+                    lane_idx,
+                    K,
+                    const_expr(self.NS[i] // 32),
+                )
 
 
-@instrumented_cutedsl_cache("aten::topk", key_fn=lambda N, K: f"register N={N} K={K}")
-def _compile_topk_register(N: int, K: int):
+@instrumented_cutedsl_cache(
+    "aten::topk", key_fn=lambda NS, K: f"register-i64 NS={NS} K={K}"
+)
+def _compile_topk_register_i64(NS: tuple[int, ...], K: int):
     batch_sym = cute.sym_int()
-    div_n = math.gcd(4, N)
     div_k = math.gcd(4, K)
-    x_fake = _make_fake_tensor(Float32, (batch_sym, N), div_n)
+    if len(NS) == 1:
+        n_shape = NS[0]
+        div_n = math.gcd(4, NS[0])
+    else:
+        n_shape = cute.sym_int(divisibility=4)
+        div_n = 4
+    x_fake = _make_fake_tensor(Float32, (batch_sym, n_shape), div_n)
     v_fake = _make_fake_tensor(Float32, (batch_sym, K), div_k)
-    i_fake = _make_fake_tensor(Int32, (batch_sym, K), div_k)
+    i_fake = _make_fake_tensor(Int64, (batch_sym, K), div_k)
     return cute.compile(
-        _RegisterTopK(N, K),
+        _RegisterTopK(NS, K),
         x_fake,
         v_fake,
         i_fake,
@@ -933,7 +1046,10 @@ def topk_register(x: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
     ``k`` in {16, 32} and ``N`` is a power of 2 in [k, 2048].
     """
     M, N = x.shape
+    from .aot import _register_rung
+
+    NS = tuple(int(n) for n in _register_rung(N, k).split("_"))
     out_v = torch.empty(M, k, dtype=torch.float32, device=x.device)
-    out_i_i32 = torch.empty(M, k, dtype=torch.int32, device=x.device)
-    _compile_topk_register(N, k)(x, out_v, out_i_i32)
-    return out_v, out_i_i32.to(torch.int64)
+    out_i = torch.empty(M, k, dtype=torch.int64, device=x.device)
+    _compile_topk_register_i64(NS, k)(x, out_v, out_i)
+    return out_v, out_i


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* #196599
* __->__ #196598

Human notes:

Remove static-`N` dependence in the kernels - move to dynamic/rungs as necessary.

Codex:

Replace exact-N radix compilation with runtime N and bounded work rungs. Scalar tails use a fixed maximum of four iterations, small vector regimes use a fixed maximum vector count, and deterministic K=512 retains its measured fixed-work rung. The register kernel uses runtime code branches for the K=16 N=64-1024 ladder while keeping occupancy outliers exact.

The alternatives were materially slower: a fully runtime deterministic tail loop regressed K=1024 by 11-20%, and capacity-padding register ladders regressed by up to 3.5x. The selected bounded-work approach stays close to exact specialization:

| Approach | Latency delta vs exact-N |
| --- | ---: |
| Register branch ladder, N=64-1024 | 0% to +9.3% |
| Fixed max scalar tail | 0% to +5.5% |
| Fully runtime scalar tail, deterministic K=1024 | +11% to +20% |
| Fixed max vector count for small N | +0.8% to +4.9% |

The same lower-commit policy was remeasured on B200 at one full wave (M=148). Each result is the median of seven interleaved measurements; positive deltas are slower than an otherwise identical exact-N kernel:

| B200 regime | Median delta vs full static | Worst delta |
| --- | ---: | ---: |
| FP32 register ladder, N=64-1024 | +2.30% | +10.91% |
| FP32 radix, nondeterministic | +4.58% | +6.03% |
| FP32 radix, deterministic fixed tail | +4.82% | +9.97% |
| FP32 radix, deterministic K=512 fixed vector | +3.04% | +3.25% |
| BF16 radix, nondeterministic | +5.54% | +6.74% |
| BF16 radix, deterministic fixed tail | +5.81% | +10.11% |
| BF16 radix, deterministic K=512 fixed vector | +1.58% | +1.96% |

Combining K=16, N=2048 into the runtime ladder regressed full-wave inputs by up to 72%, so it remains an exact JIT rung. Kernels now write int64 indices directly instead of launching a separate widening operation. Runtime-N vector loops use their runtime extent directly, while only fixed-work rungs retain an active-iteration guard. Static-N AOT callers continue to fold exact tail work.

Offline AOT build workers do not have a CUDA driver. Setting `min_blocks_per_mp=2` made CUTLASS DSL 4.6.2 query device shared-memory attributes while compiling the K=1024 launch bounds. A neutral preferred shared-memory carveout avoids that device query while preserving `nvvm.minctasm` and its register cap. Builder tests cover the static lower-commit contract and compile this path with device queries forced to fail.

Test Plan:
```bash
TORCH_DISABLE_NATIVE_AOT=1 python test/python_native/test_topk_cutedsl.py
python test/python_native/test_topk_radix_kernel.py
python test/python_native/test_topk_cutedsl.py
python test/python_native/test_native_aot.py
python test/python_native/test_topk_cutedsl_eligibility.py
spin lint
```

Authored with assistance from an AI coding assistant.