### PR TITLE
[Pipeline] Defer FSDP gradient reduction waits

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -4,6 +4,7 @@ import copy
 import csv
 import logging
 import os
+from collections import Counter
 from unittest.mock import MagicMock, patch
 
 from model_registry import MultiMLP
@@ -44,10 +45,12 @@ from torch.distributed.pipelining.schedules import (
     PipelineScheduleSingle,
     RECV_B,
     RECV_F,
+    REDUCE_GRAD,
     RESHARD,
     SEND_B,
     UNSHARD,
     W,
+    WAIT_REDUCE_GRAD,
 )
 from torch.distributed.pipelining.stage import (
     _PipelineStageBase,
@@ -704,6 +707,72 @@ class TestSchedulePlan(TestCase):
 
         self.assertEqual(count_stage_15_unshards(default_schedule), 4)
         self.assertEqual(count_stage_15_unshards(retained_schedule), 1)
+
+    def test_wait_reduce_grad_round_trip(self):
+        action = _Action(3, WAIT_REDUCE_GRAD, None)
+        self.assertEqual(str(action), "3WAIT_REDUCE_GRAD")
+        self.assertEqual(_Action.from_str(str(action)), action)
+
+    def test_defer_reduce_grad_wait_lowering(self):
+        actions = [
+            _Action(6, B, 0),
+            _Action(4, B, 0),
+            _Action(2, B, 0),
+        ]
+        default = _add_reduce_grad(actions, n_microbatches=1)
+        self.assertEqual(
+            default,
+            [
+                _Action(6, B, 0),
+                _Action(6, REDUCE_GRAD, None),
+                _Action(4, B, 0),
+                _Action(4, REDUCE_GRAD, None),
+                _Action(2, B, 0),
+                _Action(2, REDUCE_GRAD, None),
+            ],
+        )
+        self.assertFalse(
+            any(action.computation_type == WAIT_REDUCE_GRAD for action in default)
+        )
+
+        deferred = _add_reduce_grad(
+            actions,
+            n_microbatches=1,
+            defer_reduce_grad_wait=True,
+        )
+        self.assertEqual(
+            deferred,
+            [
+                _Action(6, B, 0),
+                _Action(6, REDUCE_GRAD, None),
+                _Action(4, B, 0),
+                _Action(6, WAIT_REDUCE_GRAD, None),
+                _Action(4, REDUCE_GRAD, None),
+                _Action(2, B, 0),
+                _Action(4, WAIT_REDUCE_GRAD, None),
+                _Action(2, REDUCE_GRAD, None),
+                _Action(2, WAIT_REDUCE_GRAD, None),
+            ],
+        )
+        self.assertEqual(
+            Counter(
+                action.computation_type
+                for action in deferred
+                if action.computation_type != WAIT_REDUCE_GRAD
+            ),
+            Counter(action.computation_type for action in default),
+        )
+
+        outstanding = 0
+        peak = 0
+        for action in deferred:
+            if action.computation_type == REDUCE_GRAD:
+                outstanding += 1
+                peak = max(peak, outstanding)
+            elif action.computation_type == WAIT_REDUCE_GRAD:
+                outstanding -= 1
+        self.assertEqual(outstanding, 0)
+        self.assertEqual(peak, 1)
 
     @parametrize(
         "ScheduleClass",

--- a/test/distributed/test_composability.py
+++ b/test/distributed/test_composability.py
@@ -151,7 +151,9 @@ class ComposabilityTest(MultiProcContinuousTest):
         apply_dp,
         loss_fn,
         scale_grads=True,
+        schedule_kwargs=None,
     ):
+        schedule_kwargs = schedule_kwargs or {}
         if issubclass(ScheduleClass, PipelineScheduleSingle):
             pipeline_stage, offset = self._build_pp_stage(
                 pp_group,
@@ -169,6 +171,7 @@ class ComposabilityTest(MultiProcContinuousTest):
                 n_microbatches=num_microbatches,
                 loss_fn=loss_fn,
                 scale_grads=scale_grads,
+                **schedule_kwargs,
             )
         else:
             n_virtual = 2
@@ -192,6 +195,7 @@ class ComposabilityTest(MultiProcContinuousTest):
                 n_microbatches=num_microbatches,
                 loss_fn=loss_fn,
                 scale_grads=scale_grads,
+                **schedule_kwargs,
             )
         return pipeline_schedule, partial_models, offsets
 
@@ -280,6 +284,7 @@ class ComposabilityTest(MultiProcContinuousTest):
     @skip_if_lt_x_gpu(4)
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
     @parametrize("dp_type", ["FSDP", "FSDP_MP"])
+    @parametrize("defer_reduce_grad_wait", [False, True])
     @parametrize(
         "ScheduleClass",
         [
@@ -289,8 +294,10 @@ class ComposabilityTest(MultiProcContinuousTest):
             ScheduleInterleavedZeroBubble,
         ],
     )
-    def test_pp_fsdp(self, dp_type, ScheduleClass):
+    def test_pp_fsdp(self, dp_type, defer_reduce_grad_wait, ScheduleClass):
         if TEST_WITH_ROCM:
+            return
+        if defer_reduce_grad_wait and issubclass(ScheduleClass, PipelineScheduleSingle):
             return
 
         torch.get_device_module(device_type).set_device(self.device)
@@ -347,6 +354,11 @@ class ComposabilityTest(MultiProcContinuousTest):
             total_layers,
             apply_dp,
             loss_fn,
+            schedule_kwargs=(
+                {}
+                if issubclass(ScheduleClass, PipelineScheduleSingle)
+                else {"defer_reduce_grad_wait": defer_reduce_grad_wait}
+            ),
         )
 
         # Run the pipeline
@@ -390,7 +402,8 @@ class ComposabilityTest(MultiProcContinuousTest):
     @requires_nccl()
     @skip_if_lt_x_gpu(4)
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
-    def test_pp_fsdp_outer_gradient_accumulation(self):
+    @parametrize("defer_reduce_grad_wait", [False, True])
+    def test_pp_fsdp_outer_gradient_accumulation(self, defer_reduce_grad_wait):
         if TEST_WITH_ROCM:
             return
 
@@ -423,6 +436,7 @@ class ComposabilityTest(MultiProcContinuousTest):
                 n_microbatches=n_microbatches,
                 loss_fn=loss_fn,
                 scale_grads=False,
+                defer_reduce_grad_wait=defer_reduce_grad_wait,
             )
             actions = [
                 _Action(0, _ComputationType.FORWARD, i) for i in range(n_microbatches)
@@ -458,6 +472,7 @@ class ComposabilityTest(MultiProcContinuousTest):
                 finalize_gradients=finalize_gradients,
             )
             assert_unsharded(model, not finalize_gradients)
+            self.assertIsNone(schedule._stages[0]._gradient_reduction_handle)
 
         self.assertNotIn(0, schedule.unsharded_stages)
         ref_schedule = make_schedule(ref_model, total_microbatches)

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -66,6 +66,7 @@ class _ComputationType(str, Enum):
     FULL_BACKWARD = "B"
     OVERLAP_F_B = "OVERLAP_F_B"
     REDUCE_GRAD = "REDUCE_GRAD"
+    WAIT_REDUCE_GRAD = "WAIT_REDUCE_GRAD"
 
     @staticmethod
     def from_str(action: str) -> "_ComputationType":
@@ -87,6 +88,7 @@ RECV_B = _ComputationType.RECV_B
 FULL_BACKWARD = _ComputationType.FULL_BACKWARD
 OVERLAP_F_B = _ComputationType.OVERLAP_F_B
 REDUCE_GRAD = _ComputationType.REDUCE_GRAD
+WAIT_REDUCE_GRAD = _ComputationType.WAIT_REDUCE_GRAD
 
 
 # Targets (e.g. labels) are always split along the batch dim (0). Use
@@ -103,7 +105,7 @@ B = FULL_BACKWARD
 
 # Helper to parse an action string like 1F0 into a tuple of (stage_index, computation_type, microbatch_index)
 _action_regex = re.compile(
-    r"(\d+)(F|I|B|W|UNSHARD|RESHARD|REDUCE_GRAD|SEND_F|RECV_F|SEND_B|RECV_B)(\d*)"
+    r"(\d+)(WAIT_REDUCE_GRAD|REDUCE_GRAD|UNSHARD|RESHARD|SEND_F|RECV_F|SEND_B|RECV_B|F|I|B|W)(\d*)"
 )
 
 
@@ -1480,7 +1482,9 @@ def _requires_reduce_grad(action_type: _ComputationType) -> bool:
 
 
 def _add_reduce_grad(
-    actions: list[_Action | None], n_microbatches: int
+    actions: list[_Action | None],
+    n_microbatches: int,
+    defer_reduce_grad_wait: bool = False,
 ) -> list[_Action | None]:
     """
     REDUCE_GRAD refers to joint across minibatches grad reduction.
@@ -1488,6 +1492,7 @@ def _add_reduce_grad(
     """
     actions_with_reduce_grad: list[_Action | None] = []
     cnt: dict[int, int] = defaultdict(int)
+    pending_waits: list[int] = []
 
     def _leaf_action(a, to_schedule):
         if _requires_reduce_grad(a.computation_type):
@@ -1508,7 +1513,18 @@ def _add_reduce_grad(
             _leaf_action(a, schedule_reduce_grad_stage_idxs)
 
         for stage_idx in schedule_reduce_grad_stage_idxs:
+            if defer_reduce_grad_wait:
+                actions_with_reduce_grad.extend(
+                    _Action(pending_stage_idx, WAIT_REDUCE_GRAD, None)
+                    for pending_stage_idx in pending_waits
+                )
+                pending_waits.clear()
             actions_with_reduce_grad.append(_Action(stage_idx, REDUCE_GRAD, None))
+            if defer_reduce_grad_wait:
+                pending_waits.append(stage_idx)
+    actions_with_reduce_grad.extend(
+        _Action(stage_idx, WAIT_REDUCE_GRAD, None) for stage_idx in pending_waits
+    )
     return actions_with_reduce_grad
 
 
@@ -2511,6 +2527,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
     def __init__(self, *args, **kwargs):
         self._defer_pp_recv: bool = kwargs.pop("defer_pp_recv", False)
         self._max_active_stages: int = kwargs.pop("max_active_stages", 3)
+        self._defer_reduce_grad_wait: bool = kwargs.pop("defer_reduce_grad_wait", False)
         super().__init__(*args, **kwargs)
         # Action to custom function mapping
         self._comp_type_to_function_map: dict[_ComputationType, Callable] = {}
@@ -2552,10 +2569,12 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             UNSHARD,
             RESHARD,
             REDUCE_GRAD,
+            WAIT_REDUCE_GRAD,
         ):
             raise ValueError(
                 f"Invalid computation type {computation_type}. Only FORWARD, FULL_BACKWARD, \
-                BACKWARD_INPUT, BACKWARD_WEIGHT, OVERLAP_F_B, UNSHARD, RESHARD and REDUCE_GRAD are supported."
+                BACKWARD_INPUT, BACKWARD_WEIGHT, OVERLAP_F_B, UNSHARD, RESHARD, REDUCE_GRAD, \
+                and WAIT_REDUCE_GRAD are supported."
             )
 
         # Check if computation_type is already registered
@@ -2612,6 +2631,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 self.pipeline_order_with_comms[rank] = _add_reduce_grad(  # type: ignore[assignment]
                     self.pipeline_order_with_comms[rank],  # type: ignore[arg-type]
                     self._n_microbatches,
+                    defer_reduce_grad_wait=self._defer_reduce_grad_wait,
                 )
 
             self.pipeline_order_with_comms = _add_send_recv(
@@ -2743,6 +2763,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     UNSHARD,
                     RESHARD,
                     REDUCE_GRAD,
+                    WAIT_REDUCE_GRAD,
                 )
             ):
                 raise AssertionError(f"{action=} missing mb_index")
@@ -2912,11 +2933,20 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     self._retained_stages.add(stage_idx)
                     return
                 grad_scale_factor = self._n_microbatches if self.scale_grads else 1
-                stage.perform_reduce_grad(grad_scale_factor)
+                if self._defer_reduce_grad_wait and stage_uses_fsdp:
+                    stage.start_gradient_reduction()
+                else:
+                    stage.perform_reduce_grad(grad_scale_factor)
                 if stage_uses_fsdp:
                     self.unsharded_stages.discard(stage_idx)
                     self._retained_stages.discard(stage_idx)
                     self._resharded_by_reduce.add(stage_idx)
+            elif comp_type == WAIT_REDUCE_GRAD:
+                if not self._finalize_gradients and stage_uses_fsdp:
+                    return
+                if stage_uses_fsdp:
+                    grad_scale_factor = self._n_microbatches if self.scale_grads else 1
+                    stage.wait_for_gradient_reduction(grad_scale_factor)
             else:
                 raise ValueError(f"{action=} is unknown or unsupported")
 
@@ -3001,6 +3031,7 @@ class ScheduleLoopedBFS(_PipelineScheduleRuntime):
         backward_requires_autograd: bool = True,
         defer_pp_recv: bool = False,
         max_active_stages: int = 3,
+        defer_reduce_grad_wait: bool = False,
     ):
         super().__init__(
             stages=stages,
@@ -3011,6 +3042,7 @@ class ScheduleLoopedBFS(_PipelineScheduleRuntime):
             backward_requires_autograd=backward_requires_autograd,
             defer_pp_recv=defer_pp_recv,
             max_active_stages=max_active_stages,
+            defer_reduce_grad_wait=defer_reduce_grad_wait,
         )
 
         # 1. Create the pipeline_order (all ranks do this calculation)
@@ -3240,6 +3272,7 @@ class ScheduleInterleaved1F1B(_PipelineScheduleRuntime):
         backward_requires_autograd: bool = True,
         defer_pp_recv: bool = False,
         max_active_stages: int = 3,
+        defer_reduce_grad_wait: bool = False,
     ):
         self.pp_group_size = stages[0].group_size
         super().__init__(
@@ -3253,6 +3286,7 @@ class ScheduleInterleaved1F1B(_PipelineScheduleRuntime):
             backward_requires_autograd=backward_requires_autograd,
             defer_pp_recv=defer_pp_recv,
             max_active_stages=max_active_stages,
+            defer_reduce_grad_wait=defer_reduce_grad_wait,
         )
         self.n_local_stages = len(stages)
         self.rank = stages[0].group_rank
@@ -3351,6 +3385,7 @@ class ScheduleInterleavedZeroBubble(_PipelineScheduleRuntime):
         backward_requires_autograd: bool = True,
         defer_pp_recv: bool = False,
         max_active_stages: int = 3,
+        defer_reduce_grad_wait: bool = False,
     ):
         # TODO: we don't support input/weight backward split with torch.compile
         _check_torch_compile_compatibility(stages, self.__class__.__name__)
@@ -3366,6 +3401,7 @@ class ScheduleInterleavedZeroBubble(_PipelineScheduleRuntime):
             backward_requires_autograd=backward_requires_autograd,
             defer_pp_recv=defer_pp_recv,
             max_active_stages=max_active_stages,
+            defer_reduce_grad_wait=defer_reduce_grad_wait,
         )
         self.n_local_stages = len(stages)
         self.rank = stages[0].group_rank
@@ -3550,6 +3586,7 @@ class ScheduleZBVZeroBubble(_PipelineScheduleRuntime):
         backward_requires_autograd: bool = True,
         defer_pp_recv: bool = False,
         max_active_stages: int = 3,
+        defer_reduce_grad_wait: bool = False,
     ):
         # TODO: we don't support input/weight backward split with torch.compile
         _check_torch_compile_compatibility(stages, self.__class__.__name__)
@@ -3565,6 +3602,7 @@ class ScheduleZBVZeroBubble(_PipelineScheduleRuntime):
             backward_requires_autograd=backward_requires_autograd,
             defer_pp_recv=defer_pp_recv,
             max_active_stages=max_active_stages,
+            defer_reduce_grad_wait=defer_reduce_grad_wait,
         )
         self.stage_index_to_group_rank = generate_stage_to_rank_mapping(
             self.pp_group_size, self._num_stages, style="v"
@@ -3738,6 +3776,7 @@ class ScheduleDualPipeV(_PipelineScheduleRuntime):
         backward_requires_autograd: bool = True,
         defer_pp_recv: bool = False,
         max_active_stages: int = 3,
+        defer_reduce_grad_wait: bool = False,
     ):
         # TODO: we don't support input/weight backward split with torch.compile
         _check_torch_compile_compatibility(stages, self.__class__.__name__)
@@ -3753,6 +3792,7 @@ class ScheduleDualPipeV(_PipelineScheduleRuntime):
             backward_requires_autograd=backward_requires_autograd,
             defer_pp_recv=defer_pp_recv,
             max_active_stages=max_active_stages,
+            defer_reduce_grad_wait=defer_reduce_grad_wait,
         )
         self.stage_index_to_group_rank = generate_stage_to_rank_mapping(
             self.pp_group_size, self._num_stages, style="v"

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -15,7 +15,7 @@ import torch.fx as fx
 import torch.nn as nn
 from torch._logging import warning_once
 from torch._subclasses.fake_tensor import is_fake_tensor
-from torch.distributed.fsdp import FSDPModule
+from torch.distributed.fsdp import FSDPModule, GradientReductionHandle
 from torch.distributed.pipelining._utils import (
     _derive_grad_metas,
     _DTensorMeta,
@@ -286,6 +286,7 @@ class _PipelineStageBase(ABC):
         self.bwd_cache: dict[int, tuple[torch.Tensor | None, ...]] = {}
         # Caching chunk outputs for final output merge or reduction
         self.output_chunks: list[Any] = []
+        self._gradient_reduction_handle: GradientReductionHandle | None = None
 
         # Initialize has_backward to false; this will be set to true if loss
         # function is passed to pipeline schedule
@@ -711,6 +712,9 @@ class _PipelineStageBase(ABC):
         """
         Clear runtime states of the stage.
         """
+        if self._gradient_reduction_handle is not None:
+            self._gradient_reduction_handle.wait()
+            self._gradient_reduction_handle = None
         # map microbatch ID to list of forward tensor args
         self.fwd_cache.clear()
         # Caching chunk outputs for final output merge or reduction
@@ -1279,6 +1283,25 @@ class _PipelineStageBase(ABC):
             self.submod.finalize_gradient_accumulation()
         # Call gradient scaling at the end of the backward pass
         # NOTE: this must happen after FSDP post_backward is FSDP is enabled
+        if grad_scale_factor != 1:
+            self.scale_grads(grad_scale_factor)
+
+    def start_gradient_reduction(self) -> None:
+        """Start FSDP gradient reduction without waiting for it."""
+        if not isinstance(self.submod, FSDPModule):
+            raise RuntimeError("Asynchronous gradient reduction requires FSDP")
+        if self._gradient_reduction_handle is not None:
+            raise RuntimeError("A gradient reduction is already pending")
+        self._gradient_reduction_handle = self.submod.finalize_gradient_accumulation(
+            async_op=True
+        )
+
+    def wait_for_gradient_reduction(self, grad_scale_factor: int) -> None:
+        """Wait for FSDP gradient reduction and scale the gradients."""
+        if self._gradient_reduction_handle is None:
+            raise RuntimeError("No gradient reduction is pending")
+        self._gradient_reduction_handle.wait()
+        self._gradient_reduction_handle = None
         if grad_scale_factor != 1:
             self.scale_grads(grad_scale_factor)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196727
* #196726
* #196963
* __->__ #196725
* #196724
* #196641
* #196640

Add an opt-in WAIT_REDUCE_GRAD action that leaves each reduction at its existing schedule point and delays only its wait until before the next local reduction.

Use the public asynchronous FSDP finalization handle and keep at most one stage reduction outstanding. Non-final outer accumulation steps skip both reduction actions.