### PR TITLE
[ROCm] Run the inductor-rocm-mi300 test config in four shards

### DIFF
--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -48,8 +48,10 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.mi300.1" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.mi300.1" },
+          { config: "inductor", shard: 1, num_shards: 4, runner: "linux.rocm.gpu.mi300.1" },
+          { config: "inductor", shard: 2, num_shards: 4, runner: "linux.rocm.gpu.mi300.1" },
+          { config: "inductor", shard: 3, num_shards: 4, runner: "linux.rocm.gpu.mi300.1" },
+          { config: "inductor", shard: 4, num_shards: 4, runner: "linux.rocm.gpu.mi300.1" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
Since #192262 re-enabled the MI300 workflows on 2026-08-11 with a two-shard inductor matrix, every inductor-rocm-mi300 run on main has ended with "The action 'Test' has timed out after 270 minutes" on both shards (88 timed-out jobs between 2026-09-03 and 2026-09-10; last green run 2026-08-11). It is not a hang: each sub-shard completes in 8-18 minutes and the serial list needs about 4.5 hours, so the kill always lands inside test_aot_inductor or test_torchinductor_opinfo. inductor-rocm-mi200 already runs the same config in four shards; this matches it so the workflow can finish inside the budget and give PRs carrying ciflow/inductor-rocm-mi300 a real signal instead of a guaranteed red.

Test plan: the ciflow/inductor-rocm-mi300 label on this PR; all four shards must finish well under 270 minutes and the per-shard test counts must sum to the previous two-shard totals (from the test-report XML artifacts).

This PR was authored with the assistance of an AI agent (Claude). The analysis was verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang