### PR TITLE
[Inductor] Key autotune cache on per-backend fp32_precision

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -5936,15 +5936,16 @@ class TestAutotuneCacheFp32Precision(TestCase):
     after the per-backend API has been used (#196728)."""
 
     @recover_orig_fp32_precision
-    def test_helper_prefers_new_api_and_avoids_mixed_api_error(self):
-        from torch._inductor.utils import get_autotune_cache_fp32_precision
+    def test_helper_avoids_mixed_api_error_and_keys_both_backends(self):
+        from torch._inductor.utils import fp32_matmul_precision_key
 
         torch.set_float32_matmul_precision("highest")
         torch.backends.cuda.matmul.fp32_precision = "tf32"
+        torch.backends.mkldnn.matmul.fp32_precision = "bf16"
         with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
             torch.get_float32_matmul_precision()
 
-        self.assertEqual(get_autotune_cache_fp32_precision(), "tf32")
+        self.assertEqual(fp32_matmul_precision_key(), "cuda:tf32,mkldnn:bf16")
 
     @recover_orig_fp32_precision
     def test_create_precompile_key_and_persistent_cache_lookup(self):
@@ -5953,23 +5954,25 @@ class TestAutotuneCacheFp32Precision(TestCase):
 
         torch.set_float32_matmul_precision("highest")
         torch.backends.cuda.matmul.fp32_precision = "tf32"
+        torch.backends.mkldnn.matmul.fp32_precision = "bf16"
         with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
             torch.get_float32_matmul_precision()
 
         key = create_precompile_key("mm", "inputs", [])
-        self.assertIn("tf32", key)
+        self.assertIn("cuda:tf32,mkldnn:bf16", key)
 
         timings = PersistentCache().lookup([], "mm", "inputs", None)
         self.assertEqual(timings, {})
 
     @recover_orig_fp32_precision
-    def test_helper_uses_synced_new_api_value(self):
-        from torch._inductor.utils import get_autotune_cache_fp32_precision
+    def test_helper_distinguishes_legacy_high_vs_medium(self):
+        from torch._inductor.utils import fp32_matmul_precision_key
 
-        # Legacy setter syncs both APIs; helper should read the per-backend value.
-        torch.set_float32_matmul_precision("highest")
-        self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
-        self.assertEqual(get_autotune_cache_fp32_precision(), "ieee")
+        torch.set_float32_matmul_precision("high")
+        self.assertEqual(fp32_matmul_precision_key(), "cuda:tf32,mkldnn:tf32")
+
+        torch.set_float32_matmul_precision("medium")
+        self.assertEqual(fp32_matmul_precision_key(), "cuda:tf32,mkldnn:bf16")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -84,6 +84,7 @@ from torch.testing._internal.common_utils import (
     IS_FBCODE,
     IS_SANDCASTLE,
     parametrize,
+    recover_orig_fp32_precision,
 )
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -5928,6 +5929,47 @@ class TestAutotuneCacheExtraOptions(TestCase):
         mock_local_backend.put.assert_called_once()
         saved_data = mock_local_backend.put.call_args[0][1]
         self.assertNotIn("extra_options", saved_data)
+
+
+class TestAutotuneCacheFp32Precision(TestCase):
+    """Autotune cache keys must not call the legacy matmul-precision getter
+    after the per-backend API has been used (#196728)."""
+
+    @recover_orig_fp32_precision
+    def test_helper_prefers_new_api_and_avoids_mixed_api_error(self):
+        from torch._inductor.utils import get_autotune_cache_fp32_precision
+
+        torch.set_float32_matmul_precision("highest")
+        torch.backends.cuda.matmul.fp32_precision = "tf32"
+        with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
+            torch.get_float32_matmul_precision()
+
+        self.assertEqual(get_autotune_cache_fp32_precision(), "tf32")
+
+    @recover_orig_fp32_precision
+    def test_create_precompile_key_and_persistent_cache_lookup(self):
+        from torch._inductor.codecache import PersistentCache
+        from torch._inductor.select_algorithm import create_precompile_key
+
+        torch.set_float32_matmul_precision("highest")
+        torch.backends.cuda.matmul.fp32_precision = "tf32"
+        with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
+            torch.get_float32_matmul_precision()
+
+        key = create_precompile_key("mm", "inputs", [])
+        self.assertIn("tf32", key)
+
+        timings = PersistentCache().lookup([], "mm", "inputs", None)
+        self.assertEqual(timings, {})
+
+    @recover_orig_fp32_precision
+    def test_helper_uses_synced_new_api_value(self):
+        from torch._inductor.utils import get_autotune_cache_fp32_precision
+
+        # Legacy setter syncs both APIs; helper should read the per-backend value.
+        torch.set_float32_matmul_precision("highest")
+        self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
+        self.assertEqual(get_autotune_cache_fp32_precision(), "ieee")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -105,7 +105,7 @@ from torch._inductor.utils import (
     ALIGN_BYTES,
     clear_on_fresh_cache,
     determine_aoti_mmap_flags,
-    get_autotune_cache_fp32_precision,
+    fp32_matmul_precision_key,
     is_linux,
     is_windows,
     parallel_num_threads,
@@ -467,7 +467,7 @@ class PersistentCache(CacheBase):
                     local_cache[op][inputs][choice], and return the benchmark.
                 b. `max_autotune_gemm=False`: don't benchmark the choice, return nothing.
         """
-        precision = get_autotune_cache_fp32_precision()
+        precision = fp32_matmul_precision_key()
         cache_key = f"{inputs}_{hint_override}" if hint_override is not None else inputs
 
         timings = {}

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -105,6 +105,7 @@ from torch._inductor.utils import (
     ALIGN_BYTES,
     clear_on_fresh_cache,
     determine_aoti_mmap_flags,
+    get_autotune_cache_fp32_precision,
     is_linux,
     is_windows,
     parallel_num_threads,
@@ -466,7 +467,7 @@ class PersistentCache(CacheBase):
                     local_cache[op][inputs][choice], and return the benchmark.
                 b. `max_autotune_gemm=False`: don't benchmark the choice, return nothing.
         """
-        precision = torch.get_float32_matmul_precision()
+        precision = get_autotune_cache_fp32_precision()
         cache_key = f"{inputs}_{hint_override}" if hint_override is not None else inputs
 
         timings = {}

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -86,7 +86,7 @@ from .utils import (
     ceildiv,
     do_bench_using_profiling,
     FakeIndentedBuffer,
-    get_autotune_cache_fp32_precision,
+    fp32_matmul_precision_key,
     get_dtype_size,
     is_gpu,
     Placeholder,
@@ -3918,7 +3918,7 @@ def create_precompile_key(
         [
             name,
             inputs_key,
-            get_autotune_cache_fp32_precision(),
+            fp32_matmul_precision_key(),
         ]
         + [choice.kernel_hash_key() for choice in choices]
     )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -86,6 +86,7 @@ from .utils import (
     ceildiv,
     do_bench_using_profiling,
     FakeIndentedBuffer,
+    get_autotune_cache_fp32_precision,
     get_dtype_size,
     is_gpu,
     Placeholder,
@@ -3917,7 +3918,7 @@ def create_precompile_key(
         [
             name,
             inputs_key,
-            torch.get_float32_matmul_precision(),
+            get_autotune_cache_fp32_precision(),
         ]
         + [choice.kernel_hash_key() for choice in choices]
     )

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3643,19 +3643,13 @@ def parallel_num_threads() -> int:
     return threads
 
 
-def get_autotune_cache_fp32_precision() -> str:
-    """Precision string for Inductor autotune / PersistentCache keys.
-
-    Prefer the per-backend CUDA matmul API. Calling the legacy
-    ``torch.get_float32_matmul_precision()`` after the new API has been used
-    (e.g. ``fp32_precision="bfx9"`` or ``"tf32"``) raises a mixed-API error —
-    see #196728. Fall back to the legacy getter only when the new API reports
-    ``"none"``.
-    """
-    precision = torch.backends.cuda.matmul.fp32_precision
-    if precision != "none":
-        return precision
-    return torch.get_float32_matmul_precision()
+def fp32_matmul_precision_key() -> str:
+    # Read resolved per-backend fp32 precision instead of
+    # torch.get_float32_matmul_precision(), which raises if the legacy and
+    # per-backend APIs have been mixed (#196728). Key on the (cuda, mkldnn)
+    # pair so legacy "high" (tf32/tf32) and "medium" (tf32/bf16) stay distinct.
+    getter = torch._C._get_fp32_precision_getter
+    return f"cuda:{getter('cuda', 'matmul')},mkldnn:{getter('mkldnn', 'matmul')}"
 
 
 @functools.cache

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3643,6 +3643,21 @@ def parallel_num_threads() -> int:
     return threads
 
 
+def get_autotune_cache_fp32_precision() -> str:
+    """Precision string for Inductor autotune / PersistentCache keys.
+
+    Prefer the per-backend CUDA matmul API. Calling the legacy
+    ``torch.get_float32_matmul_precision()`` after the new API has been used
+    (e.g. ``fp32_precision="bfx9"`` or ``"tf32"``) raises a mixed-API error —
+    see #196728. Fall back to the legacy getter only when the new API reports
+    ``"none"``.
+    """
+    precision = torch.backends.cuda.matmul.fp32_precision
+    if precision != "none":
+        return precision
+    return torch.get_float32_matmul_precision()
+
+
 @functools.cache
 def get_backend_num_stages() -> int:
     from .runtime.triton_helpers import get_backend_options


### PR DESCRIPTION
## Summary

Fixes #196728.

Setting `torch.backends.cuda.matmul.fp32_precision = "bfx9"` (TorchTitan on Blackwell) makes Inductor's autotune cache raise:

```text
RuntimeError: ... mix of the legacy and new APIs to set the matmul precision
```

**Root cause:** after #195301, several Inductor sites moved to the per-backend API, but these two still call the legacy getter:

- `PersistentCache.lookup` in `torch/_inductor/codecache.py` (raising frame from the issue)
- `create_precompile_key` in `torch/_inductor/select_algorithm.py`

The cache lookup is unconditional, so even bf16 FlexAttention fails.

**Fix:** add `get_autotune_cache_fp32_precision()` that:

1. Prefers `torch.backends.cuda.matmul.fp32_precision`
2. Falls back to `torch.get_float32_matmul_precision()` only when the new API is `"none"`

This matches the pattern already used in FlexAttention / other #195301 call sites, keeps legacy-only IEEE/TF32 cache keys working when the new API is unset, and makes `bfx9` a distinct autotune key (correct, since GEMM arithmetic differs).

## Test plan

- [x] Unit: `test/inductor/test_codecache.py::TestAutotuneCacheFp32Precision`
  - mixed new-API state (`highest` then `fp32_precision="tf32"`) must not raise in helper / `create_precompile_key` / `PersistentCache.lookup`
  - synced legacy setter maps to `"ieee"` via the helper
- [ ] CI: inductor / flex_attention paths

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @zasdfgbnm @ptrblck @janbernloehr @Chillee @drisspg