### PR TITLE
[ROCm] Clear MI200 test gates after root-causing each one

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -73,7 +73,6 @@ class TestFullyShardOverlap(FSDPTest):
     def world_size(self) -> int:
         return min(2, torch.get_device_module(device_type).device_count())
 
-    @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(
         not hasattr(torch.get_device_module(device_type), "_sleep"),
@@ -192,7 +191,6 @@ class TestFullyShardOverlap(FSDPTest):
         # )
         self.assertLessEqual(fwd_bwd_time, ref_fwd_bwd_time)
 
-    @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(2)
     def test_fully_shard_backward_comm_overlap(self):
         """Exercise backward with reduce-scatter sharing the shard process
@@ -485,6 +483,8 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
             dist.barrier()
             _pg_mod.foreach_reduce = orig
 
+    # Hangs on MI200: RCCL deadlocks when three communicators make
+    # progress concurrently (https://github.com/ROCm/rccl/issues/2191).
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(4)
     @unittest.skipIf(
@@ -494,6 +494,8 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
     def test_fully_shard_per_param_mesh_training_overlap(self):
         self._test_per_param_mesh_overlap(simulate_no_grad_input=False)
 
+    # Hangs on MI200: RCCL deadlocks when three communicators make
+    # progress concurrently (https://github.com/ROCm/rccl/issues/2191).
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(4)
     @unittest.skipIf(

--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -19,10 +19,8 @@ from torch.distributed.elastic.control_plane import (
 from torch.monitor import _WaitCounter
 from torch.testing._internal.common_utils import (
     IS_FBCODE,
-    MI200_ARCH,
     requires_cuda,
     run_tests,
-    skipIfRocmArch,
     TestCase,
 )
 
@@ -189,14 +187,13 @@ class WorkerServerTest(TestCase):
                 self.assertEqual(resp.status, 200, msg=path)
                 self.assertIn("pg_status", json.loads(resp.data))
 
-    @skipIfRocmArch(MI200_ARCH)
     def test_tcp(self) -> None:
         import requests
 
         from torch._C._distributed_c10d import _WorkerServer
 
-        server = _WorkerServer("", 1234)
-        out = requests.get("http://localhost:1234/handler/")
+        server = _WorkerServer("127.0.0.1", 0)
+        out = requests.get(f"http://127.0.0.1:{server.port}/handler/")
         self.assertEqual(out.status_code, 200)
 
         server.shutdown()

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -71,6 +71,8 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_SANDCASTLE,
+    isRocmArchAnyOf,
+    MI200_ARCH,
     parametrize,
     retry_on_connect_failures,
     run_tests,
@@ -3263,6 +3265,12 @@ class DistributedDataParallelTest(
                         opt_ddp = torch.optim.SGD(m_ddp.parameters(), lr=0.1)
                         has_half = any(p.dtype is torch.half for p in m.parameters())
                         tol = 3.0e-3 if has_half else 1.0e-5
+                        if has_half and TEST_WITH_ROCM and isRocmArchAnyOf(MI200_ARCH):
+                            # MIOpen picks fp16 implicit-GEMM group conv solvers on
+                            # gfx90a that lose intermediate precision, and the DDP vs
+                            # full-batch accumulation order difference amplifies it.
+                            # https://github.com/ROCm/rocm-libraries/issues/11938
+                            tol = 8.0e-3
                     except BaseException:
                         # Prints case-specific debugging info to narrow down failing case.
                         print(

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -38,13 +38,7 @@ from torch._inductor.virtualized import V
 from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
 from torch.profiler import kineto_available
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import (
-    IS_LINUX,
-    MI200_ARCH,
-    skipIfRocmArch,
-    TEST_WITH_ROCM,
-    TEST_XPU,
-)
+from torch.testing._internal.common_utils import IS_LINUX, TEST_WITH_ROCM, TEST_XPU
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU,
@@ -860,7 +854,6 @@ class TestExternKernelCaller(TestCase):
         expected = torch.mm(a, b)
         torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
 
-    @skipIfRocmArch(MI200_ARCH)
     @patches
     def test_extern_kernel_caller_hash_key_deduplication(self):
         def fn(a, b, c, d):
@@ -887,7 +880,6 @@ class TestExternKernelCaller(TestCase):
         if not torch.version.hip:  # autotuning is not guaranteed to run on ROCm
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
-    @skipIfRocmArch(MI200_ARCH)
     @patches
     def test_extern_kernel_benchmark_valid_timing(self):
         def fn(a, b):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -83,7 +83,6 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     IS_X86,
     load_tests,
-    MI200_ARCH,
     MI350_ARCH,
     parametrize,
     recover_orig_fp32_precision,
@@ -9221,7 +9220,6 @@ class TestMemPool(TestCase):
             torch.cuda.empty_cache()
 
     @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/176145")
-    @skipIfRocmArch(MI200_ARCH)
     @serialTest()
     def test_deleted_mempool_not_used_on_oom(self):
         """


### PR DESCRIPTION
Clears six MI200 (gfx90a) test gates and widens one tolerance. Each was root-caused on a 4x gfx90a host first; the two MI200 skips that turned out to be real library bugs stay, now with issue links.

- **elastic `test_tcp`** (DISABLED #144689) was never a gfx90a problem. `_WorkerServer("", 1234)` binds IPv6-only on the ROCm runners, where `getaddrinfo("localhost")` returns only `127.0.0.1`, so the request is refused; the hardcoded port was a second latent failure mode on shared runners. Binding `("127.0.0.1", 0)` and reading `_WorkerServer.port` fixes both on every platform, so the arch gate goes away with the bug.
- **`TestExternKernelCaller`** (#170205, #162803): both gates were added with no recorded root cause, and neither test has a gfx90a-specific failure mode on record. The timing test's separate gfx942 flakiness is a Triton codegen bug handled in #196673.
- **`TestFullyShardOverlap`**: one gate is from a ROCm 6.1-era DISABLED issue (#134139), the other was preemptive when the test landed (#186335); both are clean under stress on a current stack. The two `TestFullyShardPerParamMeshOverlap` gates stay - those hang 100% of the time on gfx90a with HSA queues frozen behind partially written packets, an RCCL launch-tracking deadlock filed as https://github.com/ROCm/rccl/issues/2191.
- **`test_deleted_mempool_not_used_on_oom`**: the MI200 gate is dead code under the unconditional Linux skip for #176145 above it, so dropping it changes no test selection.

The DDP fp16 grad-layout tolerance is the one real numerics change. On gfx90a the fp16 case fails deterministically at 3.0e-3, always the same 1-of-512 element at 3.067e-3 absolute, reproducing byte for byte across machines and builds. It is not fp16 arithmetic: a CPU fp16 run tracks fp64 to 7e-6 while the MIOpen GPU run is off by 2.5e-3 on a gradient whose maximum magnitude is 5.4e-3. Per-op bisection localizes it to conv1's data and weight gradients amplified through conv0's 1568-term reduction, and `MIOPEN_DEBUG_CONV_IMPLICIT_GEMM=0` drops the error ~70x; the solvers are `ConvHipImplicitGemmGroup{Bwd,Wrw}Xdlops`, which MIOpen picks for these shapes only on gfx90a. Filed as https://github.com/ROCm/rocm-libraries/issues/11938. The 8.0e-3 bound is measured, not fitted: over a 31-seed sweep the worst DDP versus full-batch difference is 3.8e-3 with each side up to 4.7e-3 from an fp64 reference, bounding the comparison at ~7.4e-3. It applies only to fp16 on gfx90a; CUDA and every other ROCm architecture keep 3.0e-3.

Test plan: on a 4x gfx90a (MI250X) host with ROCm 7.14, each affected test x25 in isolation, then its class, then the full file, plus lintrunner on every touched file. Every unskipped test is 25/25; the DDP fp16 case is 25/25 with the new tolerance and 0/10 without. Residual full-file failures reproduce identically on the unmodified files on that box. Cross-architecture coverage comes from the ciflow labels.

This description and the changes were authored with the assistance of Claude, an AI assistant, and reviewed by me.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben