### PR TITLE
Fix stale test-class name in the conv_transpose3d redispatch skip

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15967,7 +15967,7 @@ op_db: list[OpInfo] = [
                ),
                # https://github.com/pytorch/pytorch/issues/182819
                # https://github.com/pytorch/pytorch/issues/182869
-               DecorateInfo(unittest.skip, "TestTorchFunctionRedispatchOps", "test_redispatch", device_type="cuda", dtypes=(torch.float32, torch.complex64), active_if=TEST_WITH_SLOW or IS_LINUX or IS_WINDOWS)
+               DecorateInfo(unittest.skip, "TestTorchFunctionRedispatchOpsDevice", "test_redispatch", device_type="cuda", dtypes=(torch.float32, torch.complex64), active_if=TEST_WITH_SLOW or IS_LINUX or IS_WINDOWS)
            ),
            supports_out=False,),
     OpInfo('nn.functional.conv1d',


### PR DESCRIPTION
✴️ iz2: #194257 renamed `TestTorchFunctionRedispatchOps` to `TestTorchFunctionRedispatchOpsDevice`. `DecorateInfo` matches the test class by exact string equality (`DecorateInfo.is_active` in `torch/testing/_internal/opinfo/core.py`, fed `generic_cls.__name__` by `common_device_type.py`), so this skip stopped matching and `nn.functional.conv_transpose3d` CUDA `float32` and `complex64` started running again.

`float32` is now failing on trunk — observed in CUDA 13.0 and 13.2 jobs, release and debug builds, across several shards. Example: https://github.com/pytorch/pytorch/actions/runs/34451843322/job/102849907302 — `Tensor-likes are not close!`, up to 4.96e-05 against a 1e-05 allowance, with the mismatching element moving between reruns within the same job.

This points the entry at the new class name, restoring its original dtype coverage under an unchanged activation condition. `complex64` passed in the jobs I inspected, but it belongs to this same entry and has its own DISABLED issue (#182869), so I have not narrowed the entry to `float32`.

Scope: this restores the quarantine; it does not fix the numerical failure. Both issues the entry cites (#182819, #182869) are closed, and #190241 covers only float16/bfloat16/complex32.

### Test plan

No local CUDA run. Planned validation via `ciflow/trunk` on this PR: the two dtypes should be collected and reported as skipped rather than run.