### PR TITLE
[sentinel-oncall][gpu_optimization] Compile FlyDSL for the GPU we dispatched on

### DIFF
--- a/test/python_native/test_flydsl_utils.py
+++ b/test/python_native/test_flydsl_utils.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: dsl-native-ops"]
 
+import contextlib
 import os
+import threading
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -98,6 +100,142 @@ class TestFlyDSLArchResolution(TestCase):
         self.assertEqual(self._resolve(flydsl_arch="gfx950"), "gfx950")
 
 
+class TestFlyDSLCompileArchPin(TestCase):
+    """FLYDSL_GPU_ARCH as FlyDSL's own compiler reads it.
+
+    FlyDSL resolves its compile target separately and answers gfx942 whenever
+    rocm_agent_enumerator is unavailable, so a dispatch gated on gfx950 gets a
+    CDNA3 code object the HIP loader refuses. Everything below is the handoff
+    that keeps the two answers the same.
+    """
+
+    @contextlib.contextmanager
+    def _environment(self, current=None):
+        """Both variables _resolve_rocm_arch reads, under the test's control.
+
+        Only FLYDSL_GPU_ARCH is what these cases are about, but the resolver
+        falls back to HSA_OVERRIDE_GFX_VERSION before it ever asks the device.
+        Leaving a host-exported value in place lets the machine, rather than
+        the mock, decide the arch.
+        """
+        with patch.dict(os.environ, {}):
+            os.environ.pop("HSA_OVERRIDE_GFX_VERSION", None)
+            if current is None:
+                os.environ.pop("FLYDSL_GPU_ARCH", None)
+            else:
+                os.environ["FLYDSL_GPU_ARCH"] = current
+            yield
+
+    def test_pins_the_arch_the_dispatcher_gated_on(self):
+        with self._environment():
+            with flydsl_utils._pinned_compile_arch("gfx950"):
+                self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx950")
+            self.assertNotIn("FLYDSL_GPU_ARCH", os.environ)
+
+    def test_a_previous_value_is_restored(self):
+        with self._environment(current="gfx942"):
+            with flydsl_utils._pinned_compile_arch("gfx950"):
+                self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx950")
+            self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx942")
+
+    def test_a_suffixed_override_is_normalized(self):
+        # _resolve_rocm_arch strips the target features, FlyDSL uses the
+        # variable verbatim as the chip name, so it has to see the stripped one.
+        with self._environment(current="gfx950:sramecc+"):
+            with flydsl_utils._pinned_compile_arch("gfx950"):
+                self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx950")
+            self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx950:sramecc+")
+
+    def test_a_matching_value_is_left_in_place(self):
+        with self._environment(current="gfx950"):
+            with flydsl_utils._pinned_compile_arch("gfx950"):
+                self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx950")
+            self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx950")
+
+    def test_an_unresolved_arch_changes_nothing(self):
+        with self._environment(current="gfx942"):
+            with flydsl_utils._pinned_compile_arch(None):
+                self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx942")
+            self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx942")
+
+    def test_a_failed_compile_still_restores(self):
+        with self._environment():
+            with self.assertRaises(RuntimeError):
+                with flydsl_utils._pinned_compile_arch("gfx950"):
+                    raise RuntimeError("compile failed")
+            self.assertNotIn("FLYDSL_GPU_ARCH", os.environ)
+
+    def test_a_pin_survives_another_compile_finishing(self):
+        # flydsl_jit_cache compiles different specializations concurrently, so
+        # two pins overlap. Serialized, the second compile still reads its own
+        # arch after the first one has restored the variable.
+        first_pinned = threading.Event()
+        second_pinned = threading.Event()
+        first_released = threading.Event()
+        observed = []
+
+        def second_compile():
+            first_pinned.wait(timeout=30)
+            with flydsl_utils._pinned_compile_arch("gfx950"):
+                second_pinned.set()
+                first_released.wait(timeout=30)
+                observed.append(os.environ.get("FLYDSL_GPU_ARCH"))
+
+        with self._environment():
+            thread = threading.Thread(target=second_compile)
+            thread.start()
+            try:
+                with flydsl_utils._pinned_compile_arch("gfx950"):
+                    first_pinned.set()
+                    entered_while_held = second_pinned.wait(timeout=0.5)
+                first_released.set()
+            finally:
+                thread.join(timeout=30)
+
+        self.assertFalse(entered_while_held)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(observed, ["gfx950"])
+
+    def test_arch_resolution_waits_out_another_devices_pin(self):
+        # _resolve_rocm_arch is functools.cache'd, so its one environment read
+        # must not land inside another device's pin or it caches that arch for
+        # the life of the process.
+        flydsl_utils._resolve_rocm_arch.cache_clear()
+        flydsl_utils._get_flydsl_device_arch.cache_clear()
+        self.addCleanup(flydsl_utils._resolve_rocm_arch.cache_clear)
+        self.addCleanup(flydsl_utils._get_flydsl_device_arch.cache_clear)
+
+        pinned = threading.Event()
+        resolved = []
+
+        def resolve_other_device():
+            pinned.wait(timeout=30)
+            resolved.append(flydsl_utils._resolve_rocm_arch(1))
+
+        with (
+            self._environment(),
+            patch.object(torch.cuda, "is_available", return_value=True),
+            patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName="gfx942"),
+            ),
+        ):
+            thread = threading.Thread(target=resolve_other_device)
+            thread.start()
+            try:
+                with flydsl_utils._pinned_compile_arch("gfx950"):
+                    pinned.set()
+                    thread.join(timeout=0.5)
+                    blocked_by_the_pin = thread.is_alive()
+            finally:
+                thread.join(timeout=30)
+
+        self.assertTrue(blocked_by_the_pin)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(resolved, ["gfx942"])
+
+
 class TestFlyDSLSharedPredicates(TestCase):
     def setUp(self):
         super().setUp()
