### PR TITLE
[dynamo] Allow returning requires_grad_() intermediates that are differentiable w.r.t. graph inputs

### DIFF
--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -1461,7 +1461,12 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(compiled, eager)
         self.assertEqual(cnt.frame_count, 1)
 
-    def test_requires_grad_setattr_leaked_output_graph_breaks(self):
+    def test_requires_grad_setattr_output_differentiable_wrt_params_single_graph(
+        self,
+    ):
+        # The returned tensor derives from a source-less requires_grad_()
+        # intermediate, but it is also differentiable w.r.t. the parameters,
+        # so AOTAutograd keeps it differentiable and no graph break is needed.
         mod = torch.nn.Linear(4, 4)
 
         def fn(x):
@@ -1470,13 +1475,6 @@ class GraphModule(torch.nn.Module):
             return mod(y).sum()
 
         x = torch.randn(2, 4)
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "returning intermediate with requires_grad_\\(\\)",
-        ):
-            torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
-
-        torch._dynamo.reset()
         for p in mod.parameters():
             p.grad = None
         eager_out = fn(x)
@@ -1486,13 +1484,98 @@ class GraphModule(torch.nn.Module):
         for p in mod.parameters():
             p.grad = None
         cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
-        out = torch.compile(fn, backend=cnt)(x)
+        out = torch.compile(fn, backend=cnt, fullgraph=True)(x)
+        self.assertTrue(out.requires_grad)
         out.backward()
 
         self.assertEqual(out, eager_out)
         for name, p in mod.named_parameters():
             self.assertEqual(eager_grads[name], p.grad)
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_requires_grad_intermediate_force_output_single_graph(self):
+        # energy -> autograd.grad(create_graph=True) -> force, returned so a
+        # force loss can be backpropagated into the parameters.
+        mod = torch.nn.Linear(3, 1)
+
+        def energy_and_force(x):
+            create_graph = torch.is_grad_enabled()
+            pos = x.detach().requires_grad_(True)
+            with torch.enable_grad():
+                energy = mod(pos).pow(2).sum()
+                (grad,) = torch.autograd.grad(energy, pos, create_graph=create_graph)
+            return energy.detach(), -grad
+
+        def loss_fn(x):
+            energy, force = energy_and_force(x)
+            return energy + force.pow(2).sum()
+
+        x = torch.randn(4, 3)
+        for p in mod.parameters():
+            p.grad = None
+        eager_loss = loss_fn(x)
+        eager_loss.backward()
+        eager_grads = {name: p.grad.clone() for name, p in mod.named_parameters()}
+
+        for p in mod.parameters():
+            p.grad = None
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+        loss = torch.compile(loss_fn, backend=cnt, fullgraph=True)(x)
+        self.assertTrue(loss.requires_grad)
+        loss.backward()
+
+        self.assertEqual(loss, eager_loss)
+        for name, p in mod.named_parameters():
+            self.assertEqual(eager_grads[name], p.grad)
+        self.assertEqual(cnt.frame_count, 1)
+
+        with torch.no_grad():
+            energy, force = torch.compile(
+                energy_and_force, backend="aot_eager", fullgraph=True
+            )(x)
+            eager_energy, eager_force = energy_and_force(x)
+        self.assertFalse(force.requires_grad)
+        self.assertEqual(energy, eager_energy)
+        self.assertEqual(force, eager_force)
+
+    def test_requires_grad_intermediate_leaked_output_graph_breaks(self):
+        # The returned tensor depends only on the source-less intermediate:
+        # AOTAutograd would return it with requires_grad=False.
+        def fn(x):
+            x = x.sin()
+            y = x.detach().requires_grad_()
+            return y * 2
+
+        x = torch.randn(4)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "returning intermediate with requires_grad_\\(\\)",
+        ):
+            torch.compile(fn, backend="aot_eager", fullgraph=True)(x)
+
+        torch._dynamo.reset()
+        cnt = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+        out = torch.compile(fn, backend=cnt)(x)
+        self.assertTrue(out.requires_grad)
+        self.assertEqual(out, fn(x))
         self.assertEqual(cnt.frame_count, 2)
