### PR TITLE
Handle non-UTF-8 subprocess output in minifier isolate_fails

### DIFF
--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -1049,12 +1049,19 @@ def isolate_fails(
 
         stdout.seek(0)
         stderr.seek(0)
+        # errors="replace": the subprocess can emit non-UTF-8 bytes (e.g. HIP
+        # runtime output on ROCm); a strict decode here kills minification
+        # before repro.py is written. Mirrors #190696's harness-side fix.
         print(
-            textwrap.indent(stdout.read().decode("utf-8"), prefix=">>  "),
+            textwrap.indent(
+                stdout.read().decode("utf-8", errors="replace"), prefix=">>  "
+            ),
             file=sys.stdout,
         )
         print(
-            textwrap.indent(stderr.read().decode("utf-8"), prefix=">>  "),
+            textwrap.indent(
+                stderr.read().decode("utf-8", errors="replace"), prefix=">>  "
+            ),
             file=sys.stderr,
         )
         # print(f"Isolated test failed - {file_name}")


### PR DESCRIPTION
#190696 added errors="replace" decoding to the minifier test harness after the ROCm flake in #190681, but the production minifier has its own decode sites: isolate_fails reads the isolated subprocess's stdout/stderr logs with bare decode("utf-8") calls. When the subprocess emits a non-UTF-8 byte (0xb1 from HIP runtime output on ROCm), isolate_fails raises UnicodeDecodeError, minification dies before repro.py is written, and the test harness surfaces FileNotFoundError instead, as seen on inductor/test_minifier_isolate.py::MinifierIsolateTests::test_after_aot_gpu_runtime_error (most recently on #189760). Decode with errors="replace", matching the harness-side fix.

Test Plan:

Byte-level check that the bare decode raises and the patched decode does not:

```
python - <<'PYEOF'
import tempfile, textwrap
with tempfile.TemporaryFile() as f:
    f.write(b"readable HIP output \xb1 continues\n")
    f.seek(0)
    print(textwrap.indent(f.read().decode("utf-8", errors="replace"), prefix=">>  "))
PYEOF
```

CPU minifier suite with the patched file overlaid on an installed torch:

```
python test/dynamo/test_minifier.py -k cpu
```

8 pass / 4 skip; the single failure (test_if_graph_minified_cpu) reproduces identically with the unpatched file in the same overlay environment, so it is an artifact of the mixed-version overlay, not this change.

This fix was authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98