### PR TITLE
[ROCm] Fix data race in test_nvshmem_all_to_all

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -576,6 +576,8 @@ class NVSHMEMAll2AllTest(MultiProcContinuousTest):
 
         symm_mem.rendezvous(inp, group=group_name)
         symm_mem.rendezvous(out, group=group_name)
+
+        dist.barrier()
         torch.ops.symm_mem.nvshmem_all_to_all(inp, out, group_name)
 
         expected = torch.cat(


### PR DESCRIPTION
[`test_nvshmem_all_to_all`](https://github.com/pytorch/pytorch/blob/273923d47e98a76e9eea14161a460e6c0a43762a/test/distributed/test_nvshmem.py#L566) fails intermittently on `linux.rocm.gpu.gfx950.2` — [job 99574094703](https://github.com/pytorch/pytorch/actions/runs/33416463656/job/99574094703):

```
Mismatched elements: 10 / 20 (50.0%)
Greatest absolute difference: 2.0 at index (10,) (up to 1e-05 allowed)
```

The test fills `out` with `-1` at [:575](https://github.com/pytorch/pytorch/blob/273923d47e98a76e9eea14161a460e6c0a43762a/test/distributed/test_nvshmem.py#L575) and calls the all-to-all at [:579](https://github.com/pytorch/pytorch/blob/273923d47e98a76e9eea14161a460e6c0a43762a/test/distributed/test_nvshmem.py#L579) with nothing synchronizing the ranks in between. The all-to-all has no entry barrier — each rank writes into its peers' `out` as soon as it enters the kernel. When one rank's `fill_(-1)` runs after its peer's write has already landed, the fill erases the received chunk, which is what the numbers show: the peer's half of `out` is still `-1`, so ten of twenty elements are wrong, the first at index 10, and the difference is `2.0 = |-1 - 1|`.

`dist.barrier()` before the collective holds every rank until all the fills have completed, so no incoming write can land in a buffer that is still going to be overwritten.

Coauthored with Claude

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang