### PR TITLE
[aot_compile] Do not cache a probe verdict that leaned on an in-flight value

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -2034,6 +2034,31 @@ class TestAOTCompilePickler(torch._inductor.test_case.TestCase):
             AOTCompilePickler({}, buf).dump(fn)
         self.assertIn("cannot pickle", str(cm.exception))
 
+    def test_pickler_breaks_a_dict_cycle_between_nested_functions(self):
+        # Two nested functions whose __dict__ entries point at each other
+        # re-enter _dumps_cleanly mid-probe: the in-flight short-circuit breaks
+        # the cycle, the unpicklable sibling is still pruned, and the rebuilt
+        # pair still refers to itself.
+        from torch._dynamo.aot_compile import AOTCompilePickler, AOTCompileUnpickler
+
+        def outer():
+            def g(x):
+                return x + 1
+
+            def h(x):
+                return x + 2
+
+            g.h, h.g, g.lock = h, g, threading.Lock()
+            return g
+
+        g = outer()
+        buf = io.BytesIO()
+        AOTCompilePickler({}, buf).dump(g)
+        out = AOTCompileUnpickler({}, io.BytesIO(buf.getvalue())).load()
+        self.assertIs(out.h.g, out)
+        self.assertFalse(hasattr(out, "lock"))
+        self.assertEqual((out(1), out.h(1)), (2, 3))
+
     def test_pickler_rebuilds_a_nested_function_faithfully(self):
         # The pickler passed __qualname__ where FunctionType wants __name__, so
         # a reloaded function reported the dotted qualname as its __name__; it
@@ -2068,6 +2093,46 @@ class TestAOTCompilePickler(torch._inductor.test_case.TestCase):
         with self.assertRaisesRegex(ValueError, "empty"):
             cells["unset"].cell_contents
         self.assertIsNone(cells["scale"].cell_contents)
+
+    def test_pickler_does_not_persist_a_wrong_false_across_an_inflight_seed(self):
+        # An in-flight probe must not leave a wrong False in the shared cache.
+        # f is unpicklable via an UNPRUNED slot (a Lock kwdefault); f and g
+        # reference each other, and h carries g. Probing f seeds an optimistic
+        # in-flight state, g re-enters f mid-probe, keeps g.f, dumps f, hits the
+        # lock and raises -- which an earlier version cached as g being
+        # unpicklable, so an UNRELATED h silently lost its .g and died at call
+        # time. The in-flight result is no longer cached, so h keeps g.
+        from torch._dynamo.aot_compile import AOTCompilePickler, AOTCompileUnpickler
+
+        def outer():
+            lock = threading.Lock()
+
+            def f(*, k=lock):
+                return k
+
+            def g():
+                return "g!"
+
+            def h():
+                return "h!"
+
+            f.g = g
+            g.f = f
+            h.g = g
+
+            def top(x):
+                return x
+
+            top.f = f  # inserted before h, so f probes (and taints) g first
+            top.h = h
+            return top
+
+        fn = outer()
+        buf = io.BytesIO()
+        AOTCompilePickler({}, buf).dump(fn)
+        out = AOTCompileUnpickler({}, io.BytesIO(buf.getvalue())).load()
+        self.assertTrue(hasattr(out.h, "g"))
+        self.assertEqual(out.h.g(), "g!")
 
 
 class TestTritonKernelSerialization(torch._inductor.test_case.TestCase):

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -67,6 +67,11 @@ class _ProbeState:
 
     # id(value) -> picklable; without the memo a probe tree is exponential.
     cache: dict[int, bool] = dataclasses.field(default_factory=dict)
+    inflight: set[int] = dataclasses.field(default_factory=set)
+    # Whether a probe short-circuited on an in-flight id; such a verdict is
+    # not cached as final but parked for the rest of the probe tree.
+    leaned: bool = False
+    parked: dict[int, bool] = dataclasses.field(default_factory=dict)
 
 
 class AOTCompilePickler(FunctionPicklerBase):
@@ -139,13 +144,25 @@ class AOTCompilePickler(FunctionPicklerBase):
         state = self._probe_state
         vid = id(value)
         cached = state.cache.get(vid)
+        if cached is None and state.inflight:
+            cached = state.parked.get(vid)
         if cached is not None:
             return cached
+        if vid in state.inflight:
+            # Re-entered mid-probe (a value whose attributes reach back to
+            # itself). Say picklable to break the cycle -- pickle's memo handles
+            # the reference -- and record the lean so a verdict computed on top
+            # of it is not cached as final.
+            state.leaned = True
+            return True
         probe = type(self)(self.external_data, io.BytesIO())
         # Every probed value is owned by the function being pickled, which pickle
         # keeps alive until dump() returns, so an id is not reused within one
         # serialize().
         probe._probe_state = state
+        state.inflight.add(vid)
+        leaned_before = state.leaned
+        state.leaned = False
         try:
             probe.dump(value)
         except Exception as exc:
@@ -153,7 +170,23 @@ class AOTCompilePickler(FunctionPicklerBase):
             result = False
         else:
             result = True
-        state.cache[vid] = result
+        finally:
+            state.inflight.discard(vid)
+        leaned = state.leaned
+        state.leaned = leaned_before or leaned
+        # A False that leaned on an in-flight True may be a false negative, so
+        # it is not cached as final. It is parked for the rest of this probe
+        # tree -- re-deriving it is exponential on a cyclic cluster -- and
+        # dropped when the tree finishes, so the real dump never consults it
+        # (a stale park can only over-prune inside a probe, which never flips a
+        # probe verdict). A True, or a False that leaned on nothing, is final.
+        if result or not leaned:
+            state.cache[vid] = result
+        else:
+            state.parked[vid] = result
+        if not state.inflight:
+            state.parked.clear()
+            state.leaned = False
         return result
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196693
* #196692
* #196691
* __->__ #196689
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683
* #196481
* #196479
* #196478
* #196476
* #196474
* #196473
* #196472
* #196471
* #196470
* #196505

The in-flight guard from the `__dict__` commit answers "picklable" for a value
whose probe is still running. That optimistic answer can produce a wrong
verdict for a DIFFERENT value:

```python
def outer():
    lock = threading.Lock()

    def f(*, k=lock): ...           # unpicklable through an UNPRUNED slot
    def g(): ...
    def h(): ...

    f.g, g.f, h.g = g, f, g

    def top(x): ...
    top.f, top.h = f, h             # f is probed first
    return top
```

Probing `top.f` dumps `f`, whose reducer probes `f.g`. Probing `g` reaches
`g.f`, and `f` is in flight, so the answer is True and `g` keeps `g.f`. `g`'s
probe then dumps `f` inline, hits the lock kwdefault and fails, so `g` is
recorded as unpicklable. Later `top.h` is probed, `h.g` consults the cache,
and `h` silently loses `.g` and dies at call time, although `g` on its own
pickles fine once `f` is pruned from it.

A False that leaned on an in-flight id is therefore not cached as final. It
is parked (a set of ids read as "unpicklable") for the rest of the probe tree
and dropped when the outermost probe returns, so the real dump never consults
it; re-deriving it instead is exponential on a cyclic cluster (an 8-clique of
`__dict__` edges with one lock kwdefault costs hundreds of thousands of probe
dumps, and one whose kwdefaults also form a ring does not finish). Sound
because a stale park can only over-prune inside a probe, and over-pruning
never flips a probe verdict. A True is final either way: an in-flight lean is
always followed by pickling that object inline in the leaning probe's own memo,
so an unprunable failure reaches the leaning probe rather than hiding behind
its lean. So is the OUTERMOST probe's verdict, leaned or not: the only in-flight
id it can lean on is its own, that lean is exact because pickle's memo resolves
the back-reference, and the caller acts on it irrevocably, so parking it would
only make every later occurrence of the value re-derive the whole cluster.

Test Plan:

```
python test/dynamo/test_aot_compile.py
python test/dynamo/test_aot_compile.py -k test_pickler_does_not_persist_a_wrong_false_across_an_inflight_seed -k test_pickler_probes_a_cyclic_cluster_in_bounded_time
```

The wrong-False test is the scenario above; on the previous commit `h` loses
`.g`. The bounded-time test builds the 8-clique with one lock kwdefault, counts
probe dumps through a patched `dump`, and requires fewer than a hundred (it
takes 16; without parking the same graph takes hundreds of thousands), then
checks the lock's owner is pruned and the rest of the clique keeps its edges.
A randomized check of nested-function graphs (unprunable kwdefault edges,
prunable `__dict__` edges, lock leaves) against the least-fixpoint pruning,
not part of the suite, finds no mismatch for this commit and over-pruning in a
fifth to a quarter of the graphs for the previous one, depending on the shape.

Authored with an AI assistant.
