### PR TITLE
[dynamo] Preserve torch.Size semantics in Tensor constructor

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7703,6 +7703,19 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         # If this doesn't crash, the test passes
         fn(torch.ones(3))
 
+    @parametrize("sequence_type", [torch.Size, tuple, list])
+    @parametrize("shape", [(), (0,), (1, 4), (3, 4)])
+    @parametrize("dynamic", [False, True])
+    def test_tensor_ctor_sequence_shape(self, sequence_type, shape, dynamic):
+        def fn(x):
+            return torch.Tensor(sequence_type(x.size()))
+
+        x = torch.empty(shape)
+        expected_shape = shape if sequence_type is torch.Size else (len(shape),)
+        self.assertEqual(fn(x).shape, expected_shape)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True, dynamic=dynamic)
+        self.assertEqual(compiled(x).shape, expected_shape)
+
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_tensor_ctor_list_of_tensor(self):
         def fn(x):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1549,7 +1549,17 @@ class UserDefinedClassVariable(UserDefinedVariable):
         ):
             # torch.LongTensor cannot accept a list of FakeTensors.
             # So we stack the list of FakeTensors instead.
-            from .lists import ListVariable
+            from .lists import ListVariable, SizeVariable
+
+            if (
+                self.value is torch.Tensor
+                and len(args) == 1
+                and isinstance(args[0], SizeVariable)
+                and "size" not in kwargs
+            ):
+                # FX normalizes torch.Size to tuple; keep the size overload explicit.
+                kwargs = {**kwargs, "size": args[0]}
+                args = []
 
             if (
                 np


### PR DESCRIPTION
## Summary

Fixes a Dynamo correctness issue where `torch.Tensor(torch.Size(...))` changes semantics under `torch.compile`.

In eager mode, passing a `torch.Size` to the legacy `torch.Tensor` constructor selects the size overload:

```python
torch.Tensor(torch.Size([1, 4])).shape
# torch.Size([1, 4])
```

During Dynamo/FX tracing, `torch.Size` is normalized to a plain tuple before the FX node arguments are stored. This changes the generated call to:

```python
torch.Tensor((1, 4))
```

which selects sequence/data semantics instead and produces a tensor with shape `(2,)`.

## Fix

When Dynamo handles `torch.Tensor` with a single `SizeVariable` argument, preserve the selected constructor semantics before FX normalizes the value by making the size overload explicit:

```python
torch.Tensor(size=...)
```

This is intentionally scoped to `torch.Tensor` + `SizeVariable`.

Plain tuple and list arguments keep their existing data semantics.

## Tests

Added a focused regression test covering:

* `torch.Size`
* tuple
* list
* scalar shape `()`
* zero-sized shape `(0,)`
* multidimensional shapes
* static and dynamic compilation

The test compares shapes only and does not inspect values of the uninitialized tensors.

Before the fix, the `torch.Size` cases fail while tuple/list cases pass.

After the fix:

* regression test: 24 tests passed
* nearby `test_misc` tests: 28 passed, 1 skipped
* nearby `test_functions` tests: 31 passed
* original issue repro: passed
* additional compatibility checks across static/dynamic compilation and dtype/device behavior: passed
* lint/format checks: passed
* `git diff --check`: passed

Also verified that the explicit `size=` binding uses the supported `SymIntArrayRef size` constructor path and remains valid with symbolic dimensions.

Fixes #196467


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98