### PR TITLE
[DataPipe] Preserve the group key when evicting a full buffer

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -509,6 +509,13 @@ class TestIterableDataPipeBasic(TestCase):
                 rec[1][i][1].close()
         self.assertEqual(count, 8)
 
+    def test_groupby_keep_key_with_full_buffer(self):
+        datapipe = dp.iter.IterableWrapper(["a1", "a2", "b1"])
+        grouped = datapipe.groupby(
+            group_key_fn=operator.itemgetter(0), buffer_size=3, keep_key=True
+        )
+        self.assertEqual(list(grouped), [("a", ["a1", "a2"]), ("b", ["b1"])])
+
     def test_demux_mux_datapipe(self):
         numbers = NumbersDataset(10)
         n1, n2 = numbers.demux(2, lambda x: x % 2)

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -256,7 +256,7 @@ class GrouperIterDataPipe(IterDataPipe[DataChunk]):
         self.curr_buffer_size -= biggest_size
         del self.buffer_elements[biggest_key]
 
-        return result_to_yield
+        return biggest_key, result_to_yield
 
     def __iter__(self):
         for x in self.datapipe:
@@ -274,7 +274,7 @@ class GrouperIterDataPipe(IterDataPipe[DataChunk]):
                 del self.buffer_elements[key]
 
             if self.curr_buffer_size == self.max_buffer_size:
-                result_to_yield = self._remove_biggest_key()
+                key, result_to_yield = self._remove_biggest_key()
                 if result_to_yield is not None:
                     result = self.wrapper_class(result_to_yield)
                     yield (key, result) if self.keep_key else result


### PR DESCRIPTION
> ## Summary
>
> Fix `groupby` yielding an evicted group with the wrong key when `keep_key=True` and the buffer is full.
>
> Return the evicted group's key alongside its items instead of using the most recently received item's key. Add a regression test.
>
> ## Test Plan
>
> - Verified that the regression test fails before the fix and passes afterward.
> - All 27 tests in `TestIterableDataPipeBasic` and `TestFunctionalIterDataPipe` passed with the modified grouping module loaded into an existing PyTorch installation.
> - Targeted formatting and Ruff checks passed.
>
> This change was implemented with assistance from Codex.