### PR TITLE
[Native DSL] Share topk policy across JIT and AOT

### DIFF
--- a/test/python_native/test_native_aot.py
+++ b/test/python_native/test_native_aot.py
@@ -145,6 +145,7 @@ class TestNativeAotTopKDeclaration(TestCase):
             }
         )
         self.assertNotIn("N % 4", register)
+        self.assertIn("cc_major < 10 || N != 1024", register)
         self.assertIn("N % 4 == 0", radix)
 
 
@@ -167,14 +168,17 @@ class TestNativeAotTopK(TestCase):
             self.assertEqual(r["index_dtype"], "torch.int64")
 
     @skipIfNoAotLib
-    def test_register_grid_routes_to_aot(self):
+    def test_register_grid_routing(self):
         cases = [
             {"dtype": "float32", "n": n, "k": 16} for n in (64, 128, 256, 512, 1024)
         ]
         results = _run_probe(cases, {"TORCH_DISABLE_NATIVE_JIT": "1"})
+        major = torch.cuda.get_device_capability()[0]
         for case, r in zip(cases, results):
-            self.assertTrue(
-                r["ran_dsl"], f"AOT register kernel did not fire for {case}"
+            self.assertEqual(
+                r["ran_dsl"],
+                not (major >= 10 and case["n"] == 1024),
+                f"unexpected AOT register routing for {case}",
             )
             self.assertTrue(r["values_ok"], f"values mismatch for {case}")
             self.assertTrue(r["gather_ok"], f"gather mismatch for {case}")
@@ -404,6 +408,13 @@ class TestNativeAotTopK(TestCase):
         self.assertEqual(register["N"], None)
         self.assertEqual(register["N_rung"], "64_128_256_512_1024")
         self.assertTrue(register["eligible"])
+        register_1024 = mod.covered_axes(torch.empty(M, 1024, device="cuda"), 16)
+        if torch.cuda.get_device_capability()[0] >= 10:
+            self.assertIsNone(register_1024["N_rung"])
+            self.assertFalse(register_1024["eligible"])
+        else:
+            self.assertEqual(register_1024["N_rung"], "64_128_256_512_1024")
+            self.assertTrue(register_1024["eligible"])
         base = torch.empty(M, 4096, device="cuda")
         cow = base._lazy_clone()
         data_ptr = cow.const_data_ptr()
@@ -431,10 +442,10 @@ class TestNativeAotTopK(TestCase):
         try:
             torch.use_deterministic_algorithms(True)
             for n, k, expected in (
-                (4100, 64, (4, None)),
+                (4100, 64, (mod._ARCH_TAIL_ITERS, None)),
                 (5120, 512, (4, 2)),
-                (6144, 512, (4, None)),
-                (36860, 1024, (4, None)),
+                (6144, 512, (mod._ARCH_TAIL_ITERS, None)),
+                (36860, 1024, (mod._ARCH_TAIL_ITERS, None)),
             ):
                 x = torch.empty(M, n, device="cuda")
                 axes = mod.covered_axes(x, k)

--- a/test/python_native/test_native_aot.py
+++ b/test/python_native/test_native_aot.py
@@ -3,15 +3,15 @@
 
 Three-layer routing under test (declaration: torch/_native/ops/topk/aot.py):
 
-  * covered calls (fp32/bf16 on the exported grid) -> the AOT kernel in the
-    structured wrapper, because the JIT layer's conds subtract AOT coverage
-  * uncovered but JIT-eligible calls (off-grid fp32) -> the JIT override
+  * covered calls -> the AOT kernel in the structured wrapper, because the JIT
+    layer's conds subtract AOT coverage
+  * JIT-only exact-N register calls and covered calls without AOT -> the JIT override
   * everything else -> stock aten
 
 Layers are isolated with the process-level switches TORCH_DISABLE_NATIVE_JIT and
-TORCH_DISABLE_NATIVE_AOT in subprocesses: with the JIT layer off, a RadixSelectTopK
-kernel in a profile can only come from the AOT hook. Values are checked against a
-sort-based reference, which topk routing cannot affect.
+TORCH_DISABLE_NATIVE_AOT in subprocesses: with the JIT layer off, a top-k DSL kernel
+in a profile can only come from the AOT hook. Values are checked against a sort-based
+reference, which topk routing cannot affect.
 
 Tests needing the AOT kernels skip unless this build embedded them; the
 correctness tests run everywhere, since covered calls must be correct through stock
@@ -42,22 +42,19 @@ def skipIfNoAotLib(fn):
 
 
 def skipIfNoJitTopk(fn):
-    """The JIT topk override is gated to sm_100+ (cutedsl_impl._sm100_or_above), while
-    this declaration's AOT kernels cover Hopper as well, so only the tests that assert
-    the JIT layer serves a shape need the narrower device."""
+    """Both top-k routes require Hopper or newer."""
     capability = (
         torch.cuda.get_device_capability() if torch.cuda.is_available() else (0, 0)
     )
-    return unittest.skipUnless(capability[0] >= 10, "JIT topk override needs sm_100+")(
-        fn
-    )
+    return unittest.skipUnless(capability[0] >= 9, "JIT topk override needs sm_90+")(fn)
 
 
-# The exported grid (must match the manifest specs).
+# Representative points in the original measured grid.
 GRID_N = (2048, 4096, 8192, 16384)
 GRID_K = (64, 128, 256)
 # Enough rows to pass the full-wave perf gate on any current GPU.
 M = 256
+JIT_ONLY_REGISTER = ((16, 2048), (32, 256))
 
 # Subprocess probe with the JIT layer disabled and the AOT hooks live. Both layers
 # launch the same CuTeDSL kernel, so the name in the profile says a DSL kernel ran
@@ -85,7 +82,7 @@ for case in json.loads({cases!r}):
         v, i = torch.topk(x, case["k"], dim=-1, **kwargs)
         torch.cuda.synchronize()
     ran_dsl = any(
-        "RadixSelectTopK" in e.name
+        "RadixSelectTopK" in e.name or "RegisterTopK" in e.name
         for e in prof.events()
         if e.device_type.name == "CUDA"
     )
@@ -139,6 +136,48 @@ class TestNativeAotTopK(TestCase):
             self.assertEqual(r["index_dtype"], "torch.int64")
 
     @skipIfNoAotLib
+    def test_register_grid_routes_to_aot(self):
+        cases = [
+            {"dtype": "float32", "n": n, "k": 16} for n in (64, 128, 256, 512, 1024)
+        ]
+        results = _run_probe(cases, {"TORCH_DISABLE_NATIVE_JIT": "1"})
+        for case, r in zip(cases, results):
+            self.assertTrue(
+                r["ran_dsl"], f"AOT register kernel did not fire for {case}"
+            )
+            self.assertTrue(r["values_ok"], f"values mismatch for {case}")
+            self.assertTrue(r["gather_ok"], f"gather mismatch for {case}")
+            self.assertEqual(r["index_dtype"], "torch.int64")
+
+    @skipIfNoAotLib
+    def test_dynamic_n_and_work_rungs_route_to_aot(self):
+        shapes = (
+            (64, 3072),
+            (64, 4100),
+            (64, 4356),
+            (64, 4612),
+            (64, 4868),
+            (512, 4096),
+            (512, 5120),
+            (512, 6140),
+            (512, 6144),
+            (1024, 32772),
+            (1024, 34820),
+            (1024, 36860),
+        )
+        cases = [
+            {"dtype": dtype, "n": n, "k": k, "det": deterministic}
+            for dtype in ("float32", "bfloat16")
+            for deterministic in (False, True)
+            for k, n in shapes
+        ]
+        results = _run_probe(cases, {"TORCH_DISABLE_NATIVE_JIT": "1"})
+        for case, r in zip(cases, results):
+            self.assertTrue(r["ran_dsl"], f"AOT kernel did not fire for {case}")
+            self.assertTrue(r["values_ok"], f"values mismatch for {case}")
+            self.assertTrue(r["gather_ok"], f"gather mismatch for {case}")
+
+    @skipIfNoAotLib
     def test_deterministic_mode_routes_to_aot_bit_exact(self):
         # Det mode is on the grid, so its kernel must fire and match aten bit-exactly.
         # Probe values are torch.randn; ties are exercised in the next test.
@@ -182,8 +221,12 @@ class TestNativeAotTopK(TestCase):
     @skipIfNoAotLib
     def test_uncovered_calls_avoid_aot(self):
         cases = [
-            {"dtype": "float32", "n": 3072, "k": 64},  # off-grid N
+            *({"dtype": "float32", "n": n, "k": k} for k, n in JIT_ONLY_REGISTER),
+            {"dtype": "float32", "n": 124, "k": 64},  # below every radix range
+            {"dtype": "float32", "n": 4101, "k": 64},  # not vector-aligned
             {"dtype": "float32", "n": 4096, "k": 100},  # off-grid K
+            {"dtype": "float32", "n": 512, "k": 32},  # off-grid register N
+            {"dtype": "bfloat16", "n": 256, "k": 16},  # register is fp32-only
             {"dtype": "float16", "n": 4096, "k": 64},
             {"dtype": "float64", "n": 4096, "k": 64},
         ]
@@ -192,25 +235,52 @@ class TestNativeAotTopK(TestCase):
             self.assertFalse(r["ran_dsl"], f"{case} must not route to AOT")
             self.assertTrue(r["values_ok"], f"values mismatch for {case}")
 
-    @skipIfNoAotLib
     @skipIfNoJitTopk
-    def test_uncovered_fp32_served_by_jit_layer(self):
-        # JIT layer live in this process, and off-grid fp32 is uncovered, so the cond
-        # is not subtracted and the JIT DSL kernel runs.
-        from torch.profiler import profile, ProfilerActivity
+    def test_aot_coverage_is_subset_of_jit_eligibility(self):
+        from torch._native import aot_manifest
+        from torch._native.ops.topk import cutedsl_impl
+        from torch._native.ops.topk.aot import _radix_min_n
 
-        x = torch.randn(M, 3072, device="cuda")
-        torch.topk(x, 64, dim=-1)  # trigger lazy compile outside profile
-        with profile(activities=[ProfilerActivity.CUDA]) as prof:
-            torch.topk(x, 64, dim=-1)
-            torch.cuda.synchronize()
-        self.assertTrue(
-            any(
-                "RadixSelectTopK" in e.name
-                for e in prof.events()
-                if e.device_type.name == "CUDA"
-            )
-        )
+        major = torch.cuda.get_device_capability()[0]
+        cases = [
+            (torch.float32, 16, 64),
+            (torch.float32, 16, 2048),
+            (torch.float32, 32, 256),
+            (torch.float32, 32, 512),
+            (torch.bfloat16, 16, 256),
+        ]
+        for dtype_name, dtype in (
+            ("float32", torch.float32),
+            ("bfloat16", torch.bfloat16),
+        ):
+            for k in (64, 128, 256, 512, 1024):
+                min_n = _radix_min_n(dtype_name, k, major)
+                cases.extend(
+                    (
+                        (dtype, k, min_n - 4),
+                        (dtype, k, min_n),
+                        (dtype, k, min_n + 4),
+                    )
+                )
+        for dtype, k, n in cases:
+            with self.subTest(dtype=dtype, k=k, n=n):
+                x = torch.empty(M, n, dtype=dtype, device="cuda")
+                jit_eligible = cutedsl_impl._eligible(x, k, -1, True, True)
+                aot_covered = aot_manifest.covers("topk", "CUDA", (x, k), {})
+                if dtype == torch.float32 and (k, n) in JIT_ONLY_REGISTER:
+                    self.assertTrue(jit_eligible)
+                    self.assertFalse(aot_covered)
+                else:
+                    self.assertEqual(aot_covered, jit_eligible)
+
+    @skipIfNoJitTopk
+    def test_exact_n_register_cases_route_to_jit(self):
+        cases = [{"dtype": "float32", "n": n, "k": k} for k, n in JIT_ONLY_REGISTER]
+        results = _run_probe(cases, {})
+        for case, r in zip(cases, results):
+            self.assertTrue(r["ran_dsl"], f"JIT kernel did not fire for {case}")
+            self.assertTrue(r["values_ok"], f"values mismatch for {case}")
+            self.assertTrue(r["gather_ok"], f"gather mismatch for {case}")
 
     @skipIfNoAotLib
     def test_disabled_context_masks_aot_in_process(self):
@@ -224,7 +294,7 @@ class TestNativeAotTopK(TestCase):
                 torch.topk(x, 64, dim=-1)
                 torch.cuda.synchronize()
             return any(
-                "RadixSelectTopK" in e.name
+                "RadixSelectTopK" in e.name or "RegisterTopK" in e.name
                 for e in prof.events()
                 if e.device_type.name == "CUDA"
             )
@@ -269,15 +339,53 @@ class TestNativeAotTopK(TestCase):
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
 
-        x = torch.empty(4, 4096)
+        x = torch.empty(M, 4100, device="cuda")
         v = mod.covered_axes(x, 64)
-        self.assertEqual(v["N"], 4096)
+        self.assertEqual(v["kernel"], "radix")
+        self.assertEqual(v["N"], None)
         self.assertEqual(v["K"], 64)
         self.assertEqual(v["dtype"], torch.float32)
+        self.assertEqual(v["scalar_tail_iters"], None)
+        self.assertEqual(v["fixed_vec_iters"], None)
+        self.assertTrue(v["eligible"])
+        register = mod.covered_axes(torch.empty(M, 256, device="cuda"), 16)
+        self.assertEqual(register["kernel"], "register")
+        self.assertEqual(register["N"], None)
+        self.assertEqual(register["N_rung"], "64_128_256_512_1024")
+        self.assertTrue(register["eligible"])
         # Schema defaults come from the function signature itself.
         self.assertEqual(
             mod.covered_axes(x, 64), mod.covered_axes(x, 64, -1, True, True)
         )
+
+    def test_covered_axes_selects_work_rungs(self):
+        import importlib.util
+        import os
+
+        path = os.path.join(
+            os.path.dirname(torch.__file__), "_native", "ops", "topk", "aot.py"
+        )
+        spec = importlib.util.spec_from_file_location("topk_aot_work_t", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        prior = torch.are_deterministic_algorithms_enabled()
+        try:
+            torch.use_deterministic_algorithms(True)
+            for n, k, expected in (
+                (4100, 64, (4, None)),
+                (5120, 512, (4, 2)),
+                (6144, 512, (4, None)),
+                (36860, 1024, (4, None)),
+            ):
+                x = torch.empty(M, n, device="cuda")
+                axes = mod.covered_axes(x, k)
+                self.assertEqual(
+                    (axes["scalar_tail_iters"], axes["fixed_vec_iters"]), expected
+                )
+                self.assertTrue(axes["eligible"])
+        finally:
+            torch.use_deterministic_algorithms(prior)
 
     def test_flags_the_stub_declines_are_uncovered(self):
         # The stub takes only dim=last, largest and sorted; coverage must agree, or such
@@ -301,8 +409,32 @@ class TestNativeAotTopK(TestCase):
             for k in GRID_K:
                 x = torch.empty(M, n, dtype=torch.float32, device="cuda")
                 self.assertTrue(aot_manifest.covers("topk", "CUDA", (x, k), {}))
-        x = torch.empty(M, 3072, dtype=torch.float32, device="cuda")
+        for k, n in (
+            (16, 64),
+            (64, 3072),
+            (64, 4100),
+            (512, 4096),
+            (512, 6140),
+            (1024, 32772),
+            (1024, 36860),
+        ):
+            x = torch.empty(M, n, dtype=torch.float32, device="cuda")
+            self.assertTrue(aot_manifest.covers("topk", "CUDA", (x, k), {}))
+        for k, n in JIT_ONLY_REGISTER:
+            x = torch.empty(M, n, dtype=torch.float32, device="cuda")
+            self.assertFalse(aot_manifest.covers("topk", "CUDA", (x, k), {}))
+        from torch._native.ops.topk.aot import _radix_min_n
+
+        major = torch.cuda.get_device_capability()[0]
+        min_n = _radix_min_n("float32", 64, major)
+        x = torch.empty(M, min_n - 4, dtype=torch.float32, device="cuda")
         self.assertFalse(aot_manifest.covers("topk", "CUDA", (x, 64), {}))
+        x = torch.empty(M, 4101, dtype=torch.float32, device="cuda")
+        self.assertFalse(aot_manifest.covers("topk", "CUDA", (x, 64), {}))
+        x = torch.empty(M, 4092, dtype=torch.float32, device="cuda")
+        self.assertFalse(aot_manifest.covers("topk", "CUDA", (x, 512), {}))
+        x = torch.empty(M, 32764, dtype=torch.float32, device="cuda")
+        self.assertFalse(aot_manifest.covers("topk", "CUDA", (x, 1024), {}))
         xh = torch.empty(M, 4096, dtype=torch.float16, device="cuda")
         self.assertFalse(aot_manifest.covers("topk", "CUDA", (xh, 64), {}))
         # Below the full-wave gate: on-grid but NOT covered (JIT keeps it).

--- a/test/python_native/test_topk_cutedsl.py
+++ b/test/python_native/test_topk_cutedsl.py
@@ -131,13 +131,20 @@ class TestCuTeDSLTopK(TestCase):
         torch.manual_seed(14)
         k = 16
         ns = (64, 128, 256, 512, 1024)
-        compiled = _compile_topk_register_i64(ns, k)
+        major = torch.cuda.get_device_capability()[0]
+        compiled_by_rung = {}
         for n in ns:
+            rung = (n,) if major >= 10 and n == 1024 else ns
+            compiled = _compile_topk_register_i64(rung, k)
+            self.assertIs(
+                compiled_by_rung.setdefault(rung, compiled),
+                compiled,
+            )
             x = torch.randn(4, n, device="cuda")
             with torch.backends.python_native.cutedsl.disabled():
                 ref_v, _ = torch.topk(x, k, dim=-1)
             got_v, got_i = topk_register(x, k)
-            self.assertIs(_compile_topk_register_i64(ns, k), compiled)
+            self.assertIs(_compile_topk_register_i64(rung, k), compiled)
             self.assertEqual(got_v, ref_v)
             self.assertEqual(torch.gather(x, -1, got_i), got_v)
 

--- a/test/python_native/test_topk_cutedsl_eligibility.py
+++ b/test/python_native/test_topk_cutedsl_eligibility.py
@@ -7,7 +7,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestCuTeDSLTopKEligibility(TestCase):
-    def test_pre_sm100_devices_are_ineligible(self) -> None:
+    def test_pre_sm90_devices_are_ineligible(self) -> None:
         from torch._native.ops.topk import cutedsl_impl
 
         x = mock.Mock(
@@ -16,6 +16,8 @@ class TestCuTeDSLTopKEligibility(TestCase):
             device=torch.device("cuda:0"),
             shape=(256, 256),
             ndim=2,
+            data_ptr=mock.Mock(return_value=0),
+            element_size=mock.Mock(return_value=4),
         )
         with (
             mock.patch.object(cutedsl_impl, "any_cow", return_value=False),
@@ -25,11 +27,11 @@ class TestCuTeDSLTopKEligibility(TestCase):
         ):
             for capability, expected in (
                 ((8, 0), False),
-                ((9, 0), False),
+                ((9, 0), True),
                 ((10, 0), True),
             ):
                 with self.subTest(capability=capability):
-                    cutedsl_impl._sm100_or_above.cache_clear()
+                    cutedsl_impl._device_major.cache_clear()
                     get_capability.reset_mock()
                     get_capability.return_value = capability
                     for _ in range(2):

--- a/test/python_native/test_topk_radix_kernel.py
+++ b/test/python_native/test_topk_radix_kernel.py
@@ -67,6 +67,7 @@ class TestRadixKernelBuilder(TestCase):
         import cutlass.cute as cute
         import cutlass.cutlass_dsl.cutlass as cutlass_dsl
 
+        from torch._native.ops.topk.aot import _ARCH_TAIL_ITERS
         from torch._native.ops.topk.cutedsl_kernels import build
 
         b = build(
@@ -75,10 +76,11 @@ class TestRadixKernelBuilder(TestCase):
                 "dtype": "float32",
                 "K": 1024,
                 "deterministic": True,
-                "scalar_tail_iters": 4,
+                "scalar_tail_iters": _ARCH_TAIL_ITERS,
                 "fixed_vec_iters": None,
             }
         )
+        self.assertEqual(b["prefix"], "topk_radix_f32_k1024_det_vdyn_tarch")
         self.assertEqual(b["fn"].min_blocks_per_mp, 2)
         with mock.patch.object(
             cutlass_dsl.cuda_helpers,

--- a/torch/_native/ops/topk/aot.py
+++ b/torch/_native/ops/topk/aot.py
@@ -13,21 +13,24 @@ torch is imported lazily inside covered_axes.
 ATEN_OP = "topk"
 DISPATCH_KEY = "CUDA"
 KERNEL_MODULE = "cutedsl_kernels.py"
-# Stated rather than defaulted: the radix kernel is measured against aten on both
-# (48/48 of the grid faster on an H100, median 2.16x; Blackwell is the tuning target).
+# Stated rather than defaulted: the declared ranges and work rungs are measured
+# against aten on Hopper and Blackwell.
 # Both spellings of each capability, since either can appear in TORCH_CUDA_ARCH_LIST
 # and they are distinct nvcc targets.
 ARCHS = ("sm_90", "sm_90a", "sm_100", "sm_100a")
 
 _DTYPES = {"float32": "at::kFloat", "bfloat16": "at::kBFloat16"}
-_NS = [2048, 4096, 8192, 16384]
-_KS = [64, 128, 256]
 _RADIX_KS = (64, 128, 256, 512, 1024)
 _REGISTER_DYNAMIC_NS = (64, 128, 256, 512, 1024)
+_REGISTER_NS = {
+    16: (*_REGISTER_DYNAMIC_NS, 2048),
+    32: (256,),
+}
 _REGISTER_RUNGS = {
     16: (_REGISTER_DYNAMIC_NS, (2048,)),
     32: ((256,),),
 }
+_AOT_REGISTER_RUNGS = {16: (_REGISTER_DYNAMIC_NS,)}
 _RADIX_MIN_N = {
     "float32": {
         9: {64: 2048, 128: 2048, 256: 2048, 512: 4096, 1024: 32768},
@@ -48,8 +51,26 @@ def _radix_min_n(dtype, k, major):
     return _RADIX_MIN_N[dtype][capability][k]
 
 
+def _kernel_for(dtype, n, k, major):
+    if major < 9:
+        return None
+    if dtype == "float32" and k in _REGISTER_NS and n in _REGISTER_NS[k]:
+        return "register"
+    min_n = _radix_min_n(dtype, k, major)
+    if min_n is not None and n >= min_n and n % 4 == 0:
+        return "radix"
+    return None
+
+
 def _register_rung(n, k):
     for rung in _REGISTER_RUNGS.get(k, ()):
+        if n in rung:
+            return "_".join(str(value) for value in rung)
+    return None
+
+
+def _aot_register_rung(n, k):
+    for rung in _AOT_REGISTER_RUNGS.get(k, ()):
         if n in rung:
             return "_".join(str(value) for value in rung)
     return None
@@ -66,6 +87,8 @@ def _specialization(n, k, deterministic):
         fixed_vec_iters = 1
     elif deterministic and k == 512 and vec_iters == 2:
         fixed_vec_iters = vec_iters
+    # The fixed upper bound is unrolled, while a uniform runtime guard skips
+    # wholly inactive tail iterations.
     scalar_tail_iters = (
         _MAX_TAIL_ITERS if deterministic or fixed_vec_iters is not None else None
     )
@@ -73,10 +96,61 @@ def _specialization(n, k, deterministic):
 
 
 def kernel_precompile_grid():
-    # fp32 and bf16 radix kernels in both determinism modes, the deterministic one
-    # bit-exact vs aten. fp16 and off-grid shapes stay JIT-eligible.
+    # Only the multi-N register ladder is AOTed; exact-N occupancy outliers stay JIT.
+    # Radix kernels share dynamic N, with fixed upper work bounds where measured.
     return [
-        {"dtype": list(_DTYPES), "N": _NS, "K": _KS, "deterministic": [False, True]},
+        *(
+            {
+                "kernel": "register",
+                "dtype": "float32",
+                "N": None,
+                "N_rung": "_".join(str(value) for value in rung),
+                "K": k,
+                "eligible": True,
+            }
+            for k, rungs in _AOT_REGISTER_RUNGS.items()
+            for rung in rungs
+        ),
+        {
+            "kernel": "radix",
+            "dtype": list(_DTYPES),
+            "N": None,
+            "K": list(_RADIX_KS),
+            "deterministic": False,
+            "scalar_tail_iters": None,
+            "fixed_vec_iters": None,
+            "eligible": True,
+        },
+        {
+            "kernel": "radix",
+            "dtype": list(_DTYPES),
+            "N": None,
+            "K": [64, 128, 256, 1024],
+            "deterministic": True,
+            "scalar_tail_iters": _MAX_TAIL_ITERS,
+            "fixed_vec_iters": None,
+            "eligible": True,
+        },
+        {
+            "kernel": "radix",
+            "dtype": list(_DTYPES),
+            "N": None,
+            "K": 512,
+            "deterministic": True,
+            "scalar_tail_iters": _MAX_TAIL_ITERS,
+            "fixed_vec_iters": [2, None],
+            "eligible": True,
+        },
+        {
+            "kernel": "radix",
+            "dtype": "float32",
+            "N": None,
+            "K": [64, 128, 256],
+            "deterministic": [False, True],
+            "scalar_tail_iters": _MAX_TAIL_ITERS,
+            "fixed_vec_iters": 1,
+            "eligible": True,
+        },
     ]
 
 
@@ -90,29 +164,69 @@ def covered_axes(self, k, dim=-1, largest=True, sorted=True):
         n = 0
     if not largest or not sorted:
         n = 0
-    # Only gate CUDA tensors, since the device query would throw on CPU.
-    if n > 0 and self.is_cuda:
-        sm = torch.cuda.get_device_properties(self.device).multi_processor_count
-        if self.numel() // n < sm:
-            n = 0
-    return {
+    eligible = n > 0 and self.is_cuda and self.is_contiguous()
+    dtype = None
+    major = 0
+    if eligible:
+        if self.dtype == torch.float32:
+            dtype = "float32"
+        elif self.dtype == torch.bfloat16:
+            dtype = "bfloat16"
+        props = torch.cuda.get_device_properties(self.device)
+        major = props.major
+        if self.numel() // n < props.multi_processor_count:
+            eligible = False
+        if self.data_ptr() % (4 * self.element_size()):
+            eligible = False
+    kernel = _kernel_for(dtype, n, k, major) if eligible else None
+    eligible = eligible and kernel is not None
+    deterministic = torch.are_deterministic_algorithms_enabled()
+    axes = {
+        "kernel": kernel,
         "dtype": self.dtype,
-        "N": n,
+        "N": None,
         "K": k,
-        # Coverage-neutral, since both modes are on the grid, but it is a grid axis:
-        # cpp_dispatch keys each point on it to pick the deterministic kernel.
-        "deterministic": torch.are_deterministic_algorithms_enabled(),
+        "eligible": eligible,
     }
+    if kernel == "register":
+        axes["N_rung"] = _aot_register_rung(n, k)
+        axes["eligible"] = eligible and axes["N_rung"] is not None
+    elif kernel == "radix":
+        scalar_tail_iters, fixed_vec_iters = _specialization(n, k, deterministic)
+        axes.update(
+            {
+                "deterministic": deterministic,
+                "scalar_tail_iters": scalar_tail_iters,
+                "fixed_vec_iters": fixed_vec_iters,
+            }
+        )
+    return axes
 
 
 def cpp_covers():
     # C++ port of covered_axes plus grid matching, registered as
-    # torch.ops._native_aot.covers_topk, so a call does not walk the 48-point grid in
-    # Python. Covered means on-grid (dtype, N, K) at full-wave M in either determinism
-    # mode, with the flags the stub requires; layout is not part of coverage.
+    # torch.ops._native_aot.covers_topk, so a call does not walk the full grid in
+    # Python.
     dtype_accept = " || ".join(f"st == {t}" for t in _DTYPES.values())
-    n_accept = " || ".join(f"N == {n}" for n in _NS)
-    k_accept = " || ".join(f"k == {kk}" for kk in _KS)
+    register_accept = " || ".join(
+        f"(k == {k} && ({' || '.join(f'N == {n}' for n in rung)}))"
+        for k, rungs in _AOT_REGISTER_RUNGS.items()
+        for rung in rungs
+    )
+    radix_accept = {}
+    for dtype, dtype_cpp in _DTYPES.items():
+        sm90 = " || ".join(
+            f"(k == {k} && N >= {n})" for k, n in _RADIX_MIN_N[dtype][9].items()
+        )
+        sm100 = " || ".join(
+            f"(k == {k} && N >= {n})" for k, n in _RADIX_MIN_N[dtype][10].items()
+        )
+        radix_accept[dtype] = (
+            f"(st == {dtype_cpp} && "
+            f"((props->major >= 10 && ({sm100})) || "
+            f"(props->major == 9 && ({sm90}))))"
+        )
+    radix_expr = " || ".join(radix_accept.values())
     return f"""
       const auto st = self.scalar_type();
       if (!({dtype_accept})) return false;
@@ -121,8 +235,13 @@ def cpp_covers():
       if (self.dim() < 1 || c10::maybe_wrap_dim(dim, self.dim()) != self.dim() - 1) return false;
       const int64_t N = self.dim() >= 1 ? self.size(-1) : 0;
       if (N == 0) return false;
-      if (self.numel() / N < at::cuda::getDeviceProperties(self.device().index())->multiProcessorCount) return false;
-      return ({n_accept}) && ({k_accept});
+      if (!self.is_contiguous()) return false;
+      if (reinterpret_cast<uintptr_t>(self.const_data_ptr()) %
+          static_cast<uintptr_t>(4 * self.element_size()) != 0) return false;
+      const auto* props = at::cuda::getDeviceProperties(self.device().index());
+      if (self.numel() / N < props->multiProcessorCount) return false;
+      if (st == at::kFloat && ({register_accept})) return true;
+      return N % 4 == 0 && ({radix_expr});
     """
 
 
@@ -145,16 +264,46 @@ def cpp_dispatch_prelude():
       if (!_naot_aligned(self) || !_naot_aligned(values) || !_naot_aligned(indices)) return false;
       const bool det = at::globalContext().deterministicAlgorithms();
       const int64_t N = self.size(-1);
-      if (N == 0) return false;
+      if (N == 0 || N % 4 != 0) return false;
       const int64_t M = self.numel() / N;
+      const int64_t cc_major = at::cuda::getCurrentDeviceProperties()->major;
       // Perf gate: one CTA per row; below a full wave aten wins.
       if (M < at::cuda::getCurrentDeviceProperties()->multiProcessorCount) return false;
     """
 
 
 def cpp_dispatch(spec):
-    det = "det" if spec["deterministic"] else "!det"
-    return f"self.scalar_type() == {_DTYPES[spec['dtype']]} && N == {spec['N']} && k == {spec['K']} && {det}"
+    kernel = spec["kernel"]
+    k = spec["K"]
+    if kernel == "register":
+        ns = tuple(int(n) for n in spec["N_rung"].split("_"))
+        n_accept = " || ".join(f"N == {n}" for n in ns)
+        return (
+            f"self.scalar_type() == {_DTYPES[spec['dtype']]} && "
+            f"k == {k} && ({n_accept})"
+        )
+
+    deterministic = spec["deterministic"]
+    num_threads = max(k, 256)
+    tile = num_threads * 4
+    sm90_min = _RADIX_MIN_N[spec["dtype"]][9][k]
+    sm100_min = _RADIX_MIN_N[spec["dtype"]][10][k]
+    conditions = [
+        f"self.scalar_type() == {_DTYPES[spec['dtype']]}",
+        f"k == {k}",
+        "det" if deterministic else "!det",
+        f"N >= (cc_major >= 10 ? {sm100_min} : {sm90_min})",
+    ]
+    fixed_vec_iters = spec["fixed_vec_iters"]
+    if k <= 256:
+        if fixed_vec_iters is None:
+            conditions.append(f"N / {tile} >= 2")
+        else:
+            conditions.append(f"N / {tile} <= {fixed_vec_iters}")
+    elif deterministic and k == 512:
+        op = "==" if fixed_vec_iters is not None else "!="
+        conditions.append(f"N / {tile} {op} 2")
+    return " && ".join(conditions)
 
 
 def cpp_launch(spec, launch_fn):

--- a/torch/_native/ops/topk/aot.py
+++ b/torch/_native/ops/topk/aot.py
@@ -42,6 +42,7 @@ _RADIX_MIN_N = {
     },
 }
 _MAX_TAIL_ITERS = 4
+_ARCH_TAIL_ITERS = -1
 
 
 def _radix_min_n(dtype, k, major):
@@ -62,14 +63,18 @@ def _kernel_for(dtype, n, k, major):
     return None
 
 
-def _register_rung(n, k):
+def _register_rung(n, k, major):
+    if major >= 10 and k == 16 and n == 1024:
+        return "1024"
     for rung in _REGISTER_RUNGS.get(k, ()):
         if n in rung:
             return "_".join(str(value) for value in rung)
     return None
 
 
-def _aot_register_rung(n, k):
+def _aot_register_rung(n, k, major):
+    if major >= 10 and k == 16 and n == 1024:
+        return None
     for rung in _AOT_REGISTER_RUNGS.get(k, ()):
         if n in rung:
             return "_".join(str(value) for value in rung)
@@ -87,11 +92,15 @@ def _specialization(n, k, deterministic):
         fixed_vec_iters = 1
     elif deterministic and k == 512 and vec_iters == 2:
         fixed_vec_iters = vec_iters
-    # The fixed upper bound is unrolled, while a uniform runtime guard skips
-    # wholly inactive tail iterations.
-    scalar_tail_iters = (
-        _MAX_TAIL_ITERS if deterministic or fixed_vec_iters is not None else None
-    )
+    # Blackwell handles the runtime tail loop well, while Hopper needs the
+    # fixed upper bound. The sentinel lets one manifest point compile to the
+    # best loop for each target architecture.
+    if fixed_vec_iters is not None:
+        scalar_tail_iters = _MAX_TAIL_ITERS
+    elif deterministic:
+        scalar_tail_iters = _ARCH_TAIL_ITERS
+    else:
+        scalar_tail_iters = None
     return scalar_tail_iters, fixed_vec_iters
 
 
@@ -127,7 +136,7 @@ def kernel_precompile_grid():
             "N": None,
             "K": [64, 128, 256, 1024],
             "deterministic": True,
-            "scalar_tail_iters": _MAX_TAIL_ITERS,
+            "scalar_tail_iters": _ARCH_TAIL_ITERS,
             "fixed_vec_iters": None,
             "eligible": True,
         },
@@ -138,7 +147,17 @@ def kernel_precompile_grid():
             "K": 512,
             "deterministic": True,
             "scalar_tail_iters": _MAX_TAIL_ITERS,
-            "fixed_vec_iters": [2, None],
+            "fixed_vec_iters": 2,
+            "eligible": True,
+        },
+        {
+            "kernel": "radix",
+            "dtype": list(_DTYPES),
+            "N": None,
+            "K": 512,
+            "deterministic": True,
+            "scalar_tail_iters": _ARCH_TAIL_ITERS,
+            "fixed_vec_iters": None,
             "eligible": True,
         },
         {
@@ -189,7 +208,7 @@ def covered_axes(self, k, dim=-1, largest=True, sorted=True):
         "eligible": eligible,
     }
     if kernel == "register":
-        axes["N_rung"] = _aot_register_rung(n, k)
+        axes["N_rung"] = _aot_register_rung(n, k, major)
         axes["eligible"] = eligible and axes["N_rung"] is not None
     elif kernel == "radix":
         scalar_tail_iters, fixed_vec_iters = _specialization(n, k, deterministic)
@@ -240,7 +259,8 @@ def cpp_covers():
           static_cast<uintptr_t>(4 * self.element_size()) != 0) return false;
       const auto* props = at::cuda::getDeviceProperties(self.device().index());
       if (self.numel() / N < props->multiProcessorCount) return false;
-      if (st == at::kFloat && ({register_accept})) return true;
+      if (st == at::kFloat && ({register_accept}) &&
+          !(props->major >= 10 && k == 16 && N == 1024)) return true;
       return N % 4 == 0 && ({radix_expr});
     """
 
@@ -278,10 +298,13 @@ def cpp_dispatch(spec):
     if kernel == "register":
         ns = tuple(int(n) for n in spec["N_rung"].split("_"))
         n_accept = " || ".join(f"N == {n}" for n in ns)
-        return (
+        condition = (
             f"self.scalar_type() == {_DTYPES[spec['dtype']]} && "
             f"k == {k} && ({n_accept})"
         )
+        if k == 16 and 1024 in ns:
+            condition += " && (cc_major < 10 || N != 1024)"
+        return condition
 
     deterministic = spec["deterministic"]
     num_threads = max(k, 256)

--- a/torch/_native/ops/topk/cutedsl_impl.py
+++ b/torch/_native/ops/topk/cutedsl_impl.py
@@ -1,6 +1,6 @@
 """CuTeDSL override registrations for ``aten::topk``.
 
-Two kernels, picked by (K, N) - see ``cutedsl_kernels.py``:
+Two kernels, picked by dtype, capability, K, and N - see ``aot.py``:
 
   * Register-resident (small K, small N): K in {16, 32}, N a power of 2
     in a per-K range (see ``_REGISTER_N_RANGE``). Each warp sorts one
@@ -19,15 +19,15 @@ Two kernels, picked by (K, N) - see ``cutedsl_kernels.py``:
         Faster (~5-10%); indices may differ across runs on threshold ties.
 
 Common eligibility (see ``_cond``):
-  - fp32 input, CUDA on SM100 or newer, not COW
+  - fp32/bf16 input, CUDA on SM90 or newer
   - ``largest=True``, ``sorted=True``
   - reducing over the last axis, ``self`` contiguous (2D flatten is a view)
   - row count at least one full wave of SMs (perf gate)
 
 Per-kernel additional eligibility:
-  - register: K in {16, 32}, N pow2 in supported range above
-  - radix: K in {64, 128, 256, 512, 1024}, ``N >= MIN_N_MULT[k] * k``,
-    ``N % 4 == 0`` (128-bit vector loads)
+  - register: fp32, K in {16, 32}, N in the measured exact-N set
+  - radix: fp32/bf16, K in {64, 128, 256, 512, 1024}, N above the
+    dtype/capability threshold, and ``N % 4 == 0`` (128-bit vector loads)
 
 Anything else falls through to aten.
 """
@@ -44,57 +44,28 @@ from ._common import (
     last_dim_row_major_ok,
     unflatten_last_dim,
 )
+from .aot import _kernel_for, _RADIX_KS as _AOT_RADIX_KS, _RADIX_MIN_N, _REGISTER_NS
 
 
-_RADIX_KS: frozenset[int] = frozenset({64, 128, 256, 512, 1024})
-_REGISTER_KS: frozenset[int] = frozenset({16, 32})
+_RADIX_KS: frozenset[int] = frozenset(_AOT_RADIX_KS)
+_REGISTER_KS: frozenset[int] = frozenset(_REGISTER_NS)
 _SUPPORTED_KS: frozenset[int] = _RADIX_KS | _REGISTER_KS
-
-# Per-K minimum N for the radix kernel below which aten wins on B200.
-# At low N the radix sweep (4 passes + gather) has too many passes over
-# too little data to beat aten's launch-bound multi-pass kernel.
-# K=512 needs ~8*K, K=1024 needs ~32*K because their smem footprint
-# drops occupancy.
-_RADIX_MIN_N_MULTIPLIER: dict[int, int] = {
-    64: 2,
-    128: 2,
-    256: 2,
-    512: 8,
-    1024: 32,
-}
-
-# Register kernel per-K (min, max) N range, both bounds powers of 2.
-# Below the min, VEC = N/32 is too small (most lanes idle, bitonic
-# overhead dominates) and aten wins at large M. Above the max, radix
-# (K=32) or aten (K=16 N>2048) takes over.
-# Tuned on B200: K=16 wins down to N=64 across all M; K=32 only beats
-# both aten and radix at exactly N=256.
 _REGISTER_N_RANGE: dict[int, tuple[int, int]] = {
-    16: (64, 2048),
-    32: (256, 256),
+    k: (min(ns), max(ns)) for k, ns in _REGISTER_NS.items()
 }
-
-
-def _is_pow2(x: int) -> bool:
-    return x > 0 and (x & (x - 1)) == 0
-
-
-def _kernel_for(k: int, n: int) -> str | None:
-    """Pick the kernel for (K, N): "register", "radix", or None (aten)."""
-    if k in _REGISTER_KS:
-        n_min, n_max = _REGISTER_N_RANGE[k]
-        if _is_pow2(n) and n_min <= n <= n_max:
-            return "register"
-    if k in _RADIX_KS:
-        if n >= _RADIX_MIN_N_MULTIPLIER[k] * k and (n % 4) == 0:
-            return "radix"
-    return None
+# Kept as a public test/tuning aid for the original SM100 fp32 policy.
+_RADIX_MIN_N_MULTIPLIER: dict[int, int] = {
+    k: n // k for k, n in _RADIX_MIN_N["float32"][10].items()
+}
+_DTYPE_NAMES = {
+    torch.float32: "float32",
+    torch.bfloat16: "bfloat16",
+}
 
 
 @functools.cache
-def _sm100_or_above(device: int) -> bool:
-    major, _ = torch.cuda.get_device_capability(device)
-    return major >= 10
+def _device_major(device: int) -> int:
+    return torch.cuda.get_device_capability(device)[0]
 
 
 @functools.cache
@@ -108,24 +79,26 @@ def _min_rows_for_full_wave(device_idx: int) -> int:
 def _eligible(
     self: torch.Tensor, k: int, dim: int, largest: bool, sorted_: bool
 ) -> bool:
-    if not self.is_cuda or self.dtype != torch.float32:
+    if not self.is_cuda or self.dtype not in _DTYPE_NAMES:
         return False
-    if not _sm100_or_above(self.device.index or 0):
-        return False
-    if any_cow(self):
+    device = self.device.index or 0
+    major = _device_major(device)
+    if major < 9:
         return False
     if not largest or not sorted_:
         return False
     if not last_dim_row_major_ok(self, dim):
         return False
+    if self.data_ptr() % (4 * self.element_size()):
+        return False
     N = self.shape[-1] if self.ndim >= 1 else 0
-    if _kernel_for(k, N) is None:
+    if _kernel_for(_DTYPE_NAMES[self.dtype], N, k, major) is None:
         return False
     # Performance gate: reject shapes where aten is faster. One CTA per
     # row (radix) or one warp per row (register) - either way row_count
     # below SM_count leaves the GPU underutilised.
     M = math.prod(self.shape[:-1]) if self.ndim >= 1 else 0
-    if M < _min_rows_for_full_wave(self.device.index or 0):
+    if M < _min_rows_for_full_wave(device):
         return False
     return True
 
@@ -157,7 +130,7 @@ def _out_cond(
     if any_cow(values, indices):
         return False
     expected_shape = self.shape[:-1] + (k,)
-    if values.dtype != torch.float32 or values.shape != expected_shape:
+    if values.dtype != self.dtype or values.shape != expected_shape:
         return False
     if indices.dtype != torch.int64 or indices.shape != expected_shape:
         return False
@@ -169,7 +142,8 @@ def _run(self: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
 
     self_2d = flatten_last_dim(self)
     N = self_2d.shape[-1]
-    kernel = _kernel_for(k, N)
+    major = _device_major(self.device.index or 0)
+    kernel = _kernel_for(_DTYPE_NAMES[self.dtype], N, k, major)
 
     def _launch() -> tuple[torch.Tensor, torch.Tensor]:
         if kernel == "register":

--- a/torch/_native/ops/topk/cutedsl_impl.py
+++ b/torch/_native/ops/topk/cutedsl_impl.py
@@ -89,7 +89,7 @@ def _eligible(
         return False
     if not last_dim_row_major_ok(self, dim):
         return False
-    if self.const_data_ptr() % (4 * self.element_size()):
+    if self.const_data_ptr() % (4 * self.element_size()):  # type: ignore[attr-defined]
         return False
     N = self.shape[-1] if self.ndim >= 1 else 0
     if _kernel_for(_DTYPE_NAMES[self.dtype], N, k, major) is None:

--- a/torch/_native/ops/topk/cutedsl_kernels.py
+++ b/torch/_native/ops/topk/cutedsl_kernels.py
@@ -688,26 +688,60 @@ def build(spec: dict) -> dict:
     """AOT builder: one manifest spec point -> compile inputs + sidecar.
 
     ``spec`` carries scalar values (one point of the manifest grid):
-    {"dtype": "float32"|"bfloat16", "N": int, "K": int,
-     "deterministic": bool}. Returns {"prefix", "fn", "fake_args",
-    "tensor_args"}; the export tool runs ``cute.compile(fn, *fake_args)``
-    and ``export_to_c`` under ``prefix``, then writes ``tensor_args`` to
-    the marshalling sidecar.
+    {"kernel": "register"|"radix", ...}. Returns {"prefix", "fn",
+    "fake_args", "tensor_args"}; the export tool runs
+    ``cute.compile(fn, *fake_args)`` and ``export_to_c`` under ``prefix``,
+    then writes ``tensor_args`` to the marshalling sidecar.
     """
     dtype = _DTYPES[spec["dtype"]]
-    N, K = int(spec["N"]), int(spec["K"])
-    deterministic = bool(spec.get("deterministic", False))
-    from .aot import _specialization
-
-    scalar_tail_iters, fixed_vec_iters = _specialization(N, K, deterministic)
+    K = int(spec["K"])
     batch_sym = cute.sym_int()
-    div_n = math.gcd(4, N)
     div_k = math.gcd(4, K)
-    x_fake = _make_fake_tensor(dtype, (batch_sym, N), div_n)
     v_fake = _make_fake_tensor(dtype, (batch_sym, K), div_k)
     i_fake = _make_fake_tensor(Int64, (batch_sym, K), div_k)
+    if spec["kernel"] == "register":
+        NS = tuple(int(n) for n in spec["N_rung"].split("_"))
+        if len(NS) == 1:
+            n_shape = NS[0]
+            div_n = math.gcd(4, NS[0])
+            dynamic_sizes = [0]
+        else:
+            n_shape = cute.sym_int(divisibility=4)
+            div_n = 4
+            dynamic_sizes = [0, 1]
+        return {
+            "prefix": f"topk_register_f32_n{spec['N_rung']}_k{K}",
+            "fn": _RegisterTopK(NS, K),
+            "fake_args": [
+                _make_fake_tensor(dtype, (batch_sym, n_shape), div_n),
+                v_fake,
+                i_fake,
+                cute.runtime.make_fake_stream(),
+            ],
+            "tensor_args": [
+                {
+                    "name": "mX",
+                    "dynamic_sizes": dynamic_sizes,
+                    "dynamic_strides": [0],
+                    "read_only": True,
+                },
+                {"name": "mValues", "dynamic_sizes": [0], "dynamic_strides": [0]},
+                {"name": "mIndices", "dynamic_sizes": [0], "dynamic_strides": [0]},
+            ],
+        }
+
+    deterministic = bool(spec.get("deterministic", False))
+    scalar_tail_iters = spec.get("scalar_tail_iters")
+    fixed_vec_iters = spec.get("fixed_vec_iters")
+    n_sym = cute.sym_int(divisibility=4)
+    x_fake = _make_fake_tensor(dtype, (batch_sym, n_sym), 4)
     det_tag = "det" if deterministic else "nondet"
-    prefix = f"topk_radix_{_DTYPE_SHORT[spec['dtype']]}_n{N}_k{K}_{det_tag}"
+    tail_tag = "dyn" if scalar_tail_iters is None else str(scalar_tail_iters)
+    vec_tag = "dyn" if fixed_vec_iters is None else str(fixed_vec_iters)
+    prefix = (
+        f"topk_radix_{_DTYPE_SHORT[spec['dtype']]}_k{K}_{det_tag}"
+        f"_v{vec_tag}_t{tail_tag}"
+    )
     return {
         "prefix": prefix,
         "fn": _RadixSelectTopK(
@@ -730,7 +764,7 @@ def build(spec: dict) -> dict:
         "tensor_args": [
             {
                 "name": "mX",
-                "dynamic_sizes": [0],
+                "dynamic_sizes": [0, 1],
                 "dynamic_strides": [0],
                 "read_only": True,
             },

--- a/torch/_native/ops/topk/cutedsl_kernels.py
+++ b/torch/_native/ops/topk/cutedsl_kernels.py
@@ -42,10 +42,12 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import BFloat16, const_expr, Float32, Int32, Int64
 from cutlass._mlir.dialects import llvm
-from cutlass.cutlass_dsl import dsl_user_op, T
+from cutlass.cutlass_dsl import BaseDSL, dsl_user_op, T
 
 import torch
 from torch._native.instrumentation import instrumented_cutedsl_cache
+
+from .aot import _ARCH_TAIL_ITERS, _MAX_TAIL_ITERS
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +223,10 @@ class _RadixSelectTopK:
         self.deterministic = deterministic
         self.in_dtype = in_dtype
         self.index_dtype = index_dtype
-        self.scalar_tail_iters = scalar_tail_iters
+        self.arch_tail_iters = scalar_tail_iters == _ARCH_TAIL_ITERS
+        self.scalar_tail_iters = (
+            _MAX_TAIL_ITERS if self.arch_tail_iters else scalar_tail_iters
+        )
         self.fixed_vec_iters = fixed_vec_iters
         self.min_blocks_per_mp = min_blocks_per_mp
         self.NUM_THREADS = _num_threads_for_k(K)
@@ -262,6 +267,11 @@ class _RadixSelectTopK:
         VEC_TAIL_START = ACTUAL_VEC_ITERS * TILE
         if const_expr(self.scalar_tail_iters is None):
             SCALAR_TAIL_ITERS = (N - VEC_TAIL_START + NT - 1) // NT
+        elif const_expr(self.arch_tail_iters):
+            if const_expr(BaseDSL._get_dsl().get_arch_enum().major >= 10):
+                SCALAR_TAIL_ITERS = (N - VEC_TAIL_START + NT - 1) // NT
+            else:
+                SCALAR_TAIL_ITERS = const_expr(self.scalar_tail_iters)
         else:
             SCALAR_TAIL_ITERS = const_expr(self.scalar_tail_iters)
         N_HIST_BINS = const_expr(_N_HIST_BINS)
@@ -694,7 +704,13 @@ def _radix_min_blocks_per_mp(
     k: int, deterministic: bool, scalar_tail_iters: int | None
 ) -> int:
     # These K=1024 tail rungs otherwise exceed the two-CTA register budget.
-    return 2 if deterministic and k == 1024 and scalar_tail_iters in (0, 3, 4) else 0
+    return (
+        2
+        if deterministic
+        and k == 1024
+        and scalar_tail_iters in (_ARCH_TAIL_ITERS, 0, 3, 4)
+        else 0
+    )
 
 
 def build(spec: dict) -> dict:
@@ -749,7 +765,13 @@ def build(spec: dict) -> dict:
     n_sym = cute.sym_int(divisibility=4)
     x_fake = _make_fake_tensor(dtype, (batch_sym, n_sym), 4)
     det_tag = "det" if deterministic else "nondet"
-    tail_tag = "dyn" if scalar_tail_iters is None else str(scalar_tail_iters)
+    tail_tag = (
+        "dyn"
+        if scalar_tail_iters is None
+        else "arch"
+        if scalar_tail_iters == _ARCH_TAIL_ITERS
+        else str(scalar_tail_iters)
+    )
     vec_tag = "dyn" if fixed_vec_iters is None else str(fixed_vec_iters)
     prefix = (
         f"topk_radix_{_DTYPE_SHORT[spec['dtype']]}_k{K}_{det_tag}"
@@ -1095,7 +1117,8 @@ def topk_register(x: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
     M, N = x.shape
     from .aot import _register_rung
 
-    NS = tuple(int(n) for n in _register_rung(N, k).split("_"))
+    major = torch.cuda.get_device_capability(x.device)[0]
+    NS = tuple(int(n) for n in _register_rung(N, k, major).split("_"))
     out_v = torch.empty(M, k, dtype=torch.float32, device=x.device)
     out_i = torch.empty(M, k, dtype=torch.int64, device=x.device)
     _compile_topk_register_i64(NS, k)(x, out_v, out_i)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* __->__ #196599
* #196598

Human Notes:

Match JIT and AOT conditionals, unify expected coverage.

Codex:

Make the torch-free AOT declaration the shared source of truth for topk dtype, capability, K, N, and work-rung selection. JIT now imports that policy, gains the measured SM90 and bfloat16 regimes, and uses the same dynamic-N kernel variants as AOT.

Replace the exact-N AOT grid with runtime-N radix kernels and one K=16 register branch ladder. The two one-shape register outliers, K=16/N=2048 and K=32/N=256, remain JIT-only because folding N=2048 into the ladder regressed full-wave latency by up to 72%. On B200, K=16/N=1024 is also an exact JIT-only rung because the shared ladder is 10.91% slower there. This reduces the embedded manifest from 48 to 29 kernels per architecture, or 96 to 58 across SM90 and SM100; the B200 exact rung does not add an AOT kernel.

The deterministic dynamic-vector tail policy is selected at compile time inside the same manifest point. SM90 keeps the fixed four-iteration bound, while SM100 uses the runtime tail extent. Fixed-vector small-N and K=512 rungs retain their bounded work, and K=1024 retains its two-CTA launch bound. This gives each architecture its measured best aggregate policy without increasing the AOT kernel count.

The B200 matrix below uses one full wave (M=148), direct int64 outputs, and the median of seven interleaved measurements. Positive deltas are slower and negative deltas are faster than an otherwise identical full-static kernel:

| B200 selected regime | Median delta vs full static | Range |
| --- | ---: | ---: |
| FP32 register ladder, N=64-512 | +1.44% | -2.65% to +2.41% |
| FP32 register exact JIT, N=1024 | -0.08% | -0.08% |
| FP32 radix, small fixed vector, nondeterministic | +4.60% | +3.71% to +5.59% |
| FP32 radix, small fixed vector, deterministic | +4.67% | +3.08% to +5.63% |
| FP32 radix, dynamic vector, nondeterministic | +4.47% | -0.68% to +6.12% |
| FP32 radix, architecture tail, deterministic | +2.82% | -0.90% to +4.46% |
| FP32 radix, K=512 fixed vector | +3.08% | +1.85% to +3.35% |
| BF16 radix, dynamic vector, nondeterministic | +5.63% | +1.03% to +6.71% |
| BF16 radix, architecture tail, deterministic | +3.42% | -0.57% to +4.55% |
| BF16 radix, K=512 fixed vector | +1.63% | +0.87% to +1.96% |

For the dynamic-vector deterministic matrix, forcing the SM90 fixed tail on B200 raised the median delta from 3.2% to 4.8% for FP32 and from 3.5% to 5.2% for BF16, with worst cases above 10%. Exact tail residues were faster but would multiply artifacts by residue count; runtime vector extents were also slower than the retained fixed-vector rungs.

Eligibility checks previously called `data_ptr()`, which materializes copy-on-write storage even when topk subsequently rejects the case. Use `const_data_ptr()` for both JIT and AOT checks. AOT dispatch also reuses its preloaded device properties and keeps the N-divisibility requirement on radix branches rather than the shared register prelude.

Embedded H100 performance versus ATen at full-wave M:

| Regime | Speedup vs ATen |
| --- | ---: |
| FP32 register | 1.63x to 2.96x |
| FP32 radix | 1.61x to 3.53x |
| BF16, K=512/1024 | 1.74x to 2.31x |

AOT coverage is intentionally a strict subset of JIT eligibility for the exact register cases. Routing tests exercise AOT with JIT disabled, JIT with AOT present, the shared register ladder, the B200 exact rung, architecture-tail and dynamic work rungs, both determinism modes, bfloat16 functional and out variants, direct int64 indices, and copy-on-write inputs.

Test Plan:
```bash
TORCH_CUDA_ARCH_LIST='9.0;10.0' USE_CUDA=1 spin develop
python test/python_native/test_native_aot.py
python test/python_native/test_topk_cutedsl.py
python test/python_native/test_topk_cutedsl_eligibility.py
python test/python_native/test_topk_radix_kernel.py
python tools/test/test_native_aot.py
python tools/test/test_native_aot_tools.py
spin lint
```

Authored with assistance from an AI coding assistant.