### PR TITLE
[nested] Fix jagged narrow contiguous check so unbind excludes gaps

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -6454,6 +6454,20 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
                 nt.values()[nt.offsets()[i] : (nt.offsets()[i] + nt.lengths()[i])],
             )
 
+    def test_narrow_gapped_unbind(self, device):
+        # Regression for #196708: batch_size=2 with a gap between selected
+        # segments must keep lengths so unbind does not include the gap.
+        dtype = torch.float64
+        t = torch.tensor(0.7, dtype=dtype, device=device)
+        x = torch.stack((t, 2 * t, 3 * t, 4 * t)).reshape(2, 2)
+        starts = torch.tensor([0, 1], dtype=torch.int64, device=device)
+        lengths = torch.tensor([2, 1], dtype=torch.int64, device=device)
+        nt = torch.nested.narrow(x, 1, starts, lengths, layout=torch.jagged)
+        parts = nt.unbind()
+        self.assertEqual(parts[0], torch.stack((t, 2 * t)))
+        self.assertEqual(parts[1], (4 * t).reshape(1))
+        self.assertEqual(parts[0].sum() + parts[1].sum(), 7 * t)
+
     def test_njt_cat(self, device):
         offsets = torch.tensor([0, 2, 3], device=device, dtype=torch.int64)
         values_1 = torch.randn(

--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -650,15 +650,10 @@ def jagged_from_tensor_and_lengths(
     else:
         values = tensor.view(-1)
 
-    # Check if offsets and lengths make it possibly contiguous and return a regular NT
-    is_contiguous = True
-    orig_dim = tensor.shape[1]
-    if torch.any(length_list[1:-1].ne(orig_dim)):
-        is_contiguous = False
-    if torch.any(offsets[1:-2].diff().ne(orig_dim)):
-        is_contiguous = False
-    if offsets[0] + length_list[0] != orig_dim:
-        is_contiguous = False
+    # Contiguous iff selected segments abut in the flattened buffer (no gaps).
+    # The previous heuristic used length_list[1:-1] / offsets[1:-2], which is
+    # empty for batch_size <= 2 and misclassified gapped selections (#196708).
+    is_contiguous = bool(torch.all(offsets.diff() == length_list))
 
     actual_max_seqlen = int(torch.max(lengths).item())
     min_seqlen = int(torch.min(lengths).item())


### PR DESCRIPTION
## Summary

Fixes #196708.

`torch.nested.narrow(..., layout=torch.jagged)` followed by `unbind()` can include elements that were not selected. For

```python
x = [[t, 2*t], [3*t, 4*t]]
starts = [0, 1]
lengths = [2, 1]
```

the selected values are `[t, 2*t]` and `[4*t]` (sum `7*t`), but unbind currently yields sum `10*t` because it also includes `3*t`.

**Root cause:** in `jagged_from_tensor_and_lengths`, contiguity was decided with:

- `length_list[1:-1] != orig_dim`
- `offsets[1:-2].diff() != orig_dim`
- `offsets[0] + length_list[0] != orig_dim`

For `batch_size <= 2`, the first two checks see empty tensors and never fire. The third check also passes when the first row is fully selected (`0 + 2 == 2`). The path then drops `lengths` and builds an offsets-only view of `values[offsets[0]:offsets[-1]]`. Unbind sizes come from `offsets.diff()`, which spans the gap.

**Fix:** set

```python
is_contiguous = bool(torch.all(offsets.diff() == length_list))
```

so lengths are kept whenever selected segments do not abut in the flattened buffer. Existing contiguous narrow cases (including the `test_is_contiguous` contiguous-narrow fixture) still satisfy this equality.

## Test plan

- [x] Added `TestNestedTensorSubclass.test_narrow_gapped_unbind` (issue repro: unbind parts and sum must be `7*t`)
- [ ] CI: nestedtensor CPU / device tests

cc @cpuhrsch @jbschlosser @bhosmer @drisspg @soulitzer @davidberard98 @YuqingJ