### PR TITLE
[Test] Enable test/profiler/test_trace_validator.py on XPU

### DIFF
--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -558,7 +558,7 @@ class TestTraceValidatorRules(TestCase):
 # kineto's CPU/GPU timestamp clock-skew issue is fixed.
 @unittest.skip("E2E tests disabled pending kineto clock-skew fix; see per-test skips")
 @skipIfTorchDynamo("profiler tests do not work with dynamo")
-class TestTraceValidatorE2EAgnostic(_TraceValidatorE2EMixin, TestCase):
+class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
     """E2E tests for validation rules that are not tied to any specific accelerator.
 
     Category: Accelerator-AGNOSTIC
@@ -603,7 +603,7 @@ class TestTraceValidatorE2EAgnostic(_TraceValidatorE2EMixin, TestCase):
 
 
 instantiate_device_type_tests(
-    TestTraceValidatorE2EAgnostic, globals(), except_for=("cpu",)
+    TestTraceValidatorE2EAgnosticDevice, globals(), except_for=("cpu",)
 )
 
 

--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -223,9 +223,6 @@ def _load_events(trace_path):
 class _TraceValidatorE2EMixin:
     """Shared helpers for E2E trace validator test classes."""
 
-    def _events(self, payload):
-        return self._payloads[payload]
-
     @staticmethod
     def _fmt(violations, limit=5):
         lines = [f"  {v}" for v in violations[:limit]]
@@ -553,9 +550,8 @@ class TestTraceValidatorRules(TestCase):
 # ---------------------------------------------------------------------------
 
 
-# Class-level skip so setUpClass (which profiles a ResNet50 on GPU) is bypassed
-# while all E2E tests are disabled. Re-enable alongside the per-test skips once
-# kineto's CPU/GPU timestamp clock-skew issue is fixed.
+# Re-enable alongside the per-test skips once kineto's CPU/GPU timestamp
+# clock-skew issue is fixed.
 @unittest.skip("E2E tests disabled pending kineto clock-skew fix; see per-test skips")
 @skipIfTorchDynamo("profiler tests do not work with dynamo")
 class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
@@ -571,35 +567,21 @@ class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
     Instantiated per device type via ``instantiate_device_type_tests``.
     """
 
-    _trace_dir: str = ""
-    _payloads: dict = {}
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        device = torch.device(cls.device_type, 0)
-        activity = _activity_for_device_type(cls.device_type)
-        cls._trace_dir = tempfile.mkdtemp(prefix="profiler_e2e_trace_agnostic_")
-        cls._payloads = {
-            "training": _profile_training_payload(
-                os.path.join(cls._trace_dir, "training.json"),
-                device,
-                activity,
-            ),
-        }
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls._trace_dir and os.path.isdir(cls._trace_dir):
-            shutil.rmtree(cls._trace_dir, ignore_errors=True)
-        super().tearDownClass()
-
     @unittest.skip(
         "kineto backward sequence ID uniqueness not yet verified in kineto integration testing"
     )
     def test_backward_seq_id_uniqueness(self, device):
-        v = _check_backward_seq_id_uniqueness(self._events("training"))
-        self.assertEqual(len(v), 0, self._fmt(v))
+        # Kept on failure so CI leaves the trace behind for inspection.
+        trace_dir = tempfile.mkdtemp(prefix="profiler_e2e_trace_agnostic_")
+        trace_path = os.path.join(trace_dir, "training.json")
+        events = _profile_training_payload(
+            trace_path,
+            torch.device(device),
+            _activity_for_device_type(self.device_type),
+        )
+        v = _check_backward_seq_id_uniqueness(events)
+        self.assertEqual(len(v), 0, f"{self._fmt(v)}\ntrace kept at {trace_path}")
+        shutil.rmtree(trace_dir, ignore_errors=True)
 
 
 instantiate_device_type_tests(
@@ -632,6 +614,9 @@ class TestTraceValidatorE2ECUDA(_TraceValidatorE2EMixin, TestCase):
 
     _trace_dir: str = ""
     _payloads: dict = {}
+
+    def _events(self, payload):
+        return self._payloads[payload]
 
     @classmethod
     def setUpClass(cls):

--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -21,6 +21,7 @@ from torch.profiler._trace_validator import (
 )
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -251,6 +252,8 @@ class TestTraceValidatorRules(TestCase):
     These tests verify rule logic using hand-crafted event dictionaries.
     No profiling or device operations — runs on any machine.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     # --- _check_nccl_metadata ---
 
@@ -573,6 +576,8 @@ class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
     Instantiated per device type via ``instantiate_device_type_tests``.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @unittest.skip(
         "kineto backward sequence ID uniqueness not yet verified in kineto integration testing"
     )
@@ -617,6 +622,8 @@ class TestTraceValidatorE2ECUDA(_TraceValidatorE2EMixin, TestCase):
     They use CUDA-specific profiling payloads including multi-stream
     and CUDA event synchronization.
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     _trace_dir: str = ""
     _payloads: dict = {}

--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -19,7 +19,10 @@ from torch.profiler._trace_validator import (
     _check_stream_wait_corr_id_in_past,
     _check_stream_wait_corr_id_populated,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipCUDAIf,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
@@ -57,6 +60,26 @@ def _activity_for_device_type(device_type):
             f"Add it to _DEVICE_TYPE_TO_ACTIVITY."
         )
     return _DEVICE_TYPE_TO_ACTIVITY[device_type]
+
+
+def _backward_seq_events(events):
+    """The events _check_backward_seq_id_uniqueness actually indexes.
+
+    Mirrors that rule's filter exactly, including the way its ``or`` chain still
+    admits a falsy-but-present sequence number; keep the two in sync. A guard
+    built on the event name alone would accept a trace the rule finds nothing to
+    check in.
+    """
+    matched = []
+    for ev in events:
+        name = ev.get("name", "")
+        if ev.get("ph") != "X" or "autograd::engine::evaluate_function:" not in name:
+            continue
+        args = ev.get("args", {})
+        seq = args.get("Sequence number") or args.get("seq_num")
+        if seq is not None:
+            matched.append(ev)
+    return matched
 
 
 def _sync_device(device):
@@ -559,9 +582,6 @@ class TestTraceValidatorRules(TestCase):
 # ---------------------------------------------------------------------------
 
 
-# Re-enable alongside the per-test skips once kineto's CPU/GPU timestamp
-# clock-skew issue is fixed.
-@unittest.skip("E2E tests disabled pending kineto clock-skew fix; see per-test skips")
 @skipIfTorchDynamo("profiler tests do not work with dynamo")
 class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
     """E2E tests for validation rules that are not tied to any specific accelerator.
@@ -579,18 +599,20 @@ class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
 
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @unittest.skip(
-        "kineto backward sequence ID uniqueness not yet verified in kineto integration testing"
-    )
+    @skipCUDAIf(True, "backward sequence ID uniqueness not yet verified on CUDA")
     def test_backward_seq_id_uniqueness(self, device):
         # Kept on failure so CI leaves the trace behind for inspection.
         trace_dir = tempfile.mkdtemp(prefix="profiler_e2e_trace_agnostic_")
         trace_path = os.path.join(trace_dir, "training.json")
+        dev = torch.device(device)
         events = _profile_training_payload(
-            trace_path,
-            torch.device(device),
-            _activity_for_device_type(self.device_type),
+            trace_path, dev, _activity_for_device_type(self.device_type)
         )
+        # _check_backward_seq_id_uniqueness([]) returns [], so len(v) == 0 cannot tell a
+        # holding rule from a trace it found nothing to check. Guard on the rule's own
+        # predicate: a backward event without a sequence number is never indexed.
+        indexed = _backward_seq_events(events)
+        self.assertTrue(indexed, f"no indexable backward events; kept at {trace_path}")
         v = _check_backward_seq_id_uniqueness(events)
         self.assertEqual(len(v), 0, f"{self._fmt(v)}\ntrace kept at {trace_path}")
         shutil.rmtree(trace_dir, ignore_errors=True)
@@ -609,10 +631,11 @@ instantiate_device_type_tests(
 # ---------------------------------------------------------------------------
 
 
-# Class-level skip so setUpClass (which profiles a ResNet50 on GPU) is bypassed
-# while all E2E tests are disabled. Re-enable alongside the per-test skips once
-# kineto's CPU/GPU timestamp clock-skew issue is fixed.
-@unittest.skip("E2E tests disabled pending kineto clock-skew fix; see per-test skips")
+# Class-level skip so setUpClass (which profiles a ResNet50 on GPU) is bypassed while
+# this class's tests are disabled. Re-enable alongside the per-test skips once kineto's
+# CPU/GPU timestamp clock-skew issue is fixed. Scope note: the skew is CUDA-side, so it
+# does not hold TestTraceValidatorE2EAgnosticDevice, whose rule reads CPU-side events.
+@unittest.skip("CUDA E2E disabled pending kineto clock-skew fix; see per-test skips")
 @unittest.skipUnless(TEST_CUDA, "CUDA not available")
 @skipIfTorchDynamo("profiler tests do not work with dynamo")
 @instantiate_parametrized_tests

--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -8,6 +8,7 @@ import unittest
 
 import torch
 import torch.nn as nn
+from torch._C import _get_privateuse1_backend_name
 from torch._C._profiler import _ExperimentalConfig
 from torch.profiler import profile, ProfilerActivity, record_function
 from torch.profiler._trace_validator import (
@@ -38,12 +39,17 @@ _DEVICE_TYPE_TO_ACTIVITY = {
     "xpu": ProfilerActivity.XPU,
     "hpu": ProfilerActivity.HPU,
     "mtia": ProfilerActivity.MTIA,
-    "privateuse1": ProfilerActivity.PrivateUse1,
 }
 
 
 def _activity_for_device_type(device_type):
     """Map a device type string to its ProfilerActivity enum."""
+    # privateuse1 cannot be a table entry: the device_type a test sees is the
+    # registered backend name ("openreg", ...), because PrivateUse1TestBase.setUpClass
+    # overwrites device_type with _get_privateuse1_backend_name(). Resolved per call,
+    # not at import, since a backend may register after this module loads.
+    if device_type == _get_privateuse1_backend_name():
+        return ProfilerActivity.PrivateUse1
     if device_type not in _DEVICE_TYPE_TO_ACTIVITY:
         raise ValueError(
             f"No ProfilerActivity mapping for device type {device_type!r}. "

--- a/test/profiler/test_trace_validator.py
+++ b/test/profiler/test_trace_validator.py
@@ -568,10 +568,11 @@ class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
 
     Category: Accelerator-AGNOSTIC
 
-    These tests profile a real workload on whatever accelerator is available
-    and validate trace properties that are hardware-independent (autograd
-    sequence IDs). Any backend that can run a ResNet50 training loop will
-    exercise these tests.
+    These tests profile a real workload on the accelerator under test and
+    validate trace properties that are hardware-independent (autograd sequence
+    IDs). The rules themselves are backend-neutral, so any backend that can run
+    a ResNet50 training loop belongs here -- add it to the ``only_for`` list
+    below once someone has actually run these tests on it.
 
     Instantiated per device type via ``instantiate_device_type_tests``.
     """
@@ -596,7 +597,10 @@ class TestTraceValidatorE2EAgnosticDevice(_TraceValidatorE2EMixin, TestCase):
 
 
 instantiate_device_type_tests(
-    TestTraceValidatorE2EAgnosticDevice, globals(), except_for=("cpu",)
+    TestTraceValidatorE2EAgnosticDevice,
+    globals(),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True,
 )
 
 


### PR DESCRIPTION
Part of #142029.

`test/profiler/test_trace_validator.py` was classified device-specific as a whole. `TestTraceValidatorE2EAgnosticDevice` is already backend-neutral but never generated an XPU class (`allow_xpu=True` was missing), and its one test was held by a blanket skip inherited from a CUDA-side Kineto clock-skew problem that the rule it exercises never touches. Six commits, reviewable in order; each carries its own test plan.

### Coverage delta

Intel Arc B580. The XPU and no-accelerator rows are measured on this host; the CUDA row is derived from the framework code, not run.

| host | collected | executing | change |
| ---- | --------- | --------- | ------ |
| XPU (measured) | 24 -> 25 | 14 -> 15 | adds `TestTraceValidatorE2EAgnosticDeviceXPU::test_backward_seq_id_uniqueness_xpu` |
| CUDA (derived) | 25 -> 25 | 14 -> 14 | rename only; skipped before and after |
| no accelerator (measured) | 24 -> 24 | 14 -> 14 | none |

```
$ python test/profiler/test_trace_validator.py
Ran 25 tests in 5.690s
OK (skipped=10)
```

Nothing is removed on any host. Wall clock for the enabled test goes 0.007s -> 5.7s because it now really profiles a ResNet50 training step; the validator indexes 543 of the trace's 1026 backward events, and that count is asserted non-empty so a pass cannot be vacuous.

CUDA is not verified locally (no CUDA host). `skipCUDAIf` keeps the test skipped there, but dropping the class-level skip means `setUpClass`, `setUp`/`tearDown` and the CUDA memory-leak check now run around a test that skips inside its body, where `unittest` previously bypassed them entirely. CI needs to confirm that stays a skip and not an error.

CPU is deliberately not enabled here. `instantiate_device_type_tests` generates the CPU class first, and Kineto latches its `cpuOnly` flag on the first profile in a process and never re-registers it (`kineto_shim.cpp:305`), so a generated CPU class would zero device activity for every later class in the file - measured as 2617 `kernel` events dropping to 0. Enabling CPU needs a `setUpModule` prime and is a follow-up.

Authored with the assistance of an AI coding agent (Claude Code).
