### PR TITLE
[caffe2/veclib] Fix aarch64 f32->u8 type conversion divergence (#196646)

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
@@ -5,7 +5,21 @@
 
 namespace at::vec {
 inline namespace CPU_CAPABILITY {
-#if (defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256))
+#if defined(__aarch64__)
+
+// Define this specialization to match c10::convert, as defined in TypeCast.h
+template <>
+inline void convert(
+    const float* __restrict src,
+    uint8_t* __restrict dst,
+    int64_t n) {
+  uint64_t len = static_cast<uint64_t>(n);
+  for (uint64_t i = 0; i < len; i++) {
+    dst[i] = static_cast<uint8_t>(static_cast<int64_t>(src[i]));
+  }
+}
+
+#if !defined(CPU_CAPABILITY_SVE256)
 
 // Enable auto-vectorization for clang-17+
 // GCC-12 has a bug: gcc.gnu.org/bugzilla/show_bug.cgi?id=117001
@@ -102,7 +116,6 @@ CONVERT_TEMPLATE(int64_t, int64_t)
 CONVERT_TEMPLATE(int64_t, float)
 CONVERT_TEMPLATE(int64_t, double)
 CONVERT_TO_BOOL_TEMPLATE(int64_t)
-CONVERT_TEMPLATE(float, uint8_t)
 CONVERT_TEMPLATE(float, int8_t)
 CONVERT_TEMPLATE(float, int16_t)
 CONVERT_TEMPLATE(float, int32_t)
@@ -341,6 +354,59 @@ struct VecConvert<
   }
 };
 
+template <int src_n>
+inline uint8x16_t convert_float_to_uint8(const VectorizedN<float, src_n>& src) {
+  // Widening to double before truncating puts the saturation point at the
+  // int64_t bounds rather than the int32_t ones, so every input that is not
+  // astronomically large contributes its true low byte, as the scalar
+  // float -> int64_t -> uint8_t narrowing in c10::convert does. Converting via
+  // int32_t instead would be cheaper but would report 0xff rather than the
+  // true low byte across [2^31, 2^63), where FCVTZS saturates.
+  const auto lo_i64 = [](const float32x4_t f) {
+    return vcvtq_s64_f64(vcvt_f64_f32(vget_low_f32(f)));
+  };
+  const auto hi_i64 = [](const float32x4_t f) {
+    return vcvtq_s64_f64(vcvt_high_f64_f32(f));
+  };
+  // The eight indices past the 64-byte table are out of range and read as
+  // zero, so only the low half of the result carries bytes.
+  const auto low_bytes =
+      [](int64x2_t a, int64x2_t b, int64x2_t c, int64x2_t d) {
+        const uint8x16x4_t table = {
+            vreinterpretq_u8_s64(a),
+            vreinterpretq_u8_s64(b),
+            vreinterpretq_u8_s64(c),
+            vreinterpretq_u8_s64(d)};
+        const uint8x16_t low_byte_of_each_i64 = {
+            0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120};
+        return vqtbl4q_u8(table, low_byte_of_each_i64);
+      };
+
+  // Lanes past the source are zeroed, matching the VectorizedN::loadu(buf,
+  // count) that the generic fallback ends with.
+  if constexpr (src_n == 4) {
+    return vcombine_u8(
+        vget_low_u8(low_bytes(
+            lo_i64(src[0]), hi_i64(src[0]), lo_i64(src[1]), hi_i64(src[1]))),
+        vget_low_u8(low_bytes(
+            lo_i64(src[2]), hi_i64(src[2]), lo_i64(src[3]), hi_i64(src[3]))));
+  } else if constexpr (src_n >= 2) {
+    return low_bytes(
+        lo_i64(src[0]), hi_i64(src[0]), lo_i64(src[1]), hi_i64(src[1]));
+  } else {
+    const int64x2_t zero = vdupq_n_s64(0);
+    return low_bytes(lo_i64(src[0]), hi_i64(src[0]), zero, zero);
+  }
+}
+
+template <int src_n>
+struct VecConvert<uint8_t, 1, float, src_n> {
+  static inline VectorizedN<uint8_t, 1> apply(
+      const VectorizedN<float, src_n>& src) {
+    return Vectorized<uint8_t>(convert_float_to_uint8(src));
+  }
+};
+
 template <>
 struct VecConvert<float, 2, BFloat16, 1> {
   static inline VectorizedN<float, 2> apply(
@@ -394,7 +460,7 @@ struct VecConvert<Half, 1, float, 2> {
 };
 
 #endif // !defined(C10_MOBILE)
-
-#endif // defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256)
+#endif // !defined(CPU_CAPABILITY_SVE256)
+#endif // defined(__aarch64__)
 } // namespace CPU_CAPABILITY
 } // namespace at::vec

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -294,7 +294,51 @@ struct VecConvert<
 };
 #endif
 
-#if defined(CPU_CAPABILITY_SVE256) && defined(__ARM_FEATURE_BF16)
+#if defined(CPU_CAPABILITY_SVE256)
+
+// Store the low byte of (int64_t)f for each float lane of src into dst.
+// Widening to double before FCVTZS (svct) puts the saturation point at the
+// int64_t bounds rather than the int32_t ones, so every input that is not
+// astronomically large contributes its true low byte, as the scalar
+// float -> int64_t -> uint8_t narrowing in c10::convert does.
+inline void store_float_as_uint8(const Vectorized<float>& src, uint8_t* dst) {
+  const svbool_t pg64 = svptrue_b64();
+  const svuint32_t u = svreinterpret_u32_f32(src);
+  // Zero-extending each 32-bit lane to 64 bits leaves the float in the low
+  // half of the lane, which is where svcvt_f64_f32_x reads it from.
+  const svfloat32_t lo = svreinterpret_f32_u64(svunpklo_u64(u));
+  const svfloat32_t hi = svreinterpret_f32_u64(svunpkhi_u64(u));
+  svst1b_vnum_s64(
+      pg64,
+      reinterpret_cast<int8_t*>(dst),
+      0,
+      svcvt_s64_f64_x(pg64, svcvt_f64_f32_x(pg64, lo)));
+  svst1b_vnum_s64(
+      pg64,
+      reinterpret_cast<int8_t*>(dst),
+      1,
+      svcvt_s64_f64_x(pg64, svcvt_f64_f32_x(pg64, hi)));
+}
+
+template <int src_n>
+struct VecConvert<uint8_t, 1, float, src_n> {
+  static inline VectorizedN<uint8_t, 1> apply(
+      const VectorizedN<float, src_n>& src) {
+    constexpr int kFloatLanes = Vectorized<float>::size();
+    constexpr int kDstLanes = Vectorized<uint8_t>::size();
+    constexpr int kGroups = std::min(src_n, kDstLanes / kFloatLanes);
+    // Vectorized<uint8_t> has no SVE specialization, so this is the
+    // scalar-array fallback; lanes past the source stay zero, matching the
+    // VectorizedN::loadu(buf, count) the generic VecConvert ends with.
+    __at_align__ uint8_t buf[kDstLanes];
+    for (int i = 0; i < kGroups; i++) {
+      store_float_as_uint8(src[i], buf + i * kFloatLanes);
+    }
+    return Vectorized<uint8_t>::loadu(buf, kGroups * kFloatLanes);
+  }
+};
+
+#if defined(__ARM_FEATURE_BF16)
 
 template <>
 struct VecConvert<float, 1, BFloat16, 1> {
@@ -334,7 +378,8 @@ struct VecConvert<BFloat16, 1, float, 2> {
   }
 };
 
-#endif // defined(CPU_CAPABILITY_SVE256) && defined(__ARM_FEATURE_BF16)
+#endif // defined(__ARM_FEATURE_BF16)
+#endif // defined(CPU_CAPABILITY_SVE256)
 
 template <typename src_t>
 struct VecConvert<

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -53,7 +53,6 @@ from torch.testing._internal.common_utils import (
     slowTest,
     TEST_CUDA,
     TEST_WITH_ROCM,
-    xfailIf,
     xfailIfS390X,
 )
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -5930,7 +5929,6 @@ class CPUReproTests(TestCase):
         y = torch.randint(0, 255, (3, 3), dtype=torch.uint8)
         self.common(fn, (x, y))
 
-    @xfailIf(IS_ARM64)  # see https://github.com/pytorch/pytorch/issues/168972
     def test_float32_to_uint8(self):
         # https://github.com/pytorch/pytorch/issues/156788
         @torch.compile


### PR DESCRIPTION
Summary:

Fix NEON/SVE vectorized f32->u8 quant conversion routines having a different behaviour than c10::convert/AVX

The inputs differing are out-of-range

f32->uint8_t has well defined behaviour in TypeCast.h, supporting inputs fitting up to an int64_t, to get consistent results across CPU/GPU

Addresses: github.com/pytorch/pytorch/issues/168972

Test Plan: CI

Reviewed By: Rajeev975

Differential Revision: D119352973




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo