### PR TITLE
[caffe2/veclib] Fix (double)0 yielding -0.0 on AVX2 (#196607)

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -141,7 +141,6 @@ Vectorized<int32_t> inline convert_to_int_of_same_size<float>(
   return _mm256_cvttps_epi32(src);
 }
 
-// From: https://stackoverflow.com/a/41148578
 template <>
 Vectorized<double> inline convert_to_fp_of_same_size<double>(
     const Vectorized<int64_t>& src) {
@@ -160,7 +159,12 @@ Vectorized<double> inline convert_to_fp_of_same_size<double>(
   /* int64 = low32 + high32*2^32 = v_hi + v_lo - 2^52 - 2^63 - 2^84 */
   __m256d v_hi_dbl = _mm256_sub_pd(_mm256_castsi256_pd(v_hi), magic_d_all);
   __m256d result = _mm256_add_pd(v_hi_dbl, _mm256_castsi256_pd(v_lo));
-  return result;
+
+  /* The final add cancels 2^52 against -2^52 when src is 0; IEEE gives that
+      exact-zero sum a negative sign under roundTowardNegative, where SCVTF
+      would give +0.0.  Force the all-zero encoding back. */
+  __m256i is_zero = _mm256_cmpeq_epi64(src, _mm256_setzero_si256());
+  return _mm256_andnot_pd(_mm256_castsi256_pd(is_zero), result);
 }
 
 template <>


### PR DESCRIPTION
Summary:

Make conversion of 64-bit 0 into double be +0.0 instead of -0.0

In this way, AVX2-based i64->f64 conversion will be identical to other ISAs

Test Plan: CI

Differential Revision: D118971238




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01