### PR TITLE
docs: cross-link torch.unbind and torch.tensor_split (#196567)

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2110,6 +2110,11 @@ by :attr:`indices_or_sections`. This function is based on NumPy's
    :attr:`indices` can be a list or tuple of ints, or a one-dimensional long
    tensor on the CPU.
 
+.. seealso::
+
+    :func:`torch.unbind` removes a dimension and returns a tuple of all slices
+    along that dimension.
+
 Args:
     input (Tensor): the tensor to split
     dim (int, optional): dimension along which to split the tensor. Default: ``0``
@@ -13421,6 +13426,11 @@ unbind(input, dim=0) -> seq
 Removes a tensor dimension.
 
 Returns a tuple of all slices along a given dimension, already without it.
+
+.. seealso::
+
+    :func:`torch.tensor_split` splits a tensor into multiple views along a
+    dimension by a section count or split indices.
 
 Arguments:
     input (Tensor): the tensor to unbind


### PR DESCRIPTION
## Summary
- Add reciprocal See Also links between `torch.unbind` and `torch.tensor_split` docs.

Fixes https://github.com/pytorch/pytorch/issues/196567

## Test plan
- [x] Docs-only change in `torch/_torch_docs.py`
- [ ] Confirm rendered docs cross-link after merge