### PR TITLE
[inductor][cpp] Fix local buffer promotion for mutation outputs

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4337,6 +4337,23 @@ class CPUReproTests(TestCase):
                 1,
             )
 
+    @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
+    def test_local_buffer_with_mutation_output(self):
+        # https://github.com/pytorch/pytorch/issues/196570
+        # m depends on x so that dropping the index_put changes the output.
+        def fn(x):
+            m = x.clone()
+            m[torch.arange(8).unsqueeze(0), torch.arange(8).unsqueeze(1)] = 0
+            return torch.softmax(x + m, dim=-1)
+
+        torch._dynamo.reset()
+        metrics.reset()
+        self.common(fn, (torch.randn(8, 8),))
+        counts = metrics.cpp_outer_loop_fused_inner_counts
+        self.assertEqual(len(counts), 1)
+        self.assertEqual(counts[0].inner_kernel_number, 3)
+        self.assertEqual(counts[0].local_buffer_number, 1)
+
     @requires_vectorization
     @config.patch({"fx_graph_cache": False, "fx_graph_remote_cache": False})
     def test_outer_loop_local_buffer_with_tiled_outer_dim(self):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5736,13 +5736,16 @@ class CppScheduling(BaseScheduling):
                             def is_contiguous_index(x):
                                 return x == contiguous_index_expr
 
+                            # Users of a mutation output load the mutated buffer's
+                            # name, so they may have no read of this buffer.
                             return is_contiguous_index(write_index_expr) and all(
                                 isinstance(user.node, SchedulerNode)
-                                and is_contiguous_index(
-                                    user.node._body.get_read_expr(
+                                and (
+                                    read_exprs := user.node._body.get_all_read_expr(
                                         scheduler_buffer.get_name()
-                                    ),
+                                    )
                                 )
+                                and is_contiguous_index(read_exprs[0])
                                 for user in scheduler_buffer.users
                             )
 


### PR DESCRIPTION
Fixes #196570

## Summary

CPP outer-loop fusion can incorrectly consider a mutation output for local buffer promotion.

Scheduler users are tracked under the mutation output name (`buf1` in the repro), while their `LoopBody` may still load the mutation's real buffer name (`buf0`). `is_all_write_read_contiguous()` assumed every user had a read under the output name and called `LoopBody.get_read_expr()`, which raises `KeyError` in this case.

This change uses `get_all_read_expr()` and makes the buffer ineligible for promotion when a user does not load it by that name.

Besides avoiding the crash, this is required for correctness: local buffer rewriting is name-based, so promoting `buf1` while its users continue loading `buf0` could redirect the mutation store to the local buffer while later reads still use the global buffer.

## Test

Added `test_local_buffer_with_mutation_output`.

The test uses `x.clone()` so that losing the mutation produces a clear numerical difference: the correct result is `softmax(x)`, while a lost mutation produces `softmax(2 * x)`. It also verifies that the intended outer-loop fusion/local-buffer path is exercised.

Tested against CPU nightly `2.15.0.dev20260902+cpu`:

- New regression test passes with the fix and fails with `KeyError: 'buf1'` without it.
- `test_cpu_repro.py -k local_buffer -k outer_loop`: 9 tests pass.
- Issue repro matches eager.
- `lintrunner -a`: no issues.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo