### PR TITLE
[docs] CUDA generator output depends on the device's SM count; note it in the reproducibility note and the seeding docstrings

### DIFF
--- a/docs/source/notes/randomness.md
+++ b/docs/source/notes/randomness.md
@@ -44,16 +44,11 @@ It is also possible to obtain identical results from an operation that uses
 random numbers by setting {meth}`torch.manual_seed()` to the same value between
 subsequent calls.
 
-Seeding a CUDA generator makes device-side sampling reproducible on the same GPU
-model, not across GPU models. For tensors larger than one launch wave, that is
-more than `256 * multiProcessorCount * (maxThreadsPerMultiProcessor // 256)`
-elements (for example 40,960 on a T4, 218,112 on an L40, 233,472 on an H100 PCIe),
-the mapping of tensor elements to Philox counters follows the launch grid, which
-is capped by the device's number of SMs. The same seed therefore produces
-different values on GPUs with a different number of SMs, including MIG partitions
-of one card, while tensors below that size are identical on every GPU. To
-reproduce sampled tensors across devices, sample on the CPU and copy the result
-to the device.
+Seeding a CUDA generator makes device-side sampling reproducible run to run on the
+same GPU. The same seed is not guaranteed to produce the same values on a GPU of a
+different model, or on a MIG partition of the same GPU, and PyTorch does not test
+for it. If a sampled tensor must be identical across devices, generate it on the CPU
+with a seeded {class}`torch.Generator` and copy it to the device.
 
 ### Python
 

--- a/docs/source/notes/randomness.md
+++ b/docs/source/notes/randomness.md
@@ -44,6 +44,17 @@ It is also possible to obtain identical results from an operation that uses
 random numbers by setting {meth}`torch.manual_seed()` to the same value between
 subsequent calls.
 
+Seeding a CUDA generator makes device-side sampling reproducible on the same GPU
+model, not across GPU models. For tensors larger than one launch wave, that is
+more than `256 * multiProcessorCount * (maxThreadsPerMultiProcessor // 256)`
+elements (for example 40,960 on a T4, 218,112 on an L40, 233,472 on an H100 PCIe),
+the mapping of tensor elements to Philox counters follows the launch grid, which
+is capped by the device's number of SMs. The same seed therefore produces
+different values on GPUs with a different number of SMs, including MIG partitions
+of one card, while tensors below that size are identical on every GPU. To
+reproduce sampled tensors across devices, sample on the CPU and copy the result
+to the device.
+
 ### Python
 
 For custom operators, you might need to set python seed as well:

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -14320,13 +14320,6 @@ Arguments:
 Returns:
     Generator: An torch.Generator object.
 
-.. note::
-    A CUDA generator's stream is reproducible on the same GPU model. For tensors
-    larger than one launch wave, i.e. more than
-    ``256 * multiProcessorCount * (maxThreadsPerMultiProcessor // 256)`` elements,
-    the same seed produces different values on GPUs with a different number of
-    SMs, including MIG partitions of one card. See :ref:`reproducibility`.
-
 Example::
 
     >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -14320,6 +14320,13 @@ Arguments:
 Returns:
     Generator: An torch.Generator object.
 
+.. note::
+    A CUDA generator's stream is reproducible on the same GPU model. For tensors
+    larger than one launch wave, i.e. more than
+    ``256 * multiProcessorCount * (maxThreadsPerMultiProcessor // 256)`` elements,
+    the same seed produces different values on GPUs with a different number of
+    SMs, including MIG partitions of one card. See :ref:`reproducibility`.
+
 Example::
 
     >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -100,13 +100,9 @@ def manual_seed(seed: int) -> None:
         to get determinism.  To seed all GPUs, use :func:`manual_seed_all`.
 
     .. note::
-        Seeding makes device-side sampling reproducible run to run on the same
-        GPU model. Tensors larger than one launch wave, i.e. more than
-        ``256 * multiProcessorCount * (maxThreadsPerMultiProcessor // 256)``
-        elements, are drawn along a mapping of elements to Philox counters that
-        follows the device's number of SMs, so the same seed gives different
-        values on GPUs with a different SM count, including MIG partitions.
-        See :ref:`reproducibility`.
+        Seeding makes device-side sampling reproducible on the same GPU; the same
+        seed is not guaranteed to give the same values on a different GPU model or
+        on a MIG partition. See :ref:`reproducibility`.
     """
     seed = int(seed)
 
@@ -126,11 +122,6 @@ def manual_seed_all(seed: int) -> None:
 
     Args:
         seed (int): The desired seed.
-
-    .. note::
-        Seeding makes device-side sampling reproducible run to run on the same
-        GPU model, not across GPU models with a different number of SMs (see
-        :func:`manual_seed` and :ref:`reproducibility`).
     """
     seed = int(seed)
 

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -98,6 +98,15 @@ def manual_seed(seed: int) -> None:
     .. warning::
         If you are working with a multi-GPU model, this function is insufficient
         to get determinism.  To seed all GPUs, use :func:`manual_seed_all`.
+
+    .. note::
+        Seeding makes device-side sampling reproducible run to run on the same
+        GPU model. Tensors larger than one launch wave, i.e. more than
+        ``256 * multiProcessorCount * (maxThreadsPerMultiProcessor // 256)``
+        elements, are drawn along a mapping of elements to Philox counters that
+        follows the device's number of SMs, so the same seed gives different
+        values on GPUs with a different SM count, including MIG partitions.
+        See :ref:`reproducibility`.
     """
     seed = int(seed)
 
@@ -117,6 +126,11 @@ def manual_seed_all(seed: int) -> None:
 
     Args:
         seed (int): The desired seed.
+
+    .. note::
+        Seeding makes device-side sampling reproducible run to run on the same
+        GPU model, not across GPU models with a different number of SMs (see
+        :func:`manual_seed` and :ref:`reproducibility`).
     """
     seed = int(seed)
 


### PR DESCRIPTION
Documentation only. Fixes #196613.

Seeding a CUDA generator makes device-side sampling reproducible on the same GPU model, not across GPU models — and the documentation currently lets a reader believe otherwise (the reproducibility note's advice to seed, `torch.cuda.manual_seed`, `torch.Generator(device='cuda')`).

**Mechanism** (`aten/src/ATen/native/cuda/DistributionTemplates.h`, `calc_execution_policy` and the sampling kernels): the Philox subsequence is the *thread* index, and the launch grid is `min(ceil(numel / 256), multiProcessorCount * (maxThreadsPerMultiProcessor / 256))` blocks. Below one wave of threads every card computes the same (counter, key) for every element; above it the mapping follows the grid, which follows the SM count.

**Measured** (torch 2.13.0+cu129): a CPU implementation of that mapping (Philox4x32-10, cuRAND's `curand_init(seed, subsequence, offset)` layout, `_curand_uniform`) reproduces `torch.rand(n, device="cuda", generator=Generator(device="cuda").manual_seed(0))` bit for bit at n = 2^12 … 2^22 on an A10G (80 SMs × 6 blocks/SM), an L40 and an L40S (142 × 6) and an H100 PCIe (114 × 8), given only each card's SM count and threads per SM; across an eleven-instance training campaign, `randn(2^20)` from a seeded device generator gave seven distinct outputs for seven distinct (architecture, SM count) classes and identical outputs for the same SM count; MIG slices of one H100 (14 and 46 SMs) differ from the whole card. #194676's empirically found T4/L4 boundary of 40,960 elements is exactly 256 × 40 × 4 by this formula; #84234 and #87992 (2022) are the same mechanism. Details and the script are in #196613.

**Change (trimmed after review):** three sentences in `docs/source/notes/randomness.md` (under "PyTorch random number generator") stating that seeding makes device-side sampling reproducible on the same GPU, that the same seed is not guaranteed to match on a different GPU model or a MIG partition and PyTorch does not test for it, and that a tensor which must be identical across devices should be sampled on the CPU with a seeded `torch.Generator` and copied; plus a one-sentence `.. note::` on `torch.cuda.manual_seed` pointing to it. No mechanism, no numbers, no guarantee claimed; the measurement and the counter-layout derivation stay in #196613.

cc @kurtamohler (reviewed #194676), @svekars (docs)

