### PR TITLE
Add temporary merge rule for test refactoring

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -564,6 +564,17 @@
   - Lint
   - pull
 
+- name: Testing (Temporarily used for test refactoring)
+  patterns:
+  - torch/testing/**
+  - test/**
+  approved_by:
+  - fffrog
+  mandatory_checks_name:
+  - EasyCLA
+  - Lint
+  - pull
+
 - name: Metamates
   patterns:
   - '*'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #196739

Add a temporary merge rule to improve the efficiency of merging
test refactoring PRs.