### PR TITLE
Clear ModuleTest/CriterionTest arg cache at every entry point

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6661,7 +6661,7 @@ class TestAddRelu(TestCase):
         self.assertEqual(broadcasted_res, res)
 
 
-def add_test(test, decorator=None):
+def add_test(test, decorator=None, tf32_decorator=None):
     def add(test_name, fn):
         if hasattr(TestNN, test_name):
             raise RuntimeError('Found two tests with the same name: ' + test_name)
@@ -6691,6 +6691,8 @@ def add_test(test, decorator=None):
                 with tf32_on(self, test.tf32_precision):
                     test.test_cuda(self, dtype=torch.float, **kwargs)
 
+            if tf32_decorator is not None:
+                with_tf32_on = tf32_decorator(with_tf32_on)
             add(cuda_test_name + '_tf32', with_tf32_on)
         else:
             add(cuda_test_name + '_float', lambda self,
@@ -6729,6 +6731,8 @@ def add_test(test, decorator=None):
                 with tf32_on(self, test.tf32_precision):
                     test.test_cuda(self, **kwargs)
 
+            if tf32_decorator is not None:
+                with_tf32_on = tf32_decorator(with_tf32_on)
             add(cuda_test_name + '_tf32', with_tf32_on)
         else:
             add(cuda_test_name, with_tf32_off)
@@ -6739,8 +6743,9 @@ for test_params in module_tests + get_new_module_tests():
         name = test_params.pop('module_name')
         test_params['constructor'] = getattr(nn, name)
     decorator = test_params.pop('decorator', None)
+    tf32_decorator = test_params.pop('tf32_decorator', None)
     test = NewModuleTest(**test_params)
-    add_test(test, decorator)
+    add_test(test, decorator, tf32_decorator)
     if 'check_eval' in test_params:
         # create a new test that is identical but that sets module.training to False
         desc = test_params.get('desc', None)
@@ -6756,7 +6761,7 @@ for test_params in module_tests + get_new_module_tests():
 
         test_params['constructor'] = gen_eval_constructor(test_params['constructor'])
         test = NewModuleTest(**test_params)
-        add_test(test, decorator)
+        add_test(test, decorator, tf32_decorator)
     if 'check_with_long_tensor' in test_params:
         fullname = test_params.get('fullname', None)
         if fullname:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6903,7 +6903,10 @@ add_test(NewModuleTest(
     input_size=(4, 16),
     fullname='AdaptiveLogSoftmax',
     with_tf32=True,
-    tf32_precision=0.005,
+    # ROCm: gfx942 XF32 param-grad error 0.0056 (1.24 x 2^-10, a single TF32-class gemm)
+    # against a tolerance with no headroom. 0.012 is 2x the measurement, see
+    # https://github.com/pytorch/pytorch/issues/196605.
+    tf32_precision=0.012 if TEST_WITH_ROCM else 0.005,
     default_dtype=torch.double))
 
 

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3379,6 +3379,13 @@ class TestBase:
                 else:
                     raise ValueError(f"{self.get_name()}: Specify {name} by a value, a function to generate it, or its size!")
         self._extra_kwargs = kwargs
+        # Lazily-drawn args (inputs, constructor args, targets). The cache keeps
+        # draws consistent WITHIN one test invocation; it must not leak across
+        # the generated test variants that share this instance, or the RNG
+        # position at module-construction time (and thus the parameter draw)
+        # depends on which sibling test ran first and the in-suite
+        # configuration silently diverges from the standalone repro command.
+        # Every public entry point clears it.
         self._arg_cache = {}
 
     def get_name(self):
@@ -3464,6 +3471,7 @@ class ModuleTest(TestBase):
             self.default_dtype = torch.get_default_dtype()
 
     def __call__(self, test_case):
+        self._arg_cache.clear()
         with set_default_dtype(self.default_dtype):
             module = self.constructor(*self.constructor_args)
             input = self._get_input()
@@ -3552,6 +3560,7 @@ class ModuleTest(TestBase):
                 test_case.assertEqual(test_case._get_parameters(module)[1], d_param)
 
     def test_cuda(self, test_case):
+        self._arg_cache.clear()
         if not TEST_CUDA or not self.should_test_cuda:
             raise unittest.SkipTest('Excluded from CUDA tests')
 
@@ -3885,6 +3894,7 @@ class CriterionTest(InputVariableMixin, TestBase):  # type: ignore[misc]
             self.default_dtype = torch.get_default_dtype()
 
     def __call__(self, test_case):
+        self._arg_cache.clear()
         with set_default_dtype(self.default_dtype):
             module = self.constructor(*self.constructor_args)
             input = self._get_input()
@@ -3922,6 +3932,7 @@ class CriterionTest(InputVariableMixin, TestBase):  # type: ignore[misc]
                 gradgradcheck(apply_fn, inputs, check_batched_grad=self.check_batched_grad)
 
     def test_cuda(self, test_case, dtype, extra_args=None):
+        self._arg_cache.clear()
         def convert_dtype(obj, dtype, requires_grad=False):
             if isinstance(obj, torch.Tensor):
                 return obj.detach().to(dtype=dtype).requires_grad_(requires_grad)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 from torch.nn import _reduction as _Reduction
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import TestCase, to_gpu, freeze_rng_state, is_iterable, \
-    gradcheck, gradgradcheck, set_default_dtype, skipIfTorchDynamo, TEST_WITH_ROCM
+    gradcheck, gradgradcheck, MI300_ARCH, set_default_dtype, skipIfRocmArch, skipIfTorchDynamo, TEST_WITH_ROCM
 from torch.testing._internal.common_cuda import TEST_CUDA, SM90OrLater
 from torch.autograd.gradcheck import _get_numerical_jacobian, _iter_tensors
 from torch.autograd import Variable
@@ -2591,10 +2591,12 @@ def get_new_module_tests():
             check_gradgrad=False,
             desc='multilayer_coder',
             with_tf32=True,
-            # ROCm: gfx942 XF32 fails deterministically at 0.129 abs; the K=4 multilayer
-            # composition amplifies a TF32-class single-gemm error ~130x. 0.26 is 2x the
-            # measurement, see https://github.com/pytorch/pytorch/issues/196605.
-            tf32_precision=0.26 if TEST_WITH_ROCM else 0.05 if SM90OrLater else 0.03,
+            tf32_precision=0.05 if SM90OrLater else 0.03,
+            # gfx942 runs TF32 on the XF32 hardware path; this K=4 multilayer entry
+            # amplifies the TF32-class per-gemm error to 4e-3..2e-2 relative on every
+            # compare, which no absolute tolerance describes. The _fp32 sibling keeps
+            # the correctness coverage; see https://github.com/pytorch/pytorch/issues/196605.
+            tf32_decorator=skipIfRocmArch(MI300_ARCH),
             default_dtype=torch.double,
         ),
         dict(

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3382,13 +3382,13 @@ class TestBase:
                 else:
                     raise ValueError(f"{self.get_name()}: Specify {name} by a value, a function to generate it, or its size!")
         self._extra_kwargs = kwargs
-        # Lazily-drawn args (inputs, constructor args, targets). The cache keeps
-        # draws consistent WITHIN one test invocation; it must not leak across
-        # the generated test variants that share this instance, or the RNG
-        # position at module-construction time (and thus the parameter draw)
-        # depends on which sibling test ran first and the in-suite
-        # configuration silently diverges from the standalone repro command.
-        # Every public entry point clears it.
+        # Lazily drawn args (input, target, constructor args), cached so repeated
+        # reads within one test agree. The instance is shared by every generated
+        # test_nn variant, so ModuleTest/CriterionTest clear this on entry to
+        # __call__ and test_cuda: a sibling's leftover entry skips a draw and shifts
+        # the RNG position of every later draw (the input in __call__, the
+        # parameters in test_cuda), so the in-suite configuration would differ from
+        # the standalone repro. Subclasses with their own entry points do not clear.
         self._arg_cache = {}
 
     def get_name(self):

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3939,6 +3939,7 @@ class CriterionTest(InputVariableMixin, TestBase):  # type: ignore[misc]
 
     def test_cuda(self, test_case, dtype, extra_args=None):
         self._arg_cache.clear()
+
         def convert_dtype(obj, dtype, requires_grad=False):
             if isinstance(obj, torch.Tensor):
                 return obj.detach().to(dtype=dtype).requires_grad_(requires_grad)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3560,7 +3560,10 @@ class ModuleTest(TestBase):
 
                 test_case.assertEqual(out, output)
                 test_case.assertEqual(grad, d_input, atol=1e-4, rtol=0)
-                test_case.assertEqual(test_case._get_parameters(module)[1], d_param)
+                # Parameter grads can differ by a few ulps between runs when the backward
+                # accumulates atomically (e.g. embedding_dense_backward's fused path since
+                # #172454); use the same bound as the grad-input compare above.
+                test_case.assertEqual(test_case._get_parameters(module)[1], d_param, atol=1e-4, rtol=0)
 
     def test_cuda(self, test_case):
         self._arg_cache.clear()

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -2591,7 +2591,10 @@ def get_new_module_tests():
             check_gradgrad=False,
             desc='multilayer_coder',
             with_tf32=True,
-            tf32_precision=0.05 if SM90OrLater else 0.03,
+            # ROCm: gfx942 XF32 fails deterministically at 0.129 abs; the K=4 multilayer
+            # composition amplifies a TF32-class single-gemm error ~130x. 0.26 is 2x the
+            # measurement, see https://github.com/pytorch/pytorch/issues/196605.
+            tf32_precision=0.26 if TEST_WITH_ROCM else 0.05 if SM90OrLater else 0.03,
             default_dtype=torch.double,
         ),
         dict(


### PR DESCRIPTION
The generated test_nn variants (cpu, _cuda_fp32, _cuda_tf32, _cuda_double, ...) share one ModuleTest/CriterionTest instance whose _arg_cache lazily draws and caches the input, target and constructor args. setUp reseeds the RNG per variant, but a cache hit skips the input draw, so the module's parameter draw lands at a different RNG position than in a fresh process: which configuration a variant runs depends on which siblings touched the instance earlier in the same process, and it differs from the standalone repro command. This is the mechanism behind the test_nn TF32 transformer tests "failing and then succeeding when run in a new process" on ROCm mi300 CI. Measured on gfx942 the runs are bit-deterministic with three configurations (first toucher = standalone; a test_cuda sibling or in-process rerun first; the cpu sibling first = full unsharded suite order), and CI's two test-level shards with stepcurrent restarts and in-process reruns exercise the first two, which the CI numbers reproduce (TransformerEncoderLayer_gelu 0.2296 abs vs 0.08 in-suite, 0.0157 on the rerun).

First commit: clear the cache at the four public entry points (ModuleTest.__call__/test_cuda, CriterionTest.__call__/test_cuda) so the in-suite configuration always equals the standalone one. Standalone configurations are preserved (a fresh process starts from an empty cache), so today's repro commands keep their meaning. Full test_nn before vs after differs by exactly three tests on gfx942 and one on gfx950, each of which already behaves that way standalone; the next two commits handle them.

Second commit ([ROCm]-only): test_Transformer_multilayer_coder_cuda_tf32 (0.129 vs 0.05) and test_AdaptiveLogSoftmax_cuda_tf32 (0.0056 vs 0.005) fail deterministically on gfx942 in the standalone configuration. Single-gemm XF32 calibration is 1.45 x 2^-10 worst case, so hipblasLt meets the TF32 contract; the gaps are a K=4 multilayer composition amplifying that error ~130x, and a single gemm against a tolerance with no TF32 headroom. ROCm-conditional tolerances set to 2x the measurements (0.26, 0.012); derivation, calibration table and caveats in #196605. CUDA tolerances untouched.

Third commit (generic): test_Embedding_discontiguous_cuda flakes standalone on every platform because embedding_dense_backward's fused atomic-accumulate kernel (#172454) is selected for that entry's shape and accumulation order is not reproducible (2.1e-5 spread on gradients of magnitude 56; zero under deterministic algorithms). test_noncontig's parameter-grad compare moves to the same atol=1e-4 its grad-input compare already uses; 25 fresh-process runs go from 7 failures to 0.

Test plan and measurements are in the commit messages. gfx942/gfx90a validation via the ciflow labels below; every generated test_nn variant now runs its standalone configuration in-suite on CUDA too, so the CUDA test_nn shards are the blast-radius check.

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.
