### PR TITLE
Fix incorrect docstring for register_module_as_pytree_input_node

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1511,10 +1511,7 @@ def register_module_as_pytree_input_node(cls: type[torch.nn.Module]) -> None:
     Registers a module as a valid input type for :func:`torch.export.export`.
 
     Args:
-        mod: the module instance
-        serialized_type_name: The serialized name for the module. This is
-        required if you want to serialize the pytree TreeSpec containing this
-        module.
+        cls: the module type to register
 
     Example::
 
@@ -1530,7 +1527,7 @@ def register_module_as_pytree_input_node(cls: type[torch.nn.Module]) -> None:
                 return self.linear(x)
 
 
-        torch._export.utils.register_module_as_pytree_node(InputDataClass)
+        torch._export.utils.register_module_as_pytree_input_node(Module)
 
 
         class Mod(torch.nn.Module):


### PR DESCRIPTION
The docstring documented two parameters that do not exist and its example called a function that does not exist:

- Documented `mod: the module instance`, but the signature is `register_module_as_pytree_input_node(cls: type[torch.nn.Module])`, which takes a module *type*, not an instance. Passing an instance fails the `issubclass` check on the first line of the body.
- Documented `serialized_type_name`, which is not a parameter of this function.
- The example called `register_module_as_pytree_node(InputDataClass)`. No such function exists in torch, and `InputDataClass` is undefined in the example. Running it raises AttributeError.

The corrected example runs and exports successfully.