### PR TITLE
[inductor] Tighten remaining formatting annotations

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1563,7 +1563,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         )
 
     @staticmethod
-    def _stringify_cpu_triton_call_arg(arg: Any) -> str:
+    def _stringify_cpu_triton_call_arg(arg: object) -> str:
         """Render a Triton kernel call argument as a C++ expression."""
         if isinstance(arg, str):
             return arg

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1563,7 +1563,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         )
 
     @staticmethod
-    def _stringify_cpu_triton_call_arg(arg: object) -> str:
+    def _stringify_cpu_triton_call_arg(
+        arg: str | bool | int | float | SymbolicCallArg | sympy.Expr,
+    ) -> str:
         """Render a Triton kernel call argument as a C++ expression."""
         if isinstance(arg, str):
             return arg

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -200,10 +200,10 @@ def _make_disk_config_key(
     kernel_name: str,
     variant_name: str,
     accumulator_type: object,
-    scale_type_a: object | None = None,
-    scale_type_b: object | None = None,
-    swizzle_type_a: object | None = None,
-    swizzle_type_b: object | None = None,
+    scale_type_a: object = None,
+    scale_type_b: object = None,
+    swizzle_type_a: object = None,
+    swizzle_type_b: object = None,
     epilogue_source: str = "",
 ) -> tuple[str, ...]:
     return (

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -199,13 +199,13 @@ def _current_target_sm(dev_idx: int):
 def _make_disk_config_key(
     kernel_name: str,
     variant_name: str,
-    accumulator_type: Any,
-    scale_type_a: Any | None = None,
-    scale_type_b: Any | None = None,
-    swizzle_type_a: Any | None = None,
-    swizzle_type_b: Any | None = None,
+    accumulator_type: object,
+    scale_type_a: object | None = None,
+    scale_type_b: object | None = None,
+    swizzle_type_a: object | None = None,
+    swizzle_type_b: object | None = None,
     epilogue_source: str = "",
-) -> tuple:
+) -> tuple[str, ...]:
     return (
         kernel_name,
         variant_name,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -8119,7 +8119,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return f"tl.arange(0, {self.kexpr(entry.block_size())}){size}{suffix}"
 
     def iteration_ranges_scalar_code(
-        self, entry: IterationRangesRoot, value: Any
+        self, entry: IterationRangesRoot, value: str
     ) -> str:
         index_dtype = self.index_dtype
         ndim = self.triton_tensor_ndim()

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -117,7 +117,7 @@ def benchmark_all_kernels(
             shared: int | None,
             prefix: str = "",
         ) -> str:
-            if not any(x is None for x in [n_regs, n_spills, shared]):
+            if n_regs is not None and n_spills is not None and shared is not None:
                 kernel_detail_str = (
                     f"  {n_regs:3} regs  {n_spills:3} spills  {shared:8} shared mem"
                 )

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -112,9 +112,9 @@ def benchmark_all_kernels(
 
         def get_info_str(
             ms: float,
-            n_regs: Any | None,
-            n_spills: Any | None,
-            shared: Any | None,
+            n_regs: int | None,
+            n_spills: int | None,
+            shared: int | None,
             prefix: str = "",
         ) -> str:
             if not any(x is None for x in [n_regs, n_spills, shared]):


### PR DESCRIPTION
Tightens unchecked `Any` annotations at formatting-only compiler boundaries. Inputs that only stringify now use `object`; call sites with a concrete contract use `str` or `int | None`; and the NVGEMM disk key now advertises its all-string tuple result. Values forwarded into dynamic compiler paths retain their existing types.

The `safe_str` and `get_safe_global_name` candidates are already typed as `object` through #196135 and #196175, so this PR does not duplicate those landed changes. During the rebase onto `main`, the scoped flex-GEMM helpers had already been removed by upstream refactoring; their obsolete annotation edits were dropped rather than restoring deleted code.

## Test plan

```bash
pyrefly check torch/_inductor/codegen/cpp_wrapper_cpu.py torch/_inductor/codegen/triton.py torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py torch/_inductor/wrapper_benchmark.py
```

This reports the same three pre-existing errors in `codegen/triton.py` on the PR and on `origin/main`.

```bash
env -u https_proxy -u HTTPS_PROXY -u http_proxy -u HTTP_PROXY UV_NO_CONFIG=1 UV_NATIVE_TLS=true lintrunner -a --skip PYREFLY torch/_inductor/codegen/cpp_wrapper_cpu.py torch/_inductor/codegen/triton.py torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py torch/_inductor/wrapper_benchmark.py
```

```bash
PYTHONPYCACHEPREFIX=/home/bobren/local/b/pytorch/agent_space/inductor-formatting-pycache python -m py_compile torch/_inductor/codegen/cpp_wrapper_cpu.py torch/_inductor/codegen/triton.py torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py torch/_inductor/wrapper_benchmark.py
```

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