@@ -152,12 +290,24 @@ class TestFlyDSLVersionGate(TestCase):
     Every case has to clear the cache twice: ``_version_is_ok`` is
     ``functools.cache``d, so a stale verdict would leak into the next case and
     a real verdict from this machine's install would leak into the first.
+
+    ``check_native_version_skip`` is stubbed for the same reason. It answers
+    from ``TORCH_NATIVE_SKIP_VERSION_CHECK`` and is itself ``@cache``d, so a
+    developer machine that exports the override makes ``_version_is_ok``
+    return True before it ever looks at the version, and every case below that
+    expects a rejection fails. The two cases that are about the override patch
+    it themselves; an inner patch wins over this one.
     """
 
     def setUp(self):
         super().setUp()
         flydsl_utils._version_is_ok.cache_clear()
         self.addCleanup(flydsl_utils._version_is_ok.cache_clear)
+        skip_check = patch.object(
+            flydsl_utils, "check_native_version_skip", return_value=False
+        )
+        skip_check.start()
+        self.addCleanup(skip_check.stop)
 
     def _with_version(self, version):
         return patch.object(

--- a/torch/_native/flydsl_utils.py
+++ b/torch/_native/flydsl_utils.py
@@ -1,9 +1,12 @@
 """Runtime and dispatcher helpers for optional FlyDSL native operators."""
 
+import contextlib as _contextlib
 import functools
 import logging
 import sys
+from collections.abc import Iterator as _Iterator
 from os import environ as _environ
+from threading import RLock as _RLock
 from typing import cast
 
 from torch._vendor.packaging.version import Version
@@ -110,29 +113,79 @@ def _get_flydsl_device_arch(device_index: int) -> str | None:
     return None
 
 
+# Held across a compile pin, and around the one read that a pin can be seen by.
+# Reentrant so that a future caller reaching _resolve_rocm_arch from inside a
+# pin gets today's answer rather than a deadlock.
+_compile_arch_pin = _RLock()
+
+
 @functools.cache
 def _resolve_rocm_arch(device_index: int) -> str | None:
     """Return the gfx name to compile for, or None if it cannot be determined.
 
     FLYDSL_GPU_ARCH wins, then HSA_OVERRIDE_GFX_VERSION, then the device's
-    cached gcnArchName. The normalized result is cached per device.
+    cached gcnArchName. The normalized result is cached per device, so this
+    reads the environment once and holds that answer for the process; taking
+    the pin lock keeps that one read from landing inside another device's
+    _pinned_compile_arch window and caching its arch forever.
     """
-    env = _environ.get("FLYDSL_GPU_ARCH")
-    if env:
-        return env.split(":", 1)[0]
+    with _compile_arch_pin:
+        env = _environ.get("FLYDSL_GPU_ARCH")
+        if env:
+            return env.split(":", 1)[0]
 
-    hsa = _environ.get("HSA_OVERRIDE_GFX_VERSION")
-    if hsa:
-        if hsa.startswith("gfx"):
-            return hsa.split(":", 1)[0]
-        if hsa.count(".") == 2:
-            major, minor, stepping = hsa.split(".")
-            try:
-                return f"gfx{major}{minor}{int(stepping):x}"
-            except ValueError:
-                log.debug("Ignoring invalid HSA_OVERRIDE_GFX_VERSION=%s", hsa)
+        hsa = _environ.get("HSA_OVERRIDE_GFX_VERSION")
+        if hsa:
+            if hsa.startswith("gfx"):
+                return hsa.split(":", 1)[0]
+            if hsa.count(".") == 2:
+                major, minor, stepping = hsa.split(".")
+                try:
+                    return f"gfx{major}{minor}{int(stepping):x}"
+                except ValueError:
+                    log.debug("Ignoring invalid HSA_OVERRIDE_GFX_VERSION=%s", hsa)
 
     return _get_flydsl_device_arch(device_index)
+
+
+@_contextlib.contextmanager
+def _pinned_compile_arch(arch: str | None) -> _Iterator[None]:
+    """Compile for the arch the dispatcher gated on, not the one FlyDSL guesses.
+
+    FlyDSL picks its own compile target in flydsl/runtime/device.py:
+    FLYDSL_GPU_ARCH, then HSA_OVERRIDE_GFX_VERSION, then `rocm_agent_enumerator`
+    -- and a hard-coded "gfx942" whenever that subprocess raises or times out,
+    which it does wherever the tool is not on PATH. That silent fallback
+    disagrees with _resolve_rocm_arch, and the HIP loader then rejects the code
+    object with hipErrorNoBinaryForGpu.
+
+    One knob still outranks this one: flydsl's own `env.compile.arch`, read
+    from a bare `ARCH` (flydsl/utils/env.py declares it with an explicit
+    env_var, so it is not prefixed) and consulted first by
+    `RocmBackend.detect_target`. A process that already exports `ARCH` defeats
+    the pin, and every ROCm host flydsl works on today leaves it unset.
+
+    The handoff is one process-global variable, and flydsl_jit_cache locks per
+    specialization so different specializations do compile at once. The lock is
+    therefore load-bearing: without it whichever pin finishes first restores the
+    variable out from under a compile that is still running, which is the same
+    wrong-ISA artifact this is here to prevent. Each specialization compiles
+    once, so serializing them costs less than caching a bad code object.
+    """
+    if not arch:
+        yield
+        return
+
+    with _compile_arch_pin:
+        previous = _environ.get("FLYDSL_GPU_ARCH")
+        _environ["FLYDSL_GPU_ARCH"] = arch
+        try:
+            yield
+        finally:
+            if previous is None:
+                _environ.pop("FLYDSL_GPU_ARCH", None)
+            else:
+                _environ["FLYDSL_GPU_ARCH"] = previous
 
 
 @functools.cache

--- a/torch/_native/ops/norm/flydsl_rmsnorm_fwd.py
+++ b/torch/_native/ops/norm/flydsl_rmsnorm_fwd.py
@@ -14,7 +14,7 @@ from flydsl.runtime.device import is_rdna_arch
 
 import torch
 from torch._native.flydsl.compile_args import make_compile_arg, read_only_tensor
-from torch._native.flydsl_utils import _resolve_rocm_arch
+from torch._native.flydsl_utils import _pinned_compile_arch, _resolve_rocm_arch
 from torch._native.instrumentation import instrumented_flydsl_cache
 from torch._native.ops.norm.flydsl_rmsnorm_utils import (
     normalized_shape_1d,
@@ -276,17 +276,18 @@ def _compile_rmsnorm_fwd(
     # module/function handles and must be cached per device.
     del backend, device_index
     input_2d, weight, output_2d, rstd, rows_m, eps, stream = compile_args
-    launch = _build_rmsnorm_module(n, dtype, arch)
-    return flyc.compile(
-        launch,
-        make_compile_arg(input_2d, read_only=True),
-        flyc.from_torch_tensor(read_only_tensor(weight)),
-        make_compile_arg(output_2d),
-        make_compile_arg(rstd),
-        rows_m,
-        eps,
-        stream,
-    )
+    with _pinned_compile_arch(arch):
+        launch = _build_rmsnorm_module(n, dtype, arch)
+        return flyc.compile(
+            launch,
+            make_compile_arg(input_2d, read_only=True),
+            flyc.from_torch_tensor(read_only_tensor(weight)),
+            make_compile_arg(output_2d),
+            make_compile_arg(rstd),
+            rows_m,
+            eps,
+            stream,
+        )
 
 
 def rmsnorm_fwd(

--- a/torch/_native/ops/topk/flydsl_kernels.py
+++ b/torch/_native/ops/topk/flydsl_kernels.py
@@ -46,7 +46,7 @@ import torch
 from torch._native.flydsl.cache import CachedCompile, CacheInfo
 from torch._native.flydsl.compile_args import make_compile_arg, read_only_tensor
 from torch._native.flydsl.intrinsics import atomic_add, maxsi, minsi
-from torch._native.flydsl_utils import _resolve_rocm_arch
+from torch._native.flydsl_utils import _pinned_compile_arch, _resolve_rocm_arch
 from torch._native.instrumentation import instrumented_flydsl_cache
 
 
@@ -624,15 +624,16 @@ def _compile_register_topk(
     # be cached per device.
     del backend, device_index
     input_2d, values_2d, indices_2d, rows_m, stream = compile_args
-    launch = _build_register_topk_module(n, k, arch)
-    return flyc.compile(
-        launch,
-        make_compile_arg(input_2d, read_only=True),
-        make_compile_arg(values_2d),
-        make_compile_arg(indices_2d),
-        rows_m,
-        stream,
-    )
+    with _pinned_compile_arch(arch):
+        launch = _build_register_topk_module(n, k, arch)
+        return flyc.compile(
+            launch,
+            make_compile_arg(input_2d, read_only=True),
+            make_compile_arg(values_2d),
+            make_compile_arg(indices_2d),
+            rows_m,
+            stream,
+        )
 
 
 def topk_register_out(
@@ -686,15 +687,16 @@ def _compile_radix_select_topk(
 ) -> flyc.CompiledFunction:
     del backend, device_index  # cache keys only; see _compile_register_topk
     input_2d, values_2d, indices_2d, rows_m, stream = compile_args
-    launch = _build_radix_select_topk_module(n, k, deterministic, arch)
-    return flyc.compile(
-        launch,
-        make_compile_arg(input_2d, read_only=True),
-        make_compile_arg(values_2d),
-        make_compile_arg(indices_2d),
-        rows_m,
-        stream,
-    )
+    with _pinned_compile_arch(arch):
+        launch = _build_radix_select_topk_module(n, k, deterministic, arch)
+        return flyc.compile(
+            launch,
+            make_compile_arg(input_2d, read_only=True),
+            make_compile_arg(values_2d),
+            make_compile_arg(indices_2d),
+            rows_m,
+            stream,
+        )
 
 
 def topk_radix_out(


### PR DESCRIPTION
Summary:
MI350X lowering failed with `CUDA error: invalid resource handle` after `flydsl` 0.3.2 became default. PyTorch admitted the kernel for gfx950, but FlyDSL defaulted to gfx942 when `rocm_agent_enumerator` was absent on lowering RE workers. HIP then rejected the binary because it contained no gfx950 ISA.

Pass FlyDSL the resolved architecture under a process lock.

S705239 is mitigated by D119428530; this is the forward fix.

Sentinel-Council-Run: council_1789020222_007bf011
Sentinel-Council-Run: council_1789041821_3810874a
Sentinel-Council-Run: council_1789063407_fc135987
Sentinel-Council-Run: council_1789085032_d7cc0fbb
Sentinel-Harness: claude

*Modify your team agent prompt, check stats, and leave feedback: https://www.internalfb.com/sentinel_agent/rotations/gpu_optimization*
Model used: Claude Opus 5 (claude-opus-5[1m])

Test Plan:
## The failure in production

`S705239` (Live, level 3) and `T287897740` (owner `binbao`, `oncallteam-gpu_optimization`). Two
IG-CTR standalone publishes, `f1140281440` and `f1140282461`, both on `ien.lower.mi350x:116`,
failed only on the `GFX950_X86` spec while `SM90_X86`, `SM80_X86` and `GFX942_X86` passed:

```
[INFRASTRUCTURE_ERROR][GPU_ENABLEMENT] LoweringLogicException: Failed to run lowering for
lowering backend LoweringBackend.AOTINDUCTOR.
Root Exception: CUDA error: invalid resource handle
Chain of causes:
 -> GENERATE_LOWERED_MODULE
  -> AcceleratorError: CUDA error: invalid resource handle
```

The RE worker stderr, quoted on `T287897740`, has the real first error:

```
'hipModuleLoadData(&module, data)' failed with 'hipErrorNoBinaryForGpu'
'hipModuleGetFunction(...)'        failed with 'hipErrorInvalidHandle'
'hipModuleLaunchKernel(...)'       failed with 'hipErrorInvalidHandle'
```

`hipErrorNoBinaryForGpu` means the module carries no ISA for this device. The handle is then
null, and the two follow-on calls are what surface to Python as `invalid resource handle`.

Still open as of this run: Kevin Chen's Workplace thread
(`fb.workplace.com/groups/gpuinference/permalink/3685157198299588/`) is this failure, and
`garroud` reached the same root cause there independently.

## Why the binary is for the wrong GPU

Two independent answers to "which GPU are we on", and nothing makes them agree.

1. `torch/_native/flydsl_utils.py:_resolve_rocm_arch` -- `FLYDSL_GPU_ARCH`, then
   `HSA_OVERRIDE_GFX_VERSION`, then `torch.cuda.get_device_properties(i).gcnArchName`. This is
   what gates the override: `_SUPPORTED_ARCHES = ("gfx950",)` in both
   `ops/norm/flydsl_rmsnorm_impl.py` and `ops/topk/flydsl_impl.py`. It is right.
2. `flydsl/runtime/device.py:get_rocm_arch` -- `FLYDSL_GPU_ARCH`, then
   `HSA_OVERRIDE_GFX_VERSION`, then `_arch_from_hardware()`, which runs `rocm_agent_enumerator`
   in a subprocess under `try/except Exception: pass` and **returns `"gfx942"` on any failure**.
   `compiler/backends/rocm.py:20` (`detect_target`) is the only thing `flyc.compile` consults.

So on an RE worker without `rocm_agent_enumerator`, (1) says gfx950 and admits the kernel, and
(2) says gfx942 and compiles a CDNA3 code object for it.

`D118592635` ("[flydsl] Make 0.3.2 the default PyPI version", landed 2026-09-03 22:13 PDT) is
what exposed this: `_FLYDSL_SUPPORTED_RELEASES = ((0, 3),)`, so on 0.2.3 the overrides never
registered and no FlyDSL kernel was ever compiled during lowering. `D119428530` reverts that
version bump. It stops the bleeding by switching FlyDSL off again; it does not make the two
answers agree, and `D119190814` / `D119430419` are already moving back onto 0.3.x.

## At FlyDSL's own compile boundary

`RocmBackend.detect_target` computes `env.compile.arch or get_rocm_arch()`. Both modules are
dependency-free, so this loads them straight from the checked-in 0.3.2 wheel, with
`rocm_agent_enumerator` made unreachable exactly as it is on the RE workers, and asks the real
resolver what it would compile for:

```
$ python3 /tmp/flydsl_boundary.py
dispatcher (_resolve_rocm_arch) gated on : gfx950
flydsl detect_target() outside the pin   : gfx942
flydsl detect_target() inside the pin    : gfx950  (warp_size 64)
flydsl detect_target() after the pin     : gfx942
FLYDSL_GPU_ARCH left behind              : False
```

`FLYDSL_GPU_ARCH=gfx950` was independently confirmed on a real MI350 RE run by `garroud` on
`T287897740` ("Tested with env override FLYDSL_GPU_ARCH=gfx950 on RE and it works").

## Why the pin is locked

`FLYDSL_GPU_ARCH` is one process-global variable, and `flydsl_jit_cache` locks per specialization
precisely so that different specializations compile at the same time
(`torch/_native/flydsl/cache.py`: "different specializations still compile concurrently"). Two
overlapping pins therefore reproduce the very bug being fixed: the second sees the variable
already set to its own arch, does nothing, and the first pops it while the second compile is
still running.

The lock also covers the one read that could see a pin: `_resolve_rocm_arch` is
`functools.cache`d, so its single environment read is latched for the life of the process. A
first-ever call for another device landing inside a pin would cache that pin's arch forever.

Both orderings, 20 runs each, against the real functions:

```
$ python3 /tmp/pin_20runs.py
BEFORE  compile reads during another pin : None     20/20
BEFORE  _resolve_rocm_arch(1) latches    : gfx950   20/20   (device 1 is gfx942)
AFTER   compile reads during another pin : gfx950   20/20
AFTER   _resolve_rocm_arch(1) latches    : gfx942   20/20   (device 1 is gfx942)
```

`None` is what sends FlyDSL back to `_arch_from_hardware()`, i.e. `gfx942`.

The lock is an `RLock`: nothing reaches `_resolve_rocm_arch` from inside a pin today (all five
call sites -- `flydsl_rmsnorm_impl.py:25`, `flydsl_rmsnorm_fwd.py:305`, `flydsl_impl.py:92`,
`flydsl_kernels.py:648`, `:713` -- run before the compile), and reentrancy means a future one
gets today's answer instead of a deadlock.

Each specialization compiles once, so serializing compiles is cheaper than caching a code object
built for the wrong ISA -- and `flydsl_jit_cache` caches that bad object for the life of the
process. The cost to weigh against that: the pin is held across FlyDSL's own cross-process cache
lock (`jit_function.py:1019`, `FileLock(..., exclusive=True, timeout=600)`), so a contended
on-disk cache can now stall every native-op compile in the process, not just the contending
specialization.

## Unit tests

Eight cases in `test/python_native/test_flydsl_utils.py`, run against the exact source in the
checkout (both the functions and the test class are lifted by `ast`, because `torch` is not
importable in this harness -- `python3 -c "import torch"` -> `ModuleNotFoundError`):

```
$ python3 /tmp/run_pin_tests.py
test_a_failed_compile_still_restores ... ok
test_a_matching_value_is_left_in_place ... ok
test_a_pin_survives_another_compile_finishing ... ok
test_a_previous_value_is_restored ... ok
test_a_suffixed_override_is_normalized ... ok
test_an_unresolved_arch_changes_nothing ... ok
test_arch_resolution_waits_out_another_devices_pin ... ok
test_pins_the_arch_the_dispatcher_gated_on ... ok

Ran 8 tests in 1.009s

OK
```

Six fail before this diff for the plain reason that `_pinned_compile_arch` does not exist. The
two concurrency cases were also run against the unlocked version of the same functions, taken
from this diff's own earlier version with `sl cat`, and both fail on the mutual-exclusion
assertion rather than on a timing-dependent read:

```
$ python3 /tmp/run_pin_tests_before.py
test_a_pin_survives_another_compile_finishing ... FAIL
  self.assertFalse(entered_while_held)   AssertionError: True is not false
test_arch_resolution_waits_out_another_devices_pin ... FAIL
  self.assertTrue(blocked_by_the_pin)    AssertionError: False is not true

Ran 8 tests in 0.009s
FAILED (failures=2)
```

The 12 pre-existing cases in `TestFlyDSLArchResolution` and `TestFlyDSLSharedPredicates` were
re-run the same way against the changed `_resolve_rocm_arch` -- 12/12 `OK`, including
`test_resolution_is_cached_per_device`.

## Lint

```
$ arc f
alert No linters to run.
$ arc lint
ok No lint issues.
$ arc lint -e extra
ok No lint issues.
```

## Not covered, and known precedence

`test/python_native/` has no buck target (`buck2 uquery "owner(caffe2/test/python_native/
test_flydsl_utils.py)"` -> `No owner was found`); PyTorch OSS CI runs it, and that is where these
cases will run. There is no MI350 in this harness, so the end-to-end claim rests on the boundary
probe above plus `garroud`'s RE run, not on a lowering I performed.

`github-export-checks` is red and a bot cannot clear it: every commit under
`caffe2/torch/_native/` is co-developed, so this needs a `pytorch/pytorch` PR exported by a human
before it can land.

One knob still outranks the pin. `RocmBackend.detect_target` reads `env.compile.arch` first, and
`flydsl/utils/env.py:238` declares it `OptStr("", env_var="ARCH")` -- an explicit `env_var`, so
the `FLYDSL_` prefix is not applied and it reads a bare `ARCH`. A process that exports `ARCH`
defeats the pin. It is not settable safely from here (it would leak into every subprocess), and
any host where `ARCH` were set to a non-gfx value would already be failing every flydsl compile
today, so this is recorded in the docstring rather than defended against.

The Inductor FlyDSL templates set the same variable without this lock
(`torch/_inductor/kernel/templates/flydsl_mm.py.jinja`, fed by
`_inductor/codegen/flydsl/flydsl_scheduling.py`). Concurrent eager-native and Inductor-template
compiles in one process could still unpin each other. Sharing the lock means a shared helper
across the two subsystems; called out here rather than done in a SEV fix.

## Precedent

Inductor's FlyDSL path already does exactly this, for the same reason: `FlyDSLScheduling.
_build_flydsl_gpu_arch` reads `gcnArchName` and the templates set it into the environment around
the compile. The eager native-op path was the one caller missing that handoff.

## Council review

`council_1789020222_007bf011`. claude and codex both ran to completion; metacode timed out at
1500s with no output. Folded in: the `_resolve_rocm_arch` cache-poisoning window (codex, raised
blocking) is now closed by the lock rather than disclosed; the concurrency test now asserts
mutual exclusion instead of a timing-dependent value (codex); the `ARCH` precedence is documented
(claude); the FlyDSL-boundary probe replaces the resolver-only "end to end" section (codex); the
summary is under 100 words (both). Not taken: `Lock` -> `RLock` was taken, but for the new
`_resolve_rocm_arch` guard, not for the reentrancy claude and codex both judged absent.
## Council review, council_1789041821_3810874a

All three critics (claude, codex, metacode) ran to completion. `test/python_native/` still has no
buck target, so everything below ran against a scratch `python_unittest` over `//caffe2:test-lib`
carrying this revision's sources, deleted afterwards.

**Adopted -- raised independently by all three critics.** `TestFlyDSLVersionGate` read the host's
`TORCH_NATIVE_SKIP_VERSION_CHECK`. `_version_is_ok` consults `check_native_version_skip`
(`caffe2/torch/_native/common_utils.py:69`), which is `cache`d, so a machine exporting that
override answers True before the version is ever examined:

```
$ TORCH_NATIVE_SKIP_VERSION_CHECK=1 ./test_flydsl_utils.par
FAIL: test_other_versions_are_rejected_version_1_3_0
    self.assertFalse(flydsl_utils._version_is_ok())
AssertionError: True is not false
Ran 43 tests in 2.915s
FAILED (failures=7)
```

`setUp` now stubs `check_native_version_skip`, which also answers claude's separate point that its
cache was never cleared -- stubbing the function makes the cache unreachable. After the change:

```
$ (clean environment)                                                      Ran 43 tests ... OK
$ TORCH_NATIVE_SKIP_VERSION_CHECK=1                                        Ran 43 tests ... OK
$ HSA_OVERRIDE_GFX_VERSION=9.0.10                                          Ran 43 tests ... OK
$ TORCH_NATIVE_SKIP_VERSION_CHECK=1 HSA_OVERRIDE_GFX_VERSION=gfx950        Ran 43 tests ... OK
```

The stub does not weaken the two cases that are about the override. Deleting the
`check_native_version_skip()` branch from `_version_is_ok` still fails both:

```
FAIL: test_skip_check_overrides_missing_version
FAIL: test_skip_check_overrides_unsupported_version
Ran 43 tests ... FAILED (failures=2)
```

**Adopted earlier in the same run**, from the automated reviewer on the previous version:
`_environment` left `HSA_OVERRIDE_GFX_VERSION` alone, and `_resolve_rocm_arch` falls back to it
before querying the device. Before the fix:

```
$ HSA_OVERRIDE_GFX_VERSION=9.0.10 ./test_flydsl_utils.par
FAIL: test_arch_resolution_waits_out_another_devices_pin
AssertionError: String comparison failed: 'gfx90a' != 'gfx942'
```

**Refuted (metacode).** Claim: `test_a_pin_survives_another_compile_finishing` is timing-dependent
and would pass with the lock deleted. Mutation test, `with _compile_arch_pin:` removed from
`_pinned_compile_arch`, five consecutive runs -- the mutant is killed every time, by both tests:

```
FAIL: test_a_pin_survives_another_compile_finishing
    self.assertFalse(entered_while_held)            AssertionError: True is not false
FAIL: test_arch_resolution_waits_out_another_devices_pin
    self.assertTrue(blocked_by_the_pin)             AssertionError: False is not true
run 1..5: FAILED (failures=2)
```

**Not taken.** metacode: calling `_resolve_rocm_arch(other_device)` on the same thread from inside
a pin returns the pinned arch, and `functools.cache` then keeps it for that device. That is real,
and the `RLock` is what permits it -- but the alternative is the deadlock the reentrancy exists to
avoid, so closing it needs arch state carried outside the environment variable. That is a design
change, not something to fold into a SEV fix. metacode: the decimal `HSA_OVERRIDE_GFX_VERSION`
branch does not strip a `:target-features` suffix -- that suffix is not part of that variable's
decimal format, and the fall-through returns the real device arch, which is the safe answer.
codex and metacode also re-raised the Inductor-template and bare-`ARCH` gaps, both already
recorded in "Not covered, and known precedence" above.

Differential Revision: D119460451


