### PR TITLE
[FSDP2] Support asynchronous gradient finalization

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -23,6 +23,7 @@ from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     FSDPModule,
     fully_shard,
+    GradientReductionHandle,
     MixedPrecisionPolicy,
     OffloadPolicy,
     register_fsdp_forward_method,
@@ -1764,6 +1765,49 @@ class TestFullyShardGradientAccumulation(FSDPTest):
         comm_counts = comm_mode.get_comm_counts()
         self.assertEqual(comm_counts[c10d_ops._reduce_scatter_base_], 2)
 
+    @skip_if_lt_x_gpu(2, allow_cpu=True)
+    def test_finalize_gradient_accumulation_async(self):
+        torch.manual_seed(42)
+        model = nn.Sequential(
+            nn.Linear(8, 8, bias=False),
+            nn.Linear(8, 8, bias=False),
+        ).to(device_type)
+        ref_model = copy.deepcopy(model)
+        fully_shard(model[0], reshard_after_forward=False)
+        fully_shard(model[1], reshard_after_forward=False)
+        fully_shard(model, reshard_after_forward=False)
+
+        torch.manual_seed(42 + self.rank)
+        inputs = [torch.randn(4, 8, device=device_type.type) for _ in range(3)]
+        model.set_is_last_backward(False)
+        model.set_reshard_after_backward(False)
+        model.set_requires_gradient_sync(False)
+        for input_tensor in inputs:
+            model(input_tensor).sum().backward()
+
+        handle = model.finalize_gradient_accumulation(async_op=True)
+        self.assertIsInstance(handle, GradientReductionHandle)
+        state = model._get_fsdp_state()
+        self.assertTrue(state._state_ctx.gradient_reduction_pending)
+        self.assertGreater(len(state._comm_ctx.reduce_scatter_states), 0)
+        with self.assertRaisesRegex(RuntimeError, "must be waited on"):
+            model.finalize_gradient_accumulation(async_op=True)
+        with self.assertRaisesRegex(RuntimeError, "must be waited on"):
+            model(inputs[0])
+
+        handle.wait()
+        handle.wait()
+        self.assertFalse(state._state_ctx.gradient_reduction_pending)
+        self.assertEqual(len(state._comm_ctx.reduce_scatter_states), 0)
+
+        for input_tensor in inputs:
+            ref_model(input_tensor).sum().backward()
+        for ref_param, param in zip(ref_model.parameters(), model.parameters()):
+            dist.all_reduce(ref_param.grad, op=dist.ReduceOp.AVG)
+            self.assertIsInstance(param, DTensor)
+            self.assertIsNotNone(param.grad)
+            self.assertEqual(ref_param.grad, param.grad.full_tensor())
+
     @skip_if_lt_x_gpu(4, allow_cpu=True)
     def test_finalize_gradient_accumulation_rejects_partial_all_reduce(self):
         mesh = init_device_mesh(
@@ -2815,6 +2859,12 @@ class TestFullyShardCudaGraph(FSDPTest):
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
     def test_finalize_gradient_accumulation_cudagraph(self):
+        self.run_subtests(
+            {"async_op": [False, True]},
+            self._test_finalize_gradient_accumulation_cudagraph,
+        )
+
+    def _test_finalize_gradient_accumulation_cudagraph(self, async_op: bool) -> None:
         torch.cuda.set_device(self.rank)
         device = torch.device("cuda", self.rank)
         torch.manual_seed(42)
@@ -2833,7 +2883,9 @@ class TestFullyShardCudaGraph(FSDPTest):
         def run_accumulation() -> tuple[torch.Tensor, ...]:
             for input_tensor in static_inputs:
                 model(input_tensor).sum().backward()
-            model.finalize_gradient_accumulation()
+            handle = model.finalize_gradient_accumulation(async_op=async_op)
+            if handle is not None:
+                handle.wait()
             return tuple(param.grad.detach().clone() for param in model.parameters())
 
         model.set_is_last_backward(False)

--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -4,6 +4,7 @@ from ._fully_shard import (
     DataParallelMeshDims,
     FSDPModule,
     fully_shard,
+    GradientReductionHandle,
     MixedPrecisionPolicy,
     OffloadPolicy,
     register_fsdp_forward_method,
@@ -53,6 +54,7 @@ __all__ = [
     "DataParallelMeshDims",
     "FSDPModule",
     "fully_shard",
+    "GradientReductionHandle",
     "MixedPrecisionPolicy",
     "OffloadPolicy",
     "register_fsdp_forward_method",
@@ -65,6 +67,7 @@ CPUOffloadPolicy.__module__ = "torch.distributed.fsdp"
 DataParallelMeshDims.__module__ = "torch.distributed.fsdp"
 FSDPModule.__module__ = "torch.distributed.fsdp"
 fully_shard.__module__ = "torch.distributed.fsdp"
+GradientReductionHandle.__module__ = "torch.distributed.fsdp"
 MixedPrecisionPolicy.__module__ = "torch.distributed.fsdp"
 OffloadPolicy.__module__ = "torch.distributed.fsdp"
 register_fsdp_forward_method.__module__ = "torch.distributed.fsdp"

--- a/torch/distributed/fsdp/_fully_shard/__init__.py
+++ b/torch/distributed/fsdp/_fully_shard/__init__.py
@@ -7,6 +7,7 @@ from ._fsdp_api import (
 from ._fully_shard import (
     FSDPModule,
     fully_shard,
+    GradientReductionHandle,
     register_fsdp_forward_method,
     share_comm_ctx,
     UnshardHandle,
@@ -18,6 +19,7 @@ __all__ = [
     "DataParallelMeshDims",
     "FSDPModule",
     "fully_shard",
+    "GradientReductionHandle",
     "MixedPrecisionPolicy",
     "OffloadPolicy",
     "register_fsdp_forward_method",

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -51,6 +51,9 @@ class FSDPStateContext(Generic[_StateType]):
         self.post_backward_final_callback_queued: bool = False
         # Whether to finalize backward in this backward's final callback
         self.is_last_backward: bool = True
+        # An asynchronous explicit finalization must be waited on before this
+        # FSDP tree starts more work.
+        self.gradient_reduction_pending: bool = False
         # Optional user-provided event recorded after optimizer for the
         # all-gather streams to wait on in the root pre-forward
         self.post_optim_event: torch.Event | None = None
@@ -138,6 +141,10 @@ class FSDPState(_State):
         self, module: nn.Module, args: tuple[Any, ...], kwargs: dict[str, Any]
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         self._lazy_init()
+        if self._state_ctx.gradient_reduction_pending:
+            raise RuntimeError(
+                "The previous gradient reduction must be waited on before forward"
+            )
         if self._state_ctx.iter_forward_root is not None:
             return args, kwargs
         logger.debug("FSDP::root_pre_forward")
@@ -399,7 +406,9 @@ class FSDPState(_State):
 
     @_dynamo_disable
     def _root_post_backward_final_callback(
-        self, finalize_gradient_accumulation: bool = False
+        self,
+        finalize_gradient_accumulation: bool = False,
+        wait_for_gradient_reduction: bool = True,
     ) -> None:
         logger.debug("FSDP::root_post_backward")
         with torch.profiler.record_function("FSDP::root_post_backward_callback"):
@@ -430,21 +439,21 @@ class FSDPState(_State):
                         fsdp_param_group.post_backward()
                     fsdp_param_group._training_state = TrainingState.IDLE
                 state._training_state = TrainingState.IDLE
-                if self._state_ctx.is_last_backward:
-                    for fsdp_param_group in state._fsdp_param_groups:
-                        fsdp_param_group.finalize_backward()
-            if self._state_ctx.is_last_backward:
-                self._comm_ctx.post_forward_order.clear()
-                # Wait on and release any retained reduce-scatter input buffers:
-                # the last module's (which no later module's rs_wait clears) and,
-                # when set_reduce_scatter_max_input_buffers retains more than
-                # one in flight, the rest. The compute stream (which reuses the
-                # memory) is ordered past each reduce-scatter first.
-                for rs_state in self._comm_ctx.reduce_scatter_states:
-                    if rs_state.event is not None:
-                        self._device_handle.current_stream().wait_event(rs_state.event)
-                self._comm_ctx.reduce_scatter_states.clear()
+            if self._state_ctx.is_last_backward and wait_for_gradient_reduction:
+                self._wait_for_gradient_reduction()
             self._state_ctx.post_backward_final_callback_queued = False
+
+    def _wait_for_gradient_reduction(self) -> None:
+        for state in self._state_ctx.all_states:
+            for fsdp_param_group in state._fsdp_param_groups:
+                fsdp_param_group.finalize_backward()
+        self._comm_ctx.post_forward_order.clear()
+        # Wait on and release any retained reduce-scatter input buffers. The
+        # current stream may reuse their memory after these waits.
+        for rs_state in self._comm_ctx.reduce_scatter_states:
+            if rs_state.event is not None:
+                self._device_handle.current_stream().wait_event(rs_state.event)
+        self._comm_ctx.reduce_scatter_states.clear()
 
     def _join_comm_streams(self) -> None:
         if self._device.type == "cpu":
@@ -535,6 +544,7 @@ class FSDPState(_State):
                 fsdp_param_group._reset_iter_state()
         self._state_ctx.iter_forward_root = None
         self._state_ctx.post_backward_final_callback_queued = False
+        self._state_ctx.gradient_reduction_pending = False
 
 
 def _get_module_fsdp_state(module: nn.Module) -> FSDPState | None:

--- a/torch/distributed/fsdp/_fully_shard/_fully_shard.py
+++ b/torch/distributed/fsdp/_fully_shard/_fully_shard.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 __all__ = [
     "fully_shard",
     "FSDPModule",
+    "GradientReductionHandle",
     "UnshardHandle",
     "register_fsdp_forward_method",
     "get_cls_to_fsdp_cls",
@@ -410,19 +411,38 @@ class FSDPModule:
         state = self._get_fsdp_state()
         state._state_ctx.is_last_backward = is_last_backward
 
-    @_dynamo_disable
-    def finalize_gradient_accumulation(self) -> None:
-        """Finish a deferred gradient reduction on the calling thread.
+    @overload
+    def finalize_gradient_accumulation(
+        self, *, async_op: Literal[False] = False
+    ) -> None: ...
 
-        Call this after backward passes run with :meth:`set_is_last_backward`,
-        :meth:`set_reshard_after_backward`, and gradient synchronization
-        disabled. This method temporarily enables gradient synchronization and
-        resharding, reduces the accumulated gradients into sharded ``.grad``,
-        and restores those settings.
+    @overload
+    def finalize_gradient_accumulation(
+        self, *, async_op: Literal[True]
+    ) -> GradientReductionHandle: ...
+
+    @_dynamo_disable
+    def finalize_gradient_accumulation(
+        self, *, async_op: bool = False
+    ) -> GradientReductionHandle | None:
+        """Finish gradient accumulation on the calling thread.
+
+        Call this after backward passes run with
+        ``set_is_last_backward(False)`` and
+        ``set_reshard_after_backward(False)``. Earlier backward passes may use
+        ``set_requires_gradient_sync(False)``. The final backward may enable
+        synchronization to overlap reduction with its remaining computation.
 
         The autograd final callback runs on the autograd thread, where its
         stream waits cannot be CUDA graph captured. This method runs the work
         on the calling thread and is safe to call during CUDA graph capture.
+
+        Args:
+            async_op (bool): If ``True``, return a
+                :class:`GradientReductionHandle` without waiting for gradient
+                reduction. The caller must call :meth:`wait` before using the
+                gradients or starting more work on this FSDP module. If
+                ``False``, wait before returning.
 
         HSDP accumulation that disables only all-reduce is not supported.
         Enable all-reduce on the final backward pass instead.
@@ -433,6 +453,11 @@ class FSDPModule:
         if not state._is_root:
             raise RuntimeError(
                 "finalize_gradient_accumulation must be called on the root FSDP module"
+            )
+        if state._state_ctx.gradient_reduction_pending:
+            raise RuntimeError(
+                "The previous gradient reduction must be waited on before "
+                "finalizing gradient accumulation again"
             )
         param_groups = [
             group
@@ -453,10 +478,21 @@ class FSDPModule:
             self.set_requires_gradient_sync(True)
             self.set_reshard_after_backward(True)
             self.set_is_last_backward(True)
-            state._root_post_backward_final_callback(
-                finalize_gradient_accumulation=True
+            max_input_buffers = state._comm_ctx.reduce_scatter_max_input_buffers
+            num_pending_reductions = sum(
+                group._deferred_gradient_reduction for group in param_groups
             )
-            state._join_comm_streams()
+            state._comm_ctx.reduce_scatter_max_input_buffers = max(
+                max_input_buffers,
+                len(state._comm_ctx.reduce_scatter_states) + num_pending_reductions,
+            )
+            try:
+                state._root_post_backward_final_callback(
+                    finalize_gradient_accumulation=True,
+                    wait_for_gradient_reduction=False,
+                )
+            finally:
+                state._comm_ctx.reduce_scatter_max_input_buffers = max_input_buffers
         finally:
             for group, group_settings in zip(param_groups, settings):
                 (
@@ -465,6 +501,12 @@ class FSDPModule:
                     group.reshard_after_backward,
                 ) = group_settings
             self.set_is_last_backward(is_last_backward)
+        state._state_ctx.gradient_reduction_pending = True
+        handle = _GradientReductionHandleImpl(state)
+        if async_op:
+            return handle
+        handle.wait()
+        return None
 
     def set_requires_gradient_sync(
         self, requires_gradient_sync: bool, *, recurse: bool = True
@@ -953,6 +995,28 @@ class FSDPModule:
                 for fsdp_param in fsdp_param_group.fsdp_params:
                     fsdp_param.reset_sharded_param()
         return ret
+
+
+class GradientReductionHandle:
+    """A handle for asynchronous gradient accumulation finalization."""
+
+    def wait(self) -> None:
+        """Wait for gradient reduction and release its retained buffers."""
+        return
+
+
+class _GradientReductionHandleImpl(GradientReductionHandle):
+    def __init__(self, state: FSDPState):
+        self._state: FSDPState | None = state
+
+    def wait(self) -> None:
+        if self._state is None:
+            return
+        state = self._state
+        state._wait_for_gradient_reduction()
+        state._join_comm_streams()
+        state._state_ctx.gradient_reduction_pending = False
+        self._state = None
 
 
 class UnshardHandle:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196727
* #196726
* #196963
* #196725
* __->__ #196724
* #196641
* #196640

Add an async option to `finalize_gradient_accumulation` that returns a public gradient-reduction handle. The handle keeps reduction buffers alive and completes stream synchronization and cleanup when waited.

Keep synchronous finalization as the default and implement it through the same handle path.