### PR TITLE
[inductor] Route flex decoding get_split_k SM count via DeviceInterface

### DIFF
--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -155,11 +155,14 @@ flex_decoding_template = TritonTemplate(
 )
 
 
-def get_split_k(B: int, H: int, Mk: int) -> int:
-    if torch.xpu.is_available():
-        num_SM = torch.xpu.get_device_properties("xpu").gpu_subslice_count
-    else:
-        num_SM = torch.cuda.get_device_properties("cuda").multi_processor_count
+def get_split_k(B: int, H: int, Mk: int, /, *, device: torch.device) -> int:
+    # num_SM is sourced from the kernel's target device via its DeviceInterface
+    # capability (device routing, not ambient xpu/cuda detection); lazy import
+    # keeps the dynamo dependency off this module's load path.
+    from torch._dynamo import device_interface
+
+    interface = device_interface.get_interface_for_device(device)
+    num_SM = interface.get_multi_processor_count(device)
     bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
     if not isinstance(bh, (int, sympy.Integer)):
         raise AssertionError("B and H must be concrete integers")
@@ -280,7 +283,10 @@ def create_flex_decoding_kernel(*args, **kwargs):
     # TODO: fix autotuning.
 
     kernel_options.setdefault("SM_SCALE", scale)
-    kernel_options.setdefault("SPLIT_KV", get_split_k(B, Hkv, seq_len_kv))
+    device = query.get_device()
+    kernel_options.setdefault(
+        "SPLIT_KV", get_split_k(B, Hkv, seq_len_kv, device=device)
+    )
     MAX_SPLIT_KV = kernel_options["SPLIT_KV"]
 
     # create config dependent intermediate buffers


### PR DESCRIPTION
## Summary
Replace the hardcoded torch.xpu/torch.cuda if-chain in flex_decoding.get_split_k with a query against the kernel's target device through the DeviceInterface capability (#190615), so the SM count that feeds the SPLIT_KV heuristic is sourced from whichever device the decode kernel actually targets instead of ambient xpu/cuda detection. Existing behavior is preserved for single-device cuda and xpu environments (same SM count, same SPLIT_KV); mixed-backend machines now route correctly, and backends with no registered interface get a clear error instead of crashing inside CUDA device property initialization.

## Changes
torch/_inductor/kernel/flex/flex_decoding.py: get_split_k now takes the kernel target device as a required keyword argument (`device: torch.device`) and resolves its SM count via get_interface_for_device(device), then interface.get_multi_processor_count(device). The lazy import of torch._dynamo.device_interface keeps the dynamo dependency off this module's load path (matching the style of other decoupling sites). The split_k formula (num_SM // bh * 2, floored to 1) is unchanged -- only the source of num_SM moves from a hardcoded device string / is_available() probe to the device's own registered interface. The single call site (create_flex_decoding_kernel) now reads `device = query.get_device()` (the surrounding code already queried query.get_device().type two lines above) and passes it through, which also fixes a latent multi-card inaccuracy where the old code used the default "xpu"/"cuda" device instead of the kernel's actual device index.

## Motivation
get_split_k feeds SPLIT_KV, which sizes the decode KV intermediate buffer (buf_ACC_shape). The original if-chain asked the ambient environment ("is xpu available?") rather than "which device is this kernel for": on a machine with both xpu and cuda, every cuda decode kernel wrongly took the xpu branch; on a machine with neither (mtia-only, cpu-triton), the code crashed inside torch.cuda device-property initialization with no path to a usable value; tpu and out-of-tree accelerators had no legal path at all. The DeviceInterface registry already exposes get_multi_processor_count (added in #190615, already consumed by hints.py): cuda reads the standard multi_processor_count field, xpu overrides with gpu_subslice_count, mtia defaults to 64. Routing get_split_k through the same contract lets each backend report its own SM count for the device the kernel actually targets, and surfaces a clear AttributeError ("must override") for a backend whose interface has not yet been adapted -- pointing the backend author at the one method to override -- instead of an opaque CUDA init failure.

## Test Plan
CI: python -m pytest -q test/inductor/test_flex_attention.py CI: python test/inductor/test_flex_attention.py
CI: lintrunner -a torch/_inductor/kernel/flex/flex_decoding.py

Verified on GPU (cuda): flex decode end-to-end passes (the device matrix tests cover the SPLIT_KV-shaped buffer indirectly). Verified on CPU: pytest 2 passed, 582 skipped, 0 failed; python direct run 584 tests, OK (skipped=582). Same result in NPU mode and CPU mode. Verified on an Ascend NPU container: pytest 2 passed, 582 skipped, 0 failed in both NPU mode and CPU mode; the mainline get_split_k path is not reached on NPU (torch_npu overrides the flex decode lowering), so this confirms non-regression and import/collection integrity. lintrunner reports 0 violations on the changed file.

No new tests added: the existing decode end-to-end device matrix tests already cover SPLIT_KV indirectly (a changed value resizes buf_ACC_shape and turns the test red), and the must-override contract get_split_k now relies on is already tested by test_device_backend_hooks.py::TestMultiProcessorCount ::test_missing_standard_property (#190615). A standalone unit test for the formula / routing would be zero-increment over that coverage, so it is omitted to keep the PR a minimal source-only diff.

## Notes
Behavior preservation: for any single-device cuda or xpu CI environment the SM count is identical to before (cuda reads the same multi_processor_count field; xpu's override returns the same gpu_subslice_count), so SPLIT_KV is unchanged and the formula is untouched. The behavioral changes are all on paths the old code could not handle correctly:
- On a mixed xpu+cuda machine, a cuda decode kernel now reads multi_processor_count instead of wrongly taking the xpu branch. This is a bug fix; single-device CI is structurally unaffected.
- On an mtia-only / no-xpu-no-cuda machine, the previous CUDA-init crash becomes a usable value (mtia default 64).
- For an out-of-tree DeviceInterface that has not yet overridden get_multi_processor_count, the previous opaque crash becomes a clear AttributeError("must override") pointing at the method to implement; once the backend overrides it (returning its SM count), the decode heuristic works without a mainline patch. Part of the hardware decoupling effort: remove hardcoded device lists so backends register capability through their DeviceInterface instead. Authored with an AI assistant (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo