### PR TITLE
[ROCm][UT] Enable RNN tests on RDNA, keep MI skipped

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, r
     download_file, get_function_arglist, load_tests, skipIfMPS, MACOS_VERSION, \
     IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
-    skipIfTorchDynamo, gcIfJetson, set_default_dtype, skipIfNoCuteDSL, isRocmArchAnyOf, MI200_ARCH, \
+    skipIfTorchDynamo, gcIfJetson, set_default_dtype, skipIfNoCuteDSL, isRocmArchAnyOf, MI200_ARCH, MI300_ARCH, MI350_ARCH, skipIfRocmArch, \
     TEST_WITH_TORCHDYNAMO
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN, \
     SM80OrLater, SM90OrLater, _get_torch_rocm_version, has_device_side_assert
@@ -16669,13 +16669,13 @@ class TestNNCUDA(NNTestCase):
                 hx_val, grad_hy, cx_val, grad_cy)
             compare_cpu_device(outputs_cpu, outputs_device)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/182790")
+    @skipIfRocmArch(MI200_ARCH + MI300_ARCH + MI350_ARCH)
     @skipCUDAIfNoCudnn
     def test_RNN_cpu_vs_device_no_dropout(self, device):
         dtype = torch.double
         self._test_RNN_cpu_vs_device(device, 0, dtype)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/182666")
+    @skipIfRocmArch(MI200_ARCH + MI300_ARCH + MI350_ARCH)
     @skipCUDAIfNoCudnn
     def test_RNN_cpu_vs_device_with_dropout(self, device):
         # Because of dropout randomness, can only compare dropout=0 and dropout=1


### PR DESCRIPTION
Part of #196583

## Summary

`test_RNN_cpu_vs_device_no_dropout` and `test_RNN_cpu_vs_device_with_dropout`
were skipped on all of ROCm by two `@skipIfRocm` decorators added in #185013
(the bulk pass that inlined CI-bot disable entries). This replaces each blanket
skip with an MI-only `@skipIfRocmArch(MI200_ARCH + MI300_ARCH + MI350_ARCH)`,
so the tests run on validated RDNA GPUs while MI200/MI300/MI350 stay skipped
pending their own validation. `@skipCUDAIfNoCudnn` is unchanged.

## Validation

Both tests pass on gfx1100 (RDNA3), gfx1151 (RDNA3.5) and gfx1200 (RDNA4),
10 independent iterations per architecture, `2 passed` every run, with
TEST_CUDNN=True (MIOpen RNN path).

MI200/MI300/MI350 were not available locally and remain skipped; please run
`ciflow/rocm` for MI coverage.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang ...