### PR TITLE
[torchTLX] Reland tri-state tlx_mode knob, with a type-safe JK read

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1952,15 +1952,66 @@ class cpp:
     use_two_step_variance_threshold = 1024
 
 
-def tlx_mode_from_env() -> Literal["allow", "force"] | None:
-    # Only the explicit values "allow"/"force" enable torchTLX. Any other
-    # value -- unset, empty, a typo, or a legacy "default" -- maps to None so
-    # TLX stays off. See the "Knob" section of the torchTLX README under
-    # third-party/triton/.../tlx/language/tlx/inductor/README.md.
+def tlx_mode_default() -> Literal["allow", "force"] | None:
+    """Resolve torchTLX engagement, highest precedence first.
+
+    1. ``TORCHINDUCTOR_TLX_MODE``: "off", "allow" or "force". Unset is a
+       no-op. Any other value raises, so a typo fails loudly rather than
+       silently leaving TLX in whatever state the fleet is in.
+    2. ``pytorch/inductor:tlx_mode``, the fleet-wide rollout and killswitch:
+       1 off, 2 allow, 3 force. 0 is a no-op, and is also what
+       justknobs_getval_int reports for a knob that does not exist, an
+       unreachable JK, and PYTORCH_DISABLE_JUSTKNOBS -- hence a no-op rather
+       than a fleet-wide decision taken on absent information.
+    3. ``DEFAULT_MODE`` from the active Triton, which is where the TLX
+       templates live. Installing a Triton that ships the integration is
+       itself the opt-in; one that does not -- upstream OAI Triton -- has no
+       say and TLX stays off.
+
+    No fbcode gate is needed: outside fbcode the JustKnob stub reports 0,
+    which is already a no-op.
+
+    Off is spelled None rather than "off": get_hash() hashes every
+    non-compile-ignored config at its resolved value, so giving the off state
+    a new spelling would change the key for every Inductor process, TLX or
+    not, and invalidate the FX graph cache fleet-wide.
+    """
+    off_allow_force: tuple[Literal["allow", "force"] | None, ...] = (
+        None,
+        "allow",
+        "force",
+    )
+    env_modes = dict(zip(("off", "allow", "force"), off_allow_force))
+    # "default" was the documented spelling of off before this knob grew a
+    # JustKnob and a build default; keep honoring it so a job that still sets
+    # it does not die inside `import torch._inductor.config`.
+    env_modes["default"] = None
+
     mode = os.environ.get("TORCHINDUCTOR_TLX_MODE")
-    if mode in ("allow", "force"):
-        return cast("Literal['allow', 'force']", mode)
-    return None
+    if mode is not None:
+        if mode not in env_modes:
+            raise ValueError(
+                f"TORCHINDUCTOR_TLX_MODE={mode!r} is not one of {tuple(env_modes)}"
+            )
+        return env_modes[mode]
+
+    # JustKnob values 1/2/3 index off/allow/force; 0 falls through.
+    # Type-guarded, not just range-guarded: this runs at `import
+    # torch._inductor.config`, and a test that mocks the justknobs layer hands
+    # back a MagicMock, whose comparison would take that import down fleet-wide.
+    jk = torch._utils_internal.justknobs_getval_int("pytorch/inductor:tlx_mode")
+    if isinstance(jk, int) and 1 <= jk <= len(off_allow_force):
+        return off_allow_force[jk - 1]
+
+    # A Triton that does not ship torchTLX has no default, so TLX stays off.
+    # Deliberately a module directly under `triton` rather than anything in
+    # triton.language.extra.tlx: that package eagerly imports the whole TLX
+    # DSL, and this runs in every Inductor process, GPU or not.
+    try:
+        from triton._torchtlx_default import DEFAULT_MODE
+    except ImportError:
+        return None
+    return DEFAULT_MODE
 
 
 class triton:
@@ -1968,12 +2019,12 @@ class triton:
     Config specific to codegen/triton.py
     """
 
-    # torchTLX enablement. None (the default) means TLX is never considered
-    # (standard Inductor behavior); "allow" lets TLX compete via autotuning;
-    # "force" uses only TLX templates plus forced epilogue fusion. Also a
-    # no-op unless the active Triton is the fbtriton fork (the integration
-    # import in template_heuristics/tlx.py fails cleanly otherwise).
-    tlx_mode: Literal["allow", "force"] | None = tlx_mode_from_env()
+    # torchTLX enablement. None (off) means TLX is never considered (standard
+    # Inductor behavior); "allow" lets TLX compete via autotuning; "force"
+    # uses only TLX templates plus forced epilogue fusion. Also a no-op
+    # unless the active Triton ships the integration (the import in
+    # heuristics/template/tlx.py fails cleanly otherwise).
+    tlx_mode: Literal["allow", "force"] | None = tlx_mode_default()
 
     # Use cudagraphs on output code
     cudagraphs = os.environ.get("TORCHINDUCTOR_CUDAGRAPHS") == "1"

--- a/torch/_inductor/heuristics/template/tlx.py
+++ b/torch/_inductor/heuristics/template/tlx.py
@@ -1,10 +1,28 @@
-# TorchTLX lives in the fbtriton, not in
-# PyTorch. Importing the integration registers TLX template heuristics and
-# installs config.inductor_choices_class; it succeeds only when the active
-# Triton is the fbtriton fork
-# and fails cleanly on trunk triton. Actual engagement is
-# still gated at runtime by TORCHINDUCTOR_TLX_MODE (config.triton.tlx_mode).
-try:
-    import triton.language.extra.tlx.inductor.registry  # noqa: F401  # type: ignore[import-not-used]
-except ImportError:
-    pass
+# TorchTLX lives in fbtriton, not in PyTorch. Importing the integration
+# registers the TLX template heuristics and installs
+# config.inductor_choices_class; it succeeds only when the active Triton ships
+# the integration, and fails cleanly on one that does not.
+#
+# Deferred rather than done at module import: the integration monkey-patches
+# TritonTemplate / TritonTemplateKernel and replaces inductor_choices_class,
+# and none of that belongs in a process that will never engage TLX.
+# virtualized._choices_default() calls maybe_install() on first use.
+
+import functools
+
+
+@functools.cache
+def _install() -> None:
+    try:
+        import triton.language.extra.tlx.inductor.registry  # noqa: F401  # type: ignore[import-not-used]
+    except ImportError:
+        pass
+
+
+def maybe_install() -> None:
+    from torch._inductor import config
+
+    # Mode is re-read every call rather than cached with _install: tests flip
+    # it with config.patch after the first choices handler already exists.
+    if config.triton.tlx_mode is not None:
+        _install()

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -256,6 +256,11 @@ def _choices_default():
     """
     from torch._inductor import config
     from torch._inductor.choices import create_inductor_choices
+    from torch._inductor.heuristics.template import tlx
+
+    # Has to precede the inductor_choices_class read: installing the torchTLX
+    # integration is what sets it.
+    tlx.maybe_install()
 
     rv = create_inductor_choices(config.inductor_choices_class)
     setattr(threadlocal, _choices._key, rv)


### PR DESCRIPTION
Summary:
Relands D116383493, reverted as D116641958 for T285414381. That task's blame covered two distinct failure modes; both are fixed, plus a third that stopped the restored test from even importing.

- **Root cause 1 (already fixed)**: the JustKnob `pytorch/inductor:tlx_mode` did not exist. `justknobs_getval_int` swallows the lookup failure but logs the traceback, and that noise landed inside tests asserting on mocked `builtins.print`. The knob now exists, and D116600153 hardened `firetap`'s `DebugPrintScalarTest`.
- **Root cause 2 (fixed here)**: `tlx_mode_default()` did a bare `1 <= jk` on the JK read. Tests that patch `justknobs.getval` get a `MagicMock` back, so that comparison raised `TypeError` inside `import torch._inductor.config` and took down every test in the process. Now guarded with `isinstance(jk, int)`.
- **Test import fix**: `triton._torchtlx_default` was never landed in either fbsource Triton pin, so the restored test failed at listing. It is now injected via `sys.modules` rather than imported -- also the honest shape, since whether the active Triton ships it is the variable under test.
- **Conflict resolution**: `virtualized.py` rebased onto the new `create_inductor_choices()` API; `tlx.maybe_install()` still precedes the `inductor_choices_class` read.
- **No production behavior change**: unset env var + `jk == 0` + absent `_torchtlx_default` still resolves `tlx_mode` to `None`, exactly as trunk does today.
- **New regression test**: `test_non_int_justknob_is_a_no_op` pins root cause 2.

Test Plan:
Diff's own test:
```
buck2 test @//mode/opt -c fbcode.platform010_cuda_version=12.8 -m ovr_config//triton:beta fbcode//caffe2/test/inductor/fb/tlx:test_tlx_config
```
Pass 8, Fail 0. Before this diff's test fix it was a listing failure: `ImportError: cannot import name '_torchtlx_default' from 'triton'`.

Every target blamed by T285414381:
```
buck2 test @//mode/dev fbcode//firetap/adhoc/tests:test_ops fbcode//admarket/ads_copilot/botmate/test:test_runbook fbcode//fblearner/predictor/py/core/tests:multi_card_integration_test fbcode//aiplatform/modelstore/model_generation/flow/gmpp_concurrent/tests:wrapper_test
```
Pass 52, Fail 2. `firetap/adhoc/tests:test_ops` (the 6 originally blamed cases), `test_runbook` and `wrapper_test` all pass. `wrapper_test` was the root-cause-2 repro -- it failed with `TypeError: '<=' not supported between instances of 'int' and 'MagicMock'` until the `isinstance` guard.

Both failures are `fblearner/predictor/py/core/tests:multi_card_integration_test` (`test_sum_basic`, `test_exception`), which is a pre-existing local environment failure and not TLX-related:
- Fails identically in `@//mode/dev` and in `@//mode/opt` (the config TestX actually runs it in).
- Fails with `Service did not start correctly`, caused by `SMC tier fetch returned empty; retrying with 2x timeout` -- service discovery is unreachable from my devgpu.
- No `torch._inductor` / `tlx_mode_default` / justknobs frames anywhere in the traceback.
- `test_exception` was never in the T285414381 blame list at all.
- TestX reports `trunk_state: PASSING`, flakiness 0.0004, with the most recent CI and DIFF runs green.

`arc f` and `arc lint`: no lint issues.

Differential Revision: D119615928




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo