### PR TITLE
 [Feature Refactoring] Move compiled autograd CPU scalars to renamed PrivateUse1.

### DIFF
--- a/test/dynamo/test_compiled_autograd_accelerator_scalar_move.py
+++ b/test/dynamo/test_compiled_autograd_accelerator_scalar_move.py
@@ -121,6 +121,20 @@ class TestCompiledAutogradAcceleratorScalarMove(TestCase):
         self.assertEqual(indices, [])
         self.assertIsNone(target)
 
+    @mock.patch.object(
+        torch._C, "_get_privateuse1_backend_name", return_value=OOT_DEVICE
+    )
+    def test_mixed_oot_and_xpu_skip(self, _mock_name: mock.Mock) -> None:
+        indices, target, _ = _run_move_graph_nodes_to_cuda(
+            [
+                _MetaVal(_DeviceStub(OOT_DEVICE, 0), (2,)),
+                _MetaVal(_DeviceStub("xpu", 0), (2,)),
+                _MetaVal(torch.device("cpu")),
+            ]
+        )
+        self.assertEqual(indices, [])
+        self.assertIsNone(target)
+
     def test_cpu_only_graph_skips(self) -> None:
         indices, target, _ = _run_move_graph_nodes_to_cuda(
             [_MetaVal(torch.device("cpu"), (2,)), _MetaVal(torch.device("cpu"))]

--- a/test/dynamo/test_compiled_autograd_accelerator_scalar_move.py
+++ b/test/dynamo/test_compiled_autograd_accelerator_scalar_move.py
@@ -1,0 +1,161 @@
+# Owner(s): ["module: dynamo"]
+import dataclasses
+import operator
+import unittest
+from unittest import mock
+
+import torch
+from torch._dynamo.compiled_autograd import (
+    _graph_placeholders,
+    _move_cpu_scalar_to_device,
+    AutogradCompilerInstance,
+    Op,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+OOT_DEVICE = "fakeoot"
+requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
+
+
+@dataclasses.dataclass(frozen=True)
+class _DeviceStub:
+    type: str
+    index: int = 0
+
+
+class _MetaVal:
+    def __init__(
+        self, device: torch.device | _DeviceStub, shape: tuple[int, ...] = ()
+    ) -> None:
+        self._device = device
+        self._shape = shape
+
+    @property
+    def device(self) -> torch.device | _DeviceStub:
+        return self._device
+
+    def size(self) -> torch.Size:
+        return torch.Size(self._shape)
+
+
+def _build_compiled_autograd_inputs_graph(
+    input_vals: list[_MetaVal],
+) -> torch.fx.Graph:
+    graph = torch.fx.Graph()
+    for name in _graph_placeholders:
+        graph.create_node("placeholder", name, (), {})
+    inputs = next(n for n in graph.nodes if n.target == "inputs")
+    for i, val in enumerate(input_vals):
+        getitem = graph.create_node("call_function", operator.getitem, (inputs, i), {})
+        getitem.meta["val"] = val
+    return graph
+
+
+def _run_move_graph_nodes_to_cuda(
+    input_vals: list[_MetaVal],
+) -> tuple[list[int], torch.device | None, torch.fx.Graph]:
+    graph = _build_compiled_autograd_inputs_graph(input_vals)
+    inst = object.__new__(AutogradCompilerInstance)
+    indices, target = inst.move_graph_nodes_to_cuda(graph)
+    return indices, target, graph
+
+
+class TestCompiledAutogradAcceleratorScalarMove(TestCase):
+    @mock.patch.object(
+        torch._C, "_get_privateuse1_backend_name", return_value=OOT_DEVICE
+    )
+    def test_single_oot_device_moves_scalar(self, _mock_name: mock.Mock) -> None:
+        graph = _build_compiled_autograd_inputs_graph(
+            [
+                _MetaVal(_DeviceStub(OOT_DEVICE, 1), (2,)),
+                _MetaVal(torch.device("cpu")),
+            ]
+        )
+        inputs = next(n for n in graph.nodes if n.target == "inputs")
+        getitems = list(inputs.users.keys())
+        graph.create_node(
+            "call_function",
+            torch.ops.aten.mul.Tensor,
+            (getitems[1], getitems[0]),
+            {},
+        )
+
+        inst = object.__new__(AutogradCompilerInstance)
+        with mock.patch(
+            "torch._dynamo.compiled_autograd._move_cpu_scalar_to_device",
+            side_effect=lambda val, device, **kwargs: _MetaVal(device),
+        ) as move_mock:
+            indices, target = inst.move_graph_nodes_to_cuda(graph)
+
+        self.assertEqual(indices, [1])
+        self.assertEqual(target, _DeviceStub(OOT_DEVICE, 1))
+        move_mock.assert_called_once()
+        self.assertEqual(move_mock.call_args[0][1], _DeviceStub(OOT_DEVICE, 1))
+
+    @mock.patch.object(
+        torch._C, "_get_privateuse1_backend_name", return_value=OOT_DEVICE
+    )
+    def test_mixed_oot_indices_skip(self, _mock_name: mock.Mock) -> None:
+        indices, target, _ = _run_move_graph_nodes_to_cuda(
+            [
+                _MetaVal(_DeviceStub(OOT_DEVICE, 0), (2,)),
+                _MetaVal(_DeviceStub(OOT_DEVICE, 1), (2,)),
+                _MetaVal(torch.device("cpu")),
+            ]
+        )
+        self.assertEqual(indices, [])
+        self.assertIsNone(target)
+
+    @mock.patch.object(
+        torch._C, "_get_privateuse1_backend_name", return_value=OOT_DEVICE
+    )
+    def test_mixed_cuda_and_oot_skip(self, _mock_name: mock.Mock) -> None:
+        indices, target, _ = _run_move_graph_nodes_to_cuda(
+            [
+                _MetaVal(torch.device("cuda", 0), (2,)),
+                _MetaVal(_DeviceStub(OOT_DEVICE, 0), (2,)),
+                _MetaVal(torch.device("cpu")),
+            ]
+        )
+        self.assertEqual(indices, [])
+        self.assertIsNone(target)
+
+    def test_cpu_only_graph_skips(self) -> None:
+        indices, target, _ = _run_move_graph_nodes_to_cuda(
+            [_MetaVal(torch.device("cpu"), (2,)), _MetaVal(torch.device("cpu"))]
+        )
+        self.assertEqual(indices, [])
+        self.assertIsNone(target)
+
+    @mock.patch.object(
+        torch._C, "_get_privateuse1_backend_name", return_value=OOT_DEVICE
+    )
+    def test_custom_function_scalar_not_moved(self, _mock_name: mock.Mock) -> None:
+        accel = _MetaVal(_DeviceStub(OOT_DEVICE, 0), (2,))
+        scalar = _MetaVal(torch.device("cpu"))
+        graph = _build_compiled_autograd_inputs_graph([accel, scalar])
+        inputs = next(n for n in graph.nodes if n.target == "inputs")
+        getitems = list(inputs.users.keys())
+        custom_op = Op("test_custom", lambda *args: args, is_custom_function=True)
+        graph.create_node("call_function", custom_op, (getitems[1],), {})
+
+        inst = object.__new__(AutogradCompilerInstance)
+        indices, target = inst.move_graph_nodes_to_cuda(graph)
+        self.assertEqual(indices, [])
+        self.assertEqual(target, _DeviceStub(OOT_DEVICE, 0))
+
+    @requires_cuda
+    def test_move_cpu_scalar_to_device_preserves_cuda_index(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs at least 2 cuda devices")
+        target = torch.device("cuda", 1)
+        scalar = torch.tensor(2.0, device="cpu")
+        moved = _move_cpu_scalar_to_device(scalar, target)
+        self.assertEqual(moved.device, target)
+        runtime_moved = _move_cpu_scalar_to_device(scalar, target, for_runtime=True)
+        self.assertEqual(runtime_moved.device, target)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -1047,7 +1047,7 @@ class AutogradCompilerInstance:
         self, graph: torch.fx.Graph
     ) -> tuple[list[int], torch.device | None]:
         to_move: dict[int, torch.fx.Node] = {}
-        accelerator_devices: set[torch.device] = set()
+        non_cpu_meta_devices: set[torch.device] = set()
         nodes = list(graph.nodes)
         if nodes[0].target != "inputs":
             raise AssertionError(
@@ -1066,8 +1066,8 @@ class AutogradCompilerInstance:
         # getitem nodes on inputs
         for i, node in enumerate(inputs_users):
             device = node.meta["val"].device
-            if _is_compiled_autograd_accelerator_device(device, privateuse1_name):
-                accelerator_devices.add(device)
+            if device.type not in ("cpu", "meta"):
+                non_cpu_meta_devices.add(device)
                 continue
 
             is_cpu = device.type == "cpu"
@@ -1089,10 +1089,14 @@ class AutogradCompilerInstance:
                     # all users are prims/aten, can move safely
                     to_move[i] = node
 
-        # only move cpu scalars when the graph has exactly one accelerator device,
-        # this is to handle cpu-only graphs and mixed-accelerator graphs conservatively
-        if len(accelerator_devices) == 1:
-            target_device = next(iter(accelerator_devices))
+        # only move cpu scalars when the graph has exactly one non-cpu/meta device
+        # and it is cuda or renamed PrivateUse1; mixed-accelerator graphs skip
+        if len(non_cpu_meta_devices) == 1:
+            target_device = next(iter(non_cpu_meta_devices))
+            if not _is_compiled_autograd_accelerator_device(
+                target_device, privateuse1_name
+            ):
+                return [], None
             for node in to_move.values():
                 verbose_log.debug(
                     "Moving node %s from cpu to %s",

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -103,6 +103,16 @@ def snapshot_cudagraph_enabled() -> bool:
     return torch._inductor.config.triton.cudagraphs
 
 
+def _move_cpu_scalar_to_accelerator(
+    val: torch.Tensor, device_type: str, *, for_runtime: bool = False
+) -> torch.Tensor:
+    if device_type == "cuda":
+        if for_runtime:
+            return val.pin_memory().cuda(non_blocking=True)
+        return val.cuda()
+    return val.to(device_type)
+
+
 def maybe_clone(x: torch.Tensor | None) -> torch.Tensor | None:
     if x is not None:
         return clone_preserve_strides(x)
@@ -1025,10 +1035,13 @@ class AutogradCompilerInstance:
     # Eager autograd backward implements scalars as 0-dim tensors, see DivBackward0::other_.
     # When compiled autograd traces those nodes, it lifts the scalar tensors, resulting in a graph
     # with some cpu 0-dim tensor inputs. To prevent the entire graph from skipping cudagraph, we move the
-    # scalar tensors to cuda. This works because ATen/prims ops will accept cuda 0-dim tensors too.
-    def move_graph_nodes_to_cuda(self, graph: torch.fx.Graph) -> list[int]:
+    # scalar tensors to the graph's accelerator (cuda or renamed PrivateUse1). This works because
+    # ATen/prims ops will accept accelerator 0-dim tensors too.
+    def move_graph_nodes_to_cuda(
+        self, graph: torch.fx.Graph
+    ) -> tuple[list[int], str | None]:
         to_move: dict[int, torch.fx.Node] = {}
-        has_cuda_inputs = False
+        accelerator_device_type: str | None = None
         nodes = list(graph.nodes)
         if nodes[0].target != "inputs":
             raise AssertionError(
@@ -1043,13 +1056,21 @@ class AutogradCompilerInstance:
         last_getitem_idx = first_getitem_idx + len(inputs_users) - 1
         if nodes[last_getitem_idx] != inputs_users[-1]:
             raise AssertionError("Last getitem node does not match last inputs user")
+        privateuse1_name = torch._C._get_privateuse1_backend_name()
         # getitem nodes on inputs
         for i, node in enumerate(inputs_users):
-            if not has_cuda_inputs and node.meta["val"].device.type == "cuda":
-                has_cuda_inputs = True
+            device_type = node.meta["val"].device.type
+            if accelerator_device_type is None and (
+                device_type == "cuda"
+                or (
+                    privateuse1_name != "privateuseone"
+                    and device_type == privateuse1_name
+                )
+            ):
+                accelerator_device_type = device_type
                 continue
 
-            is_cpu = node.meta["val"].device.type == "cpu"
+            is_cpu = device_type == "cpu"
             is_scalar = len(node.meta["val"].size()) == 0
             if is_cpu and is_scalar:
                 node_users = list(node.users.keys())
@@ -1068,17 +1089,22 @@ class AutogradCompilerInstance:
                     # all users are prims/aten, can move safely
                     to_move[i] = node
 
-        # only move cpu scalars to cuda if there were cuda activations in this graph,
+        # only move cpu scalars to the accelerator if the graph has accelerator activations,
         # this is to handle the case where cudagraphs is enabled on a cpu-only graph
-        if has_cuda_inputs:
+        if accelerator_device_type is not None:
             for node in to_move.values():
-                verbose_log.debug("Moving node %s from cpu to cuda", node)
-                node.meta["val"] = node.meta["val"].cuda()
+                verbose_log.debug(
+                    "Moving node %s from cpu to %s",
+                    node,
+                    accelerator_device_type,
+                )
+                node.meta["val"] = _move_cpu_scalar_to_accelerator(
+                    node.meta["val"], accelerator_device_type
+                )
 
-            # return runtime indices we need to move to cuda
-            return list(to_move.keys())
+            return list(to_move.keys()), accelerator_device_type
 
-        return []
+        return [], None
 
     def dce(self) -> None:
         # Most of these removed nodes would have been removed during Dynamo and AOTDispatch
@@ -1171,8 +1197,11 @@ class AutogradCompilerInstance:
             {},
         )
         runtime_inputs_to_move: list[int] = []
+        runtime_accelerator_device_type: str | None = None
         if snapshot_cudagraph_enabled():
-            runtime_inputs_to_move = self.move_graph_nodes_to_cuda(self.fx_tracer.graph)
+            runtime_inputs_to_move, runtime_accelerator_device_type = (
+                self.move_graph_nodes_to_cuda(self.fx_tracer.graph)
+            )
 
         # We traced using dummy tensors. Delete all the metadata of the dummy tensors.
         # It's probably better to refactor this class to use a different tracer
@@ -1259,8 +1288,13 @@ class AutogradCompilerInstance:
                         else:
                             filtered_sizes.append(integer)
 
-                for i in runtime_inputs_to_move:
-                    inputs[i] = inputs[i].pin_memory().cuda(non_blocking=True)
+                if runtime_accelerator_device_type is not None:
+                    for i in runtime_inputs_to_move:
+                        inputs[i] = _move_cpu_scalar_to_accelerator(
+                            inputs[i],
+                            runtime_accelerator_device_type,
+                            for_runtime=True,
+                        )
 
                 with _disable(), make_compile_context(self.id):
                     out = compiled_fn(

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -103,14 +103,20 @@ def snapshot_cudagraph_enabled() -> bool:
     return torch._inductor.config.triton.cudagraphs
 
 
-def _move_cpu_scalar_to_accelerator(
-    val: torch.Tensor, device_type: str, *, for_runtime: bool = False
+def _is_compiled_autograd_accelerator_device(
+    device: torch.device, privateuse1_name: str
+) -> bool:
+    if device.type == "cuda":
+        return True
+    return privateuse1_name != "privateuseone" and device.type == privateuse1_name
+
+
+def _move_cpu_scalar_to_device(
+    val: torch.Tensor, device: torch.device, *, for_runtime: bool = False
 ) -> torch.Tensor:
-    if device_type == "cuda":
-        if for_runtime:
-            return val.pin_memory().cuda(non_blocking=True)
-        return val.cuda()
-    return val.to(device_type)
+    if for_runtime and device.type == "cuda":
+        return val.pin_memory().to(device, non_blocking=True)
+    return val.to(device)
 
 
 def maybe_clone(x: torch.Tensor | None) -> torch.Tensor | None:
@@ -1039,9 +1045,9 @@ class AutogradCompilerInstance:
     # ATen/prims ops will accept accelerator 0-dim tensors too.
     def move_graph_nodes_to_cuda(
         self, graph: torch.fx.Graph
-    ) -> tuple[list[int], str | None]:
+    ) -> tuple[list[int], torch.device | None]:
         to_move: dict[int, torch.fx.Node] = {}
-        accelerator_device_type: str | None = None
+        accelerator_devices: set[torch.device] = set()
         nodes = list(graph.nodes)
         if nodes[0].target != "inputs":
             raise AssertionError(
@@ -1059,18 +1065,12 @@ class AutogradCompilerInstance:
         privateuse1_name = torch._C._get_privateuse1_backend_name()
         # getitem nodes on inputs
         for i, node in enumerate(inputs_users):
-            device_type = node.meta["val"].device.type
-            if accelerator_device_type is None and (
-                device_type == "cuda"
-                or (
-                    privateuse1_name != "privateuseone"
-                    and device_type == privateuse1_name
-                )
-            ):
-                accelerator_device_type = device_type
+            device = node.meta["val"].device
+            if _is_compiled_autograd_accelerator_device(device, privateuse1_name):
+                accelerator_devices.add(device)
                 continue
 
-            is_cpu = device_type == "cpu"
+            is_cpu = device.type == "cpu"
             is_scalar = len(node.meta["val"].size()) == 0
             if is_cpu and is_scalar:
                 node_users = list(node.users.keys())
@@ -1089,20 +1089,21 @@ class AutogradCompilerInstance:
                     # all users are prims/aten, can move safely
                     to_move[i] = node
 
-        # only move cpu scalars to the accelerator if the graph has accelerator activations,
-        # this is to handle the case where cudagraphs is enabled on a cpu-only graph
-        if accelerator_device_type is not None:
+        # only move cpu scalars when the graph has exactly one accelerator device,
+        # this is to handle cpu-only graphs and mixed-accelerator graphs conservatively
+        if len(accelerator_devices) == 1:
+            target_device = next(iter(accelerator_devices))
             for node in to_move.values():
                 verbose_log.debug(
                     "Moving node %s from cpu to %s",
                     node,
-                    accelerator_device_type,
+                    target_device,
                 )
-                node.meta["val"] = _move_cpu_scalar_to_accelerator(
-                    node.meta["val"], accelerator_device_type
+                node.meta["val"] = _move_cpu_scalar_to_device(
+                    node.meta["val"], target_device
                 )
 
-            return list(to_move.keys()), accelerator_device_type
+            return list(to_move.keys()), target_device
 
         return [], None
 
@@ -1197,9 +1198,9 @@ class AutogradCompilerInstance:
             {},
         )
         runtime_inputs_to_move: list[int] = []
-        runtime_accelerator_device_type: str | None = None
+        runtime_accelerator_device: torch.device | None = None
         if snapshot_cudagraph_enabled():
-            runtime_inputs_to_move, runtime_accelerator_device_type = (
+            runtime_inputs_to_move, runtime_accelerator_device = (
                 self.move_graph_nodes_to_cuda(self.fx_tracer.graph)
             )
 
@@ -1288,11 +1289,11 @@ class AutogradCompilerInstance:
                         else:
                             filtered_sizes.append(integer)
 
-                if runtime_accelerator_device_type is not None:
+                if runtime_accelerator_device is not None:
                     for i in runtime_inputs_to_move:
-                        inputs[i] = _move_cpu_scalar_to_accelerator(
+                        inputs[i] = _move_cpu_scalar_to_device(
                             inputs[i],
-                            runtime_accelerator_device_type,
+                            runtime_accelerator_device,
                             for_runtime=True,
                         )
 


### PR DESCRIPTION
When cudagraphs is enabled, compiled autograd lifts backward scalars as cpu 0-dim inputs. Extend the existing cuda-only move path to also recognize a renamed PrivateUse1 backend via
torch._C._get_privateuse1_backend_name(), and move those scalars with .to() at compile and runtime.

Test Plan:
```bash
docker exec y00839695_pytorch bash -lc '
source /home/y00839695/npu-pytorch-214/venv_cpu/bin/activate
TORCH_SITE=$(python -c "import torch, os; print(os.path.dirname(torch.__file__))")
cp /home/y00839695/pytorch/torch/_dynamo/compiled_autograd.py "$TORCH_SITE/_dynamo/"
cd /tmp && python /home/y00839695/pytorch/test/inductor/test_cudagraph_device_gate.py -v
'
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk