### PR TITLE
[config] Add declarative implications to ConfigModule

### DIFF
--- a/test/dynamo/test_config.py
+++ b/test/dynamo/test_config.py
@@ -8,11 +8,19 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.utils import disable_cache_limit
+from torch.testing._internal import (
+    fake_config_module_with_implications as implied_config,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 
 # NB: do NOT include this test class in test_dynamic_shapes.py
 
 
+@instantiate_parametrized_tests
 class ConfigTests(torch._dynamo.test_case.TestCase):
     def _make_config_module(self, name: str):
         tmpdir = tempfile.TemporaryDirectory()
@@ -200,6 +208,31 @@ class ConfigTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(x), x + 2)
         self.assertEqual(cnt.frame_count, 1)
         self.assertTrue(config.flag)
+
+    @parametrize("nested", (False, True))
+    def test_config_implications_recompile(self, nested):
+        counter = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=counter, fullgraph=True)
+        def fn(x):
+            flag = implied_config.nested.enabled if nested else implied_config.enabled
+            return (
+                x + 1 if flag else x + 2,
+                x + implied_config.unrelated + implied_config.downstream,
+            )
+
+        x = torch.randn(4)
+        with implied_config.patch(mode="default", enabled=False, unrelated=2):
+            self.assertEqual(fn(x), (x + 2, x + 2))
+            self.assertEqual(counter.frame_count, 1)
+            with implied_config.patch(mode="strict"):
+                self.assertEqual(fn(x), (x + 1, x + 3))
+                self.assertEqual(counter.frame_count, 2)
+                with implied_config.patch(mode="default"):
+                    self.assertEqual(fn(x), (x + 2, x + 2))
+                self.assertEqual(fn(x), (x + 1, x + 3))
+            self.assertEqual(fn(x), (x + 2, x + 2))
+            self.assertEqual(counter.frame_count, 2)
 
 
 if __name__ == "__main__":

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -1133,7 +1133,7 @@ class TestConfigImplications(TestCase):
         self.assertIs(wrapper._config["items"].user_override.get(), _UNSET_SENTINEL)
 
     @parametrize("alias_offset", (False, True))
-    def test_external_alias_setters_observe_restored_config(self, alias_offset):
+    def test_external_alias_setters_observe_complete_config(self, alias_offset):
         class External(ModuleType):
             @property
             def mirror(self):
@@ -1141,6 +1141,8 @@ class TestConfigImplications(TestCase):
 
             @mirror.setter
             def mirror(self, value):
+                self.writes.append(value)
+                self.observed_flag = cfg.flag
                 self.raw = value + cfg.offset
                 self.observed_hash = cfg.get_hash()
                 self.observed_items = cfg.items
@@ -1148,25 +1150,35 @@ class TestConfigImplications(TestCase):
         external = External("test_config_external_setter")
         external.raw = 0
         external.offset = 0
+        external.writes = []
         with patch.dict(sys.modules, {external.__name__: external}):
             offset = (
                 f"Config(alias='{external.__name__}.offset')" if alias_offset else "0"
             )
             cfg = self._make_config(
-                "mode = Config(default=False, implies={True: {'flag': True}})\n"
-                f"flag = False\noffset = {offset}\nitems = []\n"
+                "a = Config(default=False, implies={True: {'flag': 1}})\n"
+                "b = Config(default=True, implies={True: {'flag': 2}})\n"
+                f"flag = 0\noffset = {offset}\nitems = []\n"
                 f"mirror = Config(alias='{external.__name__}.mirror')"
             )
             before_hash = cfg.get_hash()
-            with cfg.patch(offset=1, items=[1], mirror=4):
+            with cfg.patch(a=True, offset=1, items=[1], mirror=4, b=False):
                 self.assertEqual(cfg.mirror, 4)
+                self.assertEqual(external.observed_flag, 1)
                 self.assertNotEqual(cfg.get_hash(), before_hash)
                 self.assertEqual(external.observed_hash, cfg.get_hash())
             self.assertEqual(cfg.offset, 0)
             self.assertEqual(cfg.mirror, 0)
+            self.assertEqual(external.observed_flag, 2)
             self.assertEqual(external.observed_hash, before_hash)
             self.assertEqual(external.observed_items, [])
             self.assertIs(cfg._config["items"].user_override.get(), _UNSET_SENTINEL)
+            external.writes.clear()
+            with self.assertRaisesRegex(ValueError, "conflicting.*flag"):
+                with cfg.patch(a=True, mirror=4):
+                    pass
+            self.assertEqual(external.writes, [])
+            self.assertEqual(cfg.get_hash(), before_hash)
 
     def test_alias_load_restores_raw_target_values(self):
         cfg = self._make_config(
@@ -1201,6 +1213,28 @@ class TestConfigImplications(TestCase):
         cfg.load_config({"value": 2, "other": 3})
         self.assertEqual(sys.modules[lazy_name].observed, 2)
         self.assertEqual(cfg.other, 3)
+
+    @parametrize("overridden", (False, True))
+    def test_alias_import_restores_prior_raw_value(self, overridden):
+        cfg = self._make_config(
+            "mode = Config(default=False, implies={True: {'flag': True}})\n"
+            "flag = False\nvalue = 1\n"
+            "other = Config(alias=__name__ + '_lazy.value')"
+        )
+        self._make_lazy_module(
+            cfg, f"import {cfg.__name__} as owner\nowner.value = 7\nvalue = 0"
+        )
+        if overridden:
+            cfg.value = 3
+        before = cfg.value
+        before_raw = cfg._config["value"].user_override.get()
+        before_hash = cfg.get_hash()
+        with cfg.patch(value=2, other=3):
+            self.assertEqual(cfg.value, 2)
+            self.assertEqual(cfg.other, 3)
+        self.assertEqual(cfg.value, before)
+        self.assertIs(cfg._config["value"].user_override.get(), before_raw)
+        self.assertEqual(cfg.get_hash(), before_hash)
 
     def test_failed_cleanup_invalidates_cache(self):
         class RejectRestore(ModuleType):

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -1,9 +1,14 @@
 # Owner(s): ["module: unknown"]
+import contextlib
+import importlib.util
 import os
 import pickle
 import queue
+import sys
+import tempfile
 import threading
 import warnings
+from types import ModuleType
 from unittest.mock import patch
 
 
@@ -16,9 +21,20 @@ from torch.testing._internal import (
     fake_config_module as config,
     fake_config_module2 as config2,
     fake_config_module3 as config3,
+    fake_config_module_with_implications as implied_config,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.utils._config_module import _ConfigEntry, _UNSET_SENTINEL, Config
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+from torch.utils._config_module import (
+    _ConfigEntry,
+    _UNSET_SENTINEL,
+    Config,
+    install_config_module,
+)
 
 
 class TestConfigModule(TestCase):
@@ -852,6 +868,393 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
         self.assertFalse(config._hash_dirty_var.get())
         config.load_config(saved)
         self.assertTrue(config._hash_dirty_var.get())
+
+
+@instantiate_parametrized_tests
+class TestConfigImplications(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.stack = contextlib.ExitStack()
+        self.addCleanup(self.stack.close)
+        self.stack.enter_context(
+            implied_config.patch(
+                {
+                    "mode": "default",
+                    "enabled": False,
+                    "nested.enabled": False,
+                    "downstream": 0,
+                    "conflict": False,
+                    "unrelated": 1,
+                }
+            )
+        )
+
+    def _make_config(self, definitions):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        path = os.path.join(tmpdir.name, "config_module.py")
+        with open(path, "w") as f:
+            f.write(
+                "from typing import Literal\n"
+                "from torch.utils._config_module import Config\n" + definitions
+            )
+        name = f"implied_config_{os.path.basename(tmpdir.name)}"
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise AssertionError("expected a config module loader")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        self.addCleanup(sys.modules.pop, spec.name, None)
+        spec.loader.exec_module(module)
+        install_config_module(module)
+        return module
+
+    def test_nested_modes_restore_raw_values(self):
+        entry = implied_config._config["nested.enabled"]
+        entry.user_override.set(_UNSET_SENTINEL)
+        with implied_config.patch({"mode": "strict", "nested.enabled": False}):
+            self.assertTrue(implied_config.enabled)
+            self.assertTrue(implied_config.nested.enabled)
+            self.assertEqual(implied_config.downstream, 1)
+            with implied_config.patch(mode="default"):
+                self.assertFalse(implied_config.enabled)
+                self.assertFalse(implied_config.nested.enabled)
+                self.assertEqual(implied_config.downstream, 0)
+            self.assertTrue(implied_config.enabled)
+        self.assertIs(entry.user_override.get(), _UNSET_SENTINEL)
+
+        @implied_config.patch(mode="strict", unrelated=2)
+        def fail():
+            self.assertTrue(implied_config.enabled)
+            del implied_config.unrelated
+            del implied_config.mode
+            raise RuntimeError("test failure")
+
+        with self.assertRaisesRegex(RuntimeError, "test failure"):
+            fail()
+        self.assertEqual(implied_config.mode, "default")
+        self.assertEqual(implied_config.unrelated, 1)
+        self.assertFalse(implied_config.enabled)
+
+    def test_mock_patch_preserves_raw_value(self):
+        entry = implied_config._config["nested.enabled"]
+        entry.user_override.set(_UNSET_SENTINEL)
+        with implied_config.patch(mode="strict"):
+            implied_config.nested.enabled = False
+            self.assertTrue(implied_config.nested.enabled)
+            self.assertIs(entry.user_override.get(), _UNSET_SENTINEL)
+            with patch.object(implied_config.nested, "enabled", False):
+                with patch.object(implied_config.nested, "enabled", True):
+                    self.assertTrue(implied_config.nested.enabled)
+            with implied_config.patch(mode="default"):
+                self.assertFalse(implied_config.nested.enabled)
+        self.assertIs(entry.user_override.get(), _UNSET_SENTINEL)
+
+    def test_source_subclass_is_rejected(self):
+        class Mode(str):
+            __slots__ = ()
+
+        before = implied_config.save_config_portable(readonly_values=True)
+        before_hash = implied_config.get_hash()
+        with self.assertRaisesRegex(
+            TypeError, "implication source mode requires a plain"
+        ):
+            implied_config.mode = Mode("strict")
+        self.assertFalse(implied_config.enabled)
+        self.assertEqual(
+            implied_config.save_config_portable(readonly_values=True), before
+        )
+        self.assertEqual(implied_config.get_hash(), before_hash)
+
+    @parametrize(
+        "definitions, error, message",
+        (
+            (
+                "mode = Config(default=False, implies={True: {'missing': True}})",
+                ValueError,
+                "target.*does not exist",
+            ),
+            (
+                "mode = Config(default=False, implies={True: {'flag': 1}})\nflag = False",
+                TypeError,
+                "invalid implied value",
+            ),
+            (
+                "a = Config(default=False, implies={True: {'b': True}})\nb = Config(default=False, implies={True: {'a': True}})",
+                ValueError,
+                "implication cycle",
+            ),
+        ),
+    )
+    def test_invalid_declarations(self, definitions, error, message):
+        with self.assertRaisesRegex(error, message):
+            self._make_config(definitions)
+
+    def test_conflict_rollback(self):
+        before = implied_config.get_config_copy()
+        with self.assertRaisesRegex(ValueError, "conflicting.*enabled"):
+            with implied_config.patch(mode="strict", conflict=True):
+                pass
+        self.assertEqual(implied_config.get_config_copy(), before)
+        with implied_config.patch(mode="strict", conflict=False):
+            revert = implied_config._make_closure_patcher(mode="default")()
+            implied_config.conflict = True
+            cached_hash = implied_config.get_hash()
+            self.assertEqual(
+                implied_config.save_config_portable(readonly_values=True)["mode"],
+                "default",
+            )
+            with self.assertRaisesRegex(ValueError, "conflicting.*enabled"):
+                revert()
+            self.assertEqual(implied_config.mode, "strict")
+            self.assertEqual(
+                implied_config.save_config_portable(readonly_values=True)["mode"],
+                "strict",
+            )
+            self.assertNotEqual(implied_config.get_hash(), cached_hash)
+
+    def test_lazy_alias_changes_are_atomic(self):
+        cfg = self._make_config(
+            "a = Config(default=True, implies={True: {'flag': 1}})\n"
+            "b = Config(default=False, implies={True: {'flag': 2}})\nflag = 0"
+        )
+        ordinary = ModuleType(cfg.__name__ + "_ordinary")
+        ordinary.value = 1
+
+        def read_external(name):
+            if name == "mirror":
+                return cfg.a and not wrapper.items
+            raise AttributeError(name)
+
+        ordinary.__getattr__ = read_external
+        sys.modules[ordinary.__name__] = ordinary
+        self.addCleanup(sys.modules.pop, ordinary.__name__)
+        lazy_name = cfg.__name__ + "_lazy"
+        self.addCleanup(sys.modules.pop, lazy_name, None)
+        directory = os.path.dirname(cfg.__file__)
+        wrapper = self._make_config(
+            f"a = Config(alias='{lazy_name}.a')\n"
+            f"b = Config(alias='{cfg.__name__}.b')\nflag = Config(alias='{cfg.__name__}.flag')\n"
+            f"external = Config(alias='{ordinary.__name__}.value')\n"
+            f"mirror = Config(alias='{ordinary.__name__}.mirror')\n"
+            f"value = 1\nitems = []\nlazy_value = Config(alias='{lazy_name}.value')"
+        )
+        with open(os.path.join(directory, lazy_name + ".py"), "w") as f:
+            f.write(
+                "import sys\n"
+                "from torch.utils._config_module import Config, install_config_module\n"
+                f"import {cfg.__name__} as owner\n"
+                f"import {wrapper.__name__} as wrapper\n"
+                "observed_value = wrapper.value\nwrapper.value = 7\nvalue = 0\n"
+                "wrapper.external = 7\n"
+                "observed = owner.flag\n"
+                "a = Config(alias=owner.__name__ + '.a')\n"
+                "install_config_module(sys.modules[__name__])\n"
+            )
+        before_hash = cfg.get_hash()
+        patcher = wrapper.patch(external=2, b=True, a=False, items=[1], mirror=False)
+        self.assertNotIn(lazy_name, sys.modules)
+        with patch.object(sys, "path", [directory, *sys.path]):
+            with patcher:
+                self.assertEqual(ordinary.value, 2)
+                self.assertFalse(ordinary.mirror)
+                self.assertEqual(sys.modules[lazy_name].observed, 1)
+                self.assertEqual(cfg.flag, 2)
+                self.assertEqual(cfg._get_dict_dirty_keys_var.get(), {"a", "b"})
+                self.assertNotEqual(cfg.get_hash(), before_hash)
+                with wrapper.patch(a=True, b=False):
+                    self.assertEqual(cfg.flag, 1)
+                self.assertEqual(cfg.flag, 2)
+        self.assertEqual(cfg.flag, 1)
+        self.assertEqual(ordinary.value, 1)
+        self.assertTrue(ordinary.mirror)
+        self.assertIs(wrapper._config["items"].user_override.get(), _UNSET_SENTINEL)
+        with self.assertRaisesRegex(TypeError, "implication source b requires a plain"):
+            with wrapper.patch(items=[1], b=object()):
+                pass
+        self.assertIs(wrapper._config["items"].user_override.get(), _UNSET_SENTINEL)
+        self.assertEqual(cfg.get_hash(), before_hash)
+        self.assertTrue(cfg.save_config_portable(readonly_values=True)["a"])
+        self.assertIs(cfg._config["a"].user_override.get(), _UNSET_SENTINEL)
+        with cfg.patch(flag=3):
+            wrapper.load_config({"b": True, "a": False, "flag": 0})
+            self.assertEqual(cfg.flag, 2)
+            wrapper.load_config(pickle.dumps({"a": False, "b": False}))
+            self.assertEqual(cfg.flag, 0)
+        sys.modules.pop(lazy_name)
+        wrapper.value = 1
+        with patch.object(sys, "path", [directory, *sys.path]):
+            with wrapper.patch(value=2, lazy_value=3):
+                self.assertEqual(wrapper.value, 2)
+            self.assertEqual(wrapper.value, 1)
+            sys.modules.pop(lazy_name)
+            wrapper.load_config({"value": 2, "lazy_value": 3})
+        self.assertEqual(sys.modules[lazy_name].observed_value, 2)
+        self.assertEqual(wrapper.lazy_value, 3)
+
+    def test_failed_cleanup_invalidates_cache(self):
+        class RejectRestore(ModuleType):
+            def __setattr__(self, name, value):
+                if name == "flag" and value is False:
+                    raise RuntimeError("cannot restore external flag")
+                super().__setattr__(name, value)
+
+        target = RejectRestore("test_config_alias_restore")
+        target.__dict__["flag"] = False
+        with patch.dict(sys.modules, {target.__name__: target}):
+            cfg = self._make_config(
+                "mode = Config(default=False, implies={True: {'flag': True}})\n"
+                f"flag = False\nvalue = 0\nexternal = Config(alias='{target.__name__}.flag')"
+            )
+            before = cfg.get_hash()
+            with self.assertRaisesRegex(RuntimeError, "cannot restore external flag"):
+                with cfg.patch(value=1, external=True):
+                    self.assertNotEqual(cfg.get_hash(), before)
+                    self.assertEqual(
+                        cfg.save_config_portable(readonly_values=True)["value"], 1
+                    )
+            self.assertEqual(cfg.value, 0)
+            self.assertEqual(cfg.get_hash(), before)
+            self.assertEqual(cfg.save_config_portable(readonly_values=True)["value"], 0)
+
+    def test_serialization_preserves_raw_values(self):
+        before_hash = implied_config.get_hash()
+        with implied_config.patch(mode="strict", enabled=False):
+            saved = implied_config.save_config_portable()
+            self.assertFalse(saved["enabled"])
+            self.assertFalse(saved["nested.enabled"])
+            self.assertEqual(pickle.loads(implied_config.save_config()), saved)
+            code = implied_config.codegen_config()
+            active_hash = implied_config.get_hash()
+            self.assertNotEqual(active_hash, before_hash)
+        self.assertEqual(implied_config.get_hash(), before_hash)
+        implied_config.load_config(saved)
+        self.assertTrue(implied_config.enabled)
+        self.assertEqual(implied_config.get_hash(), active_hash)
+        implied_config.mode = "default"
+        exec(code, {"torch": sys.modules["torch"]})
+        self.assertEqual(implied_config.save_config_portable(), saved)
+        implied_config.mode = "default"
+        self.assertFalse(implied_config.enabled)
+
+    def test_rule_metadata_participates_in_hash(self):
+        import torch
+        from torch._inductor.codecache import FxGraphCachePickler, FxGraphHashDetails
+        from torch._inductor.codegen.common import custom_backend_codegen_configs
+
+        configs = [
+            self._make_config(
+                f"mode = Config(default=True, implies={{True: {{'flag': {value}}}}})\nflag = False"
+            )
+            for value in (True, False)
+        ]
+        self.assertEqual(
+            configs[0].save_config_portable(), configs[1].save_config_portable()
+        )
+        self.assertNotEqual(configs[0].flag, configs[1].flag)
+        self.assertNotEqual(configs[0].get_hash(), configs[1].get_hash())
+        cache_keys = []
+        pickler = FxGraphCachePickler(torch.fx.GraphModule({}, torch.fx.Graph()))
+        for cfg in configs:
+            with patch.dict(custom_backend_codegen_configs, {"test_implications": cfg}):
+                cache_keys.append(pickler.dumps(FxGraphHashDetails(None, [], {}, [])))
+        self.assertNotEqual(*cache_keys)
+
+    def test_justknob_resolution_is_lazy(self):
+        with patch(
+            "torch.utils._config_module.justknobs_check", side_effect=[True]
+        ) as jk:
+            cfg = self._make_config(
+                "root = Config(default=False, justknob='test/root', implies={True: {'left': True, 'right': True}})\n"
+                "left = Config(default=False, justknob='test/left', implies={True: {'flag': True}})\n"
+                "right = Config(default=False, justknob='test/right', implies={True: {'flag': True}})\n"
+                "flag = Config(default=False, justknob='test/flag')\nunrelated = 0"
+            )
+            jk.assert_not_called()
+            self.assertTrue(cfg.flag)
+            jk.assert_called_once_with(name="test/root", default=False)
+            jk.reset_mock()
+            jk.side_effect = [True]
+            cfg._validate_active_implications()
+            jk.assert_called_once_with(name="test/root", default=False)
+            jk.reset_mock()
+            jk.side_effect = None
+            jk.return_value = False
+            self.assertFalse(cfg.flag)
+            self.assertEqual(jk.call_count, 4)
+            jk.reset_mock()
+            jk.side_effect = RuntimeError("unexpected JK read")
+            with cfg.patch(), cfg.patch(unrelated=1):
+                self.assertEqual(cfg.unrelated, 1)
+            jk.assert_not_called()
+
+    def test_live_justknob_updates_cache(self):
+        import torch
+        from torch._guards import tracing, TracingContext
+        from torch._inductor.codecache import FxGraphCache
+        from torch._inductor.codegen.common import custom_backend_codegen_configs
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        cfg = self._make_config(
+            "mode = Config(default=False, justknob='test/mode', implies={True: {'flag': True}})\n"
+            "flag = False"
+        )
+        graph = torch.fx.Graph()
+        graph.output(None)
+        module = torch.fx.GraphModule({}, graph)
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        with (
+            patch(
+                "torch.utils._config_module.justknobs_check", return_value=False
+            ) as jk,
+            patch.dict(custom_backend_codegen_configs, {"test_implications": cfg}),
+            tracing(TracingContext(fake_mode)),
+        ):
+            before_hash = cfg.get_hash()
+            before, info = FxGraphCache.prepare_key(module, [], {}, [], remote=False)
+            self.assertIsNotNone(before, info)
+            jk.reset_mock()
+            jk.side_effect = [True]
+            self.assertTrue(cfg.save_config_portable(readonly_values=True)["mode"])
+            jk.assert_called_once()
+            jk.side_effect = None
+            jk.return_value = True
+            after, info = FxGraphCache.prepare_key(module, [], {}, [], remote=False)
+            self.assertIsNotNone(after, info)
+            self.assertNotEqual(before, after)
+            self.assertNotEqual(before_hash, cfg.get_hash())
+            code = cfg.codegen_config()
+            jk.return_value = False
+            exec(code, {cfg.__name__: cfg})
+            self.assertTrue(cfg.flag)
+
+    @parametrize("kind", ("drop", "change", "filter"))
+    def test_serialization_cannot_hide_sources(self, kind):
+        definitions = {
+            "drop": "def _cache_config_serializer(values):\n    values.pop('mode')\n",
+            "change": "def _cache_config_serializer(values):\n    values['mode'] = 0\n",
+            "filter": "_cache_config_ignore_prefix = ['mode']\n",
+        }[kind]
+        cfg = self._make_config(
+            definitions
+            + "mode = Config(default=False, implies={True: {'flag': True}})\nflag = False"
+        )
+        with self.assertRaisesRegex(
+            ValueError, "source mode must be serialized unchanged"
+        ):
+            cfg.save_config_portable()
+
+    def test_quoted_annotations(self):
+        cfg = self._make_config(
+            "mode: \"'str'\" = Config(default='default', implies={'strict': {'nested.flag': True}})\n"
+            "class nested:\n    flag: 'bool' = False\n"
+            "unrelated: 'UnresolvedType' = None"
+        )
+        with cfg.patch(mode="strict"):
+            self.assertTrue(cfg.nested.flag)
+        self.assertFalse(cfg.nested.flag)
+        self.assertEqual(cfg.get_type("unrelated"), "UnresolvedType")
 
 
 if __name__ == "__main__":

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -909,6 +909,20 @@ class TestConfigImplications(TestCase):
         install_config_module(module)
         return module
 
+    def _make_lazy_module(self, owner, definitions):
+        name = owner.__name__ + "_lazy"
+        directory = os.path.dirname(owner.__file__)
+        with open(os.path.join(directory, name + ".py"), "w") as f:
+            f.write(
+                "import sys\n"
+                "from torch.utils._config_module import Config, install_config_module\n"
+                + definitions
+                + "\ninstall_config_module(sys.modules[__name__])\n"
+            )
+        self.addCleanup(sys.modules.pop, name, None)
+        self.stack.enter_context(patch.object(sys, "path", [directory, *sys.path]))
+        return name
+
     def test_nested_modes_restore_raw_values(self):
         entry = implied_config._config["nested.enabled"]
         entry.user_override.set(_UNSET_SENTINEL)
@@ -936,19 +950,25 @@ class TestConfigImplications(TestCase):
         self.assertEqual(implied_config.unrelated, 1)
         self.assertFalse(implied_config.enabled)
 
-    def test_mock_patch_preserves_raw_value(self):
-        entry = implied_config._config["nested.enabled"]
-        entry.user_override.set(_UNSET_SENTINEL)
+    @parametrize("nested", (False, True))
+    def test_active_targets_preserve_assignments(self, nested):
+        target = implied_config.nested if nested else implied_config
+        key = "nested.enabled" if nested else "enabled"
+        entry = implied_config._config[key]
+        target.enabled = True
         with implied_config.patch(mode="strict"):
-            implied_config.nested.enabled = False
-            self.assertTrue(implied_config.nested.enabled)
-            self.assertIs(entry.user_override.get(), _UNSET_SENTINEL)
-            with patch.object(implied_config.nested, "enabled", False):
-                with patch.object(implied_config.nested, "enabled", True):
-                    self.assertTrue(implied_config.nested.enabled)
+            before_hash = implied_config.get_hash()
+            target.enabled = False
+            self.assertTrue(target.enabled)
+            self.assertIs(entry.user_override.get(), False)
+            self.assertFalse(implied_config.save_config_portable()[key])
+            self.assertNotEqual(implied_config.get_hash(), before_hash)
             with implied_config.patch(mode="default"):
-                self.assertFalse(implied_config.nested.enabled)
-        self.assertIs(entry.user_override.get(), _UNSET_SENTINEL)
+                self.assertFalse(target.enabled)
+            with implied_config.patch({key: True}):
+                self.assertTrue(entry.user_override.get())
+            self.assertIs(entry.user_override.get(), False)
+        self.assertFalse(target.enabled)
 
     def test_source_subclass_is_rejected(self):
         class Mode(str):
@@ -969,6 +989,36 @@ class TestConfigImplications(TestCase):
     @parametrize(
         "definitions, error, message",
         (
+            (
+                "mode = Config(default=False, implies=[])",
+                TypeError,
+                "implies must be a dictionary",
+            ),
+            (
+                "mode = Config(default=False, implies={'strict': {'flag': True}})\nflag = False",
+                TypeError,
+                "invalid implication condition",
+            ),
+            (
+                "mode = Config(default=False, implies={True: []})",
+                TypeError,
+                "targets.*must be a dictionary",
+            ),
+            (
+                "mode = Config(default=False, implies={True: {1: True}})",
+                TypeError,
+                "targets must be dotted config names",
+            ),
+            (
+                "mode = Config(default=False, implies={True: {'flag': True}})\nflag = Config(alias='missing.flag')",
+                ValueError,
+                "target flag cannot be an alias",
+            ),
+            (
+                "mode = Config(alias='missing.flag', implies={True: {'flag': True}})\nflag = False",
+                AssertionError,
+                "if alias is set",
+            ),
             (
                 "mode = Config(default=False, implies={True: {'missing': True}})",
                 ValueError,
@@ -1018,56 +1068,27 @@ class TestConfigImplications(TestCase):
             "a = Config(default=True, implies={True: {'flag': 1}})\n"
             "b = Config(default=False, implies={True: {'flag': 2}})\nflag = 0"
         )
-        ordinary = ModuleType(cfg.__name__ + "_ordinary")
-        ordinary.value = 1
-
-        def read_external(name):
-            if name == "mirror":
-                return cfg.a and not wrapper.items
-            raise AttributeError(name)
-
-        ordinary.__getattr__ = read_external
-        sys.modules[ordinary.__name__] = ordinary
-        self.addCleanup(sys.modules.pop, ordinary.__name__)
-        lazy_name = cfg.__name__ + "_lazy"
-        self.addCleanup(sys.modules.pop, lazy_name, None)
-        directory = os.path.dirname(cfg.__file__)
+        lazy_name = self._make_lazy_module(
+            cfg,
+            f"import {cfg.__name__} as owner\nobserved = owner.flag\n"
+            "a = Config(alias=owner.__name__ + '.a')",
+        )
         wrapper = self._make_config(
             f"a = Config(alias='{lazy_name}.a')\n"
-            f"b = Config(alias='{cfg.__name__}.b')\nflag = Config(alias='{cfg.__name__}.flag')\n"
-            f"external = Config(alias='{ordinary.__name__}.value')\n"
-            f"mirror = Config(alias='{ordinary.__name__}.mirror')\n"
-            f"value = 1\nitems = []\nlazy_value = Config(alias='{lazy_name}.value')"
+            f"b = Config(alias='{cfg.__name__}.b')\nitems = []"
         )
-        with open(os.path.join(directory, lazy_name + ".py"), "w") as f:
-            f.write(
-                "import sys\n"
-                "from torch.utils._config_module import Config, install_config_module\n"
-                f"import {cfg.__name__} as owner\n"
-                f"import {wrapper.__name__} as wrapper\n"
-                "observed_value = wrapper.value\nwrapper.value = 7\nvalue = 0\n"
-                "wrapper.external = 7\n"
-                "observed = owner.flag\n"
-                "a = Config(alias=owner.__name__ + '.a')\n"
-                "install_config_module(sys.modules[__name__])\n"
-            )
         before_hash = cfg.get_hash()
-        patcher = wrapper.patch(external=2, b=True, a=False, items=[1], mirror=False)
+        patcher = wrapper.patch(items=[1], b=True, a=False)
         self.assertNotIn(lazy_name, sys.modules)
-        with patch.object(sys, "path", [directory, *sys.path]):
-            with patcher:
-                self.assertEqual(ordinary.value, 2)
-                self.assertFalse(ordinary.mirror)
-                self.assertEqual(sys.modules[lazy_name].observed, 1)
-                self.assertEqual(cfg.flag, 2)
-                self.assertEqual(cfg._get_dict_dirty_keys_var.get(), {"a", "b"})
-                self.assertNotEqual(cfg.get_hash(), before_hash)
-                with wrapper.patch(a=True, b=False):
-                    self.assertEqual(cfg.flag, 1)
-                self.assertEqual(cfg.flag, 2)
+        with patcher:
+            self.assertEqual(sys.modules[lazy_name].observed, 1)
+            self.assertEqual(cfg.flag, 2)
+            self.assertEqual(cfg._get_dict_dirty_keys_var.get(), {"a", "b"})
+            self.assertNotEqual(cfg.get_hash(), before_hash)
+            with wrapper.patch(a=True, b=False):
+                self.assertEqual(cfg.flag, 1)
+            self.assertEqual(cfg.flag, 2)
         self.assertEqual(cfg.flag, 1)
-        self.assertEqual(ordinary.value, 1)
-        self.assertTrue(ordinary.mirror)
         self.assertIs(wrapper._config["items"].user_override.get(), _UNSET_SENTINEL)
         with self.assertRaisesRegex(TypeError, "implication source b requires a plain"):
             with wrapper.patch(items=[1], b=object()):
@@ -1076,21 +1097,110 @@ class TestConfigImplications(TestCase):
         self.assertEqual(cfg.get_hash(), before_hash)
         self.assertTrue(cfg.save_config_portable(readonly_values=True)["a"])
         self.assertIs(cfg._config["a"].user_override.get(), _UNSET_SENTINEL)
+
+    def test_external_alias_snapshots_precede_reads_and_imports(self):
+        cfg = self._make_config(
+            "mode = Config(default=False, implies={True: {'flag': True}})\nflag = False"
+        )
+        ordinary = ModuleType(cfg.__name__ + "_ordinary")
+        ordinary.value = 1
+
+        def read_external(name):
+            if name == "mirror":
+                return cfg.mode or bool(wrapper.items)
+            raise AttributeError(name)
+
+        ordinary.__getattr__ = read_external
+        sys.modules[ordinary.__name__] = ordinary
+        self.addCleanup(sys.modules.pop, ordinary.__name__)
+        lazy_name = self._make_lazy_module(
+            cfg,
+            f"import {ordinary.__name__} as ordinary\nordinary.value = 7\n"
+            f"mode = Config(alias='{cfg.__name__}.mode')",
+        )
+        wrapper = self._make_config(
+            f"external = Config(alias='{ordinary.__name__}.value')\n"
+            f"mode = Config(alias='{lazy_name}.mode')\nitems = []\n"
+            f"mirror = Config(alias='{ordinary.__name__}.mirror')"
+        )
+        with wrapper.patch(external=2, mode=True, items=[1], mirror=True):
+            self.assertEqual(ordinary.value, 2)
+            self.assertTrue(ordinary.mirror)
+            self.assertTrue(cfg.flag)
+        self.assertEqual(ordinary.value, 1)
+        self.assertFalse(ordinary.mirror)
+        self.assertFalse(cfg.flag)
+        self.assertIs(wrapper._config["items"].user_override.get(), _UNSET_SENTINEL)
+
+    @parametrize("alias_offset", (False, True))
+    def test_external_alias_setters_observe_restored_config(self, alias_offset):
+        class External(ModuleType):
+            @property
+            def mirror(self):
+                return self.raw - cfg.offset
+
+            @mirror.setter
+            def mirror(self, value):
+                self.raw = value + cfg.offset
+                self.observed_hash = cfg.get_hash()
+                self.observed_items = cfg.items
+
+        external = External("test_config_external_setter")
+        external.raw = 0
+        external.offset = 0
+        with patch.dict(sys.modules, {external.__name__: external}):
+            offset = (
+                f"Config(alias='{external.__name__}.offset')" if alias_offset else "0"
+            )
+            cfg = self._make_config(
+                "mode = Config(default=False, implies={True: {'flag': True}})\n"
+                f"flag = False\noffset = {offset}\nitems = []\n"
+                f"mirror = Config(alias='{external.__name__}.mirror')"
+            )
+            before_hash = cfg.get_hash()
+            with cfg.patch(offset=1, items=[1], mirror=4):
+                self.assertEqual(cfg.mirror, 4)
+                self.assertNotEqual(cfg.get_hash(), before_hash)
+                self.assertEqual(external.observed_hash, cfg.get_hash())
+            self.assertEqual(cfg.offset, 0)
+            self.assertEqual(cfg.mirror, 0)
+            self.assertEqual(external.observed_hash, before_hash)
+            self.assertEqual(external.observed_items, [])
+            self.assertIs(cfg._config["items"].user_override.get(), _UNSET_SENTINEL)
+
+    def test_alias_load_restores_raw_target_values(self):
+        cfg = self._make_config(
+            "a = Config(default=True, implies={True: {'flag': 1}})\n"
+            "b = Config(default=False, implies={True: {'flag': 2}})\nflag = 0"
+        )
+        wrapper = self._make_config(
+            f"a = Config(alias='{cfg.__name__}.a')\n"
+            f"b = Config(alias='{cfg.__name__}.b')\n"
+            f"flag = Config(alias='{cfg.__name__}.flag')"
+        )
         with cfg.patch(flag=3):
             wrapper.load_config({"b": True, "a": False, "flag": 0})
             self.assertEqual(cfg.flag, 2)
             wrapper.load_config(pickle.dumps({"a": False, "b": False}))
             self.assertEqual(cfg.flag, 0)
+
+    def test_ordinary_alias_import_order(self):
+        cfg = self._make_config(
+            "value = 1\nother = Config(alias=__name__ + '_lazy.value')"
+        )
+        lazy_name = self._make_lazy_module(
+            cfg,
+            f"import {cfg.__name__} as owner\nobserved = owner.value\n"
+            "owner.value = 7\nvalue = 0",
+        )
+        with cfg.patch(value=2, other=3):
+            self.assertEqual(cfg.value, 2)
+            self.assertEqual(sys.modules[lazy_name].observed, 1)
+        self.assertEqual(cfg.value, 1)
         sys.modules.pop(lazy_name)
-        wrapper.value = 1
-        with patch.object(sys, "path", [directory, *sys.path]):
-            with wrapper.patch(value=2, lazy_value=3):
-                self.assertEqual(wrapper.value, 2)
-            self.assertEqual(wrapper.value, 1)
-            sys.modules.pop(lazy_name)
-            wrapper.load_config({"value": 2, "lazy_value": 3})
-        self.assertEqual(sys.modules[lazy_name].observed_value, 2)
-        self.assertEqual(wrapper.lazy_value, 3)
+        cfg.load_config({"value": 2, "other": 3})
+        self.assertEqual(sys.modules[lazy_name].observed, 2)
+        self.assertEqual(cfg.other, 3)
 
     def test_failed_cleanup_invalidates_cache(self):
         class RejectRestore(ModuleType):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -129,6 +129,7 @@ from torch.fx.experimental.symbolic_shapes import (
     has_guarding_hint,
     ShapeEnv,
 )
+from torch.utils._config_module import _ImplicationConfigModule
 from torch.utils._device import _device_constructors
 from torch.utils._ordered_set import OrderedSet
 
@@ -1695,6 +1696,14 @@ class FxGraphHashDetails:
             for device, custom_config in custom_backend_codegen_configs.items()
             if custom_config is not None
         }
+        implication_hashes = {
+            device: custom_config._implication_hash
+            for device, custom_config in custom_backend_codegen_configs.items()
+            if isinstance(custom_config, _ImplicationConfigModule)
+        }
+        if implication_hashes:
+            # FxGraphCachePickler includes these rule fingerprints through self.__dict__.
+            self.custom_backend_codegen_implications = implication_hashes
 
         # Register the custom partitioner function
         self._custom_partitioner_fn = self._get_custom_partitioner_fn_detail(

--- a/torch/testing/_internal/fake_config_module_with_implications.py
+++ b/torch/testing/_internal/fake_config_module_with_implications.py
@@ -1,0 +1,21 @@
+import sys
+from typing import Literal
+
+from torch.utils._config_module import Config, install_config_module
+
+
+mode: Literal["default", "strict"] = Config(
+    default="default",
+    implies={"strict": {"enabled": True, "nested.enabled": True}},
+)
+enabled = Config(default=False, implies={True: {"downstream": 1}})
+downstream = 0
+conflict = Config(default=False, implies={True: {"enabled": False}})
+unrelated = 1
+
+
+class nested:
+    enabled = False
+
+
+install_config_module(sys.modules[__name__])

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -718,16 +718,18 @@ class ConfigModule(ModuleType):
                         raw_rollback.callback(restore_hide, entry, hide)
                     else:
                         external_undo.append((module, key, value))
-                targets, resolved_modules = self._resolve_patch_changes(changes)
-                modules.update(resolved_modules)
-                for module, key, value in targets:
+                for name, value in changes.items():
+                    resolved, touched = self._resolve_patch_changes({name: value})
+                    targets.extend(resolved)
+                    modules.update(touched)
+                    module, key, value = resolved[0]
                     if isinstance(module, _ImplicationConfigModule):
                         changed.setdefault(module, set()).add(key)
                         if key in module._implication_sources:
                             _validate_implication_source(key, value)
                     if isinstance(module, ConfigModule):
                         entry = module._config[key]
-                        # Snapshot before external getters can materialize config defaults.
+                        # Snapshot before later alias imports can change this value.
                         prior_value = entry.user_override.get()
                         token = entry.user_override.set(prior_value)
                         rollback.callback(entry.user_override.set, prior_value)
@@ -749,14 +751,19 @@ class ConfigModule(ModuleType):
                         entry.user_override.set(value)
                         if entry.hide:
                             entry.hide = False
-                    else:
-                        if (module, key) in external_prior:
-                            external_undo.append(
-                                (module, key, external_prior.pop((module, key)))
-                            )
-                        invalidate()
-                        setattr(module, key, value)
+                invalidate()
                 validate()
+                for module, key, value in targets:
+                    if isinstance(module, ConfigModule):
+                        continue
+                    if (module, key) in external_prior:
+                        external_undo.append(
+                            (module, key, external_prior.pop((module, key)))
+                        )
+                    invalidate()
+                    setattr(module, key, value)
+                if external_undo:
+                    validate()
                 undo = rollback.pop_all()
         finally:
             invalidate()

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -92,10 +92,9 @@ class _Config(Generic[T]):
             module, using dotted names for nested targets. Sources and targets
             must have bool, int, str, None, or corresponding Literal/union types.
             Aliases, cycles, and conflicting active implications are rejected.
-            Assignments and deletions of actively implied targets are ignored;
-            use ``config.patch`` to temporarily change their stored values.
-            ``mock.patch.object`` on a target is unsupported if its active
-            implications differ between entry and exit. Use ``config.patch`` instead.
+            Assignments update stored values without overriding active implications.
+            Use ``config.patch`` for temporary changes that restore stored values.
+            ``mock.patch.object`` is unsupported on targets with active implications.
     """
 
     default: T | object
@@ -677,6 +676,7 @@ class ConfigModule(ModuleType):
         targets: list[tuple[ModuleType, str, Any]] = []
         modules = {self}
         changed: dict[_ImplicationConfigModule, set[str]] = {}
+        external_undo: list[tuple[ModuleType, str, Any]] = []
 
         def invalidate() -> None:
             for module in modules:
@@ -696,16 +696,28 @@ class ConfigModule(ModuleType):
             if entry.hide != hide:
                 entry.hide = hide
 
+        def restore_external() -> None:
+            with contextlib.ExitStack() as stack:
+                for module, key, value in reversed(external_undo):
+                    stack.callback(setattr, module, key, value)
+
         try:
             with contextlib.ExitStack() as rollback:
+                raw_rollback = contextlib.ExitStack()
+                # Final token resets undo default materialization by external setters.
+                rollback.callback(raw_rollback.close)
+                rollback.callback(restore_external)
+                rollback.callback(invalidate)
                 for (module, key), (value, hide) in (prior or {}).items():
                     if isinstance(module, ConfigModule):
                         modules.add(module)
                         entry = module._config[key]
                         rollback.callback(entry.user_override.set, value)
                         rollback.callback(restore_hide, entry, hide)
+                        raw_rollback.callback(entry.user_override.set, value)
+                        raw_rollback.callback(restore_hide, entry, hide)
                     else:
-                        rollback.callback(setattr, module, key, value)
+                        external_undo.append((module, key, value))
                 targets, resolved_modules = self._resolve_patch_changes(changes)
                 modules.update(resolved_modules)
                 for module, key, value in targets:
@@ -716,9 +728,12 @@ class ConfigModule(ModuleType):
                     if isinstance(module, ConfigModule):
                         entry = module._config[key]
                         # Snapshot before external getters can materialize config defaults.
-                        token = entry.user_override.set(entry.user_override.get())
-                        rollback.callback(entry.user_override.reset, token)
+                        prior_value = entry.user_override.get()
+                        token = entry.user_override.set(prior_value)
+                        rollback.callback(entry.user_override.set, prior_value)
                         rollback.callback(restore_hide, entry, entry.hide)
+                        raw_rollback.callback(entry.user_override.reset, token)
+                        raw_rollback.callback(restore_hide, entry, entry.hide)
                 external_prior = {}
                 for module, key, _ in targets:
                     if isinstance(module, ConfigModule):
@@ -736,9 +751,10 @@ class ConfigModule(ModuleType):
                             entry.hide = False
                     else:
                         if (module, key) in external_prior:
-                            rollback.callback(
-                                setattr, module, key, external_prior.pop((module, key))
+                            external_undo.append(
+                                (module, key, external_prior.pop((module, key)))
                             )
+                        invalidate()
                         setattr(module, key, value)
                 validate()
                 undo = rollback.pop_all()
@@ -1174,6 +1190,11 @@ class ConfigModule(ModuleType):
 
             with config.patch("name", val):
                 ...
+
+        For implication targets, this changes stored values; active implications
+        still take precedence. On exit, stored values are restored before checking
+        for conflicts. If changes to other sources leave conflicting implications,
+        exit raises ValueError, including when unwinding an exception from the body.
         """
         changes: dict[str, Any]
         if arg1 is not None:
@@ -1373,25 +1394,10 @@ class _ImplicationConfigModule(ConfigModule):
         return self._get_resolved_value(name, {})
 
     def __setattr__(self, name: str, value: object) -> None:
-        if (
-            name in self._implications
-            and self._get_implied_value(name) is not _UNSET_SENTINEL
-        ):
-            self._warn_if_deprecated(name, self._config[name])
-            return
         if name in self._implication_sources:
             self._set_raw_values({name: value})
         else:
             super().__setattr__(name, value)
-
-    def __delattr__(self, name: str) -> None:
-        if (
-            name in self._implications
-            and self._get_implied_value(name) is not _UNSET_SENTINEL
-        ):
-            # Keeping the attribute present prevents mock.patch writing back an implied value.
-            return
-        super().__delattr__(name)
 
     def _is_default(self, name: str) -> bool:
         return name not in self._implication_dynamic_sources and super()._is_default(

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -14,8 +14,21 @@ import unittest
 from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
-from types import FunctionType, ModuleType
-from typing import Any, Generic, NoReturn, Optional, TYPE_CHECKING, TypeVar
+from graphlib import CycleError, TopologicalSorter
+from types import FunctionType, ModuleType, UnionType
+from typing import (
+    Any,
+    Generic,
+    get_args,
+    get_origin,
+    get_type_hints,
+    Literal,
+    NoReturn,
+    Optional,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
 from typing_extensions import deprecated
 
 from torch._utils_internal import justknobs_check
@@ -38,7 +51,7 @@ _UNSET_SENTINEL = object()
 
 @dataclass(kw_only=True)
 class _Config(Generic[T]):
-    """Represents a config with richer behaviour than just a default value.
+    r"""Represents a config with richer behaviour than just a default value.
     ::
         i.e.
         foo = Config(justknob="//foo:bar", default=False)
@@ -48,6 +61,7 @@ class _Config(Generic[T]):
 
     Precedence Order:
         alias: If set, the directly use the value of the alias.
+        implies: An active implication overrides the target's ordinary value.
         env_name_force: If set, this environment variable has precedence over
             everything after this.
             If multiple env variables are given, the precedence order is from
@@ -71,9 +85,17 @@ class _Config(Generic[T]):
         default: is the value to default this knob to in OSS.
         alias: The alias config to read instead.
         env_name_force: The environment variable, or list of, to read that is a FORCE
-            environment variable. I.e. it overrides everything except for alias.
+            environment variable. It overrides ordinary values, but not implications.
         env_name_default: The environment variable, or list of, to read that changes the
             default behaviour. I.e. user overrides take preference.
+        implies: Maps source values to forced values for other settings in this
+            module, using dotted names for nested targets. Sources and targets
+            must have bool, int, str, None, or corresponding Literal/union types.
+            Aliases, cycles, and conflicting active implications are rejected.
+            Assignments and deletions of actively implied targets are ignored;
+            use ``config.patch`` to temporarily change their stored values.
+            ``mock.patch.object`` on a target is unsupported if its active
+            implications differ between entry and exit. Use ``config.patch`` instead.
     """
 
     default: T | object
@@ -82,6 +104,7 @@ class _Config(Generic[T]):
     env_name_force: list[str] | None = None
     value_type: type | None = None
     alias: str | None = None
+    implies: dict[Any, dict[str, Any]] | None = None
     # Deprecation support
     deprecated: bool = False
     deprecation_message: str | None = None
@@ -93,6 +116,8 @@ class _Config(Generic[T]):
         self.env_name_force = _Config.string_or_list_of_string_to_list(
             self.env_name_force
         )
+        if self.implies is not None and not isinstance(self.implies, dict):
+            raise TypeError("implies must be a dictionary")
 
         if self.alias is not None:
             if (
@@ -100,10 +125,11 @@ class _Config(Generic[T]):
                 or self.justknob is not None
                 or self.env_name_default is not None
                 or self.env_name_force is not None
+                or self.implies is not None
             ):
                 raise AssertionError(
                     "if alias is set, none of {default, justknob, \
-                        env_name_default and env_name_force} can be set"
+                        env_name_default, env_name_force and implies} can be set"
                 )
 
     @staticmethod
@@ -135,6 +161,8 @@ if TYPE_CHECKING:
         # Deprecation support
         deprecated: bool = False,
         deprecation_message: str | None = None,
+        *,
+        implies: dict[Any, dict[str, Any]] | None = None,
     ) -> T: ...
 
 else:
@@ -149,6 +177,8 @@ else:
         # Deprecation support
         deprecated: bool = False,
         deprecation_message: str | None = None,
+        *,
+        implies: dict[Any, dict[str, Any]] | None = None,
     ) -> _Config[T]:
         return _Config(
             default=default,
@@ -160,6 +190,7 @@ else:
             # Deprecation support
             deprecated=deprecated,
             deprecation_message=deprecation_message,
+            implies=implies,
         )
 
 
@@ -196,7 +227,9 @@ def install_config_module(module: ModuleType) -> None:
     ) -> None:
         """Walk the module structure and move everything to module._config"""
         type_hints = inspect.get_annotations(source)
-        for key, value in list(source.__dict__.items()):
+        namespace = dict(vars(source))
+        namespaces[prefix] = namespace
+        for key, value in namespace.items():
             if (
                 key.startswith("__")
                 or isinstance(value, (ModuleType, FunctionType))
@@ -244,13 +277,28 @@ def install_config_module(module: ModuleType) -> None:
                 raise AssertionError(f"Unhandled config {key}={value} ({type(value)})")
 
     config: dict[str, _ConfigEntry] = {}
+    namespaces: dict[str, dict[str, Any]] = {}
 
     compile_ignored_keys = get_assignments_with_compile_ignored_comments(module)
 
     visit(module, module, "")
     module._config = config  # type: ignore[attr-defined]
     module._compile_ignored_keys = compile_ignored_keys  # type: ignore[attr-defined]
-    module.__class__ = ConfigModuleInstance
+    if any(entry.implies for entry in config.values()):
+
+        class ImplicationConfigModuleInstance(_ImplicationConfigModule):
+            _bypass_keys = ConfigModuleInstance._bypass_keys
+
+        implications, sources = _install_implications(config, namespaces)
+        module._implications = implications  # type: ignore[attr-defined]
+        module._implication_sources = sources  # type: ignore[attr-defined]
+        module._implication_dynamic_sources = {  # type: ignore[attr-defined]
+            name for name in sources if config[name].justknob is not None
+        }
+        module._implication_hash = repr(sorted(implications.items())).encode()  # type: ignore[attr-defined]
+        module.__class__ = ImplicationConfigModuleInstance
+    else:
+        module.__class__ = ConfigModuleInstance
     module._hash_dirty_var = ContextVar(f"{module.__name__}._hash_dirty", default=True)  # type: ignore[attr-defined]  # pyrefly: ignore[missing-attribute]
     module._hash_cache_var = ContextVar(  # pyrefly: ignore[missing-attribute]
         f"{module.__name__}._hash_cache", default=None
@@ -305,6 +353,7 @@ def get_assignments_with_compile_ignored_comments(module: ModuleType) -> set[str
 
 
 _GetDictCacheKey = tuple[tuple[str, ...], tuple[str, ...], bool]
+_ResolvedConfigChanges = tuple[list[tuple[ModuleType, str, Any]], set["ConfigModule"]]
 
 
 @dataclass
@@ -334,6 +383,7 @@ class _ConfigEntry:
     # upstream bug - python/cpython#126886
     hide: bool = False
     alias: str | None = None
+    implies: dict[Any, dict[str, Any]] | None = None
     # Deprecation support
     deprecated: bool = False
     deprecation_message: str | None = None
@@ -346,6 +396,7 @@ class _ConfigEntry:
         )
         self.justknob = config.justknob
         self.alias = config.alias
+        self.implies = config.implies
         # Deprecation fields
         self.deprecated = config.deprecated
         self.deprecation_message = config.deprecation_message
@@ -381,6 +432,84 @@ class _ConfigEntry:
                 raise AssertionError(
                     f"envvar configs only support (optional) booleans or strings, {self.value_type} is neither"
                 )
+
+
+def _matches_implication_type(value: object, value_type: Any) -> bool:
+    if type(value) not in (bool, int, str, type(None)):
+        return False
+    origin = get_origin(value_type)
+    if origin is Literal:
+        return any(type(value) is type(v) and value == v for v in get_args(value_type))
+    if origin in (Union, UnionType):
+        return any(_matches_implication_type(value, t) for t in get_args(value_type))
+    return type(value) is value_type
+
+
+def _validate_implication_source(name: str, value: object) -> None:
+    if type(value) not in (bool, int, str, type(None)):
+        raise TypeError(
+            f"implication source {name} requires a plain bool, int, str, or None; got {type(value).__name__}"
+        )
+
+
+def _install_implications(
+    config: dict[str, _ConfigEntry],
+    namespaces: dict[str, dict[str, Any]],
+) -> tuple[dict[str, tuple[tuple[str, Any, Any], ...]], set[str]]:
+    def resolve_type(name: str) -> Any:
+        entry = config[name]
+        if isinstance(entry.value_type, str):
+            annotations = ModuleType("_config_annotations")
+            annotations.__annotations__ = {"value": entry.value_type}
+            prefix = name[: name.rfind(".") + 1]
+            entry.value_type = get_type_hints(
+                annotations, namespaces[""], namespaces[prefix]
+            )["value"]
+        return entry.value_type
+
+    implications: dict[str, list[tuple[str, Any, Any]]] = {}
+    edges: dict[str, set[str]] = {}
+    for source, entry in config.items():
+        if not entry.implies:
+            continue
+        _validate_implication_source(source, entry.default)
+        for value in (entry.env_value_default, entry.env_value_force):
+            if value is not _UNSET_SENTINEL:
+                _validate_implication_source(source, value)
+        edges[source] = set()
+        for condition, targets in entry.implies.items():
+            if not _matches_implication_type(condition, resolve_type(source)):
+                raise TypeError(
+                    f"invalid implication condition {condition!r} for {source}: expected {entry.value_type}"
+                )
+            if not isinstance(targets, dict):
+                raise TypeError(
+                    f"implication targets for {source}={condition!r} must be a dictionary"
+                )
+            for target, value in targets.items():
+                if not isinstance(target, str):
+                    raise TypeError("implication targets must be dotted config names")
+                if target not in config:
+                    raise ValueError(
+                        f"implication target {target!r} does not exist in this config module"
+                    )
+                target_entry = config[target]
+                if target_entry.alias is not None:
+                    raise ValueError(f"implication target {target} cannot be an alias")
+                if not _matches_implication_type(value, resolve_type(target)):
+                    raise TypeError(
+                        f"invalid implied value {value!r} for {target}: expected {target_entry.value_type}"
+                    )
+                edges[source].add(target)
+                implications.setdefault(target, []).append((source, condition, value))
+
+    try:
+        TopologicalSorter(edges).prepare()
+    except CycleError as exc:
+        raise ValueError(f"config implication cycle: {exc.args[1]}") from exc
+    return {
+        key: tuple(sorted(rules, key=repr)) for key, rules in implications.items()
+    }, set(edges)
 
 
 class ConfigModule(ModuleType):
@@ -516,6 +645,114 @@ class ConfigModule(ModuleType):
             )
         module, constant_name = data
         setattr(module, constant_name, val)
+
+    def _resolve_patch_changes(self, changes: dict[str, Any]) -> _ResolvedConfigChanges:
+        targets = []
+        modules = {self}
+        for key, value in changes.items():
+            module: ModuleType = self
+            seen: set[tuple[ModuleType, str]] = set()
+            while isinstance(module, ConfigModule):
+                if (module, key) in seen:
+                    raise ValueError(f"config alias cycle at {module.__name__}.{key}")
+                seen.add((module, key))
+                if key not in module._config:
+                    raise AttributeError(f"{module.__name__}.{key} does not exist")
+                modules.add(module)
+                entry = module._config[key]
+                module._warn_if_deprecated(key, entry)
+                alias = module._get_alias_module_and_name(entry)
+                if alias is None:
+                    break
+                module, key = alias
+            targets.append((module, key, value))
+        return targets, modules
+
+    def _set_raw_values(
+        self,
+        changes: dict[str, Any],
+        *,
+        prior: dict[tuple[ModuleType, str], tuple[Any, bool]] | None = None,
+    ) -> Callable[[], None]:
+        targets: list[tuple[ModuleType, str, Any]] = []
+        modules = {self}
+        changed: dict[_ImplicationConfigModule, set[str]] = {}
+
+        def invalidate() -> None:
+            for module in modules:
+                module._hash_dirty_var.set(True)
+            for module, key, _ in targets:
+                if isinstance(module, ConfigModule):
+                    module._mark_get_dict_dirty(key)
+            for module, key in prior or ():
+                if isinstance(module, ConfigModule):
+                    module._mark_get_dict_dirty(key)
+
+        def validate() -> None:
+            for module, keys in changed.items():
+                module._validate_active_implications(keys)
+
+        def restore_hide(entry: _ConfigEntry, hide: bool) -> None:
+            if entry.hide != hide:
+                entry.hide = hide
+
+        try:
+            with contextlib.ExitStack() as rollback:
+                for (module, key), (value, hide) in (prior or {}).items():
+                    if isinstance(module, ConfigModule):
+                        modules.add(module)
+                        entry = module._config[key]
+                        rollback.callback(entry.user_override.set, value)
+                        rollback.callback(restore_hide, entry, hide)
+                    else:
+                        rollback.callback(setattr, module, key, value)
+                targets, resolved_modules = self._resolve_patch_changes(changes)
+                modules.update(resolved_modules)
+                for module, key, value in targets:
+                    if isinstance(module, _ImplicationConfigModule):
+                        changed.setdefault(module, set()).add(key)
+                        if key in module._implication_sources:
+                            _validate_implication_source(key, value)
+                    if isinstance(module, ConfigModule):
+                        entry = module._config[key]
+                        # Snapshot before external getters can materialize config defaults.
+                        token = entry.user_override.set(entry.user_override.get())
+                        rollback.callback(entry.user_override.reset, token)
+                        rollback.callback(restore_hide, entry, entry.hide)
+                external_prior = {}
+                for module, key, _ in targets:
+                    if isinstance(module, ConfigModule):
+                        continue
+                    target = (module, key)
+                    if target not in external_prior and (
+                        prior is None or target not in prior
+                    ):
+                        external_prior[target] = getattr(module, key)
+                for module, key, value in targets:
+                    if isinstance(module, ConfigModule):
+                        entry = module._config[key]
+                        entry.user_override.set(value)
+                        if entry.hide:
+                            entry.hide = False
+                    else:
+                        if (module, key) in external_prior:
+                            rollback.callback(
+                                setattr, module, key, external_prior.pop((module, key))
+                            )
+                        setattr(module, key, value)
+                validate()
+                undo = rollback.pop_all()
+        finally:
+            invalidate()
+
+        def revert() -> None:
+            try:
+                undo.close()
+            finally:
+                invalidate()
+            validate()
+
+        return revert
 
     _GET_DICT_DIRTY_KEYS_CAP = 16
 
@@ -669,6 +906,11 @@ class ConfigModule(ModuleType):
         config = self._get_dict(
             ignored_prefixes=prefixes, readonly_values=readonly_values
         )
+        source_values = (
+            {key: config[key] for key in self._implication_sources if key in config}
+            if isinstance(self, _ImplicationConfigModule)
+            else None
+        )
         serializer = getattr(self, "_cache_config_serializer", None)
         if serializer is not None:
             serializer(config)
@@ -685,6 +927,8 @@ class ConfigModule(ModuleType):
                             f"implement uuid(). Implement uuid() for cache key "
                             f"participation."
                         )
+        if isinstance(self, _ImplicationConfigModule):
+            self._validate_serialized_sources(config, source_values)
         return config
 
     def codegen_config(self) -> str:
@@ -816,11 +1060,21 @@ class ConfigModule(ModuleType):
 
         lines = []
         mod = self.__name__
-        for k, v in self._get_dict(
+        values = self._get_dict(
             ignored_keys=getattr(self, "_save_config_ignore", []),
             skip_default=True,
             readonly_values=True,
-        ).items():
+        )
+        if isinstance(self, _ImplicationConfigModule):
+            self._validate_serialized_sources(values, skip_default=True)
+            raw_values = {
+                k: values.pop(k)
+                for k in tuple(values)
+                if k in self._implication_sources or k in self._implications
+            }
+            if raw_values:
+                lines.append(f"{mod}.load_config({raw_values!r})")
+        for k, v in values.items():
             lines.append(get_config_line(mod, k, v))
         for import_name in imports:
             lines.insert(0, f"import {import_name}")
@@ -870,9 +1124,24 @@ class ConfigModule(ModuleType):
             config = pickle.loads(maybe_pickled_config)
         else:
             config = maybe_pickled_config
-        for k, v in config.items():
+        applied = False
+        for index, (k, v) in enumerate(config.items()):
             if k in self._config:
-                setattr(self, k, v)
+                if not applied and (
+                    isinstance(self, _ImplicationConfigModule) or self._config[k].alias
+                ):
+                    # Preserve ordinary alias import order until implications need a batch.
+                    _, modules = self._resolve_patch_changes({k: v})
+                    if any(isinstance(m, _ImplicationConfigModule) for m in modules):
+                        changes = {
+                            key: value
+                            for key, value in list(config.items())[index:]
+                            if key in self._config
+                        }
+                        self._set_raw_values(changes)
+                        applied = True
+                if not applied:
+                    setattr(self, k, v)
             else:
                 from torch._dynamo.utils import warn_once
 
@@ -935,19 +1204,53 @@ class ConfigModule(ModuleType):
                 )
         if not isinstance(changes, dict):
             raise AssertionError(f"expected `dict` got {type(changes)}")
+        if isinstance(self, _ImplicationConfigModule):
+            return _ImplicationConfigPatch(self, changes)
         config = self
 
         class ConfigPatch(ContextDecorator):
             def __init__(self) -> None:
                 self.changes = changes
-                self._prior: ContextVar[tuple[dict[str, Any], ...]] = ContextVar(
+                self._prior: ContextVar[
+                    tuple[dict[str, Any] | Callable[[], None], ...]
+                ] = ContextVar(
                     f"{config.__name__}.ConfigPatch[{id(self)}]",
                     default=(),
                 )
 
             def __enter__(self) -> None:
+                has_alias = any(
+                    config._config[key].alias
+                    for key in self.changes
+                    if key in config._config
+                )
                 prior: dict[str, Any] = {}
-                for key in self.changes:
+                raw_prior: dict[tuple[ModuleType, str], tuple[Any, bool]] = {}
+                for key, value in self.changes.items():
+                    if has_alias and key in config._config:
+                        module, name = config, key
+                        if config._config[key].alias:
+                            targets, modules = config._resolve_patch_changes(
+                                {key: value}
+                            )
+                            if any(
+                                isinstance(m, _ImplicationConfigModule) for m in modules
+                            ):
+                                revert = config._set_raw_values(
+                                    self.changes, prior=raw_prior
+                                )
+                                self._prior.set((*self._prior.get(), revert))
+                                return
+                            module, name, _ = targets[0]
+                        if isinstance(module, ConfigModule):
+                            entry = module._config[name]
+                            raw_prior.setdefault(
+                                (module, name), (entry.user_override.get(), entry.hide)
+                            )
+                        else:
+                            prior[key] = config.__getattr__(key)
+                            raw_prior.setdefault((module, name), (prior[key], False))
+                            continue
                     # KeyError on invalid entry
                     prior[key] = config.__getattr__(key)
                 prior_stack = self._prior.get()
@@ -967,8 +1270,11 @@ class ConfigModule(ModuleType):
                     )
                 prior = prior_stack[-1]
                 self._prior.set(prior_stack[:-1])
-                for k, v in prior.items():
-                    config.__setattr__(k, v)
+                if callable(prior):
+                    prior()
+                else:
+                    for k, v in prior.items():
+                        config.__setattr__(k, v)
 
         return ConfigPatch()
 
@@ -1010,6 +1316,148 @@ class ConfigModule(ModuleType):
         return change
 
 
+class _ImplicationConfigModule(ConfigModule):
+    _implications: dict[str, tuple[tuple[str, Any, Any], ...]]
+    _implication_sources: set[str]
+    _implication_dynamic_sources: set[str]
+    _implication_hash: bytes
+
+    def _get_implied_value(
+        self, name: str, resolved: dict[str, Any] | None = None
+    ) -> Any:
+        if resolved is None:
+            resolved = {}
+        result = _UNSET_SENTINEL
+        for source, condition, value in self._implications.get(name, ()):
+            if source not in resolved:
+                resolved[source] = self._get_resolved_value(source, resolved)
+            selected = resolved[source]
+            if type(selected) is not type(condition) or selected != condition:
+                continue
+            if result is not _UNSET_SENTINEL and (
+                type(result) is not type(value) or result != value
+            ):
+                raise ValueError(f"conflicting config implications for {name}")
+            result = value
+        return result
+
+    def _validate_active_implications(self, changes: set[str] | None = None) -> None:
+        if changes is not None and not changes & self._implication_sources:
+            return
+        affected: dict[str, bool] = {}
+
+        def is_affected(name: str) -> bool:
+            if changes is None:
+                return True
+            if name not in affected:
+                affected[name] = any(
+                    source in changes or is_affected(source)
+                    for source, _, _ in self._implications.get(name, ())
+                )
+            return affected[name]
+
+        resolved: dict[str, Any] = {}
+        for target in self._implications:
+            if is_affected(target):
+                self._get_implied_value(target, resolved)
+
+    def _get_resolved_value(self, name: str, resolved: dict[str, Any]) -> Any:
+        if name in self._implications and not self._config[name].hide:
+            implied = self._get_implied_value(name, resolved)
+            if implied is not _UNSET_SENTINEL:
+                self._warn_if_deprecated(name, self._config[name])
+                return implied
+        return super().__getattr__(name)
+
+    def __getattr__(self, name: str) -> Any:
+        return self._get_resolved_value(name, {})
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if (
+            name in self._implications
+            and self._get_implied_value(name) is not _UNSET_SENTINEL
+        ):
+            self._warn_if_deprecated(name, self._config[name])
+            return
+        if name in self._implication_sources:
+            self._set_raw_values({name: value})
+        else:
+            super().__setattr__(name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if (
+            name in self._implications
+            and self._get_implied_value(name) is not _UNSET_SENTINEL
+        ):
+            # Keeping the attribute present prevents mock.patch writing back an implied value.
+            return
+        super().__delattr__(name)
+
+    def _is_default(self, name: str) -> bool:
+        return name not in self._implication_dynamic_sources and super()._is_default(
+            name
+        )
+
+    def _get_dict(
+        self,
+        ignored_keys: list[str] | None = None,
+        ignored_prefixes: list[str] | None = None,
+        skip_default: bool = False,
+        readonly_values: bool = False,
+    ) -> dict[str, Any]:
+        # JustKnobs can change without a config write to invalidate cached snapshots.
+        for source in self._implication_dynamic_sources:
+            self._mark_get_dict_dirty(source)
+        return super()._get_dict(
+            ignored_keys, ignored_prefixes, skip_default, readonly_values
+        )
+
+    def _validate_serialized_sources(
+        self,
+        values: dict[str, Any],
+        source_values: dict[str, Any] | None = None,
+        *,
+        skip_default: bool = False,
+    ) -> None:
+        for source in self._implication_sources:
+            if skip_default and source not in values and self._is_default(source):
+                continue
+            saved = values.get(source, _UNSET_SENTINEL)
+            expected = (
+                source_values.get(source, _UNSET_SENTINEL)
+                if source_values is not None
+                else saved
+            )
+            if (
+                saved is _UNSET_SENTINEL
+                or type(saved) is not type(expected)
+                or saved != expected
+            ):
+                raise ValueError(
+                    f"implication source {source} must be serialized unchanged"
+                )
+
+    def save_config(self) -> bytes:
+        values = self._get_dict(
+            ignored_keys=getattr(self, "_save_config_ignore", []), readonly_values=True
+        )
+        self._validate_serialized_sources(values)
+        return pickle.dumps(values, protocol=2)
+
+    def get_hash(self) -> bytes:
+        if self._implication_sources & self._compile_ignored_keys:
+            raise ValueError("implication sources must participate in config hashing")
+        if self._implication_dynamic_sources:
+            self._hash_dirty_var.set(True)
+        return hashlib.md5(
+            super().get_hash() + self._implication_hash, usedforsecurity=False
+        ).digest()
+
+    def _make_closure_patcher(self, **changes: dict[str, Any]) -> Any:
+        # Opt-in modules validate on apply and revert; persistent conflicting changes raise.
+        return functools.partial(self._set_raw_values, changes)
+
+
 class ContextDecorator(contextlib.ContextDecorator):
     """
     Same as contextlib.ContextDecorator, but with support for
@@ -1049,6 +1497,28 @@ class ContextDecorator(contextlib.ContextDecorator):
             return _TestCase
 
         return super().__call__(func)
+
+
+class _ImplicationConfigPatch(ContextDecorator):
+    def __init__(
+        self, config: _ImplicationConfigModule, changes: dict[str, Any]
+    ) -> None:
+        self.config = config
+        self.changes = changes
+        self._prior: ContextVar[tuple[Callable[[], None], ...]] = ContextVar(
+            f"{config.__name__}.ImplicationConfigPatch[{id(self)}]", default=()
+        )
+
+    def __enter__(self) -> None:
+        revert = self.config._set_raw_values(self.changes)
+        self._prior.set((*self._prior.get(), revert))
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        prior = self._prior.get()
+        if not prior:
+            raise AssertionError("prior should not be empty when exiting config patch")
+        self._prior.set(prior[:-1])
+        prior[-1]()
 
 
 class SubConfigProxy:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196039
* #196038
* #196037
* #196036
* #196035
* #196034
* #196033
* #196032
* #196030
* #196029
* #195640
* __->__ #196663

Config modes that activate several options currently require consumers to repeat the mode-dependent logic. Add an opt-in `implies` argument to `Config` so a selected source value can force other settings in the same module through normal attribute access. Inductor strict-numerics adoption is stacked separately on this API.

```python
mode = Config(default="default", implies={"strict": {"feature": True}})
feature = False
```

`implies` defaults to `None`. In strict mode, `feature` reads as `True`, overriding explicit values and forced environment values. Dotted targets and transitive implications are supported. Installation validates names, scalar types, and cycles without evaluating JustKnobs. Sources accept plain `bool`, `int`, `str`, or `None`; subclasses are rejected to preserve hashing and replay semantics. Aliases cannot be implication sources or targets, and conflicting active implications raise an error.

Assignments store the user's preference even while an implication controls reads. Assigning `feature=False` under strict mode leaves its effective value `True`; returning to default mode exposes the stored `False`. `config.patch` temporarily changes stored values and restores the previous state, including unset values. Use it instead of `mock.patch.object`, which is unsupported on targets while implications are active. Patch exit restores raw values before validating them and can raise if persistent changes to other sources leave a conflict, including while unwinding an exception from the body.

Ordinary patches and loads preserve their existing read, write, and alias-import order. Alias-free ordinary operations bypass implication resolution. Alias wrappers switch to grouped updates when a destination enables implications. Grouped patches capture raw values before writing and validate affected dependencies. Caches are invalidated before external alias setters run during application and restoration. Cleanup restores config values before those setters, preserves their original order, and restores unset values even if a setter reads a mutable default or raises.

Serialization and codegen retain raw values rather than generated implication values. Sources must survive filtering and custom serialization unchanged. Rule fingerprints participate in config hashes and custom-backend FX/AOT cache keys. Dictionary snapshots retain per-key invalidation; live JustKnobs sources are refreshed and captured once per export so cached values do not become stale.

Authored with assistance from Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98