### PR TITLE
[XPU] Skip float16 fft.ihfft2/ihfftn python ref tests on XPU

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -821,6 +821,30 @@ python_ref_db: list[OpInfo] = [
                 dtypes=(torch.float16,),
                 device_type="cuda",
             ),
+            # XPU: oneMKL has no half DFT, so the eager kernel computes in
+            # float32 and the float16 ref cannot match its accuracy.
+            # See https://github.com/intel/torch-xpu-ops/issues/5271
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref",
+                dtypes=(torch.float16,),
+                device_type="xpu",
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref_torch_fallback",
+                dtypes=(torch.float16,),
+                device_type="xpu",
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref_executor",
+                dtypes=(torch.float16,),
+                device_type="xpu",
+            ),
         ],
     ),
     SpectralFuncPythonRefInfo(
@@ -891,6 +915,23 @@ python_ref_db: list[OpInfo] = [
                 "test_python_ref",
                 dtypes=(torch.float16,),
                 device_type="cuda",
+            ),
+            # XPU: oneMKL has no half DFT, so the eager kernel computes in
+            # float32 and the float16 ref cannot match its accuracy.
+            # See https://github.com/intel/torch-xpu-ops/issues/5271
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref",
+                dtypes=(torch.float16,),
+                device_type="xpu",
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref_executor",
+                dtypes=(torch.float16,),
+                device_type="xpu",
             ),
         ],
     ),


### PR DESCRIPTION
## Issue

Fixes https://github.com/intel/torch-xpu-ops/issues/5271

## Summary

oneMKL has no half-precision DFT, so the XPU eager kernel upcasts Half to Float,
transforms and normalizes in float32, and rounds to complex32 once at the end.
Meanwhile #171231 added `"xpu"` to `maybe_support_half` in `torch/_refs/fft.py`, so
the reference stays in float16 and rounds at every prim boundary. `test_python_ref`,
`test_python_ref_torch_fallback` and `test_python_ref_executor` compare the two with
a tolerance-free `ref_distance <= torch_distance` against a float64 baseline, and the
ref loses: 1.18x worse for `ihfftn`, 1.02x for `ihfft2`, on 1 of 10 OpInfo samples.
The XPU kernel is the more accurate side here, and no user-visible path is affected
(inductor promotes float16 FFT to float32 per #180766, and compiled output is
bit-identical to eager). This adds five xpu-scoped, float16-only skips next to the
existing cuda ones for `_refs.fft.ihfft2` and `_refs.fft.ihfftn`; it is a pure
addition and CUDA behaviour is unchanged. The alternatives — adding a tolerance to
that assertion, or making the refs compute in float32 — are discussed on the linked
issue; both reach past XPU into primTorch and are left for its owners.

## Test plan

Run on Intel Arc B570 Graphics (Battlemage):

```bash
cd third_party/torch-xpu-ops
python -m pytest test/xpu/test_ops_xpu.py -k "python_ref and (ihfft2 or ihfftn)" -v --timeout=600
lintrunner -a torch/testing/_internal/opinfo/definitions/fft.py
```

```
before (this change reverted and the @skipXPU decorators removed):  5 failed, 11 passed
after  (this change, decorators removed):        0 failed, 68 passed, 14 skipped
lintrunner:                                      ok No lint issues.
```

The five skips were cross-checked against the five measured failures by evaluating
`DecorateInfo.is_active` over both ops, all three tests and all ten instantiated
dtypes for `device_type` in `(cuda, xpu)`: the sets match exactly, and CUDA's is
untouched.

## Checklist

- [x] Passes lint (`spin fixlint`) — ran `lintrunner -a` on the changed file: "ok No
      lint issues", nothing to autofix. (Note: the PYREFLY linter panics internally on
      this file both with and without the change, so that one is unrelated and
      pre-existing.)
- [x] Added/updated tests — this change *is* the test-configuration change; no new
      test is appropriate for a skip declaration.
- [ ] Updated documentation (if applicable) — n/a
- [ ] Included benchmark results (for PRs impacting perf) — n/a, test metadata only

## BC-breaking?

No.

> Authored with AI assistance on Intel GPU hardware. 
> The diff and the test output above are that run's; the submitter is
> responsible for reading the change before this is opened, and for the words around
> this block being their own.