### PR TITLE
Iterate containers directly instead of indexing through c10::irange

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Tile.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tile.cpp
@@ -25,8 +25,9 @@ Tensor tile(const Tensor& self, const IntArrayRef repeats) {
   const int64_t size_diff = self.dim() - static_cast<int64_t>(repeats.size());
   if (size_diff > 0) {
     std::vector<int64_t> new_repeats(size_diff, 1);
-    for (const auto i : c10::irange(repeats.size())) {
-      new_repeats.emplace_back(repeats[i]);
+    new_repeats.reserve(new_repeats.size() + repeats.size());
+    for (const auto& repeat : repeats) {
+      new_repeats.emplace_back(repeat);
     }
     return self.repeat(IntArrayRef(new_repeats));
   }

--- a/torch/csrc/api/include/torch/expanding_array.h
+++ b/torch/csrc/api/include/torch/expanding_array.h
@@ -146,8 +146,8 @@ class ExpandingArrayWithOptionalElem
   /// parameter of the `ExpandingArrayWithOptionalElem`).
   /*implicit*/ ExpandingArrayWithOptionalElem(T single_size)
       : ExpandingArray<D, std::optional<T>>(0) {
-    for (const auto i : c10::irange(this->values_.size())) {
-      this->values_[i] = single_size;
+    for (auto& value : this->values_) {
+      value = single_size;
     }
   }
 

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
@@ -72,8 +72,8 @@ c10::IValue preprocess(
         "method_compile_spec inputs do not match expected number of forward inputs");
 
     example_inputs.reserve(inp_list.size());
-    for (const auto i : c10::irange(inp_list.size())) {
-      example_inputs.emplace_back(inp_list[i]);
+    for (const auto& t : inp_list) {
+      example_inputs.emplace_back(t);
     }
   } else {
     TORCH_CHECK(

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -930,9 +930,9 @@ void ProcessReduceNode(Node* n) {
       std::iota(axes_vector.begin(), axes_vector.end(), 0);
     }
 
-    for (auto idx : c10::irange(axes_vector.size())) {
-      if (axes_vector[idx] < 0) {
-        axes_vector[idx] += rank_0;
+    for (auto& axis : axes_vector) {
+      if (axis < 0) {
+        axis += rank_0;
       }
     }
     final_shape.reserve(rank_0);
@@ -1479,9 +1479,9 @@ void ComputeConstant(Node* n, int opset_version) {
           const auto& input0_shape_value = input0_shape_size.value();
           int64_t total_size = 1;
           auto is_full_static = true;
-          for (const auto i : c10::irange(input0_shape_value.size())) {
-            if (input0_shape_value[i].is_static()) {
-              total_size *= input0_shape_value[i].static_size();
+          for (const auto& shape_symbol : input0_shape_value) {
+            if (shape_symbol.is_static()) {
+              total_size *= shape_symbol.static_size();
             } else {
               is_full_static = false;
               break;

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -529,8 +529,7 @@ struct SymbolicShapeOpAnalyzer {
 
     // there are ways to compute this more efficiently but typically number of
     // Values for each symbolic set is low and this is cheap to run
-    for (const auto i : c10::irange(symbolic_set.size())) {
-      Value* v = symbolic_set[i];
+    for (Value* const v : symbolic_set) {
       Value* dominating_value = v;
       for (const auto& sym_set : symbolic_set) {
         if (dominating_value->node()->isDominatedBy(sym_set->node())) {

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -785,8 +785,8 @@ std::vector<at::Tensor> unsqueezeVarStackInputs(
     const int64_t dim) {
   std::vector<at::Tensor> result;
   result.reserve(inputs.size());
-  for (const auto i : c10::irange(inputs.size())) {
-    result.push_back(at::native::unsqueeze(inputs[i], dim));
+  for (const auto& input : inputs) {
+    result.push_back(at::native::unsqueeze(input, dim));
   }
   return result;
 }

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -462,12 +462,13 @@ Tensor computeFlatten(
     const std::optional<ScalarType>& outputType,
     at::Device device) {
   std::vector<int64_t> outputShapeVec;
-  for (const auto dim : c10::irange(outputShape.size())) {
-    outputShapeVec.push_back(outputShape[dim].AsNode<LongImm>()->value());
+  outputShapeVec.reserve(outputShape.size());
+  for (const auto& dim : outputShape) {
+    outputShapeVec.push_back(dim.AsNode<LongImm>()->value());
   }
   std::vector<ArgValue> reshapeInputs;
   reshapeInputs.push_back(inputs[0]);
-  reshapeInputs.emplace_back(outputShapeVec);
+  reshapeInputs.emplace_back(std::move(outputShapeVec));
   return computeReshape(
       reshapeInputs, outputShape, outputStrides, outputType, device);
 }
@@ -478,6 +479,7 @@ static std::pair<ScalarType, std::vector<BufHandle>> processCatList(
     throw std::runtime_error("Empty input list is passed to aten::cat");
   }
   std::vector<BufHandle> bufInputs;
+  bufInputs.reserve(bufList.size());
   std::vector<BufHandle> nonEmptyInputs;
   for (auto buf : bufList) {
     bufInputs.push_back(buf);


### PR DESCRIPTION
Each of these loops walked `c10::irange(c.size())` only to subscript `c` with
the index it produced, so the index carried nothing the element reference
doesn't. Bound as `const auto&` (`auto&` where the body mutates it).

Overlaps with #196097 (already landed), which covered most of this pattern
elsewhere. Two of this branch's original files (`ZeroTensorFallback.cpp`,
`MathBitsFallback.h`) turned out to be compile errors: both mutate through
`c10::List<Tensor>`'s proxy iterator, whose `operator*` returns a proxy by
value -- binding it to `auto&` doesn't compile, and the proxy's assignment is
`const&&`-qualified, so only `list[j] = ...` or `*it = ...` works, not a named
loop variable. Left those two on the original irange form.

Test Plan: `lintrunner --skip CLANGTIDY -a` on the touched files, clean.
Compiled each standalone with GCC 16 against the real headers; all clean
except two files missing build-generated headers (ONNX protobuf, XNNPACK
flatbuffers schema) in this environment -- isolated and verified the actual
`c10::List<Tensor>` pattern from the XNNPACK one directly instead. Not
otherwise build-verified.

Authored with an AI assistant.


cc @EikanWang @jgong5
