### PR TITLE
Fix T8 coefficient in matrix exponential

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2389,7 +2389,7 @@ Tensor compute_T8(const Tensor& A) {
   constexpr scalar_t x4 = (-271. + 29. * sqrt_177) / (315. * x3);
   constexpr scalar_t x5 = (-11. + 11. * sqrt_177) / (1260. * x3);
   constexpr scalar_t x6 = (-99. + 11. * sqrt_177) / (5040. * x3);
-  constexpr scalar_t x7 = (89. - sqrt_177) / (5040. * x3);
+  constexpr scalar_t x7 = (89. - sqrt_177) / (5040. * x3 * x3);
   constexpr scalar_t y2 = (857. - 58. * sqrt_177) / 630.;
 
   auto As = _allocate_buffer(A, 5);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8245,41 +8245,50 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     def test_linalg_matrix_exp_small_rotation(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/196592
         single = dtype in (torch.float, torch.cfloat)
-        theta = 0.5 if single else 0.04
-        atol = 3e-7 if single else 2e-15
+        theta, scale = (0.5, 0.01) if single else (0.04, 0.001)
+        forward_atol = 3e-7 if single else 2e-15
+        backward_atol = 3e-9 if single else 2e-17
+
         a = torch.tensor([[0, -theta], [theta, 0]], device=device, dtype=dtype)
         c, s = math.cos(theta), math.sin(theta)
+
         expected = torch.tensor(
             [[c, -s], [s, c]],
             device=device,
             dtype=dtype,
         )
-        for batch_shape in ((), (1,), (2,), (1, 2)):
-            x = a.expand(*batch_shape, 2, 2)
-            self.assertEqual(torch.linalg.matrix_exp(x), expected.expand_as(x),
-                             atol=atol, rtol=0)
 
-    @skipCUDAIfNoMagmaAndNoLinalgsolver
-    @skipCPUIfNoLapack
-    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
-    def test_linalg_matrix_exp_small_rotation_backward(self, device, dtype):
-        single = dtype in (torch.float, torch.cfloat)
-        theta, scale = (0.5, 0.01) if single else (0.04, 0.001)
-        atol = 3e-9 if single else 2e-17
-        a = torch.tensor([[0, -theta], [theta, 0]], device=device, dtype=dtype)
-        g = scale * torch.eye(2, device=device, dtype=dtype)
-        c, s = math.cos(theta), math.sin(theta)
         # For G = scale I, L_exp(A^H, G) = scale exp(A^H).
-        expected = scale * torch.tensor(
+        g = scale * torch.eye(2, device=device, dtype=dtype)
+        expected_grad = scale * torch.tensor(
             [[c, s], [-s, c]],
             device=device,
             dtype=dtype,
         )
+
         for batch_shape in ((), (1,), (2,), (1, 2)):
-            x = a.expand(*batch_shape, 2, 2).requires_grad_()
-            (actual,) = torch.autograd.grad(torch.linalg.matrix_exp(x), x, g.expand_as(x))
-            self.assertEqual(actual, expected.expand_as(x), atol=atol, rtol=0)
+            x = a.expand(*batch_shape, 2, 2)
+            self.assertEqual(
+                torch.linalg.matrix_exp(x),
+                expected.expand_as(x),
+                atol=forward_atol,
+                rtol=0,
+            )
+
+            x = x.requires_grad_()
+            (actual_grad,) = torch.autograd.grad(
+                torch.linalg.matrix_exp(x),
+                x,
+                g.expand_as(x),
+            )
+            self.assertEqual(
+                actual_grad,
+                expected_grad.expand_as(x),
+                atol=backward_atol,
+                rtol=0,
+            )
 
     @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8249,11 +8249,12 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         theta = 0.5 if single else 0.04
         atol = 3e-7 if single else 2e-15
         a = torch.tensor([[0, -theta], [theta, 0]], device=device, dtype=dtype)
-        # Form the reference in double precision from the represented input.
-        t = a[1, 0].real.cpu().double()
-        c, s = t.cos(), t.sin()
-        expected = torch.stack((torch.stack((c, -s)), torch.stack((s, c))))
-        expected = expected.to(device=device, dtype=dtype)
+        c, s = math.cos(theta), math.sin(theta)
+        expected = torch.tensor(
+            [[c, -s], [s, c]],
+            device=device,
+            dtype=dtype,
+        )
         for batch_shape in ((), (1,), (2,), (1, 2)):
             x = a.expand(*batch_shape, 2, 2).contiguous()
             self.assertEqual(torch.linalg.matrix_exp(x), expected.expand_as(x),
@@ -8268,12 +8269,13 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         atol = 3e-9 if single else 2e-17
         a = torch.tensor([[0, -theta], [theta, 0]], device=device, dtype=dtype)
         g = scale * torch.eye(2, device=device, dtype=dtype)
-        t = a[1, 0].real.cpu().double()
-        c, s = t.cos(), t.sin()
+        c, s = math.cos(theta), math.sin(theta)
         # For G = scale I, L_exp(A^H, G) = scale exp(A^H).
-        expected = g[0, 0].real.cpu().double() * torch.stack(
-            (torch.stack((c, s)), torch.stack((-s, c))))
-        expected = expected.to(device=device, dtype=dtype)
+        expected = scale * torch.tensor(
+            [[c, s], [-s, c]],
+            device=device,
+            dtype=dtype,
+        )
         for batch_shape in ((), (1,), (2,), (1, 2)):
             x = a.expand(*batch_shape, 2, 2).contiguous().requires_grad_()
             (actual,) = torch.autograd.grad(torch.linalg.matrix_exp(x), x, g.expand_as(x))

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8256,7 +8256,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             dtype=dtype,
         )
         for batch_shape in ((), (1,), (2,), (1, 2)):
-            x = a.expand(*batch_shape, 2, 2).contiguous()
+            x = a.expand(*batch_shape, 2, 2)
             self.assertEqual(torch.linalg.matrix_exp(x), expected.expand_as(x),
                              atol=atol, rtol=0)
 
@@ -8277,7 +8277,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
             dtype=dtype,
         )
         for batch_shape in ((), (1,), (2,), (1, 2)):
-            x = a.expand(*batch_shape, 2, 2).contiguous().requires_grad_()
+            x = a.expand(*batch_shape, 2, 2).requires_grad_()
             (actual,) = torch.autograd.grad(torch.linalg.matrix_exp(x), x, g.expand_as(x))
             self.assertEqual(actual, expected.expand_as(x), atol=atol, rtol=0)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -8243,6 +8243,44 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_linalg_matrix_exp_small_rotation(self, device, dtype):
+        single = dtype in (torch.float, torch.cfloat)
+        theta = 0.5 if single else 0.04
+        atol = 3e-7 if single else 2e-15
+        a = torch.tensor([[0, -theta], [theta, 0]], device=device, dtype=dtype)
+        # Form the reference in double precision from the represented input.
+        t = a[1, 0].real.cpu().double()
+        c, s = t.cos(), t.sin()
+        expected = torch.stack((torch.stack((c, -s)), torch.stack((s, c))))
+        expected = expected.to(device=device, dtype=dtype)
+        for batch_shape in ((), (1,), (2,), (1, 2)):
+            x = a.expand(*batch_shape, 2, 2).contiguous()
+            self.assertEqual(torch.linalg.matrix_exp(x), expected.expand_as(x),
+                             atol=atol, rtol=0)
+
+    @skipCUDAIfNoMagmaAndNoLinalgsolver
+    @skipCPUIfNoLapack
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_linalg_matrix_exp_small_rotation_backward(self, device, dtype):
+        single = dtype in (torch.float, torch.cfloat)
+        theta, scale = (0.5, 0.01) if single else (0.04, 0.001)
+        atol = 3e-9 if single else 2e-17
+        a = torch.tensor([[0, -theta], [theta, 0]], device=device, dtype=dtype)
+        g = scale * torch.eye(2, device=device, dtype=dtype)
+        t = a[1, 0].real.cpu().double()
+        c, s = t.cos(), t.sin()
+        # For G = scale I, L_exp(A^H, G) = scale exp(A^H).
+        expected = g[0, 0].real.cpu().double() * torch.stack(
+            (torch.stack((c, s)), torch.stack((-s, c))))
+        expected = expected.to(device=device, dtype=dtype)
+        for batch_shape in ((), (1,), (2,), (1, 2)):
+            x = a.expand(*batch_shape, 2, 2).contiguous().requires_grad_()
+            (actual,) = torch.autograd.grad(torch.linalg.matrix_exp(x), x, g.expand_as(x))
+            self.assertEqual(actual, expected.expand_as(x), atol=atol, rtol=0)
+
+    @skipCUDAIfNoMagmaAndNoLinalgsolver
+    @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double)
     def test_linalg_matrix_exp_batch(self, device, dtype):
 


### PR DESCRIPTION
## Issue

Fixes #196592

## Summary

Correct the missing `x3` factor in the `compute_T8` matrix exponential coefficient and add focused regression tests for the affected forward and backward paths.

The tests cover singleton inputs that select the T8 path, along with batched inputs for comparison.

Local validation:
- `python test/test_linalg.py -k matrix_exp_small_rotation`
- `python test/test_linalg.py -k matrix_exp`
- `spin quicklint`

## Checklist

- [x] Added/updated tests
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable; no performance change)

## BC-breaking?

No.

### AI assistance

I used AI coding assistants during the investigation to help inspect source paths, prepare diagnostic scripts, and edit parts of the regression tests and write-up. I reviewed and verified the patch, mathematical derivation, and test results myself.

cc @jianyuh @nikitaved @mruberry @walterddr @Lezcano