### PR TITLE
Give the nlohmann and moodycamel interface targets their include directories

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -95,7 +95,10 @@ if(NOT BUILD_LIBTORCHLESS)
   target_link_libraries(c10 PUBLIC headeronly)
   target_link_libraries(c10 PRIVATE fmt::fmt-header-only)
   target_link_libraries(c10 PRIVATE nlohmann)
-  target_link_libraries(c10 PRIVATE moodycamel)
+  # PUBLIC: c10/util/Semaphore.h includes <moodycamel/concurrentqueue.h> when
+  # std::counting_semaphore is unusable, so consumers of that header need the
+  # include directory as well.
+  target_link_libraries(c10 PUBLIC moodycamel)
 
   if(C10_USE_NUMA)
     message(STATUS "NUMA paths:")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1400,9 +1400,6 @@ endif()
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/cpp-httplib)
 
-target_include_directories(torch_cpu PRIVATE
-  ${TORCH_ROOT}/third_party/nlohmann/include)
-
 # The native .pftrace encoder's only extra build dep (perfetto) is pulled in
 # just when the CUPTI stubs were generated above (CUPTI_STUBS_GENERATED): the
 # encoder is useless without Cuspy, which is unavailable at runtime

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1772,8 +1772,10 @@ target_include_directories(httplib SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/third_
 
 # Include nlohmann-json
 add_library(nlohmann INTERFACE IMPORTED)
-include_directories(nlohmann SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/third_party/nlohmann/include)
+target_include_directories(nlohmann SYSTEM INTERFACE
+    ${PROJECT_SOURCE_DIR}/third_party/nlohmann/include)
 
 # Include moodycamel
 add_library(moodycamel INTERFACE IMPORTED)
-include_directories(moodycamel SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/third_party/concurrentqueue)
+target_include_directories(moodycamel SYSTEM INTERFACE
+    ${PROJECT_SOURCE_DIR}/third_party/concurrentqueue)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -66,7 +66,6 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
     ${TORCH_ROOT}/third_party/flatbuffers/include
     ${TORCH_ROOT}/third_party/kineto/libkineto/include
     ${TORCH_ROOT}/third_party/cpp-httplib
-    ${TORCH_ROOT}/third_party/nlohmann/include
 
     ${TORCH_SRC_DIR}/csrc
     ${TORCH_SRC_DIR}/csrc/api/include


### PR DESCRIPTION
Both are `INTERFACE IMPORTED` targets whose include path was set via
`include_directories(<target> SYSTEM INTERFACE ...)`. `include_directories`
takes no target -- the name was just consumed as another path, so neither
target carried a real usage requirement, and every consumer had to name
`third_party/nlohmann/include` for itself. `target_include_directories` is
what was meant; the two hand-written paths go with it.

c10 links moodycamel `PUBLIC` instead of `PRIVATE` for the same reason:
`Semaphore.h` includes `moodycamel/concurrentqueue.h` and holds a
`moodycamel::LightweightSemaphore` by value, so anything including that
header needs the directory too.

Test Plan: verified in isolation that `target_include_directories` propagates
through `target_link_libraries` while `include_directories(<name> ...)` does
not (matches its documented no-target signature).

```
lintrunner --skip CLANGTIDY -a c10/CMakeLists.txt caffe2/CMakeLists.txt \
    cmake/Dependencies.cmake torch/CMakeLists.txt
```

Not build-verified against the full PyTorch CMake project.

Authored with an AI assistant.
