### PR TITLE
[ROCm][Inductor] Use Origami to select FlexAttention configs

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -1,16 +1,25 @@
 # Owner(s): ["module: inductor"]
 import logging
+import math
 import os
 import unittest
 from collections.abc import Callable
+from types import SimpleNamespace
 from unittest import mock
+
+import sympy
 
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor import config
+from torch._inductor.heuristics.template import triton as triton_heuristics
 from torch._inductor.heuristics.template.triton import (
     _rocm_version as _th_rocm_version,
+    FlexAttentionConfigContext,
+    FlexConfig,
     ORIGAMI_UNSUPPORTED_ROCM_VERSION,
+    ROCmConfigHeuristic,
+    ROCmFlexConfig,
 )
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
@@ -49,6 +58,287 @@ except ImportError:
 
 
 _PRIOR_FP32_MATMUL_PRECISION: str | None = None
+
+
+class TestOrigamiFlexAttentionConfigSelection(TestCase):
+    """CPU-only coverage for the gating and projected gfx950 candidate pool."""
+
+    def setUp(self):
+        super().setUp()
+        self.heuristic = object.__new__(ROCmConfigHeuristic)
+        self.heuristic.exhaustive_flex_attn_fwd_configs = [
+            ROCmFlexConfig(
+                block_m,
+                block_n,
+                num_stages,
+                num_warps,
+                mfma,
+                waves_per_eu,
+                kpack,
+            )
+            for block_m in (16, 32, 64, 128)
+            for block_n in (32, 64, 128)
+            for num_stages in (1, 2)
+            for num_warps in (2, 4, 8)
+            for mfma in (0, 16)
+            for waves_per_eu in (0, 8 // num_warps)
+            for kpack in (1, 2)
+        ]
+        self.heuristic.flex_attn_fwd_autotune_configs = [
+            ROCmFlexConfig(128, 64, 1, 4, kpack=2)
+        ]
+        self.stock: list[FlexConfig] = [ROCmFlexConfig(128, 64, 2, 4, kpack=2)]
+        self.heuristic.gfx950_default_flex_config = {
+            (torch.float16, 64): self.stock[0],
+            (torch.float16, 128): self.stock[0],
+            (torch.float16, 256): ROCmFlexConfig(32, 64, 2, 4, kpack=2),
+        }
+
+    @staticmethod
+    def _context(**overrides):
+        values = {
+            "batch_size": 1,
+            "kv_batch_size": 1,
+            "num_heads": 16,
+            "num_kv_heads": 16,
+            "seq_len_q": 4096,
+            "seq_len_kv": 4096,
+            "qk_head_dim": 64,
+            "v_head_dim": 64,
+            "qk_head_dim_rounded": 64,
+            "v_head_dim_rounded": 64,
+            "dtype": torch.float16,
+            "device": torch.device("cuda", 0),
+            "inputs_contiguous": True,
+            "is_noop_block_mask": True,
+            "kernel_options": {},
+        }
+        values.update(overrides)
+        return FlexAttentionConfigContext(**values)
+
+    def _select(
+        self,
+        context,
+        *,
+        arch="gfx950",
+        configs: list[FlexConfig] | None = None,
+        search_space="DEFAULT",
+        origami_module=object(),
+        selected_tiles=((128, 128), (64, 128)),
+    ):
+        configs = self.stock if configs is None else configs
+        get_device_properties = mock.Mock(return_value=mock.Mock(gcnArchName=arch))
+        self.last_get_device_properties = get_device_properties
+        with (
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_flex_search_space": search_space,
+                }
+            ),
+            mock.patch.object(triton_heuristics, "origami", origami_module),
+            mock.patch.object(
+                triton_heuristics,
+                "_origami_flex_attention_tiles",
+                return_value=selected_tiles,
+            ),
+            mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                get_device_properties,
+            ),
+            mock.patch.object(
+                self.heuristic,
+                "get_flex_attn_fwd_configs",
+                return_value=self.stock,
+            ),
+        ):
+            return self.heuristic.filter_flex_attn_fwd_configs(configs, context)
+
+    def test_selects_subgemm_tiles_and_keeps_unmodeled_backend_axes(self):
+        selected = self._select(self._context())
+        self.assertEqual(len(selected), 9)
+        self.assertEqual(
+            {(config.block_m, config.block_n) for config in selected},
+            {(128, 128), (64, 128), (128, 64)},
+        )
+        self.assertEqual({config.num_stages for config in selected}, {2})
+        self.assertEqual({config.num_warps for config in selected}, {4})
+        self.assertEqual(
+            [
+                config
+                for config in selected
+                if (config.block_m, config.block_n) == (128, 64)
+            ],
+            self.stock,
+        )
+        self.assertEqual(
+            {
+                (
+                    config.matrix_instr_nonkdim,
+                    config.waves_per_eu,
+                    config.kpack,
+                )
+                for config in selected
+            },
+            {
+                (mfma, waves_per_eu, kpack)
+                for mfma in (0, 16)
+                for waves_per_eu in (0,)
+                for kpack in (1, 2)
+            },
+        )
+
+    def test_preserves_generic_d32_default(self):
+        selected = self._select(
+            self._context(
+                qk_head_dim=32,
+                v_head_dim=32,
+                qk_head_dim_rounded=32,
+                v_head_dim_rounded=32,
+            )
+        )
+        self.assertIn(ROCmFlexConfig(128, 64, 1, 4, kpack=2), selected)
+
+    def test_gqa_keeps_two_and_four_warp_variants(self):
+        selected = self._select(self._context(num_kv_heads=4))
+        self.assertEqual(len(selected), 17)
+        self.assertEqual({config.num_warps for config in selected}, {2, 4})
+
+    def test_queries_the_compiling_device(self):
+        self._select(self._context(device=torch.device("cuda", 3)))
+        self.last_get_device_properties.assert_called_once_with(3)
+
+    def test_falls_back_outside_measured_domain(self):
+        cases = {
+            "block_mask": self._context(is_noop_block_mask=False),
+            "short_sequence": self._context(seq_len_q=512),
+            "d128_transition": self._context(
+                seq_len_q=1024,
+                seq_len_kv=1024,
+                qk_head_dim=128,
+                v_head_dim=128,
+                qk_head_dim_rounded=128,
+                v_head_dim_rounded=128,
+            ),
+            "d256_transition": self._context(
+                seq_len_q=1024,
+                seq_len_kv=1024,
+                qk_head_dim=256,
+                v_head_dim=256,
+                qk_head_dim_rounded=256,
+                v_head_dim_rounded=256,
+            ),
+            "low_parallelism": self._context(num_heads=8),
+            "batch_broadcast": self._context(batch_size=2, kv_batch_size=1),
+            "mixed_head_dims": self._context(v_head_dim=128, v_head_dim_rounded=128),
+            "unmeasured_head_dim": self._context(
+                qk_head_dim=100,
+                v_head_dim=100,
+                qk_head_dim_rounded=128,
+                v_head_dim_rounded=128,
+            ),
+            "unsupported_dtype": self._context(dtype=torch.float32),
+            "dynamic_sequence": self._context(seq_len_q=sympy.Symbol("s")),
+            "noncontiguous_inputs": self._context(inputs_contiguous=False),
+            "user_tile": self._context(kernel_options={"BLOCK_M": 64}),
+            "user_rocm_option": self._context(kernel_options={"kpack": 1}),
+            "prefixed_rocm_option": self._context(
+                kernel_options={"fwd_waves_per_eu": 2}
+            ),
+        }
+        for name, context in cases.items():
+            with self.subTest(name=name):
+                self.assertIs(self._select(context), self.stock)
+        self.assertIs(self._select(self._context(), arch="gfx942"), self.stock)
+        custom: list[FlexConfig] = [ROCmFlexConfig(64, 64, 1, 4)]
+        self.assertIs(self._select(self._context(), configs=custom), custom)
+        self.assertIs(
+            self._select(self._context(), search_space="EXHAUSTIVE"), self.stock
+        )
+        self.assertIs(self._select(self._context(), origami_module=None), self.stock)
+        self.assertIs(self._select(self._context(), selected_tiles=()), self.stock)
+
+    def test_d128_and_d256_positive_boundaries(self):
+        for head_dim in (128, 256):
+            with self.subTest(head_dim=head_dim):
+                selected = self._select(
+                    self._context(
+                        seq_len_q=2048,
+                        seq_len_kv=2048,
+                        qk_head_dim=head_dim,
+                        v_head_dim=head_dim,
+                        qk_head_dim_rounded=head_dim,
+                        v_head_dim_rounded=head_dim,
+                    )
+                )
+                self.assertGreater(len(selected), 1)
+
+    @staticmethod
+    def _fake_origami(latencies):
+        fake_origami = mock.Mock()
+        fake_origami.transpose_t = SimpleNamespace(N="N", T="T")
+        fake_origami.problem_t.side_effect = SimpleNamespace
+        fake_origami.config_t.side_effect = SimpleNamespace
+
+        def dim3(m, n, k):
+            return (m, n, k)
+
+        fake_origami.dim3_t.side_effect = dim3
+        fake_origami.string_to_datatype.return_value = "f16"
+        hardware = mock.Mock(N_CU=256)
+        hardware.get_recommended_matrix_instruction.return_value = (16, 16, 32)
+        fake_origami.get_hardware_for_device.return_value = hardware
+        fake_origami.compute_total_latency.side_effect = latencies
+        return fake_origami
+
+    def _run_model(self, latencies, candidate_tiles):
+        fake_origami = self._fake_origami(latencies)
+        triton_heuristics._origami_flex_attention_tiles.cache_clear()
+        with mock.patch.object(triton_heuristics, "origami", fake_origami):
+            selected = triton_heuristics._origami_flex_attention_tiles(
+                16,
+                2048,
+                4096,
+                100,
+                80,
+                128,
+                128,
+                torch.float16,
+                0,
+                candidate_tiles,
+            )
+        return selected, fake_origami
+
+    def test_models_qk_and_pv_tile_geometry(self):
+        selected, fake_origami = self._run_model((10.0, 20.0), ((64, 128),))
+
+        self.assertEqual(selected, ((64, 128),))
+        qk_call, pv_call = fake_origami.compute_total_latency.call_args_list
+        qk_problem, _, qk_config, _ = qk_call.args
+        pv_problem, _, pv_config, _ = pv_call.args
+        self.assertEqual(qk_problem.size, (2048, 4096, 100))
+        self.assertEqual(qk_problem.batch, 16)
+        self.assertEqual(qk_problem.a_transpose, "N")
+        self.assertEqual(qk_problem.b_transpose, "T")
+        self.assertEqual(qk_config.mt, (64, 128, 128))
+        self.assertEqual(pv_problem.size, (2048, 80, 4096))
+        self.assertEqual(pv_problem.batch, 16)
+        self.assertEqual(pv_problem.a_transpose, "N")
+        self.assertEqual(pv_problem.b_transpose, "N")
+        self.assertEqual(pv_config.mt, (64, 128, 128))
+
+    def test_unions_qk_top1_and_pv_top2_without_duplicates(self):
+        tiles = ((16, 32), (32, 64), (64, 128))
+        # Calls alternate QK/PV. QK ranks A,B,C; PV ranks A,C,B, so A is
+        # deduplicated and the production union is A,C.
+        selected, _ = self._run_model((1.0, 1.0, 2.0, 3.0, 3.0, 2.0), tiles)
+        self.assertEqual(selected, (tiles[0], tiles[2]))
+
+    def test_requires_finite_results_from_both_subgemms(self):
+        tiles = ((64, 64), (128, 128))
+        selected, _ = self._run_model((math.inf, 1.0, math.inf, 2.0), tiles)
+        self.assertEqual(selected, ())
 
 
 def setUpModule():
@@ -186,6 +476,123 @@ class TestOrigami(TestCase):
             "test_configs.autotune_choice_name_regex": r"^triton_(b)?mm_",
             "triton.native_matmul": False,
         }
+
+    def test_origami_filters_dense_flex_attention_configs(self):
+        arch = torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
+        if arch != "gfx950":
+            self.skipTest("the measured FlexAttention config projection is gfx950-only")
+
+        from torch.nn.attention.flex_attention import AuxRequest, flex_attention
+        from torch._inductor.choices import InductorChoices
+
+        torch.manual_seed(0)
+        q_ref, k_ref, v_ref = (
+            torch.randn(
+                1,
+                16,
+                1024,
+                64,
+                device=GPU_TYPE,
+                dtype=torch.float16,
+                requires_grad=True,
+            )
+            for _ in range(3)
+        )
+        q, k, v = (
+            tensor.detach().clone().requires_grad_() for tensor in (q_ref, k_ref, v_ref)
+        )
+
+        def fn(q, k, v):
+            return flex_attention(q, k, v, return_aux=AuxRequest(lse=True))
+
+        expected_out, expected_aux = fn(q_ref, k_ref, v_ref)
+        expected_out.sum().backward()
+        triton_heuristics._origami_flex_attention_tiles.cache_clear()
+        filtered_sizes = []
+        appended_config_sizes = []
+        filter_configs = ROCmConfigHeuristic.filter_flex_attn_fwd_configs
+
+        def record_filter(heuristic, configs, context):
+            filtered = filter_configs(heuristic, configs, context)
+            filtered_sizes.append(len(filtered))
+            return filtered
+
+        def record_append(handler, choices, configs, *args, **kwargs):
+            appended_config_sizes.append(len(configs))
+            return choices
+
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_flex_search_space": "DEFAULT",
+                    "autotune_num_choices_displayed": 0,
+                    "rocm.origami": True,
+                }
+            ),
+            mock.patch.object(
+                triton_heuristics,
+                "_origami_flex_attention_tiles",
+                wraps=triton_heuristics._origami_flex_attention_tiles,
+            ) as select_tiles,
+            mock.patch.object(
+                ROCmConfigHeuristic,
+                "filter_flex_attn_fwd_configs",
+                record_filter,
+            ),
+            mock.patch.object(
+                InductorChoices,
+                "append_flex_attention_choices",
+                record_append,
+            ),
+        ):
+            actual_out, actual_aux = torch.compile(fn, fullgraph=True)(q, k, v)
+            actual_out.sum().backward()
+
+        self.assertGreater(select_tiles.call_count, 0)
+        self.assertEqual(filtered_sizes, [9])
+        self.assertEqual(appended_config_sizes, [25])
+        torch.testing.assert_close(actual_out, expected_out, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(
+            actual_aux.lse, expected_aux.lse, atol=2e-2, rtol=2e-2
+        )
+        for actual_grad, expected_grad in zip(
+            (q.grad, k.grad, v.grad), (q_ref.grad, k_ref.grad, v_ref.grad)
+        ):
+            torch.testing.assert_close(actual_grad, expected_grad, atol=3e-2, rtol=3e-2)
+
+    def test_origami_leaves_flex_decoding_unchanged(self):
+        from torch.nn.attention.flex_attention import flex_attention
+
+        torch.manual_seed(0)
+        q = torch.randn(1, 16, 1, 64, device=GPU_TYPE, dtype=torch.float16)
+        k, v = (
+            torch.randn(1, 16, 1024, 64, device=GPU_TYPE, dtype=torch.float16)
+            for _ in range(2)
+        )
+        expected = flex_attention(q, k, v)
+        triton_heuristics._origami_flex_attention_tiles.cache_clear()
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_flex_search_space": "DEFAULT",
+                    "autotune_num_choices_displayed": 0,
+                    "rocm.origami": True,
+                }
+            ),
+            mock.patch.object(
+                triton_heuristics,
+                "_origami_flex_attention_tiles",
+                wraps=triton_heuristics._origami_flex_attention_tiles,
+            ) as select_tiles,
+        ):
+            actual = torch.compile(flex_attention, fullgraph=True)(q, k, v)
+
+        self.assertEqual(select_tiles.call_count, 0)
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
 
     def test_origami_respects_gemm_search_space(self):
         for op_name in ("mm", "addmm", "bmm"):

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -21,6 +21,7 @@ from .heuristics.template.triton import (
     BaseConfigHeuristic,
     CPUConfigHeuristic,
     CUDAConfigHeuristic,
+    FlexAttentionConfigContext,
     IS_ROCM,
     MTIAConfigHeuristic,
     ROCmConfigHeuristic,
@@ -173,6 +174,51 @@ class InductorChoices:
     ) -> list[Any]:
         flex_heuristics = self.get_config_heuristics(device_type)
         return flex_heuristics.get_flex_attn_fwd_configs(head_dim, seq_len, dtype)
+
+    def filter_flex_attention_fwd_configs(
+        self,
+        configs: list[Any],
+        *,
+        batch_size: int | sympy.Expr,
+        kv_batch_size: int | sympy.Expr,
+        num_heads: int | sympy.Expr,
+        num_kv_heads: int | sympy.Expr,
+        seq_len_q: int | sympy.Expr,
+        seq_len_kv: int | sympy.Expr,
+        qk_head_dim: int | sympy.Expr,
+        v_head_dim: int | sympy.Expr,
+        qk_head_dim_rounded: int,
+        v_head_dim_rounded: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        inputs_contiguous: bool,
+        is_noop_block_mask: bool,
+        kernel_options: dict[str, Any],
+    ) -> list[Any]:
+        """Refine forward configs using facts unavailable to the base lookup."""
+        # Origami's import decision is intentionally load-time-only, matching
+        # the existing GEMM path. The ROCm heuristic checks that cached binding.
+        if not IS_ROCM or not config.max_autotune:
+            return configs
+        context = FlexAttentionConfigContext(
+            batch_size=batch_size,
+            kv_batch_size=kv_batch_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            seq_len_q=seq_len_q,
+            seq_len_kv=seq_len_kv,
+            qk_head_dim=qk_head_dim,
+            v_head_dim=v_head_dim,
+            qk_head_dim_rounded=qk_head_dim_rounded,
+            v_head_dim_rounded=v_head_dim_rounded,
+            dtype=dtype,
+            device=device,
+            inputs_contiguous=inputs_contiguous,
+            is_noop_block_mask=is_noop_block_mask,
+            kernel_options=kernel_options,
+        )
+        flex_heuristics = self.get_config_heuristics(device.type)
+        return flex_heuristics.filter_flex_attn_fwd_configs(configs, context)
 
     def get_flex_attention_bwd_configs(
         self, head_dim: int, dtype: torch.dtype, device_type: str | None = "cuda"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2845,24 +2845,25 @@ class rocm:
 
     # The threshold at which we trigger a contiguous subgraph transformation
     contiguous_threshold: int = 16
-    # Enable origami GEMM autotuning on Triton templates (ROCm only).
+    # Enable Origami analytical config selection for Triton templates (ROCm only).
     #
-    # When True, the rocm-origami pip package is consulted at GEMM compile time
-    # to pre-select a top-K of Triton configs from the DEFAULT search space,
-    # reducing autotuning cost while keeping runtime within ~5% of full
-    # max_autotune. Read once at config import from TORCHINDUCTOR_ORIGAMI;
+    # When True, the rocm-origami pip package is consulted at compile time to
+    # pre-select Triton configs from the DEFAULT GEMM and FlexAttention search
+    # spaces, reducing autotuning cost while retaining near-exhaustive runtime.
+    # Read once at config import from TORCHINDUCTOR_ORIGAMI;
     # toggling at runtime via config.patch has no effect because the rocm-origami
     # module import is cached at heuristics/template/triton.py load time.
     #
-    # Active only when all of these hold:
+    # The package is loaded only when all of these hold:
     #   - IS_ROCM (torch.version.hip is not None)
     #   - config.max_autotune
     #   - config.rocm.origami (this knob)
-    #   - config.max_autotune_gemm_search_space == "DEFAULT"
     #   - rocm-origami is installed (else the import gate sets it inert)
     #   - ROCm version < 10.0 (origami not supported on 10.0+)
-    # Outside DEFAULT (e.g. EXHAUSTIVE) origami is silently bypassed with a
-    # one-time warning; the regular config generator runs instead.
+    # Each consumer has additional gates. GEMM requires its DEFAULT search space.
+    # FlexAttention currently requires its DEFAULT search space plus a static,
+    # dense, contiguous fp16/bf16 gfx950 forward problem in the measured shape
+    # domain; every other case retains the regular config generator.
     #
     # Side-effect: when this is True, choices._need_to_fix_layout() returns True
     # so flexible layouts are disabled. Origami's grid/workgroup mappings depend

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 import math
 import os
-from functools import partial
+from functools import cache, partial
 from threading import Lock
 from typing import Any, TYPE_CHECKING
 
@@ -87,7 +87,7 @@ ORIGAMI_UNSUPPORTED_ROCM_VERSION = (10, 0)
 
 
 def _origami_enabled() -> bool:
-    """Check if origami GEMM optimization is enabled."""
+    """Check if Origami template config selection is enabled."""
     return config.rocm.origami and _rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION
 
 
@@ -170,10 +170,10 @@ def _filter_tdm_descriptor_block_configs(
     ]
 
 
-# rocm-origami pip pkg is only available on ROCm builds and is only used when
-# both max_autotune and config.rocm.origami are enabled (env-var driven, set once
-# at config import). Cache the import here so the hot path never pays an exception
-# and CUDA/CPU/origami-disabled processes never attempt the import.
+# rocm-origami is only available on ROCm builds and is used when max_autotune and
+# config.rocm.origami are both enabled (env-var driven, set once at config import).
+# Cache the import here so the hot path never pays an exception and
+# CUDA/CPU/origami-disabled processes never attempt the import.
 # origami is not supported on ROCm 10.0+.
 if (
     IS_ROCM
@@ -186,7 +186,7 @@ if (
     except ImportError:
         origami = None
         log.info(
-            "rocm-origami not installed; ROCm origami GEMM selection disabled. "
+            "rocm-origami not installed; ROCm Origami config selection disabled. "
             "Install via pip install rocm-origami to enable."
         )
 else:
@@ -197,8 +197,8 @@ else:
         and _rocm_version >= ORIGAMI_UNSUPPORTED_ROCM_VERSION
     ):
         log.warning(
-            "ROCm origami GEMM selection is not supported on ROCm %d.%d+ "
-            "(detected %d.%d); origami disabled.",
+            "ROCm Origami config selection is not supported on ROCm %d.%d+ "
+            "(detected %d.%d); Origami disabled.",
             *ORIGAMI_UNSUPPORTED_ROCM_VERSION,
             *_rocm_version,
         )
@@ -218,6 +218,152 @@ def _origami_hardware(selector):  # type: ignore[no-untyped-def]
 
 def _origami_configs(selector):  # type: ignore[no-untyped-def]
     return selector._configs
+
+
+ORIGAMI_FLEX_MIN_SEQUENCE_LENGTH = 1024
+ORIGAMI_FLEX_MIN_BATCH_HEADS = 16
+ORIGAMI_FLEX_QK_TOPK = 1
+ORIGAMI_FLEX_PV_TOPK = 2
+
+
+def _origami_flex_problem(
+    origami_module: Any,
+    m: int,
+    n: int,
+    k: int,
+    *,
+    batch: int,
+    dtype: Any,
+    a_transpose: Any,
+    b_transpose: Any,
+) -> Any:
+    problem = origami_module.problem_t()
+    problem.size = origami_module.dim3_t(m, n, k)
+    problem.batch = batch
+    problem.a_transpose = a_transpose
+    problem.b_transpose = b_transpose
+    problem.a_dtype = dtype
+    problem.b_dtype = dtype
+    problem.c_dtype = dtype
+    problem.d_dtype = dtype
+    problem.mi_dtype = dtype
+    return problem
+
+
+def _origami_flex_config(
+    origami_module: Any,
+    hardware: Any,
+    dtype: Any,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+) -> Any:
+    cfg = origami_module.config_t()
+    cfg.mt = origami_module.dim3_t(block_m, block_n, block_k)
+    cfg.mi = hardware.get_recommended_matrix_instruction(dtype)
+    # Match the retained compiler variants: waves_per_eu=0 leaves occupancy
+    # unconstrained rather than imposing Origami's standalone-GEMM estimate.
+    cfg.occupancy = 0
+    return cfg
+
+
+@cache
+def _origami_flex_attention_tiles(
+    batch_heads: int,
+    seq_len_q: int,
+    seq_len_kv: int,
+    qk_head_dim: int,
+    v_head_dim: int,
+    qk_head_dim_rounded: int,
+    v_head_dim_rounded: int,
+    dtype: torch.dtype,
+    device_index: int,
+    candidate_tiles: tuple[tuple[int, int], ...],
+) -> tuple[tuple[int, int], ...]:
+    """Select FlexAttention tiles from Origami's two standalone GEMM rankings.
+
+    FlexAttention does not materialize QK/P, so adding standalone GEMM latencies
+    would pretend both intermediates went through HBM. Keep the union of each
+    sub-GEMM's best tiles instead, then let measured autotuning choose among their
+    backend variants.
+    """
+    origami_module = origami
+    if origami_module is None:
+        return ()
+
+    dtype_name = {
+        torch.float16: "f16",
+        torch.bfloat16: "bf16",
+    }.get(dtype)
+    if dtype_name is None:
+        return ()
+
+    origami_dtype = origami_module.string_to_datatype(dtype_name)
+    hardware = origami_module.get_hardware_for_device(device_index)
+    qk_problem = _origami_flex_problem(
+        origami_module,
+        seq_len_q,
+        seq_len_kv,
+        qk_head_dim,
+        batch=batch_heads,
+        dtype=origami_dtype,
+        a_transpose=origami_module.transpose_t.N,
+        b_transpose=origami_module.transpose_t.T,
+    )
+    pv_problem = _origami_flex_problem(
+        origami_module,
+        seq_len_q,
+        v_head_dim,
+        seq_len_kv,
+        batch=batch_heads,
+        dtype=origami_dtype,
+        a_transpose=origami_module.transpose_t.N,
+        b_transpose=origami_module.transpose_t.N,
+    )
+
+    qk_scores: dict[tuple[int, int], float] = {}
+    pv_scores: dict[tuple[int, int], float] = {}
+    for block_m, block_n in candidate_tiles:
+        qk_config = _origami_flex_config(
+            origami_module,
+            hardware,
+            origami_dtype,
+            block_m,
+            block_n,
+            qk_head_dim_rounded,
+        )
+        pv_config = _origami_flex_config(
+            origami_module,
+            hardware,
+            origami_dtype,
+            block_m,
+            v_head_dim_rounded,
+            block_n,
+        )
+        qk_latency = origami_module.compute_total_latency(
+            qk_problem, hardware, qk_config, hardware.N_CU
+        )
+        pv_latency = origami_module.compute_total_latency(
+            pv_problem, hardware, pv_config, hardware.N_CU
+        )
+        tile = (block_m, block_n)
+        if math.isfinite(qk_latency):
+            qk_scores[tile] = qk_latency
+        if math.isfinite(pv_latency):
+            pv_scores[tile] = pv_latency
+
+    qk_ranked = sorted(qk_scores, key=lambda tile: (qk_scores[tile], tile))
+    pv_ranked = sorted(pv_scores, key=lambda tile: (pv_scores[tile], tile))
+    if not qk_ranked or not pv_ranked:
+        return ()
+    selected = []
+    for tile in (
+        *qk_ranked[:ORIGAMI_FLEX_QK_TOPK],
+        *pv_ranked[:ORIGAMI_FLEX_PV_TOPK],
+    ):
+        if tile not in selected:
+            selected.append(tile)
+    return tuple(selected)
 
 
 # Gemm Configs
@@ -396,6 +542,27 @@ class ROCmFlexDecodeConfig(FlexDecodeConfig):
     matrix_instr_nonkdim: int = 0
     waves_per_eu: int = 0
     kpack: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class FlexAttentionConfigContext:
+    """Shape and layout facts needed to refine a forward config list."""
+
+    batch_size: int | sympy.Expr
+    kv_batch_size: int | sympy.Expr
+    num_heads: int | sympy.Expr
+    num_kv_heads: int | sympy.Expr
+    seq_len_q: int | sympy.Expr
+    seq_len_kv: int | sympy.Expr
+    qk_head_dim: int | sympy.Expr
+    v_head_dim: int | sympy.Expr
+    qk_head_dim_rounded: int
+    v_head_dim_rounded: int
+    dtype: torch.dtype
+    device: torch.device
+    inputs_contiguous: bool
+    is_noop_block_mask: bool
+    kernel_options: dict[str, Any]
 
 
 class BaseHeuristicSingleton(type):
@@ -1338,6 +1505,14 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
 
         return flex_attn_fwd_configs
 
+    def filter_flex_attn_fwd_configs(
+        self,
+        configs: list[FlexConfig],
+        context: FlexAttentionConfigContext,
+    ) -> list[FlexConfig]:
+        """Optionally refine forward configs with full attention context."""
+        return configs
+
     def get_flex_attn_bwd_configs(
         self, head_dim: int, dtype: Any
     ) -> list[FlexBwDConfig]:
@@ -2164,6 +2339,156 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             flex_attn_fwd_configs.append(default_config)
 
         return flex_attn_fwd_configs
+
+    def filter_flex_attn_fwd_configs(
+        self,
+        configs: list[FlexConfig],
+        context: FlexAttentionConfigContext,
+    ) -> list[FlexConfig]:
+        """Use Origami to replace the gfx950 dense DEFAULT candidate pool."""
+        if (
+            origami is None
+            or not config.max_autotune
+            or config.max_autotune_flex_search_space != "DEFAULT"
+            or not context.is_noop_block_mask
+            or context.dtype not in (torch.float16, torch.bfloat16)
+        ):
+            return configs
+
+        # Origami models dense row/column-major GEMMs, not padding or overlap.
+        if not context.inputs_contiguous:
+            return configs
+
+        tuning_keys = (
+            "BLOCK_M",
+            "BLOCK_N",
+            "num_stages",
+            "num_warps",
+            "matrix_instr_nonkdim",
+            "waves_per_eu",
+            "kpack",
+        )
+        if any(
+            key in context.kernel_options or f"fwd_{key}" in context.kernel_options
+            for key in tuning_keys
+        ):
+            return configs
+
+        raw_dims = (
+            context.batch_size,
+            context.kv_batch_size,
+            context.num_heads,
+            context.num_kv_heads,
+            context.seq_len_q,
+            context.seq_len_kv,
+            context.qk_head_dim,
+            context.v_head_dim,
+        )
+        if any(getattr(dim, "free_symbols", None) for dim in raw_dims):
+            return configs
+        (
+            batch_size,
+            kv_batch_size,
+            num_heads,
+            num_kv_heads,
+            seq_len_q,
+            seq_len_kv,
+            qk_head_dim,
+            v_head_dim,
+        ) = (int(dim) for dim in raw_dims)
+        min_sequence_length = (
+            2 * ORIGAMI_FLEX_MIN_SEQUENCE_LENGTH
+            if qk_head_dim >= 128
+            else ORIGAMI_FLEX_MIN_SEQUENCE_LENGTH
+        )
+        if (
+            min(seq_len_q, seq_len_kv) < min_sequence_length
+            or batch_size * num_heads < ORIGAMI_FLEX_MIN_BATCH_HEADS
+            or batch_size != kv_batch_size
+            or qk_head_dim != v_head_dim
+            or qk_head_dim not in (32, 64, 128, 256)
+        ):
+            return configs
+        if configs != self.get_flex_attn_fwd_configs(
+            qk_head_dim, context.seq_len_q, context.dtype
+        ):
+            # An out-of-tree choices handler supplied this pool; it owns the
+            # policy unless it explicitly overrides the refinement hook too.
+            return configs
+
+        try:
+            device_index = (
+                context.device.index
+                if context.device.index is not None
+                else torch.cuda.current_device()
+            )
+            arch = torch.cuda.get_device_properties(device_index).gcnArchName.split(
+                ":", 1
+            )[0]
+            # The stage/warp projection below is measured on gfx950. Other Origami
+            # targets retain their stock pool until they have equivalent evidence.
+            if arch != "gfx950":
+                return configs
+
+            candidate_tiles = tuple(
+                dict.fromkeys(
+                    (candidate.block_m, candidate.block_n)
+                    for candidate in self.exhaustive_flex_attn_fwd_configs
+                )
+            )
+            selected_tiles = _origami_flex_attention_tiles(
+                batch_size * num_heads,
+                seq_len_q,
+                seq_len_kv,
+                qk_head_dim,
+                v_head_dim,
+                context.qk_head_dim_rounded,
+                context.v_head_dim_rounded,
+                context.dtype,
+                device_index,
+                candidate_tiles,
+            )
+        except (AttributeError, RuntimeError, TypeError, ValueError) as error:
+            log.debug("Origami FlexAttention selection failed: %s", error)
+            return configs
+        if not selected_tiles:
+            return configs
+
+        # Build the safety config for the query's verified gfx950 target instead
+        # of recovering it from `configs`: for D=32 the generic default is also
+        # present in the autotune list, and a heterogeneous process may have
+        # initialized that list using another device's architecture.
+        generic_default = ROCmFlexConfig(128, 64, 1, 4, kpack=2)
+        stock_default = self.gfx950_default_flex_config.get(
+            (context.dtype, qk_head_dim), generic_default
+        )
+        stock_default = dataclasses.replace(stock_default, kpack=2)
+        # Origami has no stage/warp/MFMA/kpack model for this fused kernel.
+        # gfx950 exhaustive measurements project tiles to stage 2 and
+        # unconstrained occupancy; MHA uses four warps while GQA retains two and
+        # four. The autotuner keeps both MFMA and kpack variants.
+        allowed_warps = (2, 4) if num_heads != num_kv_heads else (4,)
+        selected: list[FlexConfig] = [
+            candidate
+            for candidate in self.exhaustive_flex_attn_fwd_configs
+            if isinstance(candidate, ROCmFlexConfig)
+            and (candidate.block_m, candidate.block_n) in selected_tiles
+            and candidate.num_stages == 2
+            and candidate.num_warps in allowed_warps
+            and candidate.waves_per_eu == 0
+        ]
+        # Keep the stock architecture default even when Origami did not select
+        # its tile (or when its generic D=32 form uses a different stage count).
+        if stock_default not in selected:
+            selected.append(stock_default)
+        if not selected:
+            return configs
+        log.debug(
+            "Origami selected FlexAttention tiles %s (%d configs)",
+            selected_tiles,
+            len(selected),
+        )
+        return selected
 
     def get_flex_attn_bwd_configs(
         self, head_dim: int, dtype: Any

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -17,7 +17,13 @@ from torch._logging import warning_once
 from torch.nn.attention.flex_attention import _Backend
 from torch.utils._sympy.functions import FloorDiv
 
-from ...ir import ComputedBuffer, ExternKernel, FixedLayout, TensorBox
+from ...ir import (
+    ComputedBuffer,
+    ExternKernel,
+    FixedLayout,
+    is_dense_contiguous_storage_and_layout,
+    TensorBox,
+)
 from ...lowering import empty, empty_strided, lowerings, register_lowering, to_dtype
 from ...runtime.runtime_utils import is_power_of_2
 from ...select_algorithm import (
@@ -441,13 +447,39 @@ def flex_attention(
 
     dtype = query.get_dtype()
     head_dim = V.graph.sizevars.guard_int(query.get_size()[-1])
-    configs: list[FlexConfig] = V.choices.get_flex_attention_fwd_configs(
-        head_dim, seq_len_q, dtype, query.get_device().type
-    )
-
     # Mark SPARSE_KV_BLOCK_SIZE & SPARSE_Q_BLOCK_SIZE as static shapes and add guards.
     SPARSE_KV_BLOCK_SIZE = V.graph.sizevars.guard_int(SPARSE_KV_BLOCK_SIZE)
     SPARSE_Q_BLOCK_SIZE = V.graph.sizevars.guard_int(SPARSE_Q_BLOCK_SIZE)
+
+    unfiltered_configs: list[FlexConfig] = V.choices.get_flex_attention_fwd_configs(
+        head_dim, seq_len_q, dtype, query.get_device().type
+    )
+    is_noop_block_mask = (
+        not has_full_blocks
+        and SPARSE_Q_BLOCK_SIZE == 1 << 30
+        and SPARSE_KV_BLOCK_SIZE == 1 << 30
+        and is_trivial_mask_graph(mask_graph.graph_module)
+    )
+    configs = V.choices.filter_flex_attention_fwd_configs(
+        unfiltered_configs,
+        batch_size=B,
+        kv_batch_size=Bkv,
+        num_heads=Hq,
+        num_kv_heads=Hkv,
+        seq_len_q=seq_len_q,
+        seq_len_kv=seq_len_kv,
+        qk_head_dim=qk_head_dim,
+        v_head_dim=v_head_dim,
+        qk_head_dim_rounded=kernel_options["QK_HEAD_DIM_ROUNDED"],
+        v_head_dim_rounded=kernel_options["V_HEAD_DIM_ROUNDED"],
+        dtype=dtype,
+        device=query.get_device(),
+        inputs_contiguous=all(
+            is_dense_contiguous_storage_and_layout(node) for node in (query, key, value)
+        ),
+        is_noop_block_mask=is_noop_block_mask,
+        kernel_options=kernel_options,
+    )
 
     original_kernel_options = kernel_options.copy()
     # Default config for warp specialization
@@ -548,7 +580,7 @@ def flex_attention(
     # template choices (e.g. TLX on Blackwell in fbcode). No-op by default.
     choices = V.choices.append_flex_attention_choices(
         choices,
-        configs,
+        unfiltered_configs,
         [
             query,
             key,


### PR DESCRIPTION
## Summary

Extends the existing ROCm Origami config selector to upstream Triton FlexAttention forward on gfx950.

- Models QK and PV separately, retaining `QK top-1 ∪ PV top-2`; normal Inductor autotuning still picks the final kernel.
- Preserves the stock architecture default and falls back unchanged outside the measured static, dense, contiguous fp16/bf16 domain.
- Does not involve the Gluon path.

## Performance

MI350X (gfx950), ROCm 7.2.1, pinned Triton 3.8.0. Three Origami and three stock runs were interleaved per case. All 150 accepted measurements had no foreign GPU process and three zero-activity AMD-SMI samples before and after.

| Metric (20 active cases) | Result |
|---|---:|
| Runtime geomean | **1.109x** |
| Compile-time speedup | **1.286x** |
| Autotune candidates | **-63.0%** |
| Per-case runtime range | **0.994x–1.456x** |

Notable runtime gains: S1024/D32 **1.206x**, S2048/D32 **1.344x**, S2048/D256 **1.456x**, S4096/D256 **1.417x**, S8192/D256 **1.437x**, and Q1024/KV4096/D64 **1.116x**.

The exact production filter retained the measured best tile in 17/17 applicable 576-choice exhaustive sweeps; maximum projected-config regret was 2.43%.

## Validation

Covers selector geometry and fallbacks, D32/D128/D256 boundaries, GQA, explicit-device handling, output/LSE correctness, forward/backward gradients, decoding bypass, choices composition, Ruff, and Pyrefly.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben