### PR TITLE
[autograd] Fix logcumsumexp JVP dropping early-prefix contributions

### DIFF
--- a/test/test_ops_fwd_gradients.py
+++ b/test/test_ops_fwd_gradients.py
@@ -178,6 +178,20 @@ class TestFwdGradients(TestGradients):
             device, dtype, op, self._get_safe_inplace(op.get_inplace()), is_inplace=True
         )
 
+    def test_logcumsumexp_jvp_large_range(self, device):
+        # Regression for #196705: early-prefix JVP must not underflow to 0 when
+        # a later element along dim is much larger.
+        dtype = torch.float64
+
+        def f(t):
+            x = torch.stack((t, 1 - t, 2 * t + 3, -t, t + 2, 3 * t - 1)).reshape(2, 3)
+            w = torch.tensor([[1, 2, -1], [3, -2, 4]], dtype=t.dtype, device=t.device)
+            return (torch.logcumsumexp(x, dim=-1) * w).sum()
+
+        t = torch.tensor(-400.0, dtype=dtype, device=device)
+        _, actual = torch.func.jvp(f, (t,), (torch.ones_like(t),))
+        self.assertEqual(actual, torch.tensor(-5.0, dtype=dtype, device=device))
+
 
 instantiate_device_type_tests(TestFwdGradients, globals(), allow_xpu=True)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -521,7 +521,7 @@
 
 - name: logcumsumexp(Tensor self, int dim) -> Tensor
   self: logcumsumexp_backward(grad, self, result, dim)
-  result: logcumsumexp_jvp(self_p, self_t, dim)
+  result: logcumsumexp_jvp(self_p, self_t, result, dim)
 
 - name: cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor
   self: cumprod_backward(grad.to(self.scalar_type()), self, dim, result)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1192,10 +1192,11 @@ Tensor logcumsumexp_backward(
 Tensor logcumsumexp_jvp(
     const Tensor& self_p,
     const Tensor& self_t,
+    const Tensor& result,
     int64_t dim) {
-  // JVP of y = logcumsumexp(x) along dim:
-  //   y_t[0] = exp(x[0] - y[0]) * x_t[0]   (= x_t[0] for real inputs)
-  //   y_t[i] = exp(y[i-1] - y[i]) * y_t[i-1] + exp(x[i] - y[i]) * x_t[i]
+  // JVP: y'_i = sum_{j<=i} exp(x_j - y_i) * x'_j
+  // with y = logcumsumexp(x). Compute via a pos/neg log-domain split
+  // (same idea as logcumsumexp_backward) so early prefixes stay well scaled.
   //
   // The previous formula copied logsumexp_jvp's single max-along-dim shift.
   // That underflows early prefixes when a later element is much larger, so
@@ -1203,28 +1204,27 @@ Tensor logcumsumexp_jvp(
 
   TORCH_INTERNAL_ASSERT(!self_t._is_zerotensor())
 
-  dim = at::maybe_wrap_dim(dim, self_p.dim());
-  const auto n = self_p.size(dim);
-  if (n == 0) {
-    return at::empty_like(self_t);
-  }
+  auto scalar_min = AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      at::typeMetaToScalarType(self_t.dtype()),
+      "logcumsumexp_jvp",
+      []() { return c10::Scalar(std::numeric_limits<scalar_t>::lowest()); });
 
-  auto y = at::logcumsumexp(self_p, dim);
-  auto result = at::empty_like(self_t);
-  result.select(dim, 0).copy_(
-      (self_p.select(dim, 0) - y.select(dim, 0)).exp() *
-      self_t.select(dim, 0));
-
-  for (const auto i : c10::irange(1, n)) {
-    auto y_i = y.select(dim, static_cast<int64_t>(i));
-    auto z_i =
-        (y.select(dim, static_cast<int64_t>(i - 1)) - y_i).exp() *
-            result.select(dim, static_cast<int64_t>(i - 1)) +
-        (self_p.select(dim, static_cast<int64_t>(i)) - y_i).exp() *
-            self_t.select(dim, static_cast<int64_t>(i));
-    result.select(dim, static_cast<int64_t>(i)).copy_(z_i);
+  if (!at::is_complex(self_p)) {
+    auto t_min = at::scalar_tensor(scalar_min, self_t.options());
+    auto log_abs_t = self_t.abs().log();
+    auto log_t_pos = at::where(self_t > 0, log_abs_t, t_min);
+    auto log_t_neg = at::where(self_t < 0, log_abs_t, t_min);
+    auto pos = (at::logcumsumexp(self_p + log_t_pos, dim) - result).exp();
+    auto neg = (at::logcumsumexp(self_p + log_t_neg, dim) - result).exp();
+    return pos - neg;
+  } else {
+    // Same multiplicative structure as the old complex path, but centered on
+    // the forward result so prefixes do not depend on a global max.
+    auto log_t = self_t.log();
+    return (at::logcumsumexp(self_p + log_t, dim) - result).exp();
   }
-  return result;
 }
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1193,36 +1193,38 @@ Tensor logcumsumexp_jvp(
     const Tensor& self_p,
     const Tensor& self_t,
     int64_t dim) {
-  // Mostly taken from logsumexp_jvp
-
-  // NB: for simplicity, we recompute some values that can be reused from
-  // forward
-  auto self_p_exp = [&self_p, dim]() {
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-    if (!at::is_complex(self_p)) {
-      return (self_p - std::get<0>(at::max(self_p, dim, true)))
-          .exp(); // Use the exp-normalize trick
-    } else {
-      // at::max doesn't support complex128
-      return self_p.exp();
-    }
-  }();
-
-  auto cumsumexp_p = self_p_exp.cumsum(dim);
+  // JVP of y = logcumsumexp(x) along dim:
+  //   y_t[0] = exp(x[0] - y[0]) * x_t[0]   (= x_t[0] for real inputs)
+  //   y_t[i] = exp(y[i-1] - y[i]) * y_t[i-1] + exp(x[i] - y[i]) * x_t[i]
+  //
+  // The previous formula copied logsumexp_jvp's single max-along-dim shift.
+  // That underflows early prefixes when a later element is much larger, so
+  // those prefixes' JVP contributions become 0 (#196705).
 
   TORCH_INTERNAL_ASSERT(!self_t._is_zerotensor())
 
-  constexpr double eps = 1e-13;
-
-  if (areAnyTensorSubclassLike({self_p, self_t})) {
-    auto result = (self_p_exp * self_t).cumsum(dim);
-    result /= cumsumexp_p.add_(eps);
-    return result;
-  } else {
-    self_p_exp *= self_t;
-    auto cumsumexp_t = self_p_exp.cumsum(dim);
-    return cumsumexp_t /= cumsumexp_p.add_(eps);
+  dim = at::maybe_wrap_dim(dim, self_p.dim());
+  const auto n = self_p.size(dim);
+  if (n == 0) {
+    return at::empty_like(self_t);
   }
+
+  auto y = at::logcumsumexp(self_p, dim);
+  auto result = at::empty_like(self_t);
+  result.select(dim, 0).copy_(
+      (self_p.select(dim, 0) - y.select(dim, 0)).exp() *
+      self_t.select(dim, 0));
+
+  for (const auto i : c10::irange(1, n)) {
+    auto y_i = y.select(dim, static_cast<int64_t>(i));
+    auto z_i =
+        (y.select(dim, static_cast<int64_t>(i - 1)) - y_i).exp() *
+            result.select(dim, static_cast<int64_t>(i - 1)) +
+        (self_p.select(dim, static_cast<int64_t>(i)) - y_i).exp() *
+            self_t.select(dim, static_cast<int64_t>(i));
+    result.select(dim, static_cast<int64_t>(i)).copy_(z_i);
+  }
+  return result;
 }
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -235,6 +235,7 @@ at::Tensor logcumsumexp_backward(
 at::Tensor logcumsumexp_jvp(
     const at::Tensor& self_p,
     const at::Tensor& self_t,
+    const at::Tensor& result,
     int64_t dim);
 at::Tensor unbind_backward(const variable_list& grads, int64_t dim);
 at::Tensor unbind_backward_nested(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2137,8 +2137,11 @@ def sample_inputs_logcumsumexp(self, device, dtype, requires_grad, **kwargs):
                             low=None, high=None,
                             requires_grad=requires_grad)
 
-            if large_number and t.dim() > 0:
-                t[0] = 10000
+            # Place the large value at the *end* of `dim` so early prefixes
+            # do not contain the global max (regresses #196705). Putting it
+            # first makes every prefix safe under a naive global-max JVP.
+            if large_number and t.dim() > 0 and t.size(dim) > 0:
+                t.select(dim, -1).fill_(10000)
             yield SampleInput(t, dim)
 
 def sample_inputs_trace(self, device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
## Summary

Fixes #196705.

`torch.func.jvp` through `torch.logcumsumexp` returns about `-6` instead of `-5` on the issue repro (`float64`, `t = -400`). Forward values match; only the first-order JVP is wrong.

**Root cause:** `logcumsumexp_jvp` in `FunctionsManual.cpp` copied `logsumexp_jvp`'s **global** max-along-dim exp-normalize trick, then did `cumsum(exp(x-M)*t) / cumsum(exp(x-M))`. That is correct for a full reduction, not for prefixes. When an early prefix is far below a later max, `exp(x_early - M)` underflows to 0, so the length-1 JVP becomes 0 instead of the input tangent (off-by-about-1 in the weighted sum).

**Fix:** use the recurrence that follows from `y[i] = logaddexp(y[i-1], x[i])`:

```text
y_t[i] = exp(y[i-1] - y[i]) * y_t[i-1] + exp(x[i] - y[i]) * x_t[i]
```

with `y = logcumsumexp(x)`. Early prefixes stay well-scaled relative to their own running log-sum-exp.

## Test plan

- [x] `test/test_ops_fwd_gradients.py::TestFwdGradients::test_logcumsumexp_jvp_large_range` (issue repro)
- [ ] CI: forward-AD / autograd CPU tests

cc @albanD @soulitzer @lezcano