### PR TITLE
[aot_compile] Prune an unmarked nn.Module reached through a nested function

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -2059,6 +2059,34 @@ class TestAOTCompilePickler(torch._inductor.test_case.TestCase):
         self.assertFalse(hasattr(out, "lock"))
         self.assertEqual((out(1), out.h(1)), (2, 3))
 
+    def test_pickler_prunes_an_unmarked_module_from_a_nested_functions_dict(self):
+        # persistent_id records an nn.Module rather than raising, so a Module
+        # reached through a nested function's __dict__ would dump here and then
+        # poison serialize(); _dumps_cleanly prunes it instead -- unless the user
+        # marked it as external data, in which case it is kept by reference.
+        from torch._dynamo.aot_compile import AOTCompilePickler, AOTCompileUnpickler
+
+        mod = torch.nn.Linear(1, 1)
+
+        def outer():
+            def helper(x):
+                return x
+
+            helper.mod = mod
+            return helper
+
+        fn = outer()
+        buf = io.BytesIO()
+        pickler = AOTCompilePickler({}, buf)
+        pickler.dump(fn)
+        self.assertEqual(pickler.errors, {})
+        out = AOTCompileUnpickler({}, io.BytesIO(buf.getvalue())).load()
+        self.assertFalse(hasattr(out, "mod"))
+        buf = io.BytesIO()
+        AOTCompilePickler({"mod": mod}, buf).dump(fn)
+        out = AOTCompileUnpickler({"mod": mod}, io.BytesIO(buf.getvalue())).load()
+        self.assertIs(out.mod, mod)
+
     def test_pickler_rebuilds_a_nested_function_faithfully(self):
         # The pickler passed __qualname__ where FunctionType wants __name__, so
         # a reloaded function reported the dotted qualname as its __name__; it

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -169,7 +169,13 @@ class AOTCompilePickler(FunctionPicklerBase):
             log.debug("pruning unpicklable %r from a nested function: %s", value, exc)
             result = False
         else:
-            result = True
+            # persistent_id records nn.Module instances rather than raising, so
+            # such a value dumps here but would poison the real serialize();
+            # treat it as unpicklable so it is pruned now instead of failing the
+            # whole dump later.
+            result = not probe.errors
+            if not result:
+                log.debug("pruning unmarked nn.Module %r from a nested function", value)
         finally:
             state.inflight.discard(vid)
         leaned = state.leaned


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196693
* #196692
* #196691
* __->__ #196690
* #196689
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683
* #196481
* #196479
* #196478
* #196476
* #196474
* #196473
* #196472
* #196471
* #196470
* #196505

`persistent_id` does not raise on an `nn.Module` the user did not mark as
external data; it records the module in `pickler.errors` and `serialize()`
fails the save afterwards with the "mark these as external data" message. A
probe therefore dumps such a module cleanly, the real dump carries it, and the
save fails on a module that only reached the artifact through a helper's
`__dict__` -- the same incidental-attribute failure the probe exists to prevent.

Treat a probe that recorded an error as unpicklable, so the entry is pruned. A
module the user did mark is written by reference by `persistent_id` and kept.
A module the user genuinely intends as payload still reaches `serialize()`
through the top-level `CompileArtifacts.signature`, which is dumped unpruned,
so its diagnostic is not lost; only the incidental attribute is dropped, with a
debug log naming it.

Test Plan:

```
python test/dynamo/test_aot_compile.py
python test/dynamo/test_aot_compile.py -k test_pickler_prunes_an_unmarked_module_from_a_nested_functions_dict
```

The test puts a `Linear` in a helper's `__dict__`: unmarked, the dump records
no error and the reloaded helper has no `.mod`; marked as external data, the
reloaded `.mod` is the same object.

Authored with an AI assistant.