### PR TITLE
Reland D119407068: [inductor] Skip CPU tests pending stable-to-3.8 triton upgrade [internal-only]

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1609,7 +1609,22 @@ class TritonBlockPointerTestGPU(BlockDescriptorTestBase):
 test_torchinductor.copy_tests(CommonTemplate, TritonBlockPointerTestGPU, GPU_TYPE)
 
 
-@unittest.skipIf(not TRITON_HAS_CPU, "requires triton CPU backend")
+def _triton_cpu_supports_tensor_descriptor() -> bool:
+    # A CPU backend existing does not imply tensor descriptor support; older
+    # builds register the backend without the driver API.
+    # Internal-only: stable is an old (3.5-era) frontend with a retrofitted
+    # 3.8-based CPU backend; drop this once stable is upgraded to 3.8.
+    try:
+        from triton.backends.cpu.driver import CPUDriver
+    except ImportError:
+        return False
+    return hasattr(CPUDriver, "tensor_descriptor")
+
+
+@unittest.skipIf(
+    not TRITON_HAS_CPU or not _triton_cpu_supports_tensor_descriptor(),
+    "requires triton CPU backend with tensor descriptor support",
+)
 @config.patch({"triton.use_tensor_descriptor": True, "cpu_backend": "triton"})
 @instantiate_parametrized_tests
 class TritonTensorDescriptorTestCPU(BlockDescriptorTestBase):

--- a/test/inductor/test_triton_cpu_backend.py
+++ b/test/inductor/test_triton_cpu_backend.py
@@ -27,10 +27,22 @@ TRITON_CPU_SLOW_TESTS = (
 )
 
 if HAS_CPU and TRITON_HAS_CPU:
+    # TODO: re-enable when the stable triton CPU backend can compile
+    # inductor CPU code. The backend is newly present via the stable
+    # channel, but inductor emits constructs it cannot compile yet:
+    # missing libdevice.* lowering and no CPUDriver.tensor_descriptor.
+    # Internal-only: stable is an old (3.5-era) frontend with a retrofitted
+    # 3.8-based CPU backend; drop this once stable is upgraded to 3.8.
+    _CPU_TRITON_SKIP_REASON = (
+        "triton CPU backend in stable cannot yet compile inductor CPU code "
+        "(missing libdevice lowering and tensor descriptor support)"
+    )
+
     # SweepInputsCpuTest is only defined when CPU tests are enabled
     # (RUN_CPU); otherwise there is nothing to subclass.
     if hasattr(test_torchinductor, "SweepInputsCpuTest"):
 
+        @unittest.skip(_CPU_TRITON_SKIP_REASON)
         @config.patch(
             {
                 "cpu_backend": "triton",
@@ -41,6 +53,7 @@ if HAS_CPU and TRITON_HAS_CPU:
         class SweepInputsCpuTritonTest(test_torchinductor.SweepInputsCpuTest):
             pass
 
+    @unittest.skip(_CPU_TRITON_SKIP_REASON)
     @config.patch(
         {
             "cpu_backend": "triton",


### PR DESCRIPTION
Meta's internal triton is currently being upgraded to [3.8](https://github.com/facebookexperimental/triton/tree/release/3.8.x). Meanwhile I landed the CPU backend due to some urgent deadline: https://github.com/facebookexperimental/triton/pull/2981 This causes some triton-cpu side mismatches due to the version differences.

To mitigate this discrepancy, I'd like to pause some CPU tests temporarily. Once Meta's internal triton is full upgraded to 3.8, this can be reverted.

| Target | Before | After |
|---|---|---|
| `:triton_cpu_backend` | Pass 792, Fail 94, Skip 563 | Pass 1, Fail 0, Skip 1448 |
| TD CPU (`strided_blocks` filter) | 79 failed | 104 skipped, Fail 0 |
| Core GPU (172 targets) | Candidate-only 0 | Unchanged |

Differential Revision: D119407068

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo