### PR TITLE
[Windows] [CMake] Do not link libomp on MSVC to avoid mixing it with vcomp

### DIFF
--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -267,16 +267,6 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       set(OpenMP_libomp_LIBRARY "${MKL_OPENMP_LIBRARY}" CACHE STRING "libomp location for OpenMP")
     endif()
 
-    if ((NOT OpenMP_libomp_LIBRARY) AND MSVC AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
-      # On MSVC ARM64, OpenMP is provided by vcomp, which is a part of the Visual Studio installation.
-      find_library(OpenMP_libomp_LIBRARY
-      NAMES vcomp
-      HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
-      DOC "vcomp location for OpenMP on MSVC ARM64"
-      )
-      mark_as_advanced(OpenMP_libomp_LIBRARY)
-    endif()
-
     # Check if we are using  OpenBLAS which is linked against libgomp
     # we may end up with  multiple omp runtimes linked
     # against libtorch_cpu.so
@@ -307,7 +297,16 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       unset(_omp_clang_lib)
     endif()
 
-    if (NOT OpenMP_libomp_LIBRARY)
+    # cl.exe autolinks the runtime matching its -openmp flag (vcomp for
+    # -openmp[:experimental], libomp for -openmp:llvm), so it must not get an
+    # explicit library. The search below would find the libomp.lib shipped
+    # with Visual Studio and link it on top of vcomp: parallel regions then
+    # run on vcomp while omp_get_num_threads()/omp_get_thread_num() are
+    # answered by libomp and return 1/0 on every worker, so each worker runs
+    # the whole range as if the region were serial (pytorch/pytorch#176091,
+    # #193784). clang-cl also sets MSVC but emits __kmpc_* calls, hence the
+    # check on the compiler id.
+    if (NOT OpenMP_libomp_LIBRARY AND NOT CMAKE_${LANG}_COMPILER_ID STREQUAL "MSVC")
       find_library(OpenMP_libomp_LIBRARY
         NAMES omp gomp iomp5
         HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}


### PR DESCRIPTION
Fixes 
- #176091

## Root cause

Non-MKL MSVC source builds link **two OpenMP runtimes** into `torch_cpu.dll`:
- `-openmp:experimental` makes `cl.exe` link Microsoft's vcomp (`VCOMP140.DLL`), which runs the `#pragma omp parallel` regions;
- `FindOpenMP.cmake` additionally finds LLVM's `libomp.lib` shipped with Visual Studio and links it too, so the `omp_*` calls ATen makes (`omp_get_num_threads`, `omp_get_thread_num`, `omp_in_parallel`) go to `libomp140.x86_64.dll` instead.

Since libomp never started the region, so it tells every worker: 1 thread, id 0, not in parallel. `invoke_parallel` then runs the whole range on every thread with `at::get_thread_num() == 0`, and any kernel with per-thread state silently results in corrupted results. 

## Fix
`FindOpenMP.cmake` already special-cased MSVC ARM64 for exactly this reason and forced vcomp there. This change generalizes that approach to all MSVC targets, in the simpler form suggested in the review of #193792: instead of naming vcomp explicitly, skip the library search entirely when `CMAKE_<LANG>_COMPILER_ID` is `MSVC`, because `cl.exe` autolinks the runtime that matches its `-openmp` flag (vcomp for `-openmp[:experimental]`, libomp for `-openmp:llvm`). The ARM64 block becomes redundant and is removed. The compiler id is checked rather than `MSVC` because clang-cl also sets `MSVC=1` but emits `__kmpc_*` calls and does need libomp. The MKL path is unchanged.

## Test Plan
cmake -U "OpenMP_*" -S . -B build
pip install -e . -v --no-build-isolation
python [test_176091.py](https://github.com/user-attachments/files/32095566/test_176091.py)


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @nkhasbag-nv