### PR TITLE
[dynamo] Support delattr on exception attributes

### DIFF
--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -720,6 +720,12 @@ class ExceptionVariable(VariableTracker):
                     se.track_attribute_mutation_new(self)
                 se.store_instance_dict_attr(self, attr, args[1])
             return variables.ConstantVariable.create(None)
+        elif name == "__delattr__":
+            attr = args[0].as_python_constant()
+            getset = self.lookup_tp_getset_member(attr)
+            if getset is not None:
+                getset.setter(self, tx, None)
+                return variables.ConstantVariable.create(None)
         return super().call_method(tx, name, args, kwargs)
 
     def tp_getattro_impl(


### PR DESCRIPTION
Dynamo already models special `BaseException` attributes like `args`, `__traceback__`, `__cause__`, and `__context__`, including the errors CPython raises when code tries to delete them.

However, `delattr(exc, name)` on those attributes was not routed through that existing logic, so Dynamo reported it as unsupported. This change sends exception `__delattr__` calls for modeled attributes through the same path used by the existing setters.

Test Plan:

```bash
PYTORCH_TEST_WITH_DYNAMO=1 .venv/bin/python test/cpython/v3_13/test_exceptions.py \
  ExceptionTests.test_invalid_delattr

PYTORCH_TEST_WITH_DYNAMO=1 .venv/bin/python test/cpython/v3_13/test_exceptions.py \
  ExceptionTests.test_invalid_setattr \
  ExceptionTests.testChainingDescriptors

git diff --check
```

AI assistance: I utilized Codex while navigating the Dynamo codebase. I reproduced the issue, traced and implemented the fix myself, and ran the tests listed above.

Addresses the Exception handling __delattr__ on exception instances() in https://github.com/pytorch/pytorch/issues/195901.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98