### PR TITLE
[inductor] Gate CUDA TMA tests on CUDA devices

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -90,8 +90,8 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.logging_utils import multiple_logs_to_string
 from torch.utils._triton import (
     has_datacenter_blackwell_tma_device,
+    has_triton_cuda_tma_device,
     has_triton_stable_tma_api,
-    has_triton_tma_device,
 )
 
 
@@ -250,7 +250,7 @@ class TestMaxAutotune(TestCase):
                 )
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @unittest.skipIf(
         has_datacenter_blackwell_tma_device(),
@@ -564,7 +564,7 @@ class TestMaxAutotune(TestCase):
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     def test_max_autotune_persistent_tma_workspace_reuse(self):
         """
@@ -639,7 +639,7 @@ class TestMaxAutotune(TestCase):
             mm_heuristic.mm_configs = original_mm_configs
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     def test_workspace_size_bytes_accounts_for_dtype(self):
         """workspace_size passed to benchmark request must be in bytes, not elements."""
@@ -708,7 +708,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(size, expected_bytes)
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @unittest.skipIf(
         has_datacenter_blackwell_tma_device(),
@@ -775,7 +775,7 @@ class TestMaxAutotune(TestCase):
         FileCheck().check("triton_tem_fused_mm").check(check_str).run(code[0])
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @skipIfXpu(msg="Covered by XPU TMA")
     @parametrize("dynamic", (False, True))
@@ -806,7 +806,7 @@ class TestMaxAutotune(TestCase):
         self.assertIn("NoValidChoicesError", str(context.exception))
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @parametrize("dynamic", (False, True))
     def test_max_autotune_regular_mm_persistent_tma_illegal_output_alignment(
@@ -843,7 +843,7 @@ class TestMaxAutotune(TestCase):
         self.assertIn("NoValidChoicesError", str(context.exception))
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     def test_max_autotune_regular_mm_tma_dynamic_outer_dim(self):
         def mm(a, b):
@@ -881,7 +881,7 @@ class TestMaxAutotune(TestCase):
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @unittest.skipIf(
         has_datacenter_blackwell_tma_device(),
@@ -991,7 +991,7 @@ class TestMaxAutotune(TestCase):
             self.assertEqual((100,), extern_bias_shape)
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @unittest.skipIf(
         has_datacenter_blackwell_tma_device(),
@@ -1076,7 +1076,7 @@ class TestMaxAutotune(TestCase):
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @skipIfXpu(msg="Covered by XPU TMA")
     @parametrize("dynamic", (False, True))
@@ -1108,7 +1108,7 @@ class TestMaxAutotune(TestCase):
         self.assertIn("NoValidChoicesError", str(context.exception))
 
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     def test_max_autotune_addmm_tma_dynamic_outer_dim(self):
         def addmm(x, a, b):
@@ -1152,7 +1152,7 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support sm carveout")
     @unittest.skipIf(IS_WINDOWS, "Windows doesn't support persistent TMA")
     @unittest.skipIf(
-        not has_triton_tma_device(), "Need device-side TMA support in Triton"
+        not has_triton_cuda_tma_device(), "Need device-side TMA support in Triton"
     )
     @unittest.skipIf(
         has_datacenter_blackwell_tma_device(), "B200 doesn't support sm carveout"
@@ -3905,7 +3905,7 @@ class TestTemplateConfigPruning(TestCase):
     ):
         """Test shared memory pruning for addmm operation."""
 
-        if use_tma and (dtype == torch.float32 or not has_triton_tma_device()):
+        if use_tma and (dtype == torch.float32 or not has_triton_cuda_tma_device()):
             return
 
         def addmm_op(bias, mat1, mat2):
@@ -3952,7 +3952,7 @@ class TestTemplateConfigPruning(TestCase):
         mat2_transposed: bool,
         use_tma: bool,
     ):
-        if use_tma and (dtype == torch.float32 or not has_triton_tma_device()):
+        if use_tma and (dtype == torch.float32 or not has_triton_cuda_tma_device()):
             return
 
         def mm_op(mat1, mat2):
@@ -5605,7 +5605,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
         finally:
             mm_heuristic.mm_configs = original_mm_configs
 
-    @unittest.skipIf(not has_triton_tma_device(), "Need TMA support in Triton")
+    @unittest.skipIf(not has_triton_cuda_tma_device(), "Need TMA support in Triton")
     @skipIfXpu(msg="Bad tma config can be covered by XPU TMA")
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"

--- a/test/test_triton_utils.py
+++ b/test/test_triton_utils.py
@@ -86,6 +86,35 @@ class TestTritonUtils(TestCase):
             finally:
                 triton_utils.triton_backend.cache_clear()
 
+    def test_cuda_tma_device_rejects_rocm_with_cpu_backend(self):
+        triton_utils.has_triton_cuda_tma_device.cache_clear()
+        self.addCleanup(triton_utils.has_triton_cuda_tma_device.cache_clear)
+        with (
+            mock.patch.object(triton_utils, "has_triton_package", return_value=True),
+            mock.patch.object(
+                triton_utils, "has_triton_tma_device", return_value=True
+            ) as has_tma,
+            mock.patch("torch.cuda.is_available", return_value=True),
+            mock.patch("torch.version.hip", "6.3"),
+        ):
+            self.assertFalse(triton_utils.has_triton_cuda_tma_device())
+            has_tma.assert_not_called()
+
+    def test_cuda_tma_device_accepts_hopper(self):
+        triton_utils.has_triton_cuda_tma_device.cache_clear()
+        self.addCleanup(triton_utils.has_triton_cuda_tma_device.cache_clear)
+        with (
+            mock.patch.object(triton_utils, "has_triton_package", return_value=True),
+            mock.patch.object(
+                triton_utils, "has_triton_tma_device", return_value=True
+            ) as has_tma,
+            mock.patch("torch.cuda.is_available", return_value=True),
+            mock.patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+            mock.patch("torch.version.hip", None),
+        ):
+            self.assertTrue(triton_utils.has_triton_cuda_tma_device())
+            has_tma.assert_called_once_with()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -199,7 +199,23 @@ def _has_triton_amd_tdm_device(arch: str) -> bool:
             arch,
             exc_info=True,
         )
+    return False
+
+
+@functools.cache
+def has_triton_cuda_tma_device() -> bool:
+    """Whether the current CUDA device supports Triton device-side TMA."""
+    if not has_triton_package():
         return False
+
+    import torch
+
+    return (
+        torch.cuda.is_available()
+        and not torch.version.hip
+        and torch.cuda.get_device_capability() >= (9, 0)
+        and has_triton_tma_device()
+    )
 
 
 @functools.cache


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196636

has_triton_tma_device() reports tensor-descriptor support when any installed Triton backend supports it, including CPU and XPU. A ROCm build that also bundles the Triton CPU backend can therefore return true even though its AMD GPU cannot run CUDA TMA templates.

Add a CUDA-specific predicate requiring a non-HIP CUDA device with compute capability 9.0 or newer, and use it for the CUDA-only TMA tests. Keep the existing generic predicate unchanged for CPU and XPU tensor-descriptor coverage.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo