### PR TITLE
[caffe2/veclib] Add reduce_max to NEON's f32 layer

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -251,6 +251,9 @@ class Vectorized<float> {
         vshlq_u32(vandq_u32(is_zero_vec, vdupq_n_u32(1)), shift);
     return vaddvq_u32(bits_vec);
   }
+  float reduce_max() const {
+    return vmaxvq_f32(values);
+  }
   Vectorized<float> isnan() const {
     return vreinterpretq_f32_u32(vmvnq_u32(vceqq_f32(values, values)));
   }


### PR DESCRIPTION
Summary: Add NEON intrinsic-based Vectorized<float>::reduce_max(), otherwise implementation fallbacks to vec_base.h

Test Plan: CI

Differential Revision: D119614281




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01