### PR TITLE
[ROCm] Skip the CK-only empty-batch attention test where CK is unavailable

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3025,6 +3025,7 @@ class TestSDPAAccelerator(NNTestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention is not supported on this system")
+    @unittest.skipIf(TEST_WITH_ROCM and not PLATFORM_SUPPORTS_CK_SDPA, "ROCm empty-batch handling is CK-only")
     def test_fused_attention_empty_batch(self, device):
         # Attention over zero rows is an empty result, not an error. The composite
         # scaled_dot_product_attention short-circuits an empty input before dispatching,


### PR DESCRIPTION
test_fused_attention_empty_batch (#195812) forces preferred_rocm_fa_library("ck") on ROCm, and setting that preference raises on architectures without CK SDPA support, so the test has failed on every mi200 (gfx90a) run of rocm-mi200.yml since it landed (34 jobs between 2026-09-04 and 2026-09-10). Falling back to the default library is not an option: with AOTriton the same test aborts in backward with "batch size must be positive" (verified on gfx950), so the empty-batch fix covers the CK path only. This gates the test on PLATFORM_SUPPORTS_CK_SDPA, the predicate the other CK-only tests in this file already use, so gfx90a skips instead of erroring.

Test plan is in the commit message; gfx90a validation via ciflow/rocm-mi200 (expect the test to report skipped in the shard that runs test_transformers.py), gfx942/gfx950 keep running it.

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang