### PR TITLE
[Feature Refactoring] Use torch.accelerator in ROCm benchmark request

### DIFF
--- a/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
+++ b/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
@@ -70,7 +70,7 @@ class ROCmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
             args,
             self.extra_args,
         )
-        stream_ptr = c_void_p(torch.cuda.current_stream().cuda_stream)
+        stream_ptr = c_void_p(torch.accelerator.current_stream().native_handle)
         run_method = getattr(self.DLL, self.kernel_name)
         workspace_ptr = c_void_p(0)
         if self.workspace_size > 0:
@@ -99,7 +99,7 @@ class ROCmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
             dict.fromkeys(meta.name for meta in self.input_tensor_meta)
         )
         args = [c_void_p(None) for _ in range(unique_input_count + 1)]
-        stream_ptr = c_void_p(torch.cuda.current_stream().cuda_stream)
+        stream_ptr = c_void_p(torch.accelerator.current_stream().native_handle)
 
         run_method = getattr(self.DLL, self.kernel_name)
         # Retrieve workspace_size and initialize workspace.
@@ -114,7 +114,7 @@ class ROCmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
             None,  # null workspace ptr
             stream_ptr,
         )
-        torch.cuda.synchronize()  # shake out any CUDA errors
+        torch.accelerator.synchronize()  # shake out any CUDA errors
         self.workspace_size = c_workspace_size.value
         log.debug(
             "update_workspace_size called: new workspace size=%d, self.kernel_name=%s, self.source_file=%s, self.hash_key=%s, self.DLL=%s, args=%s, self.extra_args=%s",


### PR DESCRIPTION
## Summary
This PR replaces the hardcoded `torch.cuda.*` calls in `torch/_inductor/codegen/rocm/rocm_benchmark_request.py` with the accelerator-agnostic `torch.accelerator` API, using the portable `native_handle` stream accessor.

## Changes
- **`torch/_inductor/codegen/rocm/rocm_benchmark_request.py`**:
  - `make_run_fn` and `update_workspace_size`: `torch.cuda.current_stream().cuda_stream` → `torch.accelerator.current_stream().native_handle`. `native_handle` is defined on the generic `torch.Stream` base and dispatched through the device guard implementation (`c10::Stream::native_handle()` → `VirtualGuardImpl::getStreamNativeHandle()`), so it is valid for every backend — unlike `.cuda_stream`, which only exists on CUDA-family stream objects.
  - `update_workspace_size`: `torch.cuda.synchronize()` → `torch.accelerator.synchronize()`.

## Motivation
`ROCmBenchmarkRequest` is the only non-triton `BenchmarkRequest` under `torch/_inductor/codegen/` and serves as the natural template for backends that need extern-kernel template benchmarking. Its parent `GPUDeviceBenchmarkMixin` already goes through `get_interface_for_device(...)` / `device_interface.synchronize()`; keeping raw `torch.cuda.*` calls in the subclass invites backends to copy them verbatim. The `torch.accelerator` idiom matches what `torch/_dynamo/repro/after_aot.py` already uses upstream for the same purpose.

Behavior on ROCm is unchanged: the benchmark device is the HIP device exposed as "cuda", so `torch.accelerator.current_stream()` and `torch.accelerator.synchronize()` resolve to exactly the original calls.

## Test Plan
- Ran `lintrunner` on the modified file (no new findings vs. baseline) and `python -m py_compile torch/_inductor/codegen/rocm/rocm_benchmark_request.py`.
- On an environment with a registered out-of-tree (non-CUDA) accelerator backend:
  - `import torch._inductor.codegen.rocm.rocm_benchmark_request` succeeds.
  - `torch.accelerator.current_stream().native_handle` returns a valid raw stream handle (verified equal to the backend's own stream-pointer attribute) and `torch.accelerator.synchronize()` executes cleanly.
- The modified code paths only execute on HIP builds (`torch.version.hip` gates the CK template selection that creates this request), which was not available here; equivalence on ROCm follows from the accelerator APIs delegating to the CUDA/HIP module. Would appreciate a sanity run from a ROCm reviewer.

## Notes
- `.cuda_stream` is a CUDA-family-only attribute (the out-of-tree backend tested names its equivalent after its own device), which is why this PR uses `native_handle` rather than moving the `.cuda_stream` access behind another indirection.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben