### PR TITLE
[CPU] Validate batch norm running-stat tensor sizes

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -203,6 +203,12 @@ static std::tuple<Tensor,Tensor> batch_norm_cpu_update_stats_template(
 
   int64_t n_input = input.size(1);
   TORCH_CHECK(input.numel() != 0, "input tensor must have at least one element, but got input_sizes = ", input.sizes());
+  if (running_mean.defined()) {
+    check_dims_match_num_input_features("running_mean", input.sym_size(1), running_mean.sym_numel());
+  }
+  if (running_var.defined()) {
+    check_dims_match_num_input_features("running_var", input.sym_size(1), running_var.sym_numel());
+  }
   int64_t n = input.numel() / n_input;
 
   bool all_contiguous = is_contiguous_in_any_format(input);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4106,6 +4106,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                                     re.escape("input tensor must have at least one element, but got input_sizes = [0, 1]")):
             torch.batch_norm_update_stats(input=input, momentum=0.0, running_mean=running_mean, running_var=running_var)
 
+    def test_batch_norm_update_stats_invalid_running_stats(self):
+        input = torch.arange(8, dtype=torch.float32).reshape(2, 4, 1, 1)
+        cases = (
+            ("running_mean", torch.zeros(1), torch.ones(4)),
+            ("running_var", torch.zeros(4), torch.ones(1)),
+        )
+        for name, running_mean, running_var in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                    RuntimeError, re.escape(f"{name} should contain 4 elements not 1")
+                ):
+                    torch.ops.aten.batch_norm_update_stats(
+                        input, running_mean, running_var, 0.1
+                    )
+
     def test_native_batch_norm_eval_requires_running_stats(self):
         # The raw aten op in eval mode with no running statistics used to
         # segfault inside the kernel; it must raise instead (#194014).


### PR DESCRIPTION
## Summary

Fix the CPU implementation of `aten::batch_norm_update_stats` so malformed running-stat tensors are rejected before the native kernel indexes them by input channel. This prevents out-of-bounds access when `running_mean` or `running_var` has the wrong number of elements.

Add regression coverage for undersized `running_mean` and `running_var` tensors.

Fixes #194798

## Testing

- `python -m py_compile test/test_nn.py`
- PyTorch flake8 adapter on `test/test_nn.py`
- `git diff --check`

The full native C++ build/test was not available in the local Windows checkout because no compiler, CMake/Ninja toolchain, or build artifacts were present.