### PR TITLE
Make cublasLt the default grouped gemm backend for bf16 on CUDA 13.4+

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -396,14 +396,6 @@ void Context::setAllowTF32CuBLAS(bool b) {
   setFloat32Precision(Float32Backend::CUDA, Float32Op::MATMUL, b ? Float32Precision::TF32 : Float32Precision::IEEE);
 }
 
-bool Context::preferCublasltGroupedGemm() const {
-  return prefer_cublaslt_grouped_gemm;
-}
-
-void Context::setPreferCublasltGroupedGemm(bool b) {
-  prefer_cublaslt_grouped_gemm = b;
-}
-
 Float32MatmulPrecision Context::float32MatmulPrecision() const {
   bool invalid = float32Precision(Float32Backend::CUDA, Float32Op::MATMUL) == Float32Precision::TF32 &&
       float32_matmul_precision == at::Float32MatmulPrecision::HIGHEST;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -412,8 +412,6 @@ class TORCH_API Context {
   bool allowFP16AccumulationCuBLAS() const;
   void setAllowFP16AccumulationCuBLAS(bool /*b*/);
   bool rocmAllowGroupGemmCk() const;
-  bool preferCublasltGroupedGemm() const;
-  void setPreferCublasltGroupedGemm(bool /*b*/);
 
   // Matmuls can use a so-called "persistent" kernel which launches one CUDA
   // block for each SM on the GPU, and each block then iterates over multiple
@@ -528,7 +526,6 @@ class TORCH_API Context {
   CuBLASReductionOption allow_bf16_reduction_cublas =
       CuBLASReductionOption::AllowReducedPrecisionWithSplitK;
   bool allow_fp16_accumulation_cublas = false;
-  bool prefer_cublaslt_grouped_gemm = false;
   std::optional<int32_t> sm_carveout = std::nullopt;
   bool enabled_mkldnn = true;
   bool allow_tf32_onednn = false;

--- a/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
+++ b/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
@@ -17,54 +17,6 @@ namespace at::native {
 
 namespace {
 
-void check_cublaslt_grouped_alignment(
-    bool a_is_2d,
-    bool b_is_2d,
-    int64_t m,
-    int64_t n,
-    int64_t k,
-    int64_t alignment,
-    char transa,
-    char transb) {
-  if (a_is_2d && b_is_2d) {
-    TORCH_CHECK(
-        k % alignment == 0 || (transa == 't' && transb == 'n'),
-        "cublasLt grouped GEMM with jagged K not aligned to 16 bytes requires transa=t and transb=n, got transa=",
-        transa,
-        " transb=",
-        transb,
-        " K=",
-        k);
-  } else if (a_is_2d && !b_is_2d) {
-    TORCH_CHECK(
-        m % alignment == 0 || !(transa == 't' && transb == 't'),
-        "cublasLt grouped GEMM with jagged M not aligned to 16 bytes does not support transa=t and transb=t, got transa=",
-        transa,
-        " transb=",
-        transb,
-        " M=",
-        m);
-  } else if (!a_is_2d && b_is_2d) {
-    TORCH_CHECK(
-        n % alignment == 0 || !(transa == 'n' && transb == 'n'),
-        "cublasLt grouped GEMM with jagged N not aligned to 16 bytes does not support transa=n and transb=n, got transa=",
-        transa,
-        " transb=",
-        transb,
-        " N=",
-        n);
-  } else {
-    TORCH_CHECK(
-        k % alignment == 0 || (transa == 't' && transb == 'n'),
-        "cublasLt grouped GEMM with K not aligned to 16 bytes requires transa=t and transb=n, got transa=",
-        transa,
-        " transb=",
-        transb,
-        " K=",
-        k);
-  }
-}
-
 template <typename IndexType>
 __global__ void populate_cublas_grouped_args_kernel(
     const int32_t* __restrict__ offs,
@@ -273,17 +225,6 @@ cublasGroupedArgs::cublasGroupedArgs(
     n = cublas_n;
     k = cublas_k;
   }
-
-  const int64_t alignment = 16 / element_size;
-  check_cublaslt_grouped_alignment(
-      a_is_2d,
-      b_is_2d,
-      cublas_m,
-      cublas_n,
-      cublas_k,
-      alignment,
-      transa,
-      transb);
 
   // Determine element size for dimension arrays
   const size_t dim_elem_size = use_int64 ? sizeof(int64_t) : sizeof(int32_t);

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -105,7 +105,7 @@ bool should_use_cublaslt_grouped_gemm(
 #if CUDA_VERSION >= 13040
   return true;
 #else
-  return at::globalContext().preferCublasltGroupedGemm();
+  return false;
 #endif
 }
 #endif

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -99,8 +99,14 @@ bool should_use_cublaslt_grouped_gemm(
   if (fp16_grouped_gemm) {
     return true;
   }
-  return bf16_grouped_gemm &&
-      at::globalContext().preferCublasltGroupedGemm();
+  if (!bf16_grouped_gemm) {
+    return false;
+  }
+#if CUDA_VERSION >= 13040
+  return true;
+#else
+  return at::globalContext().preferCublasltGroupedGemm();
+#endif
 }
 #endif
 

--- a/docs/source/backends.md
+++ b/docs/source/backends.md
@@ -88,13 +88,6 @@ These backends include:
 ```
 
 ```{eval-rst}
-.. attribute::  prefer_cublaslt_grouped_gemm
-
-    A :class:`bool` that controls whether supported grouped GEMMs prefer the
-    cuBLASLt backend.
-```
-
-```{eval-rst}
 .. attribute::  allow_bf16_reduced_precision_reduction
 
     A :class:`bool` that controls whether reduced precision reductions are

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -27,11 +27,7 @@ from torch.distributed.tensor._ops.single_dim_strategy import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
-from torch.testing._internal.common_cuda import (
-    _get_torch_cuda_version,
-    PLATFORM_SUPPORTS_FP8,
-    SM90OrLater,
-)
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
 from torch.testing._internal.common_device_type import E4M3_MAX_POS, e4m3_type
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
@@ -1018,7 +1014,6 @@ class DistMatrixOpsTest(DTensorTestBase):
     @unittest.skipIf(not SM90OrLater, "Grouped gemm supported on SM90")
     @with_comms
     @skip_unless_torch_gpu
-    @parametrize("backend", ["cublaslt", "cutlass"])
     @parametrize(
         "kwargs",
         [
@@ -1049,13 +1044,7 @@ class DistMatrixOpsTest(DTensorTestBase):
             },
         ],
     )
-    def test_grouped_mm(self, backend, kwargs):
-        if backend == "cublaslt":
-            if _get_torch_cuda_version() < (13, 3):
-                self.skipTest("cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
-            sm_major = torch.cuda.get_device_capability()[0]
-            if sm_major < 9 or sm_major >= 12:
-                self.skipTest("cublaslt grouped gemm requires SM 9.0-11.0")
+    def test_grouped_mm(self, kwargs):
         # TODO: torch.nn.functional.grouped_mm can take inputs of dimension (2D, 3D) x (2D, 3D)
         # More tests need to be added.
         device_mesh = self.build_device_mesh()
@@ -1080,15 +1069,6 @@ class DistMatrixOpsTest(DTensorTestBase):
             requires_grad=True,
         )
         offs = torch.tensor([16, 64], device=self.device_type, dtype=torch.int32)
-
-        prev = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
-        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = backend == "cublaslt"
-        self.addCleanup(
-            setattr,
-            torch.backends.cuda.matmul,
-            "prefer_cublaslt_grouped_gemm",
-            prev,
-        )
 
         h = F.grouped_mm(inp, w1, offs=offs)
         out = F.grouped_mm(h, w2, offs=offs)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -80,7 +80,6 @@ from torch.library import _scoped_library
 from torch.nn import functional as F
 from torch.testing import FileCheck, make_tensor
 from torch.testing._internal.common_cuda import (
-    _get_torch_cuda_version,
     _get_torch_rocm_version,
     IS_SM90,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
@@ -20848,25 +20847,7 @@ if RUN_GPU:
         @skipCUDAIf(not SM90OrLater, "Requires sm90")
         @requires_cuda_and_triton
         @config.patch(implicit_fallbacks=True)
-        @parametrize("backend", ["cublaslt", "cutlass"])
-        def test_grouped_mm(self, backend):
-            if backend == "cublaslt":
-                if _get_torch_cuda_version() < (13, 3):
-                    self.skipTest("cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
-                sm_major = torch.cuda.get_device_capability()[0]
-                if sm_major < 9 or sm_major >= 12:
-                    self.skipTest("cublaslt grouped gemm requires SM 9.0-11.0")
-            prev = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
-            torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = (
-                backend == "cublaslt"
-            )
-            self.addCleanup(
-                setattr,
-                torch.backends.cuda.matmul,
-                "prefer_cublaslt_grouped_gemm",
-                prev,
-            )
-
+        def test_grouped_mm(self):
             @torch.compile(fullgraph=True)
             def f(a, b, offs, out_dtype):
                 return F.grouped_mm(

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1377,13 +1377,6 @@ print(mem_after_first, mem_after_set, torch.cuda.memory_allocated())
         self.assertEqual(torch._C._get_cublas_allow_tf32(), not orig)
         torch.backends.cuda.matmul.allow_tf32 = orig
 
-    def test_cublaslt_prefer_grouped_gemm_get_set(self):
-        orig = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
-        self.assertEqual(torch._C._get_cublaslt_prefer_grouped_gemm(), orig)
-        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = not orig
-        self.assertEqual(torch._C._get_cublaslt_prefer_grouped_gemm(), not orig)
-        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = orig
-
     @recover_orig_fp32_precision
     def test_float32_matmul_precision_get_set(self):
         orig = torch.get_float32_matmul_precision()

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -105,16 +105,6 @@ def rocm_group_gemm_ck_env(value):
 
 
 @contextlib.contextmanager
-def prefer_cublaslt_grouped_gemm():
-    old = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
-    try:
-        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = True
-        yield
-    finally:
-        torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = old
-
-
-@contextlib.contextmanager
 def sm_carveout(value: int | None):
     torch._C._set_sm_carveout_experimental(value)
     try:
@@ -1100,17 +1090,16 @@ class TestMatmulCuda(InductorTestCase):
         # For 2d/2d and 3d/3d, both inputs must be column major
         # For 2d/3d, A needs to be row major or B needs to be column major
         # For 3d/2d, A needs to be column major or B needs to be row major
-
+        if dtype == torch.bfloat16 and _get_torch_cuda_version() < (13, 4):
+            self.skipTest("bfloat16 cuBLASLt grouped gemm requires CUDA Toolkit >= 13.4")
         A, B, offs, aligned = self.grouped_gemm_cublaslt_common(op, jagged_size, a_row_major, b_row_major, dtype)
         if not aligned:
             with self.assertRaisesRegex(RuntimeError, self.grouped_gemm_cublaslt_alignment_error(op)):
-                with prefer_cublaslt_grouped_gemm():
-                    torch._grouped_mm(A, B, offs=offs)
+                torch._grouped_mm(A, B, offs=offs)
             return
 
         C_ref = self.grouped_gemm_reference(A, B, offs)
-        with prefer_cublaslt_grouped_gemm():
-            C = torch._grouped_mm(A, B, offs=offs)
+        C = torch._grouped_mm(A, B, offs=offs)
         self.assertEqual(C, C_ref)
 
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support cuBLASLt grouped GEMM")
@@ -1123,20 +1112,21 @@ class TestMatmulCuda(InductorTestCase):
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("mode", ["default", "reduce-overhead"])
     def test_grouped_gemm_cublaslt_compiled(self, op, jagged_size, a_row_major, b_row_major, dtype, mode):
+        if dtype == torch.bfloat16 and _get_torch_cuda_version() < (13, 4):
+            self.skipTest("bfloat16 cuBLASLt grouped gemm requires CUDA Toolkit >= 13.4")
+
         def f_ref(A, B, offs):
             return torch._grouped_mm(A, B, offs=offs)
 
         A, B, offs, aligned = self.grouped_gemm_cublaslt_common(op, jagged_size, a_row_major, b_row_major, dtype)
         if not aligned:
             with self.assertRaisesRegex(RuntimeError, self.grouped_gemm_cublaslt_alignment_error(op)):
-                with prefer_cublaslt_grouped_gemm():
-                    f_ref(A, B, offs)
+                f_ref(A, B, offs)
             return
 
-        with prefer_cublaslt_grouped_gemm():
-            f = torch.compile(f_ref, fullgraph=True, mode=mode)
-            C_ref = f_ref(A, B, offs)
-            C = f(A, B, offs)
+        f = torch.compile(f_ref, fullgraph=True, mode=mode)
+        C_ref = f_ref(A, B, offs)
+        C = f(A, B, offs)
         self.assertEqual(C, C_ref)
 
     def test_grouped_gemm_doubly_non_contiguous(self):
@@ -1167,7 +1157,7 @@ class TestMatmulCuda(InductorTestCase):
         # with M=1 or N=1 so only a small amount of storage is needed
         # despite the large stride.
         device = "cuda"
-        dtype = torch.bfloat16
+        dtype = torch.float16
 
         big_ld = (1 << 31)  # > INT32_MAX, divisible by 8
         K = 8
@@ -1217,8 +1207,7 @@ class TestMatmulCuda(InductorTestCase):
         else:
             raise AssertionError(f"Invalid op: {op}")
 
-        with prefer_cublaslt_grouped_gemm():
-            C = torch._grouped_mm(A, B, offs=offs)
+        C = torch._grouped_mm(A, B, offs=offs)
         self.assertEqual(C, C_ref)
 
     @skipCUDAIfNotRocm

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -959,8 +959,6 @@ class TestMatmulCuda(InductorTestCase):
             else:
                 B = torch.randn(k, n_align, device=device, dtype=dtype).t()[:n, :]
 
-            aligned = (jagged_size % align == 0) or (not a_row_major and not b_row_major)
-
         elif op == "2d/3d":
             # Jagged M with aligned offsets.
             n, k = 7, 32
@@ -982,8 +980,6 @@ class TestMatmulCuda(InductorTestCase):
                     -2, -1
                 )[:, :n, :]
 
-            aligned = (jagged_size % align == 0) or not (not a_row_major and b_row_major)
-
         elif op == "3d/2d":
             # Jagged N with aligned offsets.
             m, k = 3, 32
@@ -1004,8 +1000,6 @@ class TestMatmulCuda(InductorTestCase):
                 B = torch.randn(n, k_align, device=device, dtype=dtype)[:, :k]
             else:
                 B = torch.randn(k, n_align, device=device, dtype=dtype).t()[:n, :]
-
-            aligned = (jagged_size % align == 0) or not (a_row_major and not b_row_major)
 
         elif op == "3d/3d":
             # No jagged dimension, all dims fixed. Use non-multiple-of-8
@@ -1030,9 +1024,7 @@ class TestMatmulCuda(InductorTestCase):
                     -2, -1
                 )[:, :n, :]
 
-            aligned = (jagged_size % align == 0) or (not a_row_major and not b_row_major)
-
-        return A, B.transpose(-2, -1), offs, aligned
+        return A, B.transpose(-2, -1), offs
 
     def grouped_gemm_reference(self, A, B, offs):
         if A.dim() == 2 and B.dim() == 2:
@@ -1064,17 +1056,6 @@ class TestMatmulCuda(InductorTestCase):
             return torch.cat(outputs, dim=1)
         return torch.stack([torch.mm(a, b) for a, b in zip(A, B)])
 
-    def grouped_gemm_cublaslt_alignment_error(self, op):
-        if op == "2d/2d":
-            return "cublasLt grouped GEMM with jagged K not aligned to 16 bytes"
-        if op == "2d/3d":
-            return "cublasLt grouped GEMM with jagged M not aligned to 16 bytes"
-        if op == "3d/2d":
-            return "cublasLt grouped GEMM with jagged N not aligned to 16 bytes"
-        if op == "3d/3d":
-            return "cublasLt grouped GEMM with K not aligned to 16 bytes"
-        raise AssertionError(f"Invalid op: {op}")
-
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support cuBLASLt grouped GEMM")
     @unittest.skipIf(TEST_CUDA and _get_torch_cuda_version() < (13, 3), "cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
     @unittest.skipIf(not SM90OrLater or SM120OrLater, "cublaslt grouped gemm requires SM 9.0-11.0")
@@ -1083,21 +1064,10 @@ class TestMatmulCuda(InductorTestCase):
     @parametrize("a_row_major", [False, True])
     @parametrize("b_row_major", [False, True])
     @parametrize("dtype", [torch.float16, torch.bfloat16])
-    def test_grouped_gemm_cublaslt_alignment(self, op, jagged_size, a_row_major, b_row_major, dtype):
-        # Verify that cuBLASLt grouped GEMM succeeds with all expected combinations
-        # Always succeeds if jagged_size * sizeof(dtype) is divisible by 16
-        # Otherwise:
-        # For 2d/2d and 3d/3d, both inputs must be column major
-        # For 2d/3d, A needs to be row major or B needs to be column major
-        # For 3d/2d, A needs to be column major or B needs to be row major
+    def test_grouped_gemm_cublaslt(self, op, jagged_size, a_row_major, b_row_major, dtype):
         if dtype == torch.bfloat16 and _get_torch_cuda_version() < (13, 4):
             self.skipTest("bfloat16 cuBLASLt grouped gemm requires CUDA Toolkit >= 13.4")
-        A, B, offs, aligned = self.grouped_gemm_cublaslt_common(op, jagged_size, a_row_major, b_row_major, dtype)
-        if not aligned:
-            with self.assertRaisesRegex(RuntimeError, self.grouped_gemm_cublaslt_alignment_error(op)):
-                torch._grouped_mm(A, B, offs=offs)
-            return
-
+        A, B, offs = self.grouped_gemm_cublaslt_common(op, jagged_size, a_row_major, b_row_major, dtype)
         C_ref = self.grouped_gemm_reference(A, B, offs)
         C = torch._grouped_mm(A, B, offs=offs)
         self.assertEqual(C, C_ref)
@@ -1118,12 +1088,7 @@ class TestMatmulCuda(InductorTestCase):
         def f_ref(A, B, offs):
             return torch._grouped_mm(A, B, offs=offs)
 
-        A, B, offs, aligned = self.grouped_gemm_cublaslt_common(op, jagged_size, a_row_major, b_row_major, dtype)
-        if not aligned:
-            with self.assertRaisesRegex(RuntimeError, self.grouped_gemm_cublaslt_alignment_error(op)):
-                f_ref(A, B, offs)
-            return
-
+        A, B, offs = self.grouped_gemm_cublaslt_common(op, jagged_size, a_row_major, b_row_major, dtype)
         f = torch.compile(f_ref, fullgraph=True, mode=mode)
         C_ref = f_ref(A, B, offs)
         C = f(A, B, offs)

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1276,10 +1276,6 @@ def _get_cudnn_allow_tf32() -> _bool: ...  # THPModule_allowTF32CuDNN
 def _set_cudnn_allow_tf32(arg: _bool) -> None: ...  # THPModule_setAllowTF32CuDNN
 def _get_cublas_allow_tf32() -> _bool: ...  # THPModule_allowTF32CuBLAS
 def _set_cublas_allow_tf32(arg: _bool) -> None: ...  # THPModule_setAllowTF32CuBLAS
-def _get_cublaslt_prefer_grouped_gemm() -> _bool: ...  # THPModule_preferCublasltGroupedGemm
-def _set_cublaslt_prefer_grouped_gemm(
-    arg: _bool,
-) -> None: ...  # THPModule_setPreferCublasltGroupedGemm
 def _get_float32_matmul_precision() -> str: ...  # THPModule_float32MatmulPrecision
 def _set_float32_matmul_precision(
     arg: str,

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -158,8 +158,6 @@ class cuBLASModule:
     def __getattr__(self, name):
         if name == "allow_tf32":
             return torch._C._get_cublas_allow_tf32()
-        elif name == "prefer_cublaslt_grouped_gemm":
-            return torch._C._get_cublaslt_prefer_grouped_gemm()
         elif name == "allow_fp16_reduced_precision_reduction":
             allow_reduced_precision, _ = (
                 torch._C._get_cublas_allow_fp16_reduced_precision_reduction()
@@ -189,8 +187,6 @@ class cuBLASModule:
     def __setattr__(self, name, value):
         if name == "allow_tf32":
             return torch._C._set_cublas_allow_tf32(value)
-        elif name == "prefer_cublaslt_grouped_gemm":
-            return torch._C._set_cublaslt_prefer_grouped_gemm(value)
         elif name == "allow_fp16_reduced_precision_reduction":
             allow_reduced_precision, allow_splitk = self._parse_reduction_setting(
                 value, "allow_fp16_reduced_precision_reduction"

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1484,31 +1484,6 @@ static PyObject* THPModule_allowTF32CuBLAS(
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_setPreferCublasltGroupedGemm(
-    PyObject* _unused,
-    PyObject* arg) {
-  HANDLE_TH_ERRORS
-  TORCH_CHECK(
-      PyBool_Check(arg),
-      "set_prefer_cublaslt_grouped_gemm expects a bool, "
-      "but got ",
-      THPUtils_typename(arg));
-  at::globalContext().setPreferCublasltGroupedGemm(Py_IsTrue(arg));
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
-static PyObject* THPModule_preferCublasltGroupedGemm(
-    PyObject* _unused,
-    PyObject* noargs) {
-  HANDLE_TH_ERRORS
-  if (at::globalContext().preferCublasltGroupedGemm()) {
-    Py_RETURN_TRUE;
-  }
-  Py_RETURN_FALSE;
-  END_HANDLE_TH_ERRORS
-}
-
 static PyObject* THPModule_setAllowFP16ReductionCuBLAS(
     PyObject* _unused,
     PyObject* args) {
@@ -2215,14 +2190,6 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
     {"_warn_deprecation", THPModule_warnDeprecation, METH_NOARGS, nullptr},
     {"_get_cublas_allow_tf32", THPModule_allowTF32CuBLAS, METH_NOARGS, nullptr},
     {"_set_cublas_allow_tf32", THPModule_setAllowTF32CuBLAS, METH_O, nullptr},
-    {"_get_cublaslt_prefer_grouped_gemm",
-     THPModule_preferCublasltGroupedGemm,
-     METH_NOARGS,
-     nullptr},
-    {"_set_cublaslt_prefer_grouped_gemm",
-     THPModule_setPreferCublasltGroupedGemm,
-     METH_O,
-     nullptr},
     {"_get_float32_matmul_precision",
      THPModule_float32MatmulPrecision,
      METH_NOARGS,


### PR DESCRIPTION
CUDA 13.4 brings performance improvements to bf16 grouped GEMM in cuBLASLt. The cuBLASLt backend is now faster than CUTLASS on average for all relevant devices (sm90 and sm10x). This PR makes cuBLASLt the unconditional backend on 13.4+ and cleans up all of the outdated alignment and prefer flag code.

More on alignment:
The alignment constraints removed in this PR were causing test failures in the grouped_mm tests that the CUTLASS backend was used for prior to this PR. I added those alignment constraints to prevent IMAs in the cublasLt backend under certain configurations in 13.2, but it seems like cublasLt can support all possible alignment configs as of 13.3. Since the cublasLt backend is only enabled on 13.3+, the constraints are never relevant. NOTE: The alignment here is different than the required 16-byte group alignment, which is still required and enforced.

## Benchmarking
| Device | Median cuBLAS speedup |
| --- | --- |
| H100 | 7.48% |
| GB200 | 7.47% |
| GB300 | 3.08% |
| Rubin | 15.37% |

## Links
[Benchmarking script](https://gist.github.com/gderossi/29760738956a4ac9de58dd2585fa7274)
[Benchmarking results](https://docs.google.com/spreadsheets/d/1XVvftYwrmEfoRUYKE8iedSq1fOj0jZpa)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo