### PR TITLE
[ROCm] Skip test_extern_kernel_benchmark_valid_timing on gfx942 pending a Triton fix

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -41,6 +41,7 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     MI200_ARCH,
+    MI300_ARCH,
     skipIfRocmArch,
     TEST_WITH_ROCM,
     TEST_XPU,
@@ -888,6 +889,12 @@ class TestExternKernelCaller(TestCase):
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
     @skipIfRocmArch(MI200_ARCH)
+    # gfx942: the 128x128x64 / 8-warp Triton candidate is miscompiled by the AMD
+    # block-pingpong schedule (LDS race, stale-by-one-BLOCK_K A operands), so the
+    # autotune correctness check fails intermittently; the compile-worker pool
+    # does not forward TRITON_HIP_USE_BLOCK_PINGPONG, so it cannot be disabled
+    # per test. https://github.com/triton-lang/triton/issues/11696
+    @skipIfRocmArch(MI300_ARCH)
     @patches
     def test_extern_kernel_benchmark_valid_timing(self):
         def fn(a, b):


### PR DESCRIPTION
test_extern_kernel_benchmark_valid_timing flakes on mi300 CI (3 hard failures plus 11 retry-masked passes on main in one week) with "Incorrect result from choice TritonTemplateCaller(BLOCK_M=128, BLOCK_N=128, BLOCK_K=64, ..., num_warps=8, num_stages=2)": always that one candidate, always a 4x32 patch of one output tile. The cause is a Triton AMD backend bug on gfx942: the block-pingpong two-cluster schedule emits a raw s_barrier before the wait for the stage's LDS reads, so the other warp group overwrites the LDS buffer while reads are outstanding and the affected accumulator fragment consumes the next k-step's A tile. A plain-Triton matmul at that config fails 200/200 iterations on gfx942 and 0/200 with the schedule disabled; details and repro in https://github.com/triton-lang/triton/issues/11696.

The knob cannot be applied per test because inductor's compile-worker pool forwards only the cache-dir variables, so this skips the test on gfx942 until the Triton fix lands and the pin is bumped. It keeps running on gfx950, which never takes this schedule; the MI200 gate on the same test is being lifted separately.

Test plan is in the commit message. gfx942 validation via the ciflow label below (expect the test to report skipped in the shard that runs test_select_algorithm.py).

This PR was authored with the assistance of an AI agent (Claude). The analysis and test results were verified by hand.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben