### PR TITLE
[pipelining] Stagger FSDP unshards across schedule compute

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -39,6 +39,7 @@ from torch.distributed.pipelining.schedules import (
     _merge_bw,
     _PipelineSchedule,
     _PipelineScheduleRuntime,
+    _resolve_unshard_lookahead,
     _simulate_comms_compute,
     _validate_schedule,
     B,
@@ -51,6 +52,7 @@ from torch.distributed.pipelining.schedules import (
     RECV_F,
     RESHARD,
     SEND_B,
+    SEND_F,
     UNSHARD,
     W,
 )
@@ -1009,6 +1011,140 @@ class TestSchedulePlan(TestCase):
         self.assertEqual(count_stage_15_unshards(default_schedule), 4)
         self.assertEqual(count_stage_15_unshards(retained_schedule), 1)
 
+    @staticmethod
+    def _interleaved_schedule(*, unshard_lookahead=None):
+        stages = [
+            MockPipelineStage(group_size=4, group_rank=3, num_stages=16)
+            for _ in range(4)
+        ]
+        return ScheduleInterleaved1F1B(
+            stages,
+            n_microbatches=16,
+            max_active_stages=4,
+            unshard_lookahead=unshard_lookahead,
+        )
+
+    @staticmethod
+    def _unshards_before_first_compute(actions):
+        count = 0
+        for action in actions:
+            if action.computation_type == UNSHARD:
+                count += 1
+            elif action.is_compute_op:
+                break
+        return count
+
+    def test_unshard_lookahead_default_is_rank_aware(self):
+        schedule = self._interleaved_schedule()
+        self.assertEqual(
+            [
+                self._unshards_before_first_compute(
+                    schedule.pipeline_order_with_comms[rank]
+                )
+                for rank in range(4)
+            ],
+            [2, 3, 4, 4],
+        )
+
+    def test_unshard_lookahead_maximum_reproduces_legacy_prefetch(self):
+        schedule = self._interleaved_schedule(unshard_lookahead=4)
+        self.assertEqual(
+            [
+                self._unshards_before_first_compute(
+                    schedule.pipeline_order_with_comms[rank]
+                )
+                for rank in range(4)
+            ],
+            [4, 4, 4, 4],
+        )
+
+    def test_unshard_lookahead_rejects_invalid_values(self):
+        self.assertEqual(_resolve_unshard_lookahead(None, 0, 4), 2)
+        self.assertEqual(_resolve_unshard_lookahead(None, 3, 4), 4)
+        self.assertEqual(_resolve_unshard_lookahead(3, 0, 4), 3)
+        for lookahead in (True, False, 0, -1, 5, "auto"):
+            with self.subTest(unshard_lookahead=lookahead):
+                with self.assertRaises(ValueError):
+                    _resolve_unshard_lookahead(lookahead, 0, 4)  # type: ignore[arg-type]
+
+    @parametrize(
+        "ScheduleClass",
+        [
+            ScheduleLoopedBFS,
+            ScheduleInterleaved1F1B,
+            ScheduleInterleavedZeroBubble,
+            ScheduleZBVZeroBubble,
+            ScheduleDualPipeV,
+        ],
+    )
+    def test_unshard_lookahead_preserves_non_prefetch_work(self, ScheduleClass):
+        num_local_stages = (
+            2 if ScheduleClass in (ScheduleZBVZeroBubble, ScheduleDualPipeV) else 4
+        )
+        group_size = 4
+        num_stages = num_local_stages * group_size
+
+        def build(lookahead):
+            stages = [
+                MockPipelineStage(group_size=group_size, num_stages=num_stages)
+                for _ in range(num_local_stages)
+            ]
+            return ScheduleClass(
+                stages,
+                n_microbatches=16,
+                max_active_stages=num_local_stages,
+                unshard_lookahead=lookahead,
+            )
+
+        adaptive = build(None)
+        legacy = build(num_local_stages)
+        p2p = (SEND_F, SEND_B, RECV_F, RECV_B)
+
+        for rank in range(group_size):
+            with self.subTest(rank=rank):
+                adaptive_actions = adaptive.pipeline_order_with_comms[rank]
+                legacy_actions = legacy.pipeline_order_with_comms[rank]
+                self.assertEqual(
+                    sum(a.computation_type == UNSHARD for a in adaptive_actions),
+                    sum(a.computation_type == UNSHARD for a in legacy_actions),
+                )
+                self.assertEqual(
+                    sum(a.computation_type == RESHARD for a in adaptive_actions),
+                    sum(a.computation_type == RESHARD for a in legacy_actions),
+                )
+                self.assertEqual(
+                    [
+                        a
+                        for a in adaptive_actions
+                        if a.computation_type != UNSHARD
+                        and a.computation_type not in p2p
+                    ],
+                    [
+                        a
+                        for a in legacy_actions
+                        if a.computation_type != UNSHARD
+                        and a.computation_type not in p2p
+                    ],
+                )
+                self.assertEqual(
+                    {
+                        kind: sum(a.computation_type == kind for a in adaptive_actions)
+                        for kind in p2p
+                    },
+                    {
+                        kind: sum(a.computation_type == kind for a in legacy_actions)
+                        for kind in p2p
+                    },
+                )
+
+    def test_unshard_lookahead_rejects_prelowered_schedule(self):
+        schedule = self._interleaved_schedule(unshard_lookahead=2)
+        with self.assertRaisesRegex(ValueError, "already-lowered"):
+            schedule._prepare_schedule_with_comms(
+                schedule.pipeline_order_with_comms,
+                format="compute_comms",
+            )
+
     @parametrize(
         "ScheduleClass",
         [ScheduleInterleaved1F1B, ScheduleInterleavedZeroBubble],
@@ -1197,7 +1333,10 @@ class TestScheduleLowering(TestCase):
         compute_sch = self._parse_actions(test_info["compute"])
         expected_comms_sch = self._parse_actions(test_info["comms"])
 
-        comms_sch = _add_unshard_reshard(compute_sch)
+        comms_sch = _add_unshard_reshard(
+            compute_sch,
+            unshard_lookahead=3,
+        )
         for expected, actual in zip(expected_comms_sch, comms_sch):
             self.assertEqual(
                 expected,

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1795,6 +1795,8 @@ def _add_reduce_grad(
 def _add_unshard_reshard(
     compute_actions: list[_Action | None],
     max_active_stages: int = 3,
+    *,
+    unshard_lookahead: int,
 ) -> list[_Action]:
     """Given a basic schedule involving only compute actions (F,B,W,OVERLAP_F_B), add UNSHARD/RESHARD actions for FSDP.
 
@@ -1803,10 +1805,19 @@ def _add_unshard_reshard(
 
     We abandon the "timestep lock"  during lowering
 
-    max_active_stages controls how many prefetches we allow. It should be measured in mb and tuneable but in practice
-    3 stages is probably the thing we want?
-    (to account for having one f and one b active, and something else prefetching?)
+    ``max_active_stages`` controls residency and eviction. The separately
+    resolved ``unshard_lookahead`` controls how many upcoming distinct stages
+    may issue asynchronous all-gathers. Keeping these windows independent lets
+    callers stagger prefetch without introducing extra reshard/unshard cycles.
     """
+    if isinstance(unshard_lookahead, bool) or not (
+        1 <= unshard_lookahead <= max_active_stages
+    ):
+        raise ValueError(
+            "unshard_lookahead must be an integer within "
+            f"[1, max_active_stages={max_active_stages}], got "
+            f"{unshard_lookahead!r}"
+        )
 
     def next_stage_indices(count: int, next_actions: list[_Action | None]) -> list[int]:
         """Remove duplicates (same stage, different microbatch), find next 'count' stages that will do compute."""
@@ -1847,12 +1858,12 @@ def _add_unshard_reshard(
         if action is None:
             continue
 
-        # We prefetch the next N stages we'll see, dropping existing stages to make room
-        next_n = next_stage_indices(max_active_stages, compute_actions[i:])
+        resident = next_stage_indices(max_active_stages, compute_actions[i:])
+        prefetch = next_stage_indices(unshard_lookahead, compute_actions[i:])
         # Fetch needs to be ordered correctly, so don't use a set
-        fetch = list(filter(lambda s: s not in active_stages, next_n))
-        # Unclear what the best policy is for eviction, but we can maintain order so we do
-        evict = list(filter(lambda s: s not in next_n, active_stages))
+        fetch = list(filter(lambda s: s not in active_stages, prefetch))
+        # Lookahead does not evict stages that remain inside the residency window.
+        evict = list(filter(lambda s: s not in resident, active_stages))
 
         # logger.debug(
         #     "_add_unshard_reshard Step %d active: %s fetch %s, evict %s",
@@ -1873,6 +1884,27 @@ def _add_unshard_reshard(
         _reshard(stage)
 
     return fsdp_aware_actions
+
+
+def _resolve_unshard_lookahead(
+    unshard_lookahead: int | None,
+    rank: int,
+    max_active_stages: int,
+) -> int:
+    """Resolve the all-gather prefetch distance for one pipeline rank."""
+    if unshard_lookahead is None:
+        return min(rank + 2, max_active_stages)
+    if isinstance(unshard_lookahead, bool) or not isinstance(unshard_lookahead, int):
+        raise ValueError(
+            f"unshard_lookahead must be an integer or None, got {unshard_lookahead!r}"
+        )
+    if not 1 <= unshard_lookahead <= max_active_stages:
+        raise ValueError(
+            "unshard_lookahead must be within "
+            f"[1, max_active_stages={max_active_stages}], got "
+            f"{unshard_lookahead}"
+        )
+    return unshard_lookahead
 
 
 def _merge_bw(
@@ -2781,6 +2813,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
     def __init__(self, *args, **kwargs):
         self._defer_pp_recv: bool = kwargs.pop("defer_pp_recv", False)
         self._max_active_stages: int = kwargs.pop("max_active_stages", 3)
+        self._unshard_lookahead: int | None = kwargs.pop("unshard_lookahead", None)
         self._reuse_recv_buffers: bool = kwargs.pop("reuse_recv_buffers", False)
         super().__init__(*args, **kwargs)
         # Action to custom function mapping
@@ -2853,6 +2886,11 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
 
         self.pipeline_order_with_comms: dict[int, list[_Action]] = {}
         if format == "compute_comms":
+            if self._unshard_lookahead is not None:
+                raise ValueError(
+                    "unshard_lookahead cannot be applied to an already-lowered "
+                    "compute_comms schedule"
+                )
             for rank in actions:
                 self.pipeline_order_with_comms[rank] = []
                 for action in actions[rank]:
@@ -2877,8 +2915,13 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
 
             # Perform schedule lowering
             for rank in actions:
+                unshard_lookahead = _resolve_unshard_lookahead(
+                    self._unshard_lookahead, rank, self._max_active_stages
+                )
                 self.pipeline_order_with_comms[rank] = _add_unshard_reshard(
-                    actions[rank], max_active_stages=self._max_active_stages
+                    actions[rank],
+                    max_active_stages=self._max_active_stages,
+                    unshard_lookahead=unshard_lookahead,
                 )
                 self.pipeline_order_with_comms[rank] = _add_reduce_grad(  # type: ignore[assignment]
                     self.pipeline_order_with_comms[rank],  # type: ignore[arg-type]
@@ -3290,6 +3333,7 @@ class ScheduleLoopedBFS(_PipelineScheduleRuntime):
         defer_pp_recv: bool = False,
         reuse_recv_buffers: bool = False,
         max_active_stages: int = 3,
+        unshard_lookahead: int | None = None,
     ):
         super().__init__(
             stages=stages,
@@ -3301,6 +3345,7 @@ class ScheduleLoopedBFS(_PipelineScheduleRuntime):
             defer_pp_recv=defer_pp_recv,
             reuse_recv_buffers=reuse_recv_buffers,
             max_active_stages=max_active_stages,
+            unshard_lookahead=unshard_lookahead,
         )
 
         # 1. Create the pipeline_order (all ranks do this calculation)
@@ -3531,6 +3576,7 @@ class ScheduleInterleaved1F1B(_PipelineScheduleRuntime):
         defer_pp_recv: bool = False,
         reuse_recv_buffers: bool = False,
         max_active_stages: int = 3,
+        unshard_lookahead: int | None = None,
     ):
         self.pp_group_size = stages[0].group_size
         super().__init__(
@@ -3545,6 +3591,7 @@ class ScheduleInterleaved1F1B(_PipelineScheduleRuntime):
             defer_pp_recv=defer_pp_recv,
             reuse_recv_buffers=reuse_recv_buffers,
             max_active_stages=max_active_stages,
+            unshard_lookahead=unshard_lookahead,
         )
         self.n_local_stages = len(stages)
         self.rank = stages[0].group_rank
@@ -3644,6 +3691,7 @@ class ScheduleInterleavedZeroBubble(_PipelineScheduleRuntime):
         defer_pp_recv: bool = False,
         reuse_recv_buffers: bool = False,
         max_active_stages: int = 3,
+        unshard_lookahead: int | None = None,
     ):
         # TODO: we don't support input/weight backward split with torch.compile
         _check_torch_compile_compatibility(stages, self.__class__.__name__)
@@ -3660,6 +3708,7 @@ class ScheduleInterleavedZeroBubble(_PipelineScheduleRuntime):
             defer_pp_recv=defer_pp_recv,
             reuse_recv_buffers=reuse_recv_buffers,
             max_active_stages=max_active_stages,
+            unshard_lookahead=unshard_lookahead,
         )
         self.n_local_stages = len(stages)
         self.rank = stages[0].group_rank
@@ -3845,6 +3894,7 @@ class ScheduleZBVZeroBubble(_PipelineScheduleRuntime):
         defer_pp_recv: bool = False,
         reuse_recv_buffers: bool = False,
         max_active_stages: int = 3,
+        unshard_lookahead: int | None = None,
     ):
         # TODO: we don't support input/weight backward split with torch.compile
         _check_torch_compile_compatibility(stages, self.__class__.__name__)
@@ -3861,6 +3911,7 @@ class ScheduleZBVZeroBubble(_PipelineScheduleRuntime):
             defer_pp_recv=defer_pp_recv,
             reuse_recv_buffers=reuse_recv_buffers,
             max_active_stages=max_active_stages,
+            unshard_lookahead=unshard_lookahead,
         )
         self.stage_index_to_group_rank = generate_stage_to_rank_mapping(
             self.pp_group_size, self._num_stages, style="v"
@@ -4035,6 +4086,7 @@ class ScheduleDualPipeV(_PipelineScheduleRuntime):
         defer_pp_recv: bool = False,
         reuse_recv_buffers: bool = False,
         max_active_stages: int = 3,
+        unshard_lookahead: int | None = None,
     ):
         # TODO: we don't support input/weight backward split with torch.compile
         _check_torch_compile_compatibility(stages, self.__class__.__name__)
@@ -4051,6 +4103,7 @@ class ScheduleDualPipeV(_PipelineScheduleRuntime):
             defer_pp_recv=defer_pp_recv,
             reuse_recv_buffers=reuse_recv_buffers,
             max_active_stages=max_active_stages,
+            unshard_lookahead=unshard_lookahead,
         )
         self.stage_index_to_group_rank = generate_stage_to_rank_mapping(
             self.pp_group_size, self._num_stages, style="v"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196706
* __->__ #196709
* #196666
* #196665
* #196465
* #196464
* #196463
* #196462
* #196461
* #196460

Summary:
Separate the FSDP all-gather prefetch window from the stage residency window. Multi-stage schedules now use a rank-aware default prefetch distance while retaining an integer expert override; setting the override to `max_active_stages` reproduces the previous eager-prefetch burst.

The change only moves `UNSHARD` actions. Residency, `RESHARD` placement, collective counts, and wait-before-first-use semantics remain unchanged. Fully lowered `compute_comms` schedules reject a non-default override instead of silently ignoring it.

A controlled 16-GPU DeepSeek V3 PP2/VPP4 comparison measured the rank-aware policy at +1.04% tokens/s/GPU over the previous burst, with 20/20 paired steady-state wins and no material peak-memory change. This is why the adaptive policy is the default rather than a separate mode.

Test Plan:
- `python test/distributed/pipelining/test_schedule.py` (86 tests passed)
- `python test/distributed/pipelining/test_schedule_multiproc.py PerDirectionScheduleTest` (7 tests passed on 4 GPUs)
- `lintrunner` on changed files