+
+    def test_requires_grad_intermediate_leaked_output_unrelated_input_graph_breaks(
+        self,
+    ):
+        # A graph input requires grad, but the returned tensor is not
+        # differentiable w.r.t. it: its backward would reach the wrong leaves.
+        def fn(x, w):
+            y = x.detach().requires_grad_()
+            return y * 2, (w * 2).sum()
+
+        x = torch.randn(4)
+        w = torch.randn(4, requires_grad=True)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "returning intermediate with requires_grad_\\(\\)",
+        ):
+            torch.compile(fn, backend="aot_eager", fullgraph=True)(x, w)
 
     def test_requires_grad_setattr_graph_input_graph_breaks(self):
         def fn(x):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2742,6 +2742,29 @@ class OutputGraph(OutputGraphCommon):
                 restart_reason="autograd.grad consumed grad_fns of returned tensors"
             )
 
+    def _requires_grad_input_edges(self) -> set[torch.autograd.graph.Node]:
+        """Gradient edges of the graph inputs that require grad.
+
+        A graph input is a placeholder or a get_attr tensor (parameters and
+        buffers). For a leaf input the edge is its AccumulateGrad node, for a
+        non-leaf input it is the external grad_fn. These are the autograd
+        nodes AOTAutograd differentiates the compiled function against.
+        """
+        edges: set[torch.autograd.graph.Node] = set()
+        for node in self.graph.nodes:
+            if node.op not in ("placeholder", "get_attr"):
+                continue
+            example_value = node.meta.get("example_value")
+            if not isinstance(example_value, torch.Tensor):
+                continue
+            if not example_value.requires_grad:
+                continue
+            try:
+                edges.add(torch.autograd.graph.get_gradient_edge(example_value).node)
+            except RuntimeError:
+                continue
+        return edges
+
     def _check_requires_grad_intermediate_outputs(
         self, rv: list["VariableTracker"], tx: "InstructionTranslatorBase"
     ) -> None:
@@ -2751,6 +2774,16 @@ class OutputGraph(OutputGraphCommon):
         so returning them (or tensors derived from them) produces wrong results.
         We detect this via FX graph reachability: find the requires_grad_() nodes
         for source-less intermediates, then check if any output is downstream.
+
+        A downstream output is still safe when its autograd graph also reaches
+        a graph input that requires grad (see _requires_grad_input_edges).
+        AOTAutograd then returns a differentiable output whose backward is the
+        eager backward restricted to the graph inputs; the only autograd state
+        lost is the AccumulateGrad edge into the source-less intermediate, and
+        that intermediate never escapes the compiled region. This is the
+        ``energy -> autograd.grad(create_graph=True) -> force`` pattern of
+        force-supervised training, where the force is returned so that a loss
+        on it can be backpropagated into the parameters.
         """
         from .variables.tensor import TensorVariable
 
@@ -2770,6 +2803,8 @@ class OutputGraph(OutputGraphCommon):
             if any(inp in tainted_nodes for inp in node.all_input_nodes):
                 tainted_nodes.add(node)
 
+        input_edges: set[torch.autograd.graph.Node] | None = None
+
         # Check leaked outputs: tainted + requires_grad means the output
         # carries autograd state that AOTAutograd would silently drop.
         # Detached outputs (requires_grad=False) are fine — no autograd to lose.
@@ -2779,13 +2814,25 @@ class OutputGraph(OutputGraphCommon):
                 and var.requires_grad
                 and var.as_proxy().node in tainted_nodes
             ):
+                # Differentiable w.r.t. a graph input: AOTAutograd keeps the
+                # output differentiable and its backward reaches that input.
+                if input_edges is None:
+                    input_edges = self._requires_grad_input_edges()
+                if input_edges:
+                    fake_tensor = var.as_proxy().node.meta.get("example_value")
+                    if isinstance(fake_tensor, torch.Tensor):
+                        reachable = collect_reachable_grad_fns([(fake_tensor, None)])
+                        if reachable & input_edges:
+                            continue
                 msg = (
                     "An intermediate tensor that had requires_grad_() called "
                     "on it (or a tensor derived from it) is being returned "
-                    "from the compiled region. AOTAutograd's functionalization "
-                    "drops the requires_grad_() effect on graph outputs, "
-                    "producing wrong results. If you only need the tensor "
-                    "values without gradients, call .detach() before returning."
+                    "from the compiled region, and it is not differentiable "
+                    "with respect to any graph input. AOTAutograd's "
+                    "functionalization drops the requires_grad_() effect on "
+                    "graph outputs, producing wrong results. If you only need "
+                    "the tensor values without gradients, call .detach() "
+                    "before returning."
                 )
                 if tx.one_graph:
                     unimplemented(


### PR DESCRIPTION
## Summary

`OutputGraph._check_requires_grad_intermediate_outputs` refuses every graph output that still requires grad and is downstream, in the FX graph, of a source-less `requires_grad_()` intermediate. The concern is right (AOTAutograd cannot reproduce autograd state that lives only in such a leaf), but FX reachability also rejects outputs that are differentiable with respect to a graph input, and for those AOTAutograd is correct. This PR keeps the check and lets an output through only when its autograd graph reaches a graph input that requires grad.

The pattern this unblocks: a scalar computed on an internal leaf, differentiated w.r.t. that leaf with `create_graph=True`, and the gradient returned so that a loss on it is backpropagated into the parameters (the gradient is differentiable w.r.t. the parameters, not only w.r.t. the leaf).

## Context

I am compiling the training step of a machine-learned interatomic potential end-to-end with `torch.compile(fullgraph=True)`. The model maps atom positions to a scalar energy; forces are `-dE/dpos`, computed inside the model with `torch.autograd.grad(E, pos_leaf, create_graph=True)`, and the loss is on both energy and forces, so the force has to come back still attached to the parameters. With `trace_autograd_ops=True` the inference path (forces detached) is already one graph, but the training path graph-breaks at the position leaf because of this check. The break splits the step into an eager prefix plus a compiled tail and gives up the inductor speedup measured below (3.1x on the step). Moving the leaf outside the compiled region avoids the break, but the returned force is differentiable w.r.t. the parameters either way, so the check is rejecting a case AOTAutograd handles correctly.

## Minimal repro

```python
import torch
torch._dynamo.config.trace_autograd_ops = True
torch.manual_seed(0)
mod = torch.nn.Linear(3, 1, dtype=torch.float64)

def value_and_grad(x):
    leaf = x.detach().requires_grad_(True)            # source-less requires_grad_() leaf
    value = mod(leaf).pow(2).sum()
    (g,) = torch.autograd.grad(value, leaf, create_graph=True)
    return value.detach(), g                           # g is differentiable w.r.t. mod's parameters

def loss(x):
    v, g = value_and_grad(x)
    return v + g.pow(2).sum()

x = torch.randn(4, 3, dtype=torch.float64)
loss(x).backward(); ref = [p.grad.clone() for p in mod.parameters()]; mod.zero_grad()
torch.compile(loss, backend="aot_eager", fullgraph=True)(x).backward()
print(max((a - b).abs().max() for a, b in zip(ref, [p.grad for p in mod.parameters()])))

def only_leaf(x):                                      # the case the check exists for
    return x.detach().requires_grad_(True) * 2
torch.compile(only_leaf, backend="aot_eager", fullgraph=True)(x)   # must still be refused
```

`2.15.0.dev20260909+cpu`, before:

```
Unsupported: returning intermediate with requires_grad_()
only_leaf: Unsupported: returning intermediate with requires_grad_()
```

after (this PR applied on top of the same wheel):

```
compiled OK; max|param grad compiled - eager| = 0.0
only_leaf: Unsupported: returning intermediate with requires_grad_()
```

Why the check is right for `only_leaf` and too strict for `loss`, measured with the check bypassed entirely (same wheel, fp64):

| case | compiled vs eager with the check bypassed |
|---|---|
| `loss`: output differentiable w.r.t. the parameters | param grads: aot_eager 0.0, inductor 1.8e-15 |
| output depends only on the leaf | `out.requires_grad` False vs eager True |
| an unrelated input requires grad, output does not reach it | that input's `.grad` becomes zeros vs eager `None` |

The last two stay refused with this PR.

## Root cause

`torch/_dynamo/output_graph.py`, `_check_requires_grad_intermediate_outputs`: taints every source-less `requires_grad_()` intermediate, propagates the taint forward through the FX graph (`all_input_nodes`), and refuses any tainted output with `requires_grad=True`. FX reachability cannot distinguish "derived from the leaf" from "also differentiable w.r.t. a graph input". For the latter:

- the traced output requires grad, so AOTAutograd does not `mark_non_differentiable` it;
- `CompiledFunction.apply` returns it differentiable because a graph input requires grad;
- its backward is the eager backward restricted to graph inputs, which is what the joint graph computes;
- the only autograd state dropped is the `AccumulateGrad` edge into the source-less leaf, and that leaf never leaves the compiled region (returning it, or something that reaches nothing but it, is still refused).

## Fix

- New `OutputGraph._requires_grad_input_edges()`: `torch.autograd.graph.get_gradient_edge(...).node` of every placeholder / `get_attr` tensor with `requires_grad` (`AccumulateGrad` for leaves, the external `grad_fn` for non-leaves). These are the nodes AOTAutograd differentiates the compiled function against.
- In `_check_requires_grad_intermediate_outputs`, a tainted output is allowed iff its fake autograd graph (existing `collect_reachable_grad_fns`, the same walk this file already uses for the `autograd.grad` consumed-grad_fn validation) reaches one of those edges. Everything else is unchanged, including the restart / partial-graph path.
- The `explanation` string now says the output "is not differentiable with respect to any graph input"; `gb_type` and hints are unchanged, `gb_registry_linter` is clean.

## Regression

`test/dynamo/test_fwd_loss_bwd.py`:
- `test_requires_grad_setattr_leaked_output_graph_breaks` exercised exactly the safe pattern (`mod(y).sum()` with `mod` differentiable) and already asserted parameter-gradient parity across the graph break; it is rewritten as `test_requires_grad_setattr_output_differentiable_wrt_params_single_graph` asserting one graph.
- New `test_requires_grad_intermediate_force_output_single_graph`: the repro above (gradient returned with `create_graph=True`, loss backward outside) compiles to one graph with parameter gradients equal to eager; the `create_graph=False` path returns a detached gradient.
- New `test_requires_grad_intermediate_leaked_output_graph_breaks`: output depends only on the leaf → `Unsupported` under `fullgraph`, graph break with correct `requires_grad` otherwise.
- New `test_requires_grad_intermediate_leaked_output_unrelated_input_graph_breaks`: an unrelated requires-grad input does not make the output safe.

Upstream suites on `2.15.0.dev20260909+cpu`, stock wheel vs the same wheel with this PR applied (pytest `-n 8`):

| file | stock | this PR |
|---|---|---|
| `test/dynamo/test_fwd_loss_bwd.py` | 53 passed | 56 passed (+3 new) |
| `test/dynamo/test_repros.py` | 363 passed, 22 skipped, 4 xfailed | same |
| `test/dynamo/test_misc.py` | 843 passed, 1 failed, 16 skipped, 4 xfailed | same |
| `test/dynamo/test_autograd_function.py` | 92 passed, 4 skipped | same |
| `test/dynamo/test_ctx_manager.py` | 110 passed, 34 skipped | same |

The one `test_misc` failure (`test_builtin_bytes_zero_args`) is identical on the stock wheel (Python 3.14).

## Benchmark

Cost of the new walk (only runs when a tainted requires-grad output exists): 1.3 ms on the repro above (0.74 s total compile); 16 ms on the model below (5.4 s / 40 s total compile for aot_eager / inductor). No runtime cost.

What it unblocks, measured on an equivariant graph network with custom-op message passing (6.9k parameters, 256 nodes / 3080 edges, fp64, NVIDIA GH200): training step = scalar output + sum of squared returned gradient, `backward()` outside the compiled region, `fullgraph=True`.

| backend | eager | compiled | speedup | peak mem (GiB) | first compile | max param-grad diff vs eager |
|---|---|---|---|---|---|---|
| aot_eager | 43.5 ms | 42.7 ms | 1.02x | 0.048 -> 0.044 | 5.4 s | 5.7e-14 |
| inductor | 43.5 ms | 13.9 ms | 3.14x | 0.048 -> 0.044 | 40.4 s | 9.2e-14 |

`torch._dynamo.explain` of that step: 1 graph, 0 breaks (stock: 1 break at the `requires_grad_()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012u8tFcerRMrVM5GD2UGNCv


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98