### PR TITLE
[xpu][test] Port 4 distributed tests (fsdp folder) cases on Intel GPUs

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -89,10 +89,13 @@ mp_only_param_and_buf = MixedPrecision(
 # Nothing is cast (thus param, comm, grad, and buffer should be in the full precision)
 mp_no_mixed_precision = MixedPrecision()
 
-nccl_supports_bf16 = dist.is_nccl_available() and nccl.version() >= (2, 10)
+# XCCL supports bfloat16 collectives unconditionally; NCCL needs 2.10+.
+backend_supports_bf16 = dist.is_xccl_available() or (
+    dist.is_nccl_available() and nccl.version() >= (2, 10)
+)
 
 mp_configs = [default_mp, mp_only_reduce, mp_only_param_and_buf, mp_no_mixed_precision]
-if nccl_supports_bf16:
+if backend_supports_bf16:
     mp_diff_buffer_and_reduce = MixedPrecision(
         param_dtype=torch.float16,
         buffer_dtype=torch.bfloat16,
@@ -129,7 +132,7 @@ test_name_mapping = {
     "enable_sharded_grad_scaler": "enable_sharded_grad_scaler",
 }
 
-if nccl_supports_bf16:
+if backend_supports_bf16:
     test_name_mapping.update(
         {
             str(mp_diff_buffer_and_reduce): "mp_diff_buffer_reduce",
@@ -540,7 +543,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
     def test_mixed_precision_no_reshard_after_forward(self):
         # Note that we don't exercise all possible different configs so as to
         # not increase test TTS too much.
-        mp = default_mp if not nccl_supports_bf16 else mp_diff_buffer_and_reduce
+        mp = default_mp if not backend_supports_bf16 else mp_diff_buffer_and_reduce
         self._run_test_mixed_precision_e2e(
             mp_config=mp,
             cpu_offload=CPUOffload(offload_params=True),
@@ -1065,7 +1068,7 @@ class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
     def test_mixed_precision_no_reshard_after_forward(self):
         # Note that we don't exercise all possible different configs so as to
         # not increase test TTS too much.
-        mp = default_mp if not nccl_supports_bf16 else mp_diff_buffer_and_reduce
+        mp = default_mp if not backend_supports_bf16 else mp_diff_buffer_and_reduce
         self._run_test_mixed_precision_e2e(
             mp_config=mp,
             cpu_offload=CPUOffload(offload_params=True),
@@ -1078,7 +1081,7 @@ class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
 
     @skip_if_lt_x_gpu(1)
     def test_mixed_precision_e2e_full_shard(self):
-        mp = default_mp if not nccl_supports_bf16 else mp_diff_buffer_and_reduce
+        mp = default_mp if not backend_supports_bf16 else mp_diff_buffer_and_reduce
         self._run_test_mixed_precision_e2e(
             mp_config=mp,
             cpu_offload=CPUOffload(offload_params=True),

--- a/test/distributed/fsdp/test_fsdp_multiple_forward.py
+++ b/test/distributed/fsdp/test_fsdp_multiple_forward.py
@@ -77,7 +77,7 @@ class TestMultiForward(FSDPTestContinuous):
         self.assertEqual(ddp_state, fsdp_state)
 
 
-devices = ("cpu", "hpu", "xpu")
+devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
     TestMultiForward, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_multiple_forward.py
+++ b/test/distributed/fsdp/test_fsdp_multiple_forward.py
@@ -77,7 +77,7 @@ class TestMultiForward(FSDPTestContinuous):
         self.assertEqual(ddp_state, fsdp_state)
 
 
-devices = ("cuda", "hpu", "xpu")
+devices = ("cpu", "hpu", "xpu")
 instantiate_device_type_tests(
     TestMultiForward, globals(), only_for=devices, allow_xpu=True
 )

--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -18,8 +18,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_HPU,
     TEST_WITH_DEV_DBG_ASAN,
-    TEST_XPU,
-    xfailIf,
 )
 
 
@@ -35,6 +33,7 @@ if TEST_WITH_DEV_DBG_ASAN:
     sys.exit(0)
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+device_module = torch.get_device_module(device_type)
 
 
 class Layer(nn.Module):
@@ -53,8 +52,8 @@ class Layer(nn.Module):
         # Record the fake forward compute time.
         self.e1.record()
         if self.sleep_cycles > 0:
-            if torch.cuda.is_available():
-                torch.cuda._sleep(self.sleep_cycles)
+            if hasattr(device_module, "_sleep"):
+                device_module._sleep(self.sleep_cycles)
         if self.optional_param is not None:
             x = x + self.optional_param  # force the param to be part of the graph
         self.e2.record()
@@ -141,8 +140,8 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
                 def _delayed_all_gather(*args, **kwargs):
                     nonlocal all_gather_called
                     all_gather_called = True
-                    if torch.cuda.is_available():
-                        torch.cuda._sleep(all_gather_cycles)
+                    if hasattr(device_module, "_sleep"):
+                        device_module._sleep(all_gather_cycles)
                     if not orig_all_gather:
                         raise AssertionError("Expected orig_all_gather to be truthy")
                     return orig_all_gather(*args, **kwargs)
@@ -193,7 +192,7 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
                 "gpu_total": gpu_total.avg(),
             }
 
-        sleep_cycles = int(100 * get_cycles_per_ms())
+        sleep_cycles = int(100 * get_cycles_per_ms(device_type))
 
         e1 = run(0, 0)  # no compute, no all-gather
         e2 = run(0, sleep_cycles)  # no compute, only all-gather
@@ -249,7 +248,6 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
             self.assertTrue(compute_only + all_gather_only > 1.1 * both)
 
     @unittest.skipIf(TEST_HPU, "HPU doesn't has HW sleep API support, skipping")
-    @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1504
     @skip_if_lt_x_gpu(2)
     def test_forward_overlap(self):
         self._dist_train()

--- a/test/distributed/fsdp/test_fsdp_traversal.py
+++ b/test/distributed/fsdp/test_fsdp_traversal.py
@@ -29,7 +29,7 @@ if TEST_WITH_DEV_DBG_ASAN:
 class TestTraversal(FSDPTestContinuous):
     @property
     def world_size(self):
-        if torch.torch.accelerator.is_available():
+        if torch.accelerator.is_available():
             gpu_cnt = torch.accelerator.device_count()
             if gpu_cnt < 2:
                 return gpu_cnt

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -33,7 +33,6 @@ from torch.distributed.fsdp.wrap import (
 )
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.modules.batchnorm import _BatchNorm
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _move_to_device,
@@ -50,6 +49,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_CUDA,
+    TEST_MULTIACCELERATOR,
     TEST_XPU,
     TestCase,
 )
@@ -420,7 +420,7 @@ class TestAutoWrap(TestCase):
         # For all the tests here, we use a fake group
         self.process_group = DummyProcessGroup(rank=0, size=1)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_wrap(self, wrap_method):
         if wrap_method == WrapMethod.WRAP_API:
@@ -440,7 +440,7 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, self.process_group.rank())
         self.assertEqual(layer.world_size, self.process_group.size())
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_wrap_disabled_outside_context(self):
         pg = self.process_group
 
@@ -457,7 +457,7 @@ class TestAutoWrap(TestCase):
         self.assertFalse(isinstance(model.lin, FSDP))
         self.assertTrue(isinstance(model.lin, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_wrap_override_defaults(self):
         new_process_group = DummyProcessGroup(rank=0, size=2)
         with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group):
@@ -479,7 +479,7 @@ class TestAutoWrap(TestCase):
         )
         TestFSDPWrap.NestedSequentialModel.verify_model_all_wrapped(self, model)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_transformer_auto_wrap_policy(self):
         """Tests the ``transformer_auto_wrap_policy``."""
         auto_wrap_policy = functools.partial(
@@ -488,7 +488,7 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_module_wrap_policy(self):
         """Tests the ``ModuleWrapPolicy``."""
         auto_wrap_policy = ModuleWrapPolicy(
@@ -496,7 +496,7 @@ class TestAutoWrap(TestCase):
         )
         self._test_transformer_wrapping(auto_wrap_policy)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_module_wrap_policy_callable(self):
         """Tests the ``ModuleWrapPolicy`` as a ``Callable``."""
         auto_wrap_policy = ModuleWrapPolicy(
@@ -526,7 +526,7 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_custom_policy(self):
         """
         Tests ``CustomPolicy`` with both a lambda function that uses uniform
@@ -629,7 +629,7 @@ class TestAutoWrap(TestCase):
             else:
                 self.assertFalse(isinstance(module, FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_auto_wrap_api(self):
         """
         Test to ensure with auto wrap, we wrap child modules correctly based on the min_num_params.
@@ -647,7 +647,7 @@ class TestAutoWrap(TestCase):
 
         TestFSDPWrap.NestedSequentialModel.verify_model(self, model)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_auto_wrap_preset_exclude_wrap(self):
         """
         Test to ensure excluded modules are not wrapped, regardless if the total param size is greater than the
@@ -668,7 +668,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model[0], nn.Linear))
         self.assertTrue(isinstance(model[1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_auto_wrap_preset_exclude_wrap_include_children(self):
         """
         Test to ensure excluded modules are not wrapped, but children are if param size is greater than
@@ -687,7 +687,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model, FSDP))
         self.assertTrue(isinstance(model[0], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_auto_wrap_preset_force_leaf(self):
         """
         Test to ensure force-leaf modules are not wrapped, and children are not wrapped. The
@@ -707,7 +707,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[1], nn.MultiheadAttention))
         self.assertTrue(isinstance(model.module[1].out_proj, nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_auto_wrap_preset_force_leaf_custom(self):
         """
         Test to ensure force-leaf modules are not wrapped.
@@ -801,7 +801,7 @@ class TestAutoWrap(TestCase):
         except FileNotFoundError:
             pass
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_always_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
         sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
@@ -826,7 +826,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2].module[0], nn.Linear))
         self.assertTrue(isinstance(model.module[2].module[1], FSDP))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     @parametrize("wrap_method", [WrapMethod.FSDP_CTOR, WrapMethod.WRAP_API])
     def test_auto_wrap_with_ignored_modules(self, wrap_method: WrapMethod):
         sequential = TestFSDPWrap.NestedSequentialModel.get_model(device=False)
@@ -859,7 +859,7 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[2][0], nn.Linear))
         self.assertTrue(isinstance(model.module[2][1], nn.Linear))
 
-    @unittest.skipIf(not TEST_MULTIGPU, "Requires at least 2 GPUs")
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "Requires at least 2 GPUs")
     def test_frozen_params(self):
         """
         Tests that mixing frozen/non-frozen parameters in an FSDP instance


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU.
We will enable Intel GPU with following methods and keep the original code styles:

Example: "torch.accelerator.current_accelerator()" to determine the accelerator backend

enabled XPU for the following files:

1. test/distributed/fsdp/test_fsdp_mixed_precision.py
2. test/distributed/fsdp/test_fsdp_overlap.py
3. test/distributed/fsdp/test_fsdp_traversal.py
4. test/distributed/fsdp/test_wrap.py

cc @newtdms, @guangyey, @etaf, @CuiYifeng, @liangan1, @astachowiczhabana, @pbielak.