### PR TITLE
[PrismNet][ROCm] Mirror the empty-batch skip in the AOTriton flash-attention forward (#195814)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -185,7 +185,6 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   const int head_size_og = sizes[3];
   const int seqlen_k = k.size(1);
   const int num_heads_k = k.size(2);
-  TORCH_CHECK(batch_size > 0, "batch size must be positive");
   TORCH_CHECK(head_size_og % 8 == 0, "head_size must be a multiple of 8, this is ensured by padding!");
   TORCH_CHECK(head_size_og <= 512, "FlashAttention on ROCm forward only supports head dimension at most 512");
   TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -254,6 +253,13 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   at::Tensor atomic_counter;
   if (is_causal) {
     atomic_counter = at::zeros({1}, opts.dtype(at::kInt));
+  }
+
+  // An empty batch has no work: the tensors allocated above are already the correct
+  // empty result, so skip the launch rather than reject it.
+  if (batch_size == 0) {
+    return {out, q_padded, k_padded, v_padded,
+            M.view({batch_size, num_heads, seqlen_q}), seed_t, offset_t, softmax_fa_t};
   }
 
   using sdp::aotriton_adapter::mk_aotensor;


### PR DESCRIPTION
Summary:

`mha_fwd_aot` carries the same `TORCH_CHECK(batch_size > 0, ...)` as the CK entries, so an
OSS ROCm build, which selects AOTriton by default, still aborts on an empty batch even with
the two CK diffs below applied. The fix returns the tensors already allocated above the
launch -- at zero rows they are the correct empty result -- instead of rejecting the call.

There is no internal result to report, and that is why this is a separate diff.
`hip/flash_attn/fb/aotriton.cpp` replaces all four `*_aot` entries with stubs that raise
"AOTriton is not supported in the internal stack", and the internal build links those stubs
rather than this file: `mha_all_aot.hip` appears only in the `caffe2:torch_sources` and
`caffe2:src-files` source lists, with no compile rule of its own, unlike its CK sibling
which is additionally owned by `caffe2:ATen-hip-ck`. So no internal test can reach the
changed line. Upstream ROCm CI covers it after the ShipIt sync. Keeping it out of the CK
diffs means their hardware-verified claim stays clean.

Test Plan:
Not testable internally. `hip/flash_attn/fb/aotriton.cpp` replaces all four `*_aot`
entries with stubs that raise "AOTriton is not supported in the internal stack", so no
fbcode target compiles this file. Covered by upstream ROCm CI after the ShipIt sync.

The two CK diffs below carry the hardware-verified coverage:
https://www.internalfb.com/intern/testinfra/testrun/22236523204207138

Reviewed By: izaitsevfb

Differential Revision: D119272216




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang