### PR TITLE
 [Feature Refactoring]Allow PrivateUse1 backends through the cudagraph device gate.

### DIFF
--- a/test/inductor/test_cudagraph_device_gate.py
+++ b/test/inductor/test_cudagraph_device_gate.py
@@ -1,9 +1,11 @@
 # Owner(s): ["module: inductor"]
 
+import contextlib
 from unittest import mock
 
 import torch
 from torch._dynamo.device_interface import (
+    CudaInterface,
     device_interfaces,
     DeviceInterface,
     register_interface_for_device,
@@ -11,9 +13,15 @@ from torch._dynamo.device_interface import (
 from torch._inductor.cudagraph_utils import (
     _graph_capture_compatible_device_type,
     check_multiple_devices_or_any_cpu_nodes,
+    is_graph_capture_runtime_ready,
 )
-from torch._inductor.output_code import _cudagraph_capture_runtime_ready
+from torch._inductor.output_code import (
+    cudagraph_partition_post_compile,
+    cudagraph_post_compile,
+)
 from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import BoxedBool, GraphPartitionMap
+from torch.utils._ordered_set import OrderedSet
 
 
 class _FakeNode:
@@ -35,6 +43,83 @@ class _RegisteredInterface(DeviceInterface):
         return True
 
 
+class _CaptureInterface(DeviceInterface):
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+    @staticmethod
+    def is_graph_capture_supported(device=None) -> bool:
+        return True
+
+
+@contextlib.contextmanager
+def temporary_device_interface(device_type: str, interface_cls: type[DeviceInterface]):
+    had_entry = device_type in device_interfaces
+    previous = device_interfaces.get(device_type)
+    register_interface_for_device(device_type, interface_cls)
+    try:
+        yield
+    finally:
+        if had_entry:
+            device_interfaces[device_type] = previous
+        else:
+            device_interfaces.pop(device_type, None)
+
+
+def _make_post_compile_graph(*, device_type: str = "npu", with_partition: bool = False):
+    from torch._inductor.cudagraph_utils import CudagraphCachedInfo, PlaceholderInfo
+
+    def identity(x):
+        return x
+
+    placeholder = PlaceholderInfo(
+        name="x",
+        stack_trace=None,
+        users=[],
+        mutating_use_stack_trace=None,
+    )
+
+    class _Graph:
+        pass
+
+    graph = _Graph()
+    graph.device_types = OrderedSet([device_type])
+    graph.device_idxs = OrderedSet([0])
+    graph.mutated_input_idxs = OrderedSet()
+    graph.kernel_free_cudagraph = False
+    graph.cudagraph_info = CudagraphCachedInfo(
+        placeholders=(placeholder,),
+        stack_traces=[None],
+        user_visible_output_idxs=(0,),
+        cudagraph_fail_reasons=[],
+    )
+    graph.fx_kwargs = {
+        "is_inference": False,
+        "is_backward": False,
+        "static_input_idxs": (),
+    }
+    graph.current_callable = identity
+    graph.disabled_cudagraphs_reason = None
+    graph.partition_maps = None
+    graph.cudagraphify_calls = []
+
+    def recursively_apply_fns(fns):
+        graph.cudagraphify_calls.extend(fns)
+
+    graph.recursively_apply_fns = recursively_apply_fns
+    if with_partition:
+        graph.partition_maps = [
+            GraphPartitionMap(
+                id=0,
+                input_index_mapping=[0],
+                output_index_mapping=[[0]],
+                constant_names=[],
+            )
+        ]
+    return graph
+
+
 class TestGraphCaptureCompatibleDeviceType(TestCase):
     def test_cuda(self):
         self.assertTrue(_graph_capture_compatible_device_type("cuda"))
@@ -50,36 +135,73 @@ class TestGraphCaptureCompatibleDeviceType(TestCase):
             self.assertFalse(_graph_capture_compatible_device_type("npu"))
 
     def test_renamed_with_interface(self):
-        register_interface_for_device("npu", _RegisteredInterface)
-        try:
+        with temporary_device_interface("npu", _RegisteredInterface):
             with mock.patch(
                 "torch._C._get_privateuse1_backend_name", return_value="npu"
             ):
                 self.assertTrue(_graph_capture_compatible_device_type("npu"))
-        finally:
-            device_interfaces.pop("npu", None)
 
 
-class TestCudagraphCaptureRuntimeReady(TestCase):
-    def test_cuda_only_uses_builtin(self):
-        self.assertTrue(_cudagraph_capture_runtime_ready({"cuda"}))
+class TestGraphCaptureRuntimeReady(TestCase):
+    def test_cuda(self):
+        self.assertTrue(is_graph_capture_runtime_ready({"cuda"}))
+        self.assertTrue(CudaInterface.is_graph_capture_supported())
 
-    def test_npu_without_runtime_override(self):
-        self.assertFalse(_cudagraph_capture_runtime_ready({"npu"}))
+    def test_npu_without_capture_bit(self):
+        with temporary_device_interface("npu", _RegisteredInterface):
+            self.assertFalse(is_graph_capture_runtime_ready({"npu"}))
 
-    def test_npu_with_replaced_cudagraphify(self):
+    def test_npu_with_capture_bit(self):
+        with temporary_device_interface("npu", _CaptureInterface):
+            self.assertTrue(is_graph_capture_runtime_ready({"npu"}))
+
+
+class TestCudagraphPostCompileRuntimeDispatch(TestCase):
+    def test_post_compile_skips_without_capture_bit(self):
         from torch._inductor import compile_fx
 
-        orig = compile_fx.cudagraphify
+        graph = _make_post_compile_graph(device_type="npu")
+        cudagraphs = BoxedBool(True)
+        with temporary_device_interface("npu", _RegisteredInterface):
+            with mock.patch.object(
+                compile_fx,
+                "cudagraphify",
+                side_effect=AssertionError("cudagraphify must not run"),
+            ):
+                cudagraph_post_compile([], graph, cudagraphs, {}, None)
+        self.assertFalse(cudagraphs.value)
 
-        def npugraphify(*args, **kwargs):
-            return orig(*args, **kwargs)
+    def test_partition_post_compile_skips_without_capture_bit(self):
+        from torch._inductor import compile_fx
 
-        try:
-            compile_fx.cudagraphify = npugraphify
-            self.assertTrue(_cudagraph_capture_runtime_ready({"npu"}))
-        finally:
-            compile_fx.cudagraphify = orig
+        graph = _make_post_compile_graph(device_type="npu", with_partition=True)
+        cudagraphs = BoxedBool(True)
+        with temporary_device_interface("npu", _RegisteredInterface):
+            with mock.patch.object(
+                compile_fx,
+                "cudagraphify",
+                side_effect=AssertionError("cudagraphify must not run"),
+            ):
+                cudagraph_partition_post_compile([], graph, cudagraphs, {}, None)
+        self.assertFalse(cudagraphs.value)
+        self.assertEqual(graph.cudagraphify_calls, [])
+
+    def test_post_compile_runs_with_capture_bit(self):
+        from torch._inductor import compile_fx
+
+        calls: list[str] = []
+
+        def npugraphify(model, static_input_idxs, **kwargs):
+            calls.append("npu")
+            return model
+
+        graph = _make_post_compile_graph(device_type="npu")
+        cudagraphs = BoxedBool(True)
+        with temporary_device_interface("npu", _CaptureInterface):
+            with mock.patch.object(compile_fx, "cudagraphify", npugraphify):
+                cudagraph_post_compile([], graph, cudagraphs, {}, None)
+        self.assertEqual(calls, ["npu"])
+        self.assertTrue(cudagraphs.value)
 
 
 class TestCudagraphDeviceGate(TestCase):
@@ -96,16 +218,13 @@ class TestCudagraphDeviceGate(TestCase):
         self.assertIn("multiple devices", msg)
 
     def test_renamed_privateuse1_with_interface_allowed(self):
-        register_interface_for_device("npu", _RegisteredInterface)
-        try:
+        with temporary_device_interface("npu", _RegisteredInterface):
             node = _FakeNode()
             mapping = {_FakeDevice("npu"): node}
             with mock.patch(
                 "torch._C._get_privateuse1_backend_name", return_value="npu"
             ):
                 self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
-        finally:
-            device_interfaces.pop("npu", None)
 
     def test_renamed_privateuse1_without_interface_skipped(self):
         node = _FakeNode()

--- a/test/inductor/test_cudagraph_device_gate.py
+++ b/test/inductor/test_cudagraph_device_gate.py
@@ -10,9 +10,9 @@ from torch._dynamo.device_interface import (
     DeviceInterface,
     register_interface_for_device,
 )
+import torch._inductor.cudagraph_utils as cudagraph_utils
 from torch._inductor.cudagraph_utils import (
     _graph_capture_compatible_device_type,
-    check_multiple_devices_or_any_cpu_nodes,
     is_graph_capture_runtime_ready,
 )
 from torch._inductor.output_code import (
@@ -22,6 +22,9 @@ from torch._inductor.output_code import (
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import BoxedBool, GraphPartitionMap
 from torch.utils._ordered_set import OrderedSet
+
+# Synthetic renamed PrivateUse1 backend; not tied to any real OOT device.
+OOT_DEVICE = "fakeoot"
 
 
 class _FakeNode:
@@ -54,6 +57,14 @@ class _CaptureInterface(DeviceInterface):
 
 
 @contextlib.contextmanager
+def renamed_privateuse1(device_type: str = OOT_DEVICE):
+    with mock.patch(
+        "torch._C._get_privateuse1_backend_name", return_value=device_type
+    ):
+        yield
+
+
+@contextlib.contextmanager
 def temporary_device_interface(device_type: str, interface_cls: type[DeviceInterface]):
     had_entry = device_type in device_interfaces
     previous = device_interfaces.get(device_type)
@@ -67,7 +78,20 @@ def temporary_device_interface(device_type: str, interface_cls: type[DeviceInter
             device_interfaces.pop(device_type, None)
 
 
-def _make_post_compile_graph(*, device_type: str = "npu", with_partition: bool = False):
+@contextlib.contextmanager
+def without_device_interface(device_type: str):
+    filtered = {
+        name: interface
+        for name, interface in device_interfaces.items()
+        if name != device_type
+    }
+    with mock.patch.dict(device_interfaces, filtered, clear=True):
+        yield
+
+
+def _make_post_compile_graph(
+    *, device_type: str = OOT_DEVICE, with_partition: bool = False
+):
     from torch._inductor.cudagraph_utils import CudagraphCachedInfo, PlaceholderInfo
 
     def identity(x):
@@ -125,21 +149,17 @@ class TestGraphCaptureCompatibleDeviceType(TestCase):
         self.assertTrue(_graph_capture_compatible_device_type("cuda"))
 
     def test_default_privateuseone_slot_unused(self):
-        with mock.patch(
-            "torch._C._get_privateuse1_backend_name", return_value="privateuseone"
-        ):
+        with renamed_privateuse1("privateuseone"):
             self.assertFalse(_graph_capture_compatible_device_type("privateuseone"))
 
     def test_renamed_without_interface(self):
-        with mock.patch("torch._C._get_privateuse1_backend_name", return_value="npu"):
-            self.assertFalse(_graph_capture_compatible_device_type("npu"))
+        with without_device_interface(OOT_DEVICE), renamed_privateuse1():
+            self.assertFalse(_graph_capture_compatible_device_type(OOT_DEVICE))
 
     def test_renamed_with_interface(self):
-        with temporary_device_interface("npu", _RegisteredInterface):
-            with mock.patch(
-                "torch._C._get_privateuse1_backend_name", return_value="npu"
-            ):
-                self.assertTrue(_graph_capture_compatible_device_type("npu"))
+        with temporary_device_interface(OOT_DEVICE, _RegisteredInterface):
+            with renamed_privateuse1():
+                self.assertTrue(_graph_capture_compatible_device_type(OOT_DEVICE))
 
 
 class TestGraphCaptureRuntimeReady(TestCase):
@@ -147,22 +167,31 @@ class TestGraphCaptureRuntimeReady(TestCase):
         self.assertTrue(is_graph_capture_runtime_ready({"cuda"}))
         self.assertTrue(CudaInterface.is_graph_capture_supported())
 
-    def test_npu_without_capture_bit(self):
-        with temporary_device_interface("npu", _RegisteredInterface):
-            self.assertFalse(is_graph_capture_runtime_ready({"npu"}))
+    def test_oot_without_capture_bit(self):
+        with temporary_device_interface(OOT_DEVICE, _RegisteredInterface):
+            self.assertFalse(is_graph_capture_runtime_ready({OOT_DEVICE}))
 
-    def test_npu_with_capture_bit(self):
-        with temporary_device_interface("npu", _CaptureInterface):
-            self.assertTrue(is_graph_capture_runtime_ready({"npu"}))
+    def test_oot_with_capture_bit(self):
+        with temporary_device_interface(OOT_DEVICE, _CaptureInterface):
+            self.assertTrue(is_graph_capture_runtime_ready({OOT_DEVICE}))
+
+    def test_cuda_with_cpu_is_ready(self):
+        self.assertTrue(is_graph_capture_runtime_ready({"cuda", "cpu"}))
+
+    def test_empty_device_types_not_ready(self):
+        self.assertFalse(is_graph_capture_runtime_ready(set()))
+
+    def test_multiple_accelerators_not_ready(self):
+        self.assertFalse(is_graph_capture_runtime_ready({"cuda", "xpu"}))
 
 
 class TestCudagraphPostCompileRuntimeDispatch(TestCase):
     def test_post_compile_skips_without_capture_bit(self):
         from torch._inductor import compile_fx
 
-        graph = _make_post_compile_graph(device_type="npu")
+        graph = _make_post_compile_graph()
         cudagraphs = BoxedBool(True)
-        with temporary_device_interface("npu", _RegisteredInterface):
+        with temporary_device_interface(OOT_DEVICE, _RegisteredInterface):
             with mock.patch.object(
                 compile_fx,
                 "cudagraphify",
@@ -174,9 +203,9 @@ class TestCudagraphPostCompileRuntimeDispatch(TestCase):
     def test_partition_post_compile_skips_without_capture_bit(self):
         from torch._inductor import compile_fx
 
-        graph = _make_post_compile_graph(device_type="npu", with_partition=True)
+        graph = _make_post_compile_graph(with_partition=True)
         cudagraphs = BoxedBool(True)
-        with temporary_device_interface("npu", _RegisteredInterface):
+        with temporary_device_interface(OOT_DEVICE, _RegisteredInterface):
             with mock.patch.object(
                 compile_fx,
                 "cudagraphify",
@@ -191,16 +220,16 @@ class TestCudagraphPostCompileRuntimeDispatch(TestCase):
 
         calls: list[str] = []
 
-        def npugraphify(model, static_input_idxs, **kwargs):
-            calls.append("npu")
+        def oot_cudagraphify(model, static_input_idxs, **kwargs):
+            calls.append("oot")
             return model
 
-        graph = _make_post_compile_graph(device_type="npu")
+        graph = _make_post_compile_graph()
         cudagraphs = BoxedBool(True)
-        with temporary_device_interface("npu", _CaptureInterface):
-            with mock.patch.object(compile_fx, "cudagraphify", npugraphify):
+        with temporary_device_interface(OOT_DEVICE, _CaptureInterface):
+            with mock.patch.object(compile_fx, "cudagraphify", oot_cudagraphify):
                 cudagraph_post_compile([], graph, cudagraphs, {}, None)
-        self.assertEqual(calls, ["npu"])
+        self.assertEqual(calls, ["oot"])
         self.assertTrue(cudagraphs.value)
 
 
@@ -208,39 +237,39 @@ class TestCudagraphDeviceGate(TestCase):
     def test_single_cuda_allowed(self):
         node = _FakeNode()
         mapping = {torch.device("cuda:0"): node}
-        self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+        self.assertIsNone(
+            cudagraph_utils.check_multiple_devices_or_any_cpu_nodes(mapping)
+        )
 
     def test_single_xpu_skipped(self):
         node = _FakeNode()
         mapping = {torch.device("xpu:0"): node}
-        msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        msg = cudagraph_utils.check_multiple_devices_or_any_cpu_nodes(mapping)
         self.assertIsNotNone(msg)
         self.assertIn("multiple devices", msg)
 
-    def test_renamed_privateuse1_with_interface_allowed(self):
-        with temporary_device_interface("npu", _RegisteredInterface):
+    def test_renamed_oot_with_interface_allowed(self):
+        with temporary_device_interface(OOT_DEVICE, _RegisteredInterface):
             node = _FakeNode()
-            mapping = {_FakeDevice("npu"): node}
-            with mock.patch(
-                "torch._C._get_privateuse1_backend_name", return_value="npu"
-            ):
-                self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+            mapping = {_FakeDevice(OOT_DEVICE): node}
+            with renamed_privateuse1():
+                self.assertIsNone(
+                    cudagraph_utils.check_multiple_devices_or_any_cpu_nodes(mapping)
+                )
 
-    def test_renamed_privateuse1_without_interface_skipped(self):
+    def test_renamed_oot_without_interface_skipped(self):
         node = _FakeNode()
-        mapping = {_FakeDevice("npu"): node}
-        with mock.patch("torch._C._get_privateuse1_backend_name", return_value="npu"):
-            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        mapping = {_FakeDevice(OOT_DEVICE): node}
+        with without_device_interface(OOT_DEVICE), renamed_privateuse1():
+            msg = cudagraph_utils.check_multiple_devices_or_any_cpu_nodes(mapping)
         self.assertIsNotNone(msg)
         self.assertIn("multiple devices", msg)
 
     def test_default_privateuseone_skipped(self):
         node = _FakeNode()
         mapping = {torch.device("privateuseone:0"): node}
-        with mock.patch(
-            "torch._C._get_privateuse1_backend_name", return_value="privateuseone"
-        ):
-            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        with renamed_privateuse1("privateuseone"):
+            msg = cudagraph_utils.check_multiple_devices_or_any_cpu_nodes(mapping)
         self.assertIsNotNone(msg)
         self.assertIn("multiple devices", msg)
 

--- a/test/inductor/test_cudagraph_device_gate.py
+++ b/test/inductor/test_cudagraph_device_gate.py
@@ -12,6 +12,7 @@ from torch._inductor.cudagraph_utils import (
     _graph_capture_compatible_device_type,
     check_multiple_devices_or_any_cpu_nodes,
 )
+from torch._inductor.output_code import _cudagraph_capture_runtime_ready
 from torch._inductor.test_case import run_tests, TestCase
 
 
@@ -57,6 +58,28 @@ class TestGraphCaptureCompatibleDeviceType(TestCase):
                 self.assertTrue(_graph_capture_compatible_device_type("npu"))
         finally:
             device_interfaces.pop("npu", None)
+
+
+class TestCudagraphCaptureRuntimeReady(TestCase):
+    def test_cuda_only_uses_builtin(self):
+        self.assertTrue(_cudagraph_capture_runtime_ready({"cuda"}))
+
+    def test_npu_without_runtime_override(self):
+        self.assertFalse(_cudagraph_capture_runtime_ready({"npu"}))
+
+    def test_npu_with_replaced_cudagraphify(self):
+        from torch._inductor import compile_fx
+
+        orig = compile_fx.cudagraphify
+
+        def npugraphify(*args, **kwargs):
+            return orig(*args, **kwargs)
+
+        try:
+            compile_fx.cudagraphify = npugraphify
+            self.assertTrue(_cudagraph_capture_runtime_ready({"npu"}))
+        finally:
+            compile_fx.cudagraphify = orig
 
 
 class TestCudagraphDeviceGate(TestCase):

--- a/test/inductor/test_cudagraph_device_gate.py
+++ b/test/inductor/test_cudagraph_device_gate.py
@@ -1,0 +1,107 @@
+# Owner(s): ["module: inductor"]
+
+from unittest import mock
+
+import torch
+from torch._dynamo.device_interface import (
+    device_interfaces,
+    DeviceInterface,
+    register_interface_for_device,
+)
+from torch._inductor.cudagraph_utils import (
+    _graph_capture_compatible_device_type,
+    check_multiple_devices_or_any_cpu_nodes,
+)
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class _FakeNode:
+    name = "n"
+
+
+class _FakeDevice:
+    def __init__(self, device_type: str, index: int = 0) -> None:
+        self.type = device_type
+        self.index = index
+
+    def __repr__(self) -> str:
+        return f"{self.type}:{self.index}"
+
+
+class _RegisteredInterface(DeviceInterface):
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class TestGraphCaptureCompatibleDeviceType(TestCase):
+    def test_cuda(self):
+        self.assertTrue(_graph_capture_compatible_device_type("cuda"))
+
+    def test_default_privateuseone_slot_unused(self):
+        with mock.patch(
+            "torch._C._get_privateuse1_backend_name", return_value="privateuseone"
+        ):
+            self.assertFalse(_graph_capture_compatible_device_type("privateuseone"))
+
+    def test_renamed_without_interface(self):
+        with mock.patch("torch._C._get_privateuse1_backend_name", return_value="npu"):
+            self.assertFalse(_graph_capture_compatible_device_type("npu"))
+
+    def test_renamed_with_interface(self):
+        register_interface_for_device("npu", _RegisteredInterface)
+        try:
+            with mock.patch(
+                "torch._C._get_privateuse1_backend_name", return_value="npu"
+            ):
+                self.assertTrue(_graph_capture_compatible_device_type("npu"))
+        finally:
+            device_interfaces.pop("npu", None)
+
+
+class TestCudagraphDeviceGate(TestCase):
+    def test_single_cuda_allowed(self):
+        node = _FakeNode()
+        mapping = {torch.device("cuda:0"): node}
+        self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+
+    def test_single_xpu_skipped(self):
+        node = _FakeNode()
+        mapping = {torch.device("xpu:0"): node}
+        msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        self.assertIsNotNone(msg)
+        self.assertIn("multiple devices", msg)
+
+    def test_renamed_privateuse1_with_interface_allowed(self):
+        register_interface_for_device("npu", _RegisteredInterface)
+        try:
+            node = _FakeNode()
+            mapping = {_FakeDevice("npu"): node}
+            with mock.patch(
+                "torch._C._get_privateuse1_backend_name", return_value="npu"
+            ):
+                self.assertIsNone(check_multiple_devices_or_any_cpu_nodes(mapping))
+        finally:
+            device_interfaces.pop("npu", None)
+
+    def test_renamed_privateuse1_without_interface_skipped(self):
+        node = _FakeNode()
+        mapping = {_FakeDevice("npu"): node}
+        with mock.patch("torch._C._get_privateuse1_backend_name", return_value="npu"):
+            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        self.assertIsNotNone(msg)
+        self.assertIn("multiple devices", msg)
+
+    def test_default_privateuseone_skipped(self):
+        node = _FakeNode()
+        mapping = {torch.device("privateuseone:0"): node}
+        with mock.patch(
+            "torch._C._get_privateuse1_backend_name", return_value="privateuseone"
+        ):
+            msg = check_multiple_devices_or_any_cpu_nodes(mapping)
+        self.assertIsNotNone(msg)
+        self.assertIn("multiple devices", msg)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -103,6 +103,16 @@ def snapshot_cudagraph_enabled() -> bool:
     return torch._inductor.config.triton.cudagraphs
 
 
+def _move_cpu_scalar_to_accelerator(
+    val: torch.Tensor, device_type: str, *, for_runtime: bool = False
+) -> torch.Tensor:
+    if device_type == "cuda":
+        if for_runtime:
+            return val.pin_memory().cuda(non_blocking=True)
+        return val.cuda()
+    return val.to(device_type)
+
+
 def maybe_clone(x: torch.Tensor | None) -> torch.Tensor | None:
     if x is not None:
         return clone_preserve_strides(x)
@@ -1025,10 +1035,13 @@ class AutogradCompilerInstance:
     # Eager autograd backward implements scalars as 0-dim tensors, see DivBackward0::other_.
     # When compiled autograd traces those nodes, it lifts the scalar tensors, resulting in a graph
     # with some cpu 0-dim tensor inputs. To prevent the entire graph from skipping cudagraph, we move the
-    # scalar tensors to cuda. This works because ATen/prims ops will accept cuda 0-dim tensors too.
-    def move_graph_nodes_to_cuda(self, graph: torch.fx.Graph) -> list[int]:
+    # scalar tensors to the graph's accelerator (cuda or renamed PrivateUse1). This works because
+    # ATen/prims ops will accept accelerator 0-dim tensors too.
+    def move_graph_nodes_to_cuda(
+        self, graph: torch.fx.Graph
+    ) -> tuple[list[int], str | None]:
         to_move: dict[int, torch.fx.Node] = {}
-        has_cuda_inputs = False
+        accelerator_device_type: str | None = None
         nodes = list(graph.nodes)
         if nodes[0].target != "inputs":
             raise AssertionError(
@@ -1043,13 +1056,21 @@ class AutogradCompilerInstance:
         last_getitem_idx = first_getitem_idx + len(inputs_users) - 1
         if nodes[last_getitem_idx] != inputs_users[-1]:
             raise AssertionError("Last getitem node does not match last inputs user")
+        privateuse1_name = torch._C._get_privateuse1_backend_name()
         # getitem nodes on inputs
         for i, node in enumerate(inputs_users):
-            if not has_cuda_inputs and node.meta["val"].device.type == "cuda":
-                has_cuda_inputs = True
+            device_type = node.meta["val"].device.type
+            if accelerator_device_type is None and (
+                device_type == "cuda"
+                or (
+                    privateuse1_name != "privateuseone"
+                    and device_type == privateuse1_name
+                )
+            ):
+                accelerator_device_type = device_type
                 continue
 
-            is_cpu = node.meta["val"].device.type == "cpu"
+            is_cpu = device_type == "cpu"
             is_scalar = len(node.meta["val"].size()) == 0
             if is_cpu and is_scalar:
                 node_users = list(node.users.keys())
@@ -1068,17 +1089,22 @@ class AutogradCompilerInstance:
                     # all users are prims/aten, can move safely
                     to_move[i] = node
 
-        # only move cpu scalars to cuda if there were cuda activations in this graph,
+        # only move cpu scalars to the accelerator if the graph has accelerator activations,
         # this is to handle the case where cudagraphs is enabled on a cpu-only graph
-        if has_cuda_inputs:
+        if accelerator_device_type is not None:
             for node in to_move.values():
-                verbose_log.debug("Moving node %s from cpu to cuda", node)
-                node.meta["val"] = node.meta["val"].cuda()
+                verbose_log.debug(
+                    "Moving node %s from cpu to %s",
+                    node,
+                    accelerator_device_type,
+                )
+                node.meta["val"] = _move_cpu_scalar_to_accelerator(
+                    node.meta["val"], accelerator_device_type
+                )
 
-            # return runtime indices we need to move to cuda
-            return list(to_move.keys())
+            return list(to_move.keys()), accelerator_device_type
 
-        return []
+        return [], None
 
     def dce(self) -> None:
         # Most of these removed nodes would have been removed during Dynamo and AOTDispatch
@@ -1171,8 +1197,11 @@ class AutogradCompilerInstance:
             {},
         )
         runtime_inputs_to_move: list[int] = []
+        runtime_accelerator_device_type: str | None = None
         if snapshot_cudagraph_enabled():
-            runtime_inputs_to_move = self.move_graph_nodes_to_cuda(self.fx_tracer.graph)
+            runtime_inputs_to_move, runtime_accelerator_device_type = (
+                self.move_graph_nodes_to_cuda(self.fx_tracer.graph)
+            )
 
         # We traced using dummy tensors. Delete all the metadata of the dummy tensors.
         # It's probably better to refactor this class to use a different tracer
@@ -1259,8 +1288,13 @@ class AutogradCompilerInstance:
                         else:
                             filtered_sizes.append(integer)
 
-                for i in runtime_inputs_to_move:
-                    inputs[i] = inputs[i].pin_memory().cuda(non_blocking=True)
+                if runtime_accelerator_device_type is not None:
+                    for i in runtime_inputs_to_move:
+                        inputs[i] = _move_cpu_scalar_to_accelerator(
+                            inputs[i],
+                            runtime_accelerator_device_type,
+                            for_runtime=True,
+                        )
 
                 with _disable(), make_compile_context(self.id):
                     out = compiled_fn(

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -103,16 +103,6 @@ def snapshot_cudagraph_enabled() -> bool:
     return torch._inductor.config.triton.cudagraphs
 
 
-def _move_cpu_scalar_to_accelerator(
-    val: torch.Tensor, device_type: str, *, for_runtime: bool = False
-) -> torch.Tensor:
-    if device_type == "cuda":
-        if for_runtime:
-            return val.pin_memory().cuda(non_blocking=True)
-        return val.cuda()
-    return val.to(device_type)
-
-
 def maybe_clone(x: torch.Tensor | None) -> torch.Tensor | None:
     if x is not None:
         return clone_preserve_strides(x)
@@ -1035,13 +1025,10 @@ class AutogradCompilerInstance:
     # Eager autograd backward implements scalars as 0-dim tensors, see DivBackward0::other_.
     # When compiled autograd traces those nodes, it lifts the scalar tensors, resulting in a graph
     # with some cpu 0-dim tensor inputs. To prevent the entire graph from skipping cudagraph, we move the
-    # scalar tensors to the graph's accelerator (cuda or renamed PrivateUse1). This works because
-    # ATen/prims ops will accept accelerator 0-dim tensors too.
-    def move_graph_nodes_to_cuda(
-        self, graph: torch.fx.Graph
-    ) -> tuple[list[int], str | None]:
+    # scalar tensors to cuda. This works because ATen/prims ops will accept cuda 0-dim tensors too.
+    def move_graph_nodes_to_cuda(self, graph: torch.fx.Graph) -> list[int]:
         to_move: dict[int, torch.fx.Node] = {}
-        accelerator_device_type: str | None = None
+        has_cuda_inputs = False
         nodes = list(graph.nodes)
         if nodes[0].target != "inputs":
             raise AssertionError(
@@ -1056,21 +1043,13 @@ class AutogradCompilerInstance:
         last_getitem_idx = first_getitem_idx + len(inputs_users) - 1
         if nodes[last_getitem_idx] != inputs_users[-1]:
             raise AssertionError("Last getitem node does not match last inputs user")
-        privateuse1_name = torch._C._get_privateuse1_backend_name()
         # getitem nodes on inputs
         for i, node in enumerate(inputs_users):
-            device_type = node.meta["val"].device.type
-            if accelerator_device_type is None and (
-                device_type == "cuda"
-                or (
-                    privateuse1_name != "privateuseone"
-                    and device_type == privateuse1_name
-                )
-            ):
-                accelerator_device_type = device_type
+            if not has_cuda_inputs and node.meta["val"].device.type == "cuda":
+                has_cuda_inputs = True
                 continue
 
-            is_cpu = device_type == "cpu"
+            is_cpu = node.meta["val"].device.type == "cpu"
             is_scalar = len(node.meta["val"].size()) == 0
             if is_cpu and is_scalar:
                 node_users = list(node.users.keys())
@@ -1089,22 +1068,17 @@ class AutogradCompilerInstance:
                     # all users are prims/aten, can move safely
                     to_move[i] = node
 
-        # only move cpu scalars to the accelerator if the graph has accelerator activations,
+        # only move cpu scalars to cuda if there were cuda activations in this graph,
         # this is to handle the case where cudagraphs is enabled on a cpu-only graph
-        if accelerator_device_type is not None:
+        if has_cuda_inputs:
             for node in to_move.values():
-                verbose_log.debug(
-                    "Moving node %s from cpu to %s",
-                    node,
-                    accelerator_device_type,
-                )
-                node.meta["val"] = _move_cpu_scalar_to_accelerator(
-                    node.meta["val"], accelerator_device_type
-                )
+                verbose_log.debug("Moving node %s from cpu to cuda", node)
+                node.meta["val"] = node.meta["val"].cuda()
 
-            return list(to_move.keys()), accelerator_device_type
+            # return runtime indices we need to move to cuda
+            return list(to_move.keys())
 
-        return [], None
+        return []
 
     def dce(self) -> None:
         # Most of these removed nodes would have been removed during Dynamo and AOTDispatch
@@ -1197,11 +1171,8 @@ class AutogradCompilerInstance:
             {},
         )
         runtime_inputs_to_move: list[int] = []
-        runtime_accelerator_device_type: str | None = None
         if snapshot_cudagraph_enabled():
-            runtime_inputs_to_move, runtime_accelerator_device_type = (
-                self.move_graph_nodes_to_cuda(self.fx_tracer.graph)
-            )
+            runtime_inputs_to_move = self.move_graph_nodes_to_cuda(self.fx_tracer.graph)
 
         # We traced using dummy tensors. Delete all the metadata of the dummy tensors.
         # It's probably better to refactor this class to use a different tracer
@@ -1288,13 +1259,8 @@ class AutogradCompilerInstance:
                         else:
                             filtered_sizes.append(integer)
 
-                if runtime_accelerator_device_type is not None:
-                    for i in runtime_inputs_to_move:
-                        inputs[i] = _move_cpu_scalar_to_accelerator(
-                            inputs[i],
-                            runtime_accelerator_device_type,
-                            for_runtime=True,
-                        )
+                for i in runtime_inputs_to_move:
+                    inputs[i] = inputs[i].pin_memory().cuda(non_blocking=True)
 
                 with _disable(), make_compile_context(self.id):
                     out = compiled_fn(

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -234,6 +234,15 @@ class DeviceInterface:
             )
         return mp_count
 
+    @staticmethod
+    def is_graph_capture_supported(device: torch.types.Device = None) -> bool:
+        """Whether the backend opts into Inductor graph capture on this device.
+
+        Default ``False``. Backends enable this after installing a capture
+        runtime (e.g. by patching ``compile_fx.cudagraphify``).
+        """
+        return False
+
     @classmethod
     def raise_if_triton_unavailable(cls, device: torch.types.Device = None) -> None:
         """
@@ -368,6 +377,10 @@ class CudaInterface(DeviceInterface):
             torch.version.hip is not None
             or CudaInterface.Worker.get_device_properties(device).major >= 7
         )
+
+    @staticmethod
+    def is_graph_capture_supported(device: torch.types.Device = None) -> bool:
+        return True
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -341,6 +341,36 @@ def _get_use_stack_trace(node: torch.fx.Node) -> str | None:
     return None
 
 
+def get_single_accelerator_device_type(
+    device_types: AbstractSet[str],
+) -> str | None:
+    accelerator_types = [
+        device_type
+        for device_type in device_types
+        if device_type not in ("cpu", "meta")
+    ]
+    if len(accelerator_types) == 1:
+        return accelerator_types[0]
+    return None
+
+
+def is_graph_capture_runtime_ready(device_types: AbstractSet[str]) -> bool:
+    """Whether post-compile may dispatch to a graph capture runtime.
+
+    CUDA is always ready. Other accelerators require
+    ``DeviceInterface.is_graph_capture_supported()`` on the registered backend.
+    """
+    device_type = get_single_accelerator_device_type(device_types)
+    if device_type is None:
+        return False
+    if device_type == "cuda":
+        return True
+    try:
+        return get_interface_for_device(device_type).is_graph_capture_supported()
+    except NotImplementedError:
+        return False
+
+
 def _graph_capture_compatible_device_type(device_type: str) -> bool:
     """Whether a single-device FX graph may pass the cudagraph device gate.
 

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Literal, TYPE_CHECKING, TypeVar
 
 import torch
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import counters, get_metrics_context
 from torch._inductor.utils import GraphPartitionMap, InputType
 from torch._subclasses.fake_tensor import get_plain_tensors, is_fake
@@ -340,6 +341,28 @@ def _get_use_stack_trace(node: torch.fx.Node) -> str | None:
     return None
 
 
+def _graph_capture_compatible_device_type(device_type: str) -> bool:
+    """Whether a single-device FX graph may pass the cudagraph device gate.
+
+    CUDA always passes here. Out-of-tree backends share the PrivateUse1 slot:
+    only after rename (name differs from the default ``privateuseone``) and
+    with a registered ``DeviceInterface``. This gate does not perform capture;
+    backends still supply their own graph runtime (e.g. NPUGraph via OOT).
+    """
+    if device_type == "cuda":
+        return True
+    privateuse1_name = torch._C._get_privateuse1_backend_name()
+    if privateuse1_name == "privateuseone":
+        return False
+    if device_type != privateuse1_name:
+        return False
+    try:
+        get_interface_for_device(device_type)
+    except NotImplementedError:
+        return False
+    return True
+
+
 def check_multiple_devices_or_any_cpu_nodes(
     device_node_mapping: dict[torch.device, torch.fx.Node],
 ) -> str | None:
@@ -358,11 +381,10 @@ def check_multiple_devices_or_any_cpu_nodes(
 
         return format_default_skip_message(msg)
 
-    if (
-        len(device_node_mapping) == 1
-        and next(iter(device_node_mapping.keys())).type == "cuda"
-    ):
-        return None
+    if len(device_node_mapping) == 1:
+        device_type = next(iter(device_node_mapping.keys())).type
+        if _graph_capture_compatible_device_type(device_type):
+            return None
 
     keys_repr = (repr(key) for key in device_node_mapping)
     return format_default_skip_message(f"multiple devices: {', '.join(keys_repr)}")

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -39,11 +39,11 @@ from torch._inductor.cudagraph_utils import (
     cudagraph_trees_clone_live_user_visible_outputs,
     CudagraphCachedInfo,
     CudagraphMetadata,
-    CUDAGraphPolicy,
     get_input_storage_mutation_info,
     get_input_storage_mutation_reason,
     get_partition_cudagraph_metadata,
     get_placeholder_info,
+    is_graph_capture_runtime_ready,
     log_cudagraph_skip_and_bump_counter,
 )
 from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
@@ -228,26 +228,21 @@ def prepare_cudagraph_post_compile(
         boxed_forward_device_index.set(next(iter(compiled_graph.device_idxs)))
 
 
-def _cudagraph_capture_runtime_ready(device_types: OrderedSet[str]) -> bool:
-    """Whether ``cudagraph_post_compile`` may dispatch to a capture runtime.
+def _skip_cudagraphs_without_capture_runtime(
+    compiled_graph: CompiledFxGraph,
+    cudagraphs: BoxedBool,
+    boxed_forward_device_index: BoxedDeviceIndex | None,
+) -> bool:
+    if is_graph_capture_runtime_ready(compiled_graph.device_types):
+        return False
 
-    The lowering device gate only checks device-type compatibility; this
-    second check ensures a non-CUDA graph is not handed to the built-in CUDA
-    ``compile_fx.cudagraphify``. OOT backends replace that entry point or
-    override ``CUDAGraphPolicy.cudagraphify``.
-    """
-    if not device_types or device_types <= OrderedSet(["cuda"]):
-        return True
-    policy = config.cudagraph_policy
-    if (
-        policy is not None
-        and type(policy).cudagraphify is not CUDAGraphPolicy.cudagraphify
-    ):
-        return True
-    # compile_fx imports output_code; import lazily to avoid a cycle.
-    from torch._inductor import compile_fx
-
-    return compile_fx.cudagraphify.__name__ != "cudagraphify"
+    BoxedBool.disable(cudagraphs)
+    maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
+    log_cudagraph_skip_and_bump_counter(
+        "skipping cudagraphs due to no capture runtime for "
+        f"{set(compiled_graph.device_types)}"
+    )
+    return True
 
 
 def cudagraph_post_compile(
@@ -296,13 +291,9 @@ def cudagraph_post_compile(
             compiled_graph, example_inputs, boxed_forward_device_index
         )
 
-        if not _cudagraph_capture_runtime_ready(compiled_graph.device_types):
-            BoxedBool.disable(cudagraphs)
-            maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
-            log_cudagraph_skip_and_bump_counter(
-                "skipping cudagraphs due to no capture runtime for "
-                f"{set(compiled_graph.device_types)}"
-            )
+        if _skip_cudagraphs_without_capture_runtime(
+            compiled_graph, cudagraphs, boxed_forward_device_index
+        ):
             return
 
         current_callable = compiled_graph.current_callable
@@ -429,6 +420,11 @@ def cudagraph_partition_post_compile(
     prepare_cudagraph_post_compile(
         compiled_graph, example_inputs, boxed_forward_device_index
     )
+
+    if _skip_cudagraphs_without_capture_runtime(
+        compiled_graph, cudagraphs, boxed_forward_device_index
+    ):
+        return
 
     from .compile_fx import cudagraphify
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -39,6 +39,7 @@ from torch._inductor.cudagraph_utils import (
     cudagraph_trees_clone_live_user_visible_outputs,
     CudagraphCachedInfo,
     CudagraphMetadata,
+    CUDAGraphPolicy,
     get_input_storage_mutation_info,
     get_input_storage_mutation_reason,
     get_partition_cudagraph_metadata,
@@ -227,6 +228,28 @@ def prepare_cudagraph_post_compile(
         boxed_forward_device_index.set(next(iter(compiled_graph.device_idxs)))
 
 
+def _cudagraph_capture_runtime_ready(device_types: OrderedSet[str]) -> bool:
+    """Whether ``cudagraph_post_compile`` may dispatch to a capture runtime.
+
+    The lowering device gate only checks device-type compatibility; this
+    second check ensures a non-CUDA graph is not handed to the built-in CUDA
+    ``compile_fx.cudagraphify``. OOT backends replace that entry point or
+    override ``CUDAGraphPolicy.cudagraphify``.
+    """
+    if not device_types or device_types <= OrderedSet(["cuda"]):
+        return True
+    policy = config.cudagraph_policy
+    if (
+        policy is not None
+        and type(policy).cudagraphify is not CUDAGraphPolicy.cudagraphify
+    ):
+        return True
+    # compile_fx imports output_code; import lazily to avoid a cycle.
+    from torch._inductor import compile_fx
+
+    return compile_fx.cudagraphify.__name__ != "cudagraphify"
+
+
 def cudagraph_post_compile(
     example_inputs: Sequence[InputType],
     compiled_graph: CompiledFxGraph,
@@ -272,6 +295,15 @@ def cudagraph_post_compile(
         prepare_cudagraph_post_compile(
             compiled_graph, example_inputs, boxed_forward_device_index
         )
+
+        if not _cudagraph_capture_runtime_ready(compiled_graph.device_types):
+            BoxedBool.disable(cudagraphs)
+            maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
+            log_cudagraph_skip_and_bump_counter(
+                "skipping cudagraphs due to no capture runtime for "
+                f"{set(compiled_graph.device_types)}"
+            )
+            return
 
         current_callable = compiled_graph.current_callable
         if current_callable is None:


### PR DESCRIPTION
Replace the hardcoded cuda-only check in
check_multiple_devices_or_any_cpu_nodes with
_graph_capture_compatible_device_type(): cuda always passes; renamed PrivateUse1 backends pass only when get_interface_for_device succeeds. This relaxes the device gate only; capture runtime remains OOT.

Test Plan:

```
python test/inductor/test_cudagraph_device_gate.py -v
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk