### PR TITLE
Create an example test to verify autorevert for periodic-strict

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -795,6 +795,24 @@ if __name__ == "__main__":
 instantiate_parametrized_tests(TestPeriodicDecorator)
 
 
+# Trivial tests that give the periodic-strict workflow a passing CPU and GPU
+# test to gate on; deliberately breaking one exercises its auto-revert.
+class TestPeriodicCanary(TestCase):
+    @periodic
+    @onlyCPU
+    def test_cpu_canary(self, device):
+        self.assertEqual(torch.arange(4, device=device).sum().item(), 6)
+
+    @periodic
+    @onlyCUDA
+    def test_gpu_canary(self, device):
+        x = torch.ones(4, 4, device=device)
+        self.assertEqual(x @ x, torch.full((4, 4), 4.0, device=device))
+
+
+instantiate_device_type_tests(TestPeriodicCanary, globals(), only_for=("cpu", "cuda"))
+
+
 class TestEnvironmentDefFlag(TestCase):
     """Verify env-var-vs-implication precedence in TestEnvironment.def_flag."""
 


### PR DESCRIPTION
### Summary

We will soon enable autorevert for the periodic-strict workflow. To ensure it works, I am introducing a good test. Once autorevert is enabled, I will intentionally break this test and force-merge it into main. We then expect autorevert to revert that offending diff.

### Test Plan

```
$ pytest test/test_testing.py::TestPeriodicCanaryCPU test/test_testing.py::TestPeriodicCanaryCUDA
```

CPU job ([artifact](https://gha-artifacts.s3.amazonaws.com/pytorch/pytorch/34527978427/1/artifact/logs-test-periodic-1-2-mt-l-x86iavx512-8-64_103044821251.zip)):
```
test_testing.py::TestPeriodicDecorator::test_periodic_smoke PASSED [0.0021s] [ 33%]
test_testing.py::TestPeriodicCanaryCPU::test_cpu_canary_cpu PASSED [0.0022s] [ 66%]
test_testing.py::TestPeriodicCanaryCPU::test_gpu_canary_cpu SKIPPED [0.0012s] (Only runs on cuda) [100%]
```

CUDA job ([artifact](https://gha-artifacts.s3.amazonaws.com/pytorch/pytorch/34527978427/1/artifact/logs-test-periodic-1-2-mt-l-x86aavx2-29-113-l4_103052155505.zip)):
```
test_testing.py::TestPeriodicDecorator::test_periodic_smoke PASSED [0.9636s] [ 33%]
test_testing.py::TestPeriodicCanaryCUDA::test_cpu_canary_cuda SKIPPED [0.0032s] (Only runs on cpu) [ 66%]
test_testing.py::TestPeriodicCanaryCUDA::test_gpu_canary_cuda PASSED [0.1267s] [100%]
```