### PR TITLE
Upgrade Nvidia's Windows CRCR Repo to L2

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -39,11 +39,11 @@
 L1:
   - riseproject-dev/pytorch-ci
   - NVIDIA-dev/pytorch-oot-internal
-  - NVIDIA/pytorch-windows-ci
   - google-pytorch/torch_tpu
   - Isalia20/pytorch-mps-ci
 
 L2:
+  - NVIDIA/pytorch-windows-ci
   - TorchedHat/pytorch-redhat-ci
   - Ascend/pytorch
   - torch-spyre/torch-spyre


### PR DESCRIPTION
The [Nvidia's pytorch-windows-ci](https://github.com/NVIDIA/pytorch-windows-ci) repo is ready to move to L2.

PR https://github.com/NVIDIA/pytorch-windows-ci/pull/15 implements the required OIDC authentication and HUD callbacks for the 2 nightly pipelines, Windows RTX (x86_64) and Windows on Arm (ARM64).

CC: @atalman @albanD @nkhasbag-nv 