### PR TITLE
[inductor] Represent ranked reduction results in shared scheduling

### DIFF
--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -1,7 +1,10 @@
 # Owner(s): ["module: inductor"]
 import contextlib
 
+import sympy
+
 import torch
+from torch._inductor import dependencies
 from torch._inductor.codegen.cpp_utils import CppCSEVariable
 from torch._inductor.dependencies import MemoryDep
 from torch._inductor.graph import GraphLowering
@@ -12,14 +15,20 @@ from torch._inductor.ir import (
     Pointwise,
     ShapeAsConstantBuffer,
 )
+from torch._inductor.loop_body import LoopBody
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
+@instantiate_parametrized_tests
 class TestDependencies(InductorTestCase):
     def _create_buffer(self, name, shape, dtype=torch.float32):
         return Buffer(
@@ -143,6 +152,79 @@ class TestDependencies(InductorTestCase):
         )
         self.assertEqual(dep1.get_offset(), 0)
         self.assertEqual(dep2.get_offset(), 1024)
+
+    @parametrize("normalize", [False, True])
+    @parametrize("transform", ["clone", "merge", "reorder", "reindex"])
+    @parametrize("result_size", [1, 3])
+    def test_reduction_result_domain(self, normalize, transform, result_size):
+        def fn(index, reduction):
+            row = 3 * index[0] + index[1]
+            (rank,) = reduction
+            value = ops.load("input", 33 * row + rank)
+            values = ops.constant(1, torch.float32)
+            ops.store_reduction(
+                "output",
+                result_size * row + rank,
+                values,
+                result_range=(rank, result_size),
+            )
+            reduced = ops.reduction(torch.float32, torch.float32, "sum", value)
+            ops.store_reduction("sum", row, reduced)
+            ops.store("full", 33 * row + rank, value)
+
+        args, ranges = dependencies.index_vars_squeeze([2, 3], [33], prefix="q")
+        body = LoopBody(fn, args, ranges, *args)
+        if transform == "clone":
+            body = LoopBody(body, args, ranges, *args, allow_same_symbol_in_index=True)
+        elif transform == "merge":
+            body = body.merge_loops()
+        elif transform == "reorder":
+            body = body.reorder_iter_loops([1, 0])
+        else:
+            body = body.reindex_iter_loops([6])
+
+        fast = dependencies.extract_read_writes(body, *body.sizes, normalize=normalize)
+        traced = dependencies.extract_read_writes(
+            lambda *args: body(*args), *body.sizes, normalize=normalize
+        )
+        self.assertEqual(fast.reads, traced.reads)
+        self.assertEqual(fast.writes, traced.writes)
+        self.assertEqual(fast.index_exprs, traced.index_exprs)
+
+        t0 = sympy_index_symbol("t0")
+        for dep in (*fast.reads, *fast.writes):
+            numel = {"output": 6 * result_size, "sum": 6}.get(dep.name, 198)
+            self.assertEqual(
+                dep.normalize_with_stride_order(),
+                MemoryDep(dep.name, t0, (t0,), (sympy.Integer(numel),)),
+            )
+        self.assertEqual(len(body.get_write_exprs()), 3)
+        self.assertEqual(
+            body.get_write_expr("output"), body.get_all_write_expr("output")[0]
+        )
+
+    @parametrize("normalize", [False, True])
+    def test_reduction_result_projected_domain(self, normalize):
+        def fn(index, reduction):
+            (row,) = index
+            (rank,) = reduction
+            value = ops.load("input", 33 * row + rank)
+            ops.store_reduction("output", 3 * row + rank, value, result_range=(rank, 3))
+
+        args, ranges = dependencies.index_vars_squeeze([6], [33], prefix="q")
+        body = LoopBody(fn, args, ranges, *args)
+        fast = dependencies.extract_read_writes(
+            body, [6], hidden_args=[[sympy.S.Zero]], normalize=normalize
+        )
+        traced = dependencies.extract_read_writes(
+            fn, [6], hidden_args=[[sympy.S.Zero]], normalize=normalize
+        )
+        self.assertEqual(fast.reads, traced.reads)
+        self.assertEqual(fast.writes, traced.writes)
+        self.assertEqual(fast.index_exprs, traced.index_exprs)
+        (write,) = fast.writes
+        self.assertEqual(write.size, (6,))
+        self.assertEqual(write.index, 3 * write.var_names[0])
 
     def test_cpp_cse_value_expr_tracks_dependent_itervars(self):
         x = sympy_index_symbol("x")

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -22,19 +22,32 @@ from torch._inductor.codegen.simd import (
 from torch._inductor.codegen.simd_kernel_features import (
     DisableReduction,
     EnableReduction,
+    MemoryEstimator,
+    SIMDKernelFeatures,
 )
-from torch._inductor.dependencies import Dep, MemoryDep, ReadWrites, StarDep, WeakDep
+from torch._inductor.codegen.triton import TritonScheduling
+from torch._inductor.dependencies import (
+    Dep,
+    index_vars_squeeze,
+    MemoryDep,
+    ReadWrites,
+    StarDep,
+    WeakDep,
+)
 from torch._inductor.ir import GraphPartitionSignature
-from torch._inductor.loop_body import MemoryEntry, MemoryUsageType
+from torch._inductor.loop_body import LoopBody, MemoryEntry, MemoryUsageType
 from torch._inductor.scheduler import (
     _get_benchmarkable_extern_fn,
     BaseSchedulerNode,
+    BaseScheduling,
     ExternKernelSchedulerNode,
     ForeachKernelSchedulerNode,
     FusedNestedReductions,
+    FusedSchedulerNode,
     MemoryDepMatch,
     NestedReduction,
     OrderedParentNodes,
+    refresh_group_node_dependencies,
     Scheduler,
     SchedulerNode,
     SubParentAccessRelation,
@@ -44,7 +57,7 @@ from torch._inductor.scheduler import (
 )
 from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.utils import fresh_inductor_cache, snode_args_kwargs
-from torch._inductor.virtualized import V
+from torch._inductor.virtualized import ops, V
 from torch.testing._internal.common_cuda import SM70OrLater
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -126,6 +139,7 @@ class TestScheduler(TestCase):
         node.used_buffer_names.return_value = OrderedSet()
         node.is_template.return_value = False
         node.is_reduction.return_value = False
+        node.has_reduction_result.return_value = False
         return node
 
     def _extern_snode_for_op(self, op_overload, python_kernel_name):
@@ -165,6 +179,7 @@ class TestScheduler(TestCase):
             node.__class__ = SchedulerNode
             node.node = Mock(spec=ir.ComputedBuffer)
             node.node.data = Mock()
+            node._body.memory_usage = {MemoryUsageType.STORE_REDUCTION: []}
 
         def make_dep(dep_name):
             return MemoryDep(dep_name, sympy.S.Zero, (), ())
@@ -208,7 +223,7 @@ class TestScheduler(TestCase):
         )
 
         self.assertEqual(
-            schedule, [first, second, DisableReduction, EnableReduction, final]
+            schedule, [first, second, DisableReduction(), EnableReduction(), final]
         )
 
     def test_generate_node_schedule_required_boundary_reuses_enable_marker(self):
@@ -221,7 +236,7 @@ class TestScheduler(TestCase):
         )
 
         self.assertEqual(
-            schedule, [first, DisableReduction, outside, EnableReduction, final]
+            schedule, [first, DisableReduction(), outside, EnableReduction(), final]
         )
 
     def test_generate_node_schedule_required_boundary_reuses_final_loop(self):
@@ -240,7 +255,7 @@ class TestScheduler(TestCase):
 
         self.assertEqual(
             schedule,
-            [reduction, DisableReduction, EnableReduction, post_reduction, final],
+            [reduction, DisableReduction(), EnableReduction(), post_reduction, final],
         )
 
     def test_generate_node_schedule_rejects_invalid_required_boundary(self):
@@ -266,6 +281,163 @@ class TestScheduler(TestCase):
                 8,
                 16,
                 required_post_reduction_index=1,
+            )
+
+    @parametrize("result_size", [1, 3])
+    def test_memory_estimator_reduction_output_domain(self, result_size):
+        graph = Mock(sizevars=SizeVarAllocator())
+        graph.scheduler.can_buffer_be_removed_through_fusion.return_value = False
+
+        def make_node(name, width):
+            def fn(index, reduction):
+                row, rank = index
+                offset = width * row + rank
+                ops.store(f"{name}_out", offset, ops.load(name, offset))
+
+            args, ranges = index_vars_squeeze([2, width], [])
+            node = Mock(spec=SchedulerNode)
+            node._body = LoopBody(fn, args, ranges, *args)
+            node.get_ranges.return_value = node._body.sizes
+            node.get_name.return_value = name
+            return node
+
+        with V.set_graph_handler(graph):
+            before = make_node("before", 33)
+            output = make_node("output", result_size)
+            after = make_node("after", 33)
+            schedule = [
+                before,
+                DisableReduction(result_size),
+                output,
+                EnableReduction(),
+                after,
+            ]
+            features = SIMDKernelFeatures(schedule, sympy.Integer(2), sympy.Integer(33))
+            estimate = MemoryEstimator(features, (sympy.Integer(2), sympy.Integer(33)))
+
+            self.assertEqual(list(features.scheduler_nodes()), [before, output, after])
+            self.assertEqual(list(EnableReduction.filter(schedule)), [before, after])
+            self.assertEqual(set(estimate.outside_loop.reads), {"output"})
+            (output_read,) = estimate.outside_loop.reads["output"]
+            self.assertEqual(output_read.get_numel(), 2 * result_size)
+            self.assertEqual(
+                [set(loop.reads) for loop in estimate.loops], [{"before"}, {"after"}]
+            )
+            for loop in estimate.loops:
+                (read,) = next(iter(loop.reads.values()))
+                self.assertEqual(read.get_numel(), 66)
+
+    def _reduction_result_node(self, name, result_size, *, outer_ranges=(2,)):
+        def fn(index, reduction):
+            row = sympy.S.Zero
+            for idx, size in zip(index, outer_ranges):
+                row = row * size + idx
+            (rank,) = reduction
+            value = ops.load("input", 33 * row + rank)
+            reduced = ops.reduction(torch.float32, torch.float32, "sum", value)
+            ops.store_reduction(
+                name,
+                row if result_size is None else result_size * row + rank,
+                reduced,
+                result_range=None if result_size is None else (rank, result_size),
+            )
+            ops.store_reduction(f"{name}_scalar", row, reduced)
+            ops.store(f"{name}_full", 33 * row + rank, value)
+
+        args, ranges = index_vars_squeeze(outer_ranges, [33], prefix="q")
+        node = object.__new__(SchedulerNode)
+        node.node = Mock(spec=ir.ComputedBuffer)
+        node.node.get_name.return_value = name
+        node.node.get_operation_name.return_value = name
+        node.node.get_reduction_type.return_value = "sum"
+        node.node.data = Mock()
+        node.scheduler = Mock(available_buffer_names=OrderedSet())
+        node.outputs = []
+        node.mutation_renames = {}
+        node.group = (None, (sympy.prod(outer_ranges), sympy.Integer(33)))
+        node._loop_state_gen = 0
+        node._body = LoopBody(fn, args, ranges, *args)
+        node._sizes = node._body.sizes
+        node.read_writes = ReadWrites(OrderedSet(), OrderedSet(), OrderedSet())
+        node.unmet_dependencies = OrderedSet()
+        node.refresh_dependencies(normalize=False, need_clear_tiling_cache=False)
+        return node
+
+    @parametrize("ranked", [False, True])
+    def test_reduction_result_cache_refresh_and_restore(self, ranked):
+        with V.set_graph_handler(Mock(sizevars=SizeVarAllocator())):
+            node = self._reduction_result_node("output", 3 if ranked else None)
+            group = object.__new__(FusedSchedulerNode)
+            group.scheduler = node.scheduler
+            group.snodes = [node]
+            with (
+                patch.object(node, "get_nodes", wraps=node.get_nodes) as leaf_nodes,
+                patch.object(group, "get_nodes", wraps=group.get_nodes) as group_nodes,
+            ):
+                for _ in range(2):
+                    self.assertEqual(node.has_reduction_result(), ranked)
+                    self.assertEqual(group.has_reduction_result(), ranked)
+                leaf_nodes.assert_called_once()
+                group_nodes.assert_called_once()
+
+            state = node.snapshot_loop_state()
+            replacement = self._reduction_result_node("output", None if ranked else 3)
+            node._body = replacement._body
+            node.refresh_dependencies(normalize=False, need_clear_tiling_cache=False)
+            refresh_group_node_dependencies(group)
+            self.assertEqual(node.has_reduction_result(), not ranked)
+            self.assertEqual(group.has_reduction_result(), not ranked)
+
+            node.restore_loop_state(state)
+            refresh_group_node_dependencies(group)
+            self.assertEqual(node.has_reduction_result(), ranked)
+            self.assertEqual(group.has_reduction_result(), ranked)
+
+    @parametrize("result_sizes", [(1, 1), (3, 3), (1, 3), (2, 3)])
+    def test_reduction_result_size_requires_common_size(self, result_sizes):
+        with V.set_graph_handler(Mock(sizevars=SizeVarAllocator())):
+            nodes = [
+                self._reduction_result_node(f"output{i}", size)
+                for i, size in enumerate(result_sizes)
+            ]
+            scalar = self._reduction_result_node("scalar", None)
+            common_size = (
+                result_sizes[0] if result_sizes[0] == result_sizes[1] else None
+            )
+            self.assertEqual(SIMDScheduling._reduction_result_size([scalar]), 1)
+            self.assertEqual(
+                SIMDScheduling._reduction_result_size([*nodes, scalar]), common_size
+            )
+            if common_size is None:
+                self.assertFalse(TritonScheduling(None).can_fuse_reduction_pair(*nodes))
+
+    @parametrize("result_size", [1, 3])
+    @parametrize("reverse", [False, True])
+    def test_nested_planners_reject_reduction_results(self, result_size, reverse):
+        with (
+            V.set_graph_handler(Mock(sizevars=SizeVarAllocator())),
+            inductor_config.patch({"triton.nested_reduction": True}),
+            patch(
+                "torch._inductor.scheduler._is_gpu_triton_backend", return_value=True
+            ),
+        ):
+            ranked = self._reduction_result_node("ranked", result_size)
+            scalar = self._reduction_result_node("scalar", None)
+            nodes = (scalar, ranked) if reverse else (ranked, scalar)
+            self.assertTrue(NestedReduction._is_enabled_for(scalar, scalar))
+            self.assertFalse(NestedReduction._is_enabled_for(*nodes))
+            self.assertFalse(NestedReduction.is_candidate(*nodes))
+            self.assertIsNone(NestedReduction.plan(*nodes))
+            self.assertIsNone(NestedReduction.sub_parent_epilogue_plan(nodes, 2, 33))
+            self.assertIsNone(
+                NestedReduction._get_grouped_reduction_and_size(
+                    ranked, sympy.Integer(33)
+                )
+            )
+            self.assertIsNone(
+                NestedReduction.plan_from_topology(
+                    *nodes, scalar, sympy.Integer(33), NestedReduction.GroupedAxis.R
+                )
             )
 
     def test_get_benchmarkable_extern_fn_uses_op_overload(self):
@@ -1249,6 +1421,199 @@ class TestScheduler(TestCase):
         scheduler.shared_data_after_inverting_indexing.assert_not_called()
         scheduler._try_reindex_pointwise_for_reduction.assert_not_called()
 
+    @parametrize("ranked", [False, True])
+    def test_reduction_contract_requires_backend_support(self, ranked):
+        producer = self._mock_base_snode("producer")
+        consumer = self._mock_base_snode("consumer")
+        producer.has_reduction_result.return_value = ranked
+        self.assertEqual(
+            BaseScheduling(None).can_fuse_reduction_pair(producer, consumer),
+            not ranked,
+        )
+
+    def test_reduction_result_rejects_split_scan(self):
+        ranked = self._mock_schedule_node("ranked", is_reduction=True)
+        scan = self._mock_schedule_node("scan", is_reduction=True)
+        ranked.has_reduction_result.return_value = True
+        ranked._body.memory_usage[MemoryUsageType.STORE_REDUCTION] = [
+            MemoryEntry("store", "ranked", None, ("rank", 3))
+        ]
+        ranked.is_split_scan.return_value = False
+        scan.is_split_scan.return_value = True
+        self.assertFalse(TritonScheduling(None).can_fuse_reduction_pair(ranked, scan))
+
+    @parametrize("reverse", [False, True])
+    def test_reduction_result_rejects_template_output(self, reverse):
+        scheduler = object.__new__(Scheduler)
+        scheduler.available_buffer_names = OrderedSet()
+        scheduler._fusion_blocked_by_placement = Mock(return_value=False)
+        backend = TritonScheduling(scheduler)
+        scheduler.get_backend = Mock(return_value=backend)
+
+        template = Mock(spec=ir.TemplateBuffer)
+        template.get_name.return_value = "template"
+        template.is_multi_outputs_template.return_value = True
+        output = object.__new__(ir.MultiOutput)
+        output.name = output.operation_name = "template_output"
+        output.origins = OrderedSet()
+        output.layout = ir.FixedLayout(
+            torch.device("cuda"), torch.float32, [4, 33], [33, 1]
+        )
+        output.inputs = [template]
+        output.mutation_outputs = []
+
+        ranked = self._mock_schedule_node(
+            "ranked", writes=["selected"], group=(4, 33), is_reduction=True
+        )
+        ranked.has_reduction_result.return_value = True
+        ranked.is_split_scan.return_value = False
+        ranked.is_native_matmul.return_value = False
+        ranked._body.memory_usage[MemoryUsageType.STORE_REDUCTION] = [
+            MemoryEntry("store", "selected", None, ("rank", 3))
+        ]
+
+        with V.set_graph_handler(Mock(sizevars=SizeVarAllocator())):
+            producer = scheduler.create_scheduler_node(output)
+            self.assertIsInstance(producer, ExternKernelSchedulerNode)
+            self.assertFalse(scheduler.unfusable_node(producer))
+            pair = (ranked, producer) if reverse else (producer, ranked)
+            self.assertFalse(scheduler._can_fuse(*pair))
+
+    @parametrize("vertical_fusion_legal", [False, True])
+    def test_reduction_result_allows_loop_reordering_only(self, vertical_fusion_legal):
+        producer = self._mock_base_snode("producer", torch.device("cpu"))
+        consumer = self._mock_base_snode("consumer", torch.device("cpu"))
+        producer.has_reduction_result.return_value = True
+        producer.has_strict_reduction.return_value = False
+        consumer.has_strict_reduction.return_value = False
+        producer.ancestors = OrderedSet()
+        consumer.ancestors = OrderedSet(["producer"])
+        producer.get_operation_names.return_value = OrderedSet(["producer"])
+        consumer.get_operation_names.return_value = OrderedSet(["consumer"])
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._fusion_blocked_by_placement = Mock(return_value=False)
+        scheduler._prove_staged_fusion_dependencies = Mock(
+            side_effect=AssertionError("ranked results must not plan staged fusion")
+        )
+        scheduler._score_fusion_memory_for_can_fuse = Mock(return_value=0)
+        scheduler.shared_data_after_reordering_loop = Mock(return_value=8)
+        scheduler.get_expand_dim_for_pointwise_nodes = Mock(
+            side_effect=AssertionError("ranked results must prevent expansion")
+        )
+        scheduler.shared_data_after_inverting_indexing = Mock(
+            side_effect=AssertionError("ranked results must prevent inversion")
+        )
+        scheduler.can_fuse_vertical = Mock(return_value=vertical_fusion_legal)
+        scheduler._try_reindex_pointwise_for_reduction = Mock(
+            side_effect=AssertionError("ranked results must prevent reindexing")
+        )
+        backend = Mock()
+        backend.can_fuse_vertical.return_value = True
+        scheduler.get_backend = Mock(return_value=backend)
+        graph = Mock(no_fuse_buffer_names=OrderedSet())
+        choices = Mock()
+        choices.can_fuse.return_value = True
+        choices.can_fuse_vertical.return_value = True
+
+        with (
+            V.set_graph_handler(graph),
+            V.set_choices_handler(choices),
+            inductor_config.patch(
+                {
+                    "expand_dimension_for_pointwise_nodes": True,
+                    "loop_ordering_after_fusion": True,
+                    "loop_reindexing_after_fusion": True,
+                    "loop_index_inversion_in_fusion": True,
+                }
+            ),
+        ):
+            self.assertEqual(
+                scheduler._can_fuse(producer, consumer, can_reorder=True),
+                vertical_fusion_legal,
+            )
+
+        scheduler.shared_data_after_reordering_loop.assert_called_once()
+        scheduler.can_fuse_vertical.assert_called_once()
+        scheduler.get_expand_dim_for_pointwise_nodes.assert_not_called()
+        scheduler.shared_data_after_inverting_indexing.assert_not_called()
+        scheduler._try_reindex_pointwise_for_reduction.assert_not_called()
+
+    @parametrize("compact", [False, True])
+    def test_reduction_result_reindex_fallback_preserves_domain(self, compact):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.available_buffer_names = OrderedSet()
+        scheduler.get_backend = Mock(return_value=SIMDScheduling(None))
+        scheduler._selected_tiling_memory = Mock(return_value=None)
+        scheduler.score_fusion_memory = Mock(return_value=8)
+        gpu = torch.device("cuda")
+
+        def make_node(name, source, ranked=False):
+            def fn(index, reduction):
+                if ranked:
+                    (row,), (rank,) = index, reduction
+                    value = ops.load(source, 33 * row + rank)
+                    ops.store_reduction(
+                        name, 3 * row + rank, value, result_range=(rank, 3)
+                    )
+                else:
+                    (offset,) = index
+                    ops.store(name, offset, ops.load(source, offset))
+
+            sizes = ([2], [33]) if ranked else ([6 if compact else 66], [])
+            args, ranges = index_vars_squeeze(*sizes, prefix="q")
+            node = object.__new__(SchedulerNode)
+            node.node = Mock(spec=ir.ComputedBuffer)
+            node.node.get_reduction_type.return_value = "sort" if ranked else None
+            node.node.get_device.return_value = gpu
+            node.node.get_device_or_error.return_value = gpu
+            node.scheduler = scheduler
+            node.outputs = []
+            node.mutation_renames = {}
+            node._loop_mutation_listener = None
+            node._loop_state_gen = 0
+            node._body = LoopBody(fn, args, ranges, *args)
+            node._sizes = node._body.sizes
+            node.group = (gpu, scheduler.get_backend(gpu).group_fn(node._sizes))
+            node.read_writes = ReadWrites(OrderedSet(), OrderedSet(), OrderedSet())
+            node.refresh_dependencies(normalize=False, need_clear_tiling_cache=False)
+            return node
+
+        with (
+            V.set_graph_handler(Mock(sizevars=SizeVarAllocator())),
+            inductor_config.patch(
+                loop_ordering_after_fusion=False, loop_reindexing_after_fusion=True
+            ),
+        ):
+            ranked = make_node("ranked", "input", ranked=True)
+            pointwise = make_node("pointwise", "ranked" if compact else "input")
+            before = pointwise.snapshot_loop_state()
+            ranked_state = ranked.snapshot_loop_state()
+            self.assertTrue(ranked.has_reduction_result())
+            with patch.object(
+                pointwise,
+                "apply_loop_reindexing",
+                wraps=pointwise.apply_loop_reindexing,
+            ) as reindex:
+                score = scheduler.shared_data_after_reordering_loop(ranked, pointwise)
+
+            self.assertEqual(ranked.snapshot_loop_state(), ranked_state)
+            if compact:
+                self.assertEqual(score, -1)
+                reindex.assert_not_called()
+                self.assertEqual(pointwise.snapshot_loop_state(), before)
+            else:
+                self.assertEqual(score, 8)
+                reindex.assert_called_once_with([2, 33])
+                self.assertEqual(
+                    [list(s) for s in pointwise.get_ranges()], [[2, 33], []]
+                )
+                after = pointwise.read_writes.reads_and_writes()
+                self.assertEqual(
+                    {dep.normalize() for dep in after},
+                    {dep.normalize() for dep in before[3].reads_and_writes()},
+                )
+
     def test_vertical_fusion_retries_after_reindexing(self):
         producer = self._mock_base_snode("producer", torch.device("cuda"))
         consumer = self._mock_base_snode("consumer", torch.device("cuda"))
@@ -1878,6 +2243,8 @@ class TestScheduler(TestCase):
             prologue_node.is_template.return_value = False
             template_node.is_template.return_value = True
             prologue_node.is_reduction.return_value = False
+            prologue_node.has_reduction_result.return_value = False
+            template_node.has_reduction_result.return_value = False
             prologue_node.ancestors = OrderedSet()
             template_node.ancestors = OrderedSet(["prologue"])
             prologue_node.get_operation_names.return_value = OrderedSet(["prologue"])

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -506,6 +506,7 @@ class BackendFeature(Enum):
     MASKED_SCATTER_WITH_INDEX = auto()
     SCAN = auto()
     SORT = auto()
+    REDUCTION_RESULT = auto()
     TUPLE_REDUCTION = auto()
     PREFER_STORE_LOOP_ORDER = auto()
     TRITON_TEMPLATES = auto()

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1254,7 +1254,14 @@ class OpOverrides(BasicMathOpsMixin, OpDecompositions, OpsHandler[Any]):
             f"{type(self).__name__}: device_assert_async should be handled by CSEProxy"
         )
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: OpVarT) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: OpVarT,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
         raise NotImplementedError(
             f"{type(self).__name__}: store_reduction should be handled by CSEProxy"
         )
@@ -2465,7 +2472,14 @@ class Kernel(CodeGen, Generic[CSEVariableType]):
         finally:
             self.loads = prior
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
         raise NotImplementedError
 
     def store(
@@ -3131,16 +3145,24 @@ class CSEProxy(DefaultHandler):
     def partial_accumulate(self, *args: Any) -> None:
         self.kernel.partial_accumulate(*args)
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
         self.kernel.store_buffer_names.add(name)
         self._update_store_cache(name, value)
-
         if name not in V.graph.removed_buffers:
             self.kernel.num_store += 1
             self.kernel.store_buffer_counts[name] = (
                 self.kernel.store_buffer_counts.get(name, 0) + 1
             )
-            return self.kernel.store_reduction(name, index, value)
+            if result_range is None:
+                return self.kernel.store_reduction(name, index, value)
+            self.kernel.store_reduction(name, index, value, result_range=result_range)
 
     def reduction(
         self,

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2548,7 +2548,9 @@ class CppKernel(Kernel):
         self.reduction_cse.reduction_cache[reduction_key] = result
         return result
 
-    def store_reduction(self, name, index, value):
+    def store_reduction(self, name, index, value, *, result_range=None):
+        if result_range is not None:
+            raise NotImplementedError("C++ reductions require scalar results")
         index = self.rename_indexing(index)
         var = self.args.output(name)
         self.reduction_suffix.writeline(
@@ -3505,7 +3507,9 @@ class CppVecKernel(CppKernel):
         self.reduction_cse.reduction_cache[reduction_key] = result
         return result
 
-    def store_reduction(self, name, index, value):
+    def store_reduction(self, name, index, value, *, result_range=None):
+        if result_range is not None:
+            raise NotImplementedError("C++ reductions require scalar results")
         index = self.rename_indexing(index)
         var = self.args.output(name)
         out_dtype = V.graph.get_dtype(name)

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -354,7 +354,9 @@ class LocalizeBufferHandler(V.WrapperHandler):  # type: ignore[name-defined]
             V.kernel.store_buffer_names.discard(local_buffer_name)
         return res
 
-    def store_reduction(self, name, index, value):
+    def store_reduction(self, name, index, value, *, result_range=None):
+        if result_range is not None:
+            raise NotImplementedError("localized reductions require scalar results")
         # pyrefly: ignore [bad-argument-count]
         return self._inner.store_reduction(*self.localize(name, index), value)
 

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -166,6 +166,7 @@ class CUDACombinedScheduling(BaseScheduling):
             not self._nv_universal_gemm_scheduling.has_conflicting_epilogue_reductions(
                 node1, node2
             )
+            and self._triton_scheduling.can_fuse_reduction_pair(node1, node2)
         )
 
     def can_fuse_reduction_epilogue(

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -611,7 +611,16 @@ class MetalKernel(SIMDKernel):
         else:
             self.stores.writeline(DeferredLine(name, line))
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
+        if result_range is not None:
+            raise NotImplementedError("MPS reductions require scalar results")
         var = self.args.output(name)
         index = self.prepare_indexing(index)
         dtype_str = self.dtype_to_str(V.graph.get_dtype(name))

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2857,6 +2857,12 @@ class SIMDScheduling(BaseScheduling):
 
         Dependency matching proves each fused read hits the position that was
         written; these rules only keep nodes in stages that can hold their values.
+
+        Other passes decline ranked results at their own entry points rather
+        than here: the nested-reduction planners, foreach kernels, the loop
+        rewrites in Scheduler._can_fuse that re-express a consumer over the
+        candidate domain, coalescing analysis, and non-default tiling. A new
+        pass that assumes one result per row must add its own decline.
         """
         if not (node1.has_reduction_result() or node2.has_reduction_result()):
             return super().can_fuse_reduction_pair(node1, node2)
@@ -3094,6 +3100,10 @@ class SIMDScheduling(BaseScheduling):
                     f"got {rnumel1} and {rnumel2}"
                 )
             ordinary_fusion = False
+            # A pointwise node over rows*k is a valid partner for a ranked
+            # (rows, N) reduction: it runs in the k-wide result stage. The
+            # precondition above admits it; this keeps the ordinary numel
+            # check from rejecting it.
             stage_rnumel = rnumel2
             if node2.has_reduction_result():
                 result_size = self._reduction_result_size(node2.get_nodes())

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -38,6 +38,7 @@ from .. import config, ir, scheduler
 from ..analyze_preserves_zero_mask import prologue_preserves_zero_mask
 from ..codecache import code_hash, PyCodeCache
 from ..dependencies import MemoryDep, StarDep, WeakDep
+from .common import BackendFeature
 
 
 if TYPE_CHECKING:
@@ -2840,7 +2841,6 @@ class SIMDScheduling(BaseScheduling):
 
     kernel_type: type[Any] = SIMDKernel  # override in subclass
     supports_sub_parent_epilogue = False
-    supports_reduction_result = False
 
     def group_fn(self, sizes):
         return tuple(V.graph.sizevars.simplify(sympy_product(s)) for s in sizes)
@@ -2868,7 +2868,9 @@ class SIMDScheduling(BaseScheduling):
             return super().can_fuse_reduction_pair(node1, node2)
         why = WhyNoFuse(node1, node2)
         nodes = [*node1.get_nodes(), *node2.get_nodes()]
-        if not self.supports_reduction_result:
+        if BackendFeature.REDUCTION_RESULT not in self.get_backend_features(
+            node1.get_device()
+        ):
             why("backend does not support ranked reduction results")
             return False
         if any(
@@ -2888,7 +2890,9 @@ class SIMDScheduling(BaseScheduling):
             return False
         _, (numel, rnumel) = reductions[0].group
         # The compact result lives in a persistent [rows, k] tile: split scans
-        # and multi-axis tilings such as native matmul cannot hold it.
+        # and multi-axis tilings such as native matmul cannot hold it. This is
+        # the same select_tiling call codegen makes later; only ranked pairs pay
+        # for it at fusion time.
         if (
             any(n.is_split_scan() for n in nodes)
             or len(self.select_tiling(nodes, numel, rnumel)) != 2

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -726,7 +726,16 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         used in the fused kernel.
         """
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
+        if result_range is not None:
+            raise NotImplementedError("reduction result ranges are not supported")
         prior = self.inside_reduction
         self.inside_reduction = False
         try:
@@ -794,7 +803,13 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         new_index = sympy_subs(index, dict(zip(index_vars, reindex(new_index_vars))))
         return new_index
 
-    def disable_reduction(self) -> contextlib.AbstractContextManager[None]:
+    def disable_reduction(
+        self, result_size: int = 1
+    ) -> contextlib.AbstractContextManager[None]:
+        if result_size != 1:
+            raise NotImplementedError(
+                "backend does not support ranked reduction results"
+            )
         should_flush = self.range_trees[-1].is_loop or self.cooperative_reduction
 
         @contextlib.contextmanager
@@ -1625,8 +1640,8 @@ class _DerivedIterationFamily:
     ) -> None:
         """Mark values as valid on their materialized derived-domain tiles.
 
-        The planner proves exact divisibility, so the target-family mask is
-        equivalent to projecting the source mask through every lane.
+        Callers must prove that values are valid throughout this family's
+        logical domain; the family masks exclude physical padding.
         """
         # Internal sources may materialize before epilogue activation. Their
         # parent body is still pending, so loop-local headers stay in that pass.
@@ -2284,7 +2299,16 @@ class _GroupedReductionOpsHandler(WrapperHandler):  # type: ignore[type-arg]
             self._layout.output_shape,
         )
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
+        if result_range is not None:
+            raise NotImplementedError("grouped reductions require scalar results")
         remapped_index = self._family.remap_index(index)
         with self._family.ensure_active(self._kernel):
             self._inner.store(name, remapped_index, value)
@@ -2636,10 +2660,17 @@ class _SubParentValueResolver(WrapperHandler):  # type: ignore[type-arg]
         if mode is None:
             self._record(name, value, store=True)
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: CSEVariable) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
         """Record an in-kernel reduction source after ordinary codegen emits it."""
         value = self._resolve_pending(value)
-        self._inner.store_reduction(name, index, value)
+        self._inner.store_reduction(name, index, value, result_range=result_range)
         self._record(name, value, store=True)
 
     def _materialize(self, value: CSEVariable) -> MaterializedSubParentValue | None:
@@ -2809,9 +2840,95 @@ class SIMDScheduling(BaseScheduling):
 
     kernel_type: type[Any] = SIMDKernel  # override in subclass
     supports_sub_parent_epilogue = False
+    supports_reduction_result = False
 
     def group_fn(self, sizes):
         return tuple(V.graph.sizevars.simplify(sympy_product(s)) for s in sizes)
+
+    @staticmethod
+    def _reduction_result_size(nodes: Sequence[BaseSchedulerNode]) -> int | None:
+        sizes = OrderedSet(
+            size for _, size in scheduler._reduction_result_ranges(nodes)
+        )
+        return next(iter(sizes), 1) if len(sizes) <= 1 else None
+
+    def can_fuse_reduction_pair(self, node1, node2) -> bool:
+        """Result-stage precondition; the ordinary fusion ladder still runs after it.
+
+        Dependency matching proves each fused read hits the position that was
+        written; these rules only keep nodes in stages that can hold their values.
+        """
+        if not (node1.has_reduction_result() or node2.has_reduction_result()):
+            return super().can_fuse_reduction_pair(node1, node2)
+        why = WhyNoFuse(node1, node2)
+        nodes = [*node1.get_nodes(), *node2.get_nodes()]
+        if not self.supports_reduction_result:
+            why("backend does not support ranked reduction results")
+            return False
+        if any(
+            isinstance(n, scheduler.FusedStagedReduction) for n in (node1, node2)
+        ) or any(
+            not isinstance(n, scheduler.SchedulerNode) or n.is_template() for n in nodes
+        ):
+            why("ranked results require loop nodes without staged or template fusion")
+            return False
+        rank_size = self._reduction_result_size(nodes)
+        if rank_size is None:
+            why("ranked result sizes differ")
+            return False
+        reductions = [n for n in nodes if n.is_reduction()]
+        if not reductions:
+            why("ranked results require a reduction input domain")
+            return False
+        _, (numel, rnumel) = reductions[0].group
+        # The compact result lives in a persistent [rows, k] tile: split scans
+        # and multi-axis tilings such as native matmul cannot hold it.
+        if (
+            any(n.is_split_scan() for n in nodes)
+            or len(self.select_tiling(nodes, numel, rnumel)) != 2
+        ):
+            why("kernel layout does not support ranked reduction results")
+            return False
+        if any(n.group[1] != (numel, rnumel) for n in reductions):
+            why("ranked results require one reduction iteration space")
+            return False
+
+        result_numel = numel * rank_size
+        result_buffers = OrderedSet(
+            name
+            for n in nodes
+            if n.has_reduction_result() or n.group[1] == (result_numel, 1)
+            for name in n.get_buffer_names()
+        )
+        for n in nodes:
+            node_numel, node_rnumel = n.group[1]
+            in_result_stage = node_rnumel == 1 and node_numel == result_numel
+            if not in_result_stage and any(
+                dep.name in result_buffers for dep in n.read_writes.reads
+            ):
+                why("result-stage buffers are only readable in the result stage")
+                return False
+            if n.is_reduction():
+                continue
+            if in_result_stage:
+                stage = (numel, sympy.Integer(rank_size))
+            elif node_numel == numel * rnumel:
+                stage = (numel, rnumel)
+            elif node_numel == numel:
+                continue
+            else:
+                why(
+                    "numel mismatch (ranked) (%s, %s), (%s, %s)",
+                    numel,
+                    rnumel,
+                    node_numel,
+                    node_rnumel,
+                )
+                return False
+            if not SIMDKernel.is_compatible(stage, n.get_ranges()):
+                why("node ranges incompatible with its stage")
+                return False
+        return True
 
     def can_fuse(self, node1, node2):
         """
@@ -2977,9 +3094,14 @@ class SIMDScheduling(BaseScheduling):
                     f"got {rnumel1} and {rnumel2}"
                 )
             ordinary_fusion = False
-            if numel1 == numel2 * rnumel2:
+            stage_rnumel = rnumel2
+            if node2.has_reduction_result():
+                result_size = self._reduction_result_size(node2.get_nodes())
+                if result_size is not None and numel1 == numel2 * result_size:
+                    stage_rnumel = sympy.Integer(result_size)
+            if numel1 == numel2 * stage_rnumel:
                 ordinary_fusion = all(
-                    SIMDKernel.is_compatible((numel2, rnumel2), n.get_ranges())
+                    SIMDKernel.is_compatible((numel2, stage_rnumel), n.get_ranges())
                     for n in node1.get_nodes()
                 )
                 if not ordinary_fusion:
@@ -2992,7 +3114,7 @@ class SIMDScheduling(BaseScheduling):
                         node1.get_tiling(numel1, sympy.S.One).values()
                     ) in (
                         (numel1, 1),
-                        (numel2, rnumel2, 1),
+                        (numel2, stage_rnumel, 1),
                     )
                     if not ordinary_fusion:
                         why("invalid tiling for reduction")
@@ -3180,6 +3302,10 @@ class SIMDScheduling(BaseScheduling):
         maybe_split_index: int | None = None
         current_loop_has_reduction = False
         completed_reduction_loop = False
+        result_size = self._reduction_result_size(nodes)
+        if result_size is None:
+            raise AssertionError("fused reductions must have compatible output ranges")
+        last_result_size = 1
 
         def fits_in_main_body(n):
             _, (node_numel, node_rnumel) = n.group
@@ -3189,7 +3315,11 @@ class SIMDScheduling(BaseScheduling):
 
         def fits_outside_reduction(n):
             _, (node_numel, node_rnumel) = n.group
-            return node_numel == numel and node_rnumel == 1 and rnumel != 1
+            return (
+                node_numel in (numel, numel * result_size)
+                and node_rnumel == 1
+                and rnumel != 1
+            )
 
         def expect_improved_memory_usage(n):
             for read in n.read_writes.reads:
@@ -3217,20 +3347,25 @@ class SIMDScheduling(BaseScheduling):
                 current_loop_buffer_usage.update([x.name for x in n.read_writes.writes])
 
         @contextlib.contextmanager
-        def end_current_reduction_loop():
+        def end_current_reduction_loop(output_size=1):
             nonlocal completed_reduction_loop, current_loop_has_reduction
-            nonlocal maybe_split_index
+            nonlocal maybe_split_index, last_result_size
             completed_reduction_loop |= current_loop_has_reduction
-            if node_schedule and node_schedule[-1] is EnableReduction:
+            if (
+                node_schedule
+                and isinstance(node_schedule[-1], EnableReduction)
+                and last_result_size == output_size
+            ):
                 node_schedule.pop()
             else:
-                node_schedule.append(DisableReduction)
+                node_schedule.append(DisableReduction(output_size))
+                last_result_size = output_size
             if maybe_split_index:
-                node_schedule.insert(maybe_split_index, DisableReduction)
-                node_schedule.insert(maybe_split_index + 1, EnableReduction)
+                node_schedule.insert(maybe_split_index, DisableReduction())
+                node_schedule.insert(maybe_split_index + 1, EnableReduction())
                 maybe_split_index = None
             yield
-            node_schedule.append(EnableReduction)
+            node_schedule.append(EnableReduction())
             not_ready_yet_nodes.clear()
             current_loop_buffer_usage.clear()
             current_loop_has_reduction = False
@@ -3291,7 +3426,8 @@ class SIMDScheduling(BaseScheduling):
 
                 schedule_node_in_loop(node)
             elif fits_outside_reduction(node):
-                with end_current_reduction_loop():
+                output_size = 1 if node.group[1][0] == numel else result_size
+                with end_current_reduction_loop(output_size):
                     node_schedule.append(node)
             else:
                 raise NotImplementedError(
@@ -3874,7 +4010,7 @@ class SIMDScheduling(BaseScheduling):
         )
         parent_full_load_transform = _ParentFullLoadTransform(kernel, layout)
         for sn in grouped_schedule:
-            if sn in (DisableReduction, EnableReduction):
+            if isinstance(sn, NodeScheduleMarker):
                 # These markers only control standalone reduction-loop
                 # emission. Nested codegen lowers the grouped reduction as a
                 # local reshape+reduce inside the outer kernel, so there is no
@@ -4221,7 +4357,10 @@ class SIMDScheduling(BaseScheduling):
         if len(nodes) == 0:
             return
 
-        if torch._inductor.config.triton.coalesce_tiling_analysis:
+        if (
+            torch._inductor.config.triton.coalesce_tiling_analysis
+            and not node.has_reduction_result()
+        ):
             if len(nodes) != len(node.get_nodes()):
                 if not self.scheduler:
                     raise AssertionError("expected self.scheduler to be set")
@@ -4434,9 +4573,9 @@ class SIMDScheduling(BaseScheduling):
 
         # First pass to collect indexing and decide inplace updates
         for node in node_schedule:
-            if node is DisableReduction:
-                stack.enter_context(kernel.disable_reduction())
-            elif node is EnableReduction:
+            if isinstance(node, DisableReduction):
+                stack.enter_context(kernel.disable_reduction(node.result_size))
+            elif isinstance(node, EnableReduction):
                 stack.close()
             else:
                 node.decide_inplace_update()
@@ -4449,9 +4588,9 @@ class SIMDScheduling(BaseScheduling):
 
         # Second pass to do codegen
         for node in node_schedule:
-            if node is DisableReduction:
-                stack.enter_context(kernel.disable_reduction())
-            elif node is EnableReduction:
+            if isinstance(node, DisableReduction):
+                stack.enter_context(kernel.disable_reduction(node.result_size))
+            elif isinstance(node, EnableReduction):
                 stack.close()
             else:
                 # TODO - use split ranges ?
@@ -5991,6 +6130,12 @@ class SIMDScheduling(BaseScheduling):
                     tiling = cls.create_tiling(range_y_x, range_r)
                     return _TilingSelection(tiling, None, None)
 
+        if any(
+            node.has_reduction_result()
+            for node in NodeScheduleMarker.only_nodes(node_schedule)
+        ):
+            return _TilingSelection(default_tiling, None, None)
+
         # # TODO: enable by default
         if (
             torch._inductor.config.triton.coalesce_tiling_analysis
@@ -6125,6 +6270,7 @@ class SIMDScheduling(BaseScheduling):
             if (
                 coalesce_analysis is None
                 and torch._inductor.config.triton.coalesce_tiling_analysis
+                and not any(node.has_reduction_result() for node in nodes)
             ):
                 from torch._inductor.tiling_utils import (
                     analyze_memory_coalescing_for_nodes,

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -61,25 +61,28 @@ class NodeScheduleMarker:
     @staticmethod
     def only_nodes(it: Iterable[NodeScheduleEntry]) -> Iterable[SchedulerNode]:
         for item in it:
-            if not (item is DisableReduction or item is EnableReduction):
-                yield item  # type: ignore[misc]
+            if not isinstance(item, NodeScheduleMarker):
+                yield item
 
     @staticmethod
     def is_reduction() -> bool:
         return False
 
 
-NodeScheduleEntry = SchedulerNode | type[NodeScheduleMarker]
+NodeScheduleEntry = SchedulerNode | NodeScheduleMarker
 
 
+@dataclasses.dataclass(frozen=True)
 class DisableReduction(NodeScheduleMarker):
     """
-    Marker to invoke `kernel.disable_reduction()`.  This closes a
-    reduction loop and allows for pointwise ops to occur on the output
-    of a reduction.
+    Close a reduction loop and run pointwise operations over its output.
+    Scalar reductions have result_size=1; compact outputs retain that extent.
     """
 
+    result_size: int = 1
 
+
+@dataclasses.dataclass(frozen=True)
 class EnableReduction(NodeScheduleMarker):
     """
     Marker to end a DisableReduction block.
@@ -93,13 +96,11 @@ class EnableReduction(NodeScheduleMarker):
         """
         disabled = False
         for node in node_schedule:
-            if node in (EnableReduction, DisableReduction):
+            if isinstance(node, NodeScheduleMarker):
                 # Don't tile stuff outside the main reduction loop
-                disabled = node is DisableReduction
-            elif disabled:
-                pass
-            else:
-                yield node  # type: ignore[misc]
+                disabled = isinstance(node, DisableReduction)
+            elif not disabled:
+                yield node
 
 
 class SIMDKernelFeatures:
@@ -433,16 +434,15 @@ class MemoryEstimator:
     def simulate_codegen(self) -> None:
         from .simd import SIMDKernel
 
-        kernel_size_outside_loop = (*self.groups[:-1], sympy.S.One)
         kernel_size_inside_loop = tuple(self.groups)
         self.kernel_sizes = kernel_size_inside_loop
 
         for node in self.features.node_schedule:
-            if node is DisableReduction:
+            if isinstance(node, DisableReduction):
                 self.inside_reduction = False
-                self.kernel_sizes = kernel_size_outside_loop
+                self.kernel_sizes = (*self.groups[:-1], sympy.Integer(node.result_size))
                 continue
-            elif node is EnableReduction:
+            elif isinstance(node, EnableReduction):
                 self.inside_reduction = True
                 self.kernel_sizes = kernel_size_inside_loop
                 self.loops.append(MemoryEstimate())

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -8499,7 +8499,6 @@ class TritonScheduling(SIMDScheduling):
     """Scheduling backend for Triton kernel code generation."""
 
     supports_sub_parent_epilogue = True
-    supports_reduction_result = True
     kernel_type: type[Any] = TritonKernel
     backend_features = OrderedSet(
         [
@@ -8509,6 +8508,7 @@ class TritonScheduling(SIMDScheduling):
             BackendFeature.MASKED_SCATTER_WITH_INDEX,
             BackendFeature.SCAN,
             BackendFeature.SORT,
+            BackendFeature.REDUCTION_RESULT,
             BackendFeature.TRITON_TEMPLATES,
             BackendFeature.TUPLE_REDUCTION,
         ]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -119,6 +119,7 @@ from .common import (
     WorkspaceZeroMode,
 )
 from .simd import (
+    _DerivedIterationFamily,
     constant_repr,
     DerivedIterationRangesRoot,
     IterationRanges,
@@ -3353,6 +3354,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             collections.defaultdict(dict)
         )
         self.tma_min_block_sizes = dict[str, int]()
+        self.reduction_result_families: dict[int, _DerivedIterationFamily] = {}
         # TensorDescriptorOptions for pointwise/reduction kernels; template
         # kernels set a resolved {block_shape, shape, strides} dict directly
         # (see TritonTemplateKernel.tma_descriptor).
@@ -6417,7 +6419,21 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         name: str,
         index: sympy.Expr,
         value: CSEVariable,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
     ):
+        if result_range is not None:
+            rank, rank_size = result_range
+            family = self.reduction_result_family(rank_size)
+            output_rank = family.range_trees[-1].full_range().symbol()
+            result_index = index.subs(rank, output_rank)
+            if output_rank not in result_index.free_symbols:
+                raise AssertionError(
+                    f"expected result rank {rank} in store index {index}"
+                )
+            with family.ensure_active(self):
+                self.store(name, result_index, value)
+            return
         if not self.inside_reduction:
             raise AssertionError("expected inside_reduction")
         self.inside_reduction = False
@@ -6813,6 +6829,33 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             result_var.mask_vars = OrderedSet(masks)
 
         return tuple(result_vars)
+
+    @contextlib.contextmanager
+    def disable_reduction(self, result_size: int = 1):
+        if result_size == 1:
+            with super().disable_reduction():
+                yield
+        else:
+            self.codegen_body()
+            with self.reduction_result_family(result_size).activate(self):
+                yield
+                self.codegen_body()
+
+    def reduction_result_family(self, rank_size: int) -> _DerivedIterationFamily:
+        if rank_size not in self.reduction_result_families:
+            if not self.persistent_reduction or self.num_reduction_dims != 1:
+                raise AssertionError("reduction results require one persistent axis")
+            rank_tree = DerivedIterationRangesRoot(
+                self.range_trees[-1],
+                numel=sympy.Integer(rank_size),
+                block_size=sympy.Integer(next_power_of_2(rank_size)),
+                block_offset=sympy.S.Zero,
+                name_suffix=f"result{rank_size}",
+            )
+            self.reduction_result_families[rank_size] = _DerivedIterationFamily(
+                range_trees=(*self.range_trees[:-1], rank_tree),
+            )
+        return self.reduction_result_families[rank_size]
 
     def sort(
         self,
@@ -8456,6 +8499,7 @@ class TritonScheduling(SIMDScheduling):
     """Scheduling backend for Triton kernel code generation."""
 
     supports_sub_parent_epilogue = True
+    supports_reduction_result = True
     kernel_type: type[Any] = TritonKernel
     backend_features = OrderedSet(
         [

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -1246,7 +1246,7 @@ def set_kernel_post_grad_provenance_tracing(
         return None
 
     try:
-        from .codegen.simd_kernel_features import DisableReduction, EnableReduction
+        from .codegen.simd_kernel_features import NodeScheduleMarker
 
         global _inductor_triton_kernel_to_post_grad_node_info
         global _inductor_kernel_stack_trace
@@ -1328,7 +1328,7 @@ def set_kernel_post_grad_provenance_tracing(
                 raise AssertionError(f"expected list, got {type(node_schedule)}")
             stack_traces_set: OrderedSet[str] = OrderedSet()
             for snode in node_schedule:
-                if snode not in (EnableReduction, DisableReduction):
+                if not isinstance(snode, NodeScheduleMarker):
                     if snode.node is not None:
                         curr_node_info = (
                             _inductor_triton_kernel_to_post_grad_node_info.setdefault(

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -667,7 +667,9 @@ class _RecordLoadStoreInner(V.MockHandler):  # type: ignore[name-defined]
             return
         rank, rank_size = result_range
         if rank == 0:
-            # Projected dependency queries omit the reduction coordinate.
+            # SchedulerNode.pointwise_or_reduction_read_writes projects the
+            # reduction coordinate to zero; treat the store as scalar there. A
+            # real ranked store always passes its rank loop variable.
             self.store(name, index, value)
             return
         if not isinstance(rank, sympy.Symbol) or rank not in self._var_ranges:

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -621,11 +621,13 @@ class _RecordLoadStoreInner(V.MockHandler):  # type: ignore[name-defined]
         return index, tuple(new_vars), tuple(new_sizes)  # type: ignore[arg-type]
 
     def canonicalize(
-        self, index: sympy.Expr
+        self, index: sympy.Expr, var_ranges: VarRanges | None = None
     ) -> tuple[sympy.Expr, tuple[sympy.Symbol, ...], tuple[sympy.Expr, ...]]:
+        if var_ranges is None:
+            var_ranges = self._var_ranges
         if not self._should_normalize:
-            sizes = [V.graph.sizevars.simplify(x) for x in self._var_ranges.values()]
-            var_names = [k for k, v in zip(self._var_ranges.keys(), sizes) if v != 1]
+            sizes = [V.graph.sizevars.simplify(x) for x in var_ranges.values()]
+            var_names = [k for k, v in zip(var_ranges.keys(), sizes) if v != 1]
             sizes = [v for v in sizes if v != 1]
 
             self.drop_unused_symbols(index, var_names, sizes)
@@ -633,7 +635,7 @@ class _RecordLoadStoreInner(V.MockHandler):  # type: ignore[name-defined]
             return index, tuple(var_names), tuple(sizes)  # type: ignore[return-value, arg-type]
         var_ranges = {
             k: V.graph.sizevars.simplify(v)
-            for k, v in self._var_ranges.items()
+            for k, v in var_ranges.items()
             # TODO(jansel): explore this further normalization
             # if k in free_symbols
         }
@@ -652,8 +654,29 @@ class _RecordLoadStoreInner(V.MockHandler):  # type: ignore[name-defined]
     ) -> None:
         self._writes.add(MemoryDep(name, *self.canonicalize(index), mode=mode))
 
-    def store_reduction(self, name: str, index: sympy.Expr, value: str) -> None:
-        self.store(name, index, f"store_reduction({value})")
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: str,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
+        if result_range is None:
+            self.store(name, index, value)
+            return
+        rank, rank_size = result_range
+        if rank == 0:
+            # Projected dependency queries omit the reduction coordinate.
+            self.store(name, index, value)
+            return
+        if not isinstance(rank, sympy.Symbol) or rank not in self._var_ranges:
+            raise AssertionError(f"expected a result-rank loop variable, got {rank}")
+        result_ranges = {**self._var_ranges, rank: sympy.Integer(rank_size)}
+        if rank_size == 1:
+            index = sympy_subs(index, {rank: sympy.S.Zero})
+        index = V.graph.sizevars.simplify_with_ranges(index, result_ranges)
+        self._writes.add(MemoryDep(name, *self.canonicalize(index, result_ranges)))
 
     def index_expr(self, index: sympy.Expr, dtype: torch.dtype | None) -> None:
         self._index_exprs.add(IndexExprDep(*self.canonicalize(index)))
@@ -788,10 +811,15 @@ def extract_loop_body_with_args(
             entry.mode,
         )
     for entry in fn.memory_usage[MemoryUsageType.STORE_REDUCTION]:
+        result_range = None
+        if entry.result_range is not None:
+            rank_name, rank_size = entry.result_range
+            result_range = (name_to_index[rank_name], rank_size)
         inner.store_reduction(
             entry.buffer_name,
             name_to_index[entry.index_name],
             None,  # type: ignore[arg-type]
+            result_range=result_range,
         )
     for entry in fn.memory_usage[MemoryUsageType.INDEX_EXPR]:
         inner.index_expr(name_to_index[entry.index_name], None)

--- a/torch/_inductor/dtype_propagation.py
+++ b/torch/_inductor/dtype_propagation.py
@@ -348,7 +348,13 @@ class DtypePropagationOpsHandler:
         return torch.float
 
     @staticmethod
-    def store_reduction(name: str, index, value: DTypeArg) -> None:
+    def store_reduction(
+        name: str,
+        index,
+        value: DTypeArg,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
         return None
 
     @staticmethod

--- a/torch/_inductor/kernel/loop_ir_epilogue_lowering.py
+++ b/torch/_inductor/kernel/loop_ir_epilogue_lowering.py
@@ -165,8 +165,15 @@ class _GemmEpilogueIRHandler(DefaultHandler):
         self.stores[name] = GemmEpilogueIRStore(index, value)
 
     def store_reduction(
-        self, name: str, index: sympy.Expr, value: GemmEpilogueIRExpression
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: GemmEpilogueIRExpression,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
     ) -> None:
+        if result_range is not None:
+            raise NotImplementedError("GEMM epilogues require scalar reduction results")
         self.stores[name] = GemmEpilogueIRStore(index, value)
 
 

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -78,6 +78,7 @@ class MemoryEntry(NamedTuple):
     index_name: str  # LoopBody.indexing_exprs[index_name]
     buffer_name: str | None
     mode: str | None  # V.ops.store(..., mode=mode)
+    result_range: tuple[str, int] | None = None  # (rank index name, rank size)
 
 
 class MemoryUsageType(Enum):
@@ -511,9 +512,10 @@ class LoopBody:
     def add_index_expr(
         self,
         expr: sympy.Expr,
-        mtype: MemoryUsageType,
+        mtype: MemoryUsageType | None,
         buffer_name: str | None = None,
         mode: str | None = None,
+        result_range: tuple[str, int] | None = None,
     ):
         expr = self._wrap_int_to_sympy_integer(expr)
         name = self.indexing_exprs_name.get(expr)
@@ -521,7 +523,10 @@ class LoopBody:
             name = f"index{len(self.indexing_exprs)}"
             self.indexing_exprs_name[expr] = name
             self.indexing_exprs[name] = expr
-        self.memory_usage[mtype].append(MemoryEntry(name, buffer_name, mode))
+        if mtype is not None:
+            self.memory_usage[mtype].append(
+                MemoryEntry(name, buffer_name, mode, result_range)
+            )
         return name
 
     def add_submodule(self, block, prefix):
@@ -715,6 +720,8 @@ class CountOps(DefaultHandler):
 
 
 class CaptureIndexing(WrapperHandler):
+    r"""Capture symbolic indices and memory accesses while tracing a LoopBody."""
+
     name = "CaptureIndexing"
 
     def __init__(
@@ -758,12 +765,28 @@ class CaptureIndexing(WrapperHandler):
         )
         return self._inner.store(name, index, value, mode)
 
-    def store_reduction(self, name, index, value):
+    def store_reduction(self, name, index, value, *, result_range=None):
+        rank_range = None
+        if result_range is not None:
+            rank, rank_size = result_range
+            rank_name = self.body.add_index_expr(rank, None)
+            rank_range = (rank_name, rank_size)
+            rank = self.tracer.create_proxy(
+                "call_module", "get_index", (rank_name,), {}
+            )
+            result_range = (rank, rank_size)
         index = self._simplify(index)
         index = self._add_index(
-            index, MemoryUsageType.STORE_REDUCTION, buffer_name=name
+            index,
+            MemoryUsageType.STORE_REDUCTION,
+            buffer_name=name,
+            result_range=rank_range,
         )
-        return self._inner.store_reduction(name, index, value)
+        if result_range is None:
+            return self._inner.store_reduction(name, index, value)
+        return self._inner.store_reduction(
+            name, index, value, result_range=result_range
+        )
 
     def reduction(self, dtype, src_dtype, reduction_type, value):
         result = self._inner.reduction(dtype, src_dtype, reduction_type, value)

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -301,7 +301,10 @@ class OpsHandler(Generic[T]):
 
         With ``result_range=(rank, size)``, the value is stored once per rank
         in ``[0, size)`` instead of once per row; only this store uses that
-        result domain, and input loads keep the full reduction extent.
+        result domain, and input loads keep the full reduction extent. The
+        Triton emitter keeps ranked results in registers, so the producing
+        kernel must be a persistent, non-cooperative reduction; ops.sort
+        guarantees this, and any other producer must too.
         """
         raise NotImplementedError
 

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -287,10 +287,21 @@ class OpsHandler(Generic[T]):
     # TODO: in practice, this seems to actually return None, but not returning
     # a T makes common __getattr__ idioms not type correctly.  Figure out if
     # this should be returning something.
-    def store_reduction(self, name: str, index: sympy.Expr, value: T) -> None:
+    def store_reduction(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: T,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
         """
         Store the fully accumulated result of 'reduction' to the memory
         location 'name' offset by 'expr'.
+
+        With ``result_range=(rank, size)``, the value is stored once per rank
+        in ``[0, size)`` instead of once per row; only this store uses that
+        result domain, and input loads keep the full reduction extent.
         """
         raise NotImplementedError
 

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -241,7 +241,12 @@ class _ValueUseRules:
         )
 
     def store_reduction(
-        self, name: str, index: sympy.Expr, value: object
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: object,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
     ) -> _ValueUseRule:
         return _ValueUseRule(
             value_sinks=(value,),

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -70,7 +70,7 @@ from .ir import (
     MultiOutputLayout,
     NoneLayout,
 )
-from .loop_body import LoopBody
+from .loop_body import LoopBody, MemoryUsageType
 from .memory import MemoryPlanningInfoForBuffer, MemoryPlanningInfoForNode
 from .runtime.hints import DeviceProperties, ReductionHint
 from .runtime.runtime_utils import green_text, is_power_of_2, red_text
@@ -566,6 +566,8 @@ class NestedReduction:
             and _is_gpu_triton_backend(outer_node, grouped_node)
             and not outer_node.has_strict_reduction()
             and not grouped_node.has_strict_reduction()
+            and not outer_node.has_reduction_result()
+            and not grouped_node.has_reduction_result()
         )
 
     @classmethod
@@ -712,6 +714,8 @@ class NestedReduction:
         ``None`` when the candidate cannot be emitted safely. See Note
         [Sub-parent reduction epilogues].
         """
+        if any(node.has_reduction_result() for node in nodes):
+            return None
         parent_rnumel = V.graph.sizevars.simplify(rnumel)
         if not cls._mutations_survive_hoisting(nodes):
             return None
@@ -1667,7 +1671,7 @@ class NestedReduction:
         cls, grouped_node: BaseSchedulerNode, grouped_rnumel: sympy.Expr
     ) -> tuple[SchedulerNode, sympy.Integer] | None:
         """Validate the candidate as a single simple grouped reduction."""
-        if not grouped_node.is_reduction():
+        if not grouped_node.is_reduction() or grouped_node.has_reduction_result():
             return None
         reductions = [sn for sn in grouped_node.get_nodes() if sn.is_reduction()]
         if len(reductions) != 1:
@@ -2153,6 +2157,8 @@ class NestedReduction:
         extend the grouped topology. The approved axis and group size remain
         stable while ranges and domains are rebuilt from the final nodes.
         """
+        if outer_node.has_reduction_result() or grouped_node.has_reduction_result():
+            return None
         _, (outer_numel, outer_rnumel) = outer_node.group
         _, (grouped_numel, grouped_rnumel) = grouped_node.group
         domain_context = cls.PointwiseDomainContext.create(
@@ -2612,6 +2618,17 @@ class SchedulerDonatedBuffer(SchedulerBuffer):
     defining_op: BaseSchedulerNode | None = None
 
 
+def _reduction_result_ranges(
+    nodes: Iterable[BaseSchedulerNode],
+) -> Iterator[tuple[str, int]]:
+    """Yield (rank index name, result size) for every ranked store_reduction."""
+    for node in nodes:
+        if isinstance(node, SchedulerNode) and node._body is not None:
+            for entry in node._body.memory_usage[MemoryUsageType.STORE_REDUCTION]:
+                if entry.result_range is not None:
+                    yield entry.result_range
+
+
 class BaseSchedulerNode:
     """
     One unit of work the scheduler orders, fuses and then hands to a backend.
@@ -2787,6 +2804,7 @@ class BaseSchedulerNode:
         typing.cast(Any, self.get_tiling).clear_cache(self)
         self.read_write_deps.clear_cache(self)
         self.read_size_by_name.clear_cache(self)
+        self.has_reduction_result.clear_cache(self)
 
     @cache_on_self
     def get_coalesce_analysis(self) -> CoalesceVarAnalysis | None:
@@ -2919,6 +2937,10 @@ class BaseSchedulerNode:
             and node.node.data.strict_reduction_rblock is not None
             for node in self.get_nodes()
         )
+
+    @cache_on_self
+    def has_reduction_result(self) -> bool:
+        return next(_reduction_result_ranges(self.get_nodes()), None) is not None
 
     def get_outputs(self) -> Sequence[SchedulerBuffer]:
         return self.outputs
@@ -5021,7 +5043,9 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
 
         # Keep strict reductions standalone so their planned R0_BLOCK cannot change.
         filtered_nodes = [
-            node for node in filtered_nodes if not node.has_strict_reduction()
+            node
+            for node in filtered_nodes
+            if not node.has_strict_reduction() and not node.has_reduction_result()
         ]
 
         # Filter out reduction nodes if combo_kernels_pointwise_only is enabled
@@ -10202,6 +10226,16 @@ class Scheduler:
         else:
             plan = None
 
+        reduction_result = node1.has_reduction_result() or node2.has_reduction_result()
+        # Ranked results keep their result-domain coordinates. Dimension
+        # expansion, index inversion, and the late reindex retry could
+        # re-express a compact consumer over the candidate domain, so they are
+        # skipped. Loop reordering re-traces bodies and re-extracts
+        # dependencies, and its reindex fallback only applies to pointwise
+        # nodes covering the full candidate extent, so it stays allowed.
+        allow_loop_rewrites = plan is None and not reduction_result
+        allow_loop_reorder = plan is None
+
         # A plan authorizes fusion only after every cross-domain producer
         # dependency is proved.
         staged_matches = None
@@ -10228,7 +10262,7 @@ class Scheduler:
             )
 
         if (
-            plan is None
+            allow_loop_rewrites
             and config.expand_dimension_for_pointwise_nodes
             and (
                 expand_analysis := self.get_expand_dim_for_pointwise_nodes(node1, node2)
@@ -10242,7 +10276,7 @@ class Scheduler:
             )
 
         if (
-            plan is None
+            allow_loop_reorder
             and can_reorder
             and shared_data_score < config.score_fusion_memory_threshold
             and (
@@ -10254,7 +10288,7 @@ class Scheduler:
                 shared_data_score = new_shared_data_score
 
         if (
-            plan is None
+            allow_loop_rewrites
             and config.loop_index_inversion_in_fusion
             and shared_data_score < config.score_fusion_memory_threshold
         ):
@@ -10296,7 +10330,7 @@ class Scheduler:
             # reduction's domain and retry. A staged plan keeps its original
             # frame because reindexing would invalidate its exact matches.
             if (
-                plan is None
+                allow_loop_rewrites
                 and config.loop_reindexing_after_fusion
                 and self._try_reindex_pointwise_for_reduction(node1, node2)
             ):
@@ -12465,7 +12499,8 @@ class BaseScheduling:  # noqa: docstring_linter
     def can_fuse_reduction_pair(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
-        return True
+        """Admit reduction contracts before fusion checks; unknown contracts decline."""
+        return not (node1.has_reduction_result() or node2.has_reduction_result())
 
     def can_fuse_multi_outputs_template(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode

--- a/torch/_inductor/shape_propagation.py
+++ b/torch/_inductor/shape_propagation.py
@@ -99,7 +99,13 @@ class ShapePropagationOpsHandler:
             return ()
 
     @staticmethod
-    def store_reduction(name: str, index: int, value: ShapeArg) -> None:
+    def store_reduction(
+        name: str,
+        index: int,
+        value: ShapeArg,
+        *,
+        result_range: tuple[sympy.Expr, int] | None = None,
+    ) -> None:
         return None
 
     @staticmethod

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -1634,8 +1634,13 @@ class SimplifyIndexing(V.WrapperHandler):  # type: ignore[name-defined]
     def store(self, name, index, value, mode=None):
         return self._inner.store(name, self._simplify(index), value, mode=mode)
 
-    def store_reduction(self, name, index, value):
-        return self._inner.store_reduction(name, self._simplify(index), value)
+    def store_reduction(self, name, index, value, *, result_range=None):
+        index = self._simplify(index)
+        if result_range is None:
+            return self._inner.store_reduction(name, index, value)
+        return self._inner.store_reduction(
+            name, index, value, result_range=result_range
+        )
 
     def index_expr(self, index, dtype):
         return self._inner.index_expr(self._simplify(index), dtype)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4241,12 +4241,10 @@ def dump_node_schedule(node_schedule: Sequence[BaseSchedulerNode]) -> None:
     print(f"Node schedule with {len(node_schedule)} nodes")
     for idx, node in enumerate(node_schedule):
         print(f" {idx:3}:")
-        # pyrefly: ignore [unnecessary-comparison]
-        if node is EnableReduction:
+        if isinstance(node, EnableReduction):
             print("enable reduction")
-        # pyrefly: ignore [unnecessary-comparison]
-        elif node is DisableReduction:
-            print("disable reduction")
+        elif isinstance(node, DisableReduction):
+            print(f"disable reduction (result_size={node.result_size})")
         elif isinstance(node, SchedulerNode):
             is_red = node.is_reduction()
             print(f"{'red' if is_red else 'pw'} scheduler node")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195614
* #195613
* __->__ #196660

A reduction-like loop can read N candidates per row and write k results per
row instead of one. Give store_reduction an optional result_range=(rank, k)
keyword that scopes the rank variable to [0, k) for that store. Dependency
extraction then records the write over (rows, k) while the input reads keep N,
so a [rows, k] consumer matches the write exactly like a scalar consumer
matches a scalar reduction's write. The reduction schedule opens a k-wide
result stage, DisableReduction(result_size=k), in which ordinary pointwise
consumers of the result run; in the Triton kernel that stage activates a
derived iteration family (the grouped-reduction mechanism) whose rank axis
has logical extent k and physical width next_power_of_2(k). Scalar
reductions keep the implicit result size of one; their code paths are
unchanged, and the full GPU inductor suite gives the same results on this
stack as on its base. Backends declare BackendFeature.REDUCTION_RESULT to
accept ranked stores; only Triton does, and lowerings check it, so other
backends keep their existing kernels. This commit enables no new lowering;
the top-k commit on top of it is the first user.

Fusion legality reuses the existing dependency matcher, which is what proves
that forwarding a value through the store cache is safe: a consumer may
read a producer's register value only when its read matches the producer's
write index and extent. SIMDScheduling.can_fuse_reduction_pair adds the
stage rules the matcher cannot express and runs before the ordinary fusion
ladder rather than replacing it: one result size per kernel, result-stage
buffers are read only by result-stage nodes, no split scan, no multi-axis
tiling, no templates or staged plans. Loop rewrites that re-express a
consumer over the candidate domain (dimension expansion, index inversion,
the reindex retry) are skipped for these pairs; loop reordering re-traces
bodies and re-extracts dependencies, so it stays allowed. Nested and grouped
reduction planners, mix-order fusion, foreach kernels, coalescing analysis,
and non-default tiling decline these nodes, and backends other than Triton
decline them.

What this buys, with the top-k commit on top: honest write dependencies for
k-wide results, and direct pointwise epilogues and gathers by the returned
indices fusing into the selection kernel, 20 to 43 percent lower latency at
the measured points with an epilogue. The fleet's dominant top-k consumer, a
softmax over the k results, still splits; admitting a reduction over the
result stage is the planned follow-up, and the reason this is infrastructure
rather than a top-k special case.

Behavior change to note: DisableReduction and EnableReduction are now frozen
dataclass instances rather than bare classes. In-tree identity comparisons
were updated; out-of-tree code comparing them by identity must use
isinstance.

Suggested review order: ops_handler.py and loop_body.py (the store contract
and its capture), dependencies.py (scoped extraction), simd_kernel_features.py
(markers and the memory estimator), simd.py (schedule construction and the
fusion precondition), triton.py (the result family and store), scheduler.py
(the capability query and the rewrite gates), then the handler signature
plumbing in the remaining files.

Test Plan:

```
python test/inductor/test_inductor_scheduler.py
python test/inductor/test_dependencies.py
python test/inductor/test_loop_ordering.py
python test/inductor/test_op_completeness.py
```

Scheduler: 186 passed, 6 skipped. Dependencies: 26 passed. Loop
ordering: 124 passed; test_interaction_with_multi_template fails
identically on the unchanged base. Op completeness: 4 passed, 1 skipped.
Existing scalar reduction probes (persistent and looped softmax, two-stage
and mixed-axis reductions) generate unchanged kernels.

Authored with the help of an AI assistant.

> Mixed-order planners explicitly decline compact reduction results both when
> forming a mixed group and when adding nodes to an existing group. Equal
> numeric scheduler groups can describe opposite-axis reductions on square
> inputs, and per-half append checks do not establish compatibility with the
> mixed emitter's RSPLIT loops. Declining these cases prevents a result epilogue
> from reading a temporary defined in a different loop. Ordinary mixed-order
> reductions and full-width stores retain their existing fusion paths.
>
> Validation on the updated stack: 186 scheduler tests passed with 6 skipped,
> and all 26 dependency tests passed. CUDA regressions in the next PR cover
> both initial-group and append admission; removing only the append check
> reproduces its compilation failure.