### PR TITLE
[inductor] Skip addmm decomposition for zero alpha or beta

### DIFF
--- a/test/inductor/test_mmdecomp.py
+++ b/test/inductor/test_mmdecomp.py
@@ -417,6 +417,22 @@ class TestDecomp(NNTestCase):
             init_tensor([[[1], [2], [3], [4]]] * bs, dtype=dtype, device=device),
         )
 
+    # Shapes hit each addmm decomp branch: CPU dot, CPU small mat2, non-CPU k == 1.
+    @parametrize("m,k,n", [(1, 4, 1), (1, 4, 4), (4, 1, 4)])
+    @parametrize("beta,alpha", [(0, 1), (1, 0), (0, 0)])
+    def test_addmm_zero_scalar_ignores_operand(self, device, m, k, n, beta, alpha):
+        def fn(x, a, b):
+            return torch.addmm(x, a, b, beta=beta, alpha=alpha)
+
+        x = torch.randn(n, device=device)
+        a = torch.randn(m, k, device=device)
+        b = torch.randn(k, n, device=device)
+        if beta == 0:
+            x.fill_(float("nan"))
+        if alpha == 0:
+            a.fill_(float("nan"))
+        self.assertEqual(torch.compile(fn, fullgraph=True)(x, a, b), fn(x, a, b))
+
     @parametrize("dtype", [torch.float, torch.bfloat16])
     def test_dynamic_shape_mm(self, device, dtype):
         # Test that the mm decomp does not evaluate expressions for dynamic shapes

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -504,6 +504,11 @@ def addmm(
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:
+    # A zero scalar means its operand is ignored entirely, so NaN/inf in it must
+    # not propagate, which multiplying by zero cannot guarantee.
+    if beta == 0 or alpha == 0:
+        return NotImplemented
+
     def add_input(out: torch.Tensor) -> torch.Tensor:
         if alpha != 1:
             out = alpha * out
@@ -512,8 +517,6 @@ def addmm(
         return out + self
 
     if mat1.device.type not in ["cpu", "mps"]:
-        if beta == 0 and mat1.device.type == "cuda":
-            return NotImplemented
         if (
             statically_known_true(mat1.size(-1) == 1)
             and statically_known_true(mat1.size(0) != 1)


### PR DESCRIPTION
## Issue

Fixes #196596

## Summary

The Inductor `addmm` decomposition materializes both scaled terms as
`alpha * out + beta * self`. This does not preserve eager zero-scalar behavior
when an operand contains NaN or inf, since `0 * NaN` is still NaN.

The two scalars have different semantics:

* `beta == 0` is documented: "If beta is 0, then the content of input will be
  ignored, and nan and inf in it will not be propagated" (`torch/_torch_docs.py`).
* `alpha == 0` has no equivalent documented guarantee. Its behavior depends on
  the BLAS implementation: an MKL build skips the GEMM and returns a finite
  result, while a build configured with `USE_EIGEN_FOR_BLAS=ON` multiplies
  through and returns NaN for the same input.

Return `NotImplemented` when either scalar is zero, generalizing the existing
CUDA `beta == 0` bailout. This avoids encoding zero-scalar behavior in the
decomposition and instead preserves the eager behavior of the active backend on
the default fallback path.

An alternative would be to keep the CPU decomposition for `beta == 0` and skip
only the bias term, as the core `baddbmm` reference decomposition does. I kept
the bailout instead to make the fix small and avoid adding separate zero-scalar
semantics to each decomposition branch; `alpha == 0` would still require a
fallback.

Known gap, left for a follow-up: under `max_autotune`, a Triton template can win
and its epilogue computes `acc * alpha` and `bias * beta`
(`torch/_inductor/kernel/mm_common.py`), so the NaN can reappear. The CPP GEMM
template has the same issue for `alpha`, although it already skips the bias
epilogue when `beta` is zero.

## Tests

`test_addmm_zero_scalar_matches_eager` asserts that the decomposition returns
`NotImplemented` and that the compiled result matches eager. This holds for
both tested BLAS behaviors.

`test_addmm_zero_beta_drops_nan_bias` additionally asserts the stronger
backend-independent invariant that no NaN from `input` reaches the output when
`beta == 0`, since that behavior is part of the documented `torch.addmm`
contract.

On CPU, 8 of the 12 new cases fail without the change. The other four use the
`(4, 1, 4)` shape, which exercises the non-CPU `k == 1` decomposition branch
but does not decompose on CPU. CUDA and XPU numerics were not tested locally.

## Checklist

* [x] Passes lint (`spin fixlint`)
* [x] Added/updated tests
* [ ] Updated documentation (not applicable)
* [ ] Included benchmark results (not applicable)

## BC-breaking?

No


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo