### PR TITLE
Fix dtype promotion for 0-dim bool mask assignment (#150017)

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -583,11 +583,20 @@ inline Tensor handleDimInMultiDimIndexing(
       } else {
         result = result.unsqueeze(*dim_ptr);
         if (scalar_type == at::kBool) {
-          impl::recordTensorIndex(
-              impl::boolToIndexingTensor(
-                  result, tensor.item<bool>() != 0, original_tensor_device),
-              outIndices,
-              dim_ptr);
+          // Keep the original bool mask (unsqueezed to line up with the
+          // dimension we just inserted) instead of eagerly resolving it to a
+          // plain Long select-index via `.item()`. Converting to a Long
+          // index here causes `x[mask] = value` (0-dim `x`, 0-dim `mask`) to
+          // lose the masked_fill_ dtype-promotion fast path that
+          // identically-shaped N-dim bool masks get, since
+          // canDispatchToMaskedFill only recognizes Bool/Byte-typed indices.
+          // See GitHub issue #150017. (The deprecated uint8/Byte mask case
+          // below keeps the old conversion: masked_fill_'s tensor-mask
+          // overload only accepts Bool, so a Byte mask can't take this same
+          // shortcut.)
+          TORCH_INTERNAL_ASSERT(
+              tensor.dim() == 0 && tensor.scalar_type() == at::kBool);
+          impl::recordTensorIndex(tensor.unsqueeze(0), outIndices, dim_ptr);
         } else {
           impl::recordTensorIndex(
               impl::boolToIndexingTensor(

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1017,6 +1017,23 @@ class TestIndexingDevice(TestCase):
         v[:, mask] = 0
         self.assertEqual(v, torch.tensor([[0, 2], [0, 4]], device=device))
 
+    def test_zero_dim_bool_mask_assignment_dtype_promotion(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/150017
+        # A 0-dim bool mask used to be resolved to a plain Long select-index
+        # before reaching index_put, which skipped the masked_fill_ dtype
+        # promotion fast path that identically-shaped N-dim bool masks get.
+        x = torch.tensor(1.0, dtype=torch.float64, device=device)
+        x[torch.tensor(True, device=device)] = torch.tensor(
+            2.0, dtype=torch.float32, device=device
+        )
+        self.assertEqual(x, torch.tensor(2.0, dtype=torch.float64, device=device))
+
+        x = torch.tensor(1.0, dtype=torch.float64, device=device)
+        x[torch.tensor(False, device=device)] = torch.tensor(
+            2.0, dtype=torch.float32, device=device
+        )
+        self.assertEqual(x, torch.tensor(1.0, dtype=torch.float64, device=device))
+
     def test_multi_dimensional_bool_mask_assignment(self, device):
         v = torch.tensor([[[[1], [2]], [[3], [4]]]], device=device)
         mask = torch.tensor([[1, 0], [0, 1]], dtype=torch.bool, device=device)


### PR DESCRIPTION
# Bug

`x[mask]=val` raised an error when everything was 0-dim and dtype between `val` and `x` do not match. In other dimensions this works fine, so this is a bug rather than strictness. See issue #150017

# Root cause

The 0-dim bool was converted into a long index in `handleDimInMultiDimIndexing`. Because of this conversion a later check for bools would not catch on (https://github.com/moerlemans/pytorch/blob/2f5f7ede8d9c2959ad9e6af9fa1f4edc11db46ab/aten/src/ATen/TensorIndexing.h#L354). As this check did not find a bool but a long, the conversion path was rejected.

# Fix (fixes #150017)

In the lines where the bool is converted into long we instead keep a bool. Such that later functions also encounter a bool and it resolves to the correct path where the x and val become the same type. We have now retained the correct bool logic by unsqueezing it to keep the correct dimension.

New code keeping the bool and not transforming in long: https://github.com/moerlemans/pytorch/blob/2f5f7ede8d9c2959ad9e6af9fa1f4edc11db46ab/aten/src/ATen/TensorIndexing.h#L585-L599

Where the conversion path is decided for `val` (based on the dtype of the mask):

https://github.com/moerlemans/pytorch/blob/2f5f7ede8d9c2959ad9e6af9fa1f4edc11db46ab/aten/src/ATen/TensorIndexing.h#L354

Where the actual conversion for `val` happens (correct version):

https://github.com/moerlemans/pytorch/blob/2f5f7ede8d9c2959ad9e6af9fa1f4edc11db46ab/aten/src/ATen/native/TensorAdvancedIndexing.cpp#L981-L983

Where the dtype check for `val` happened and crashed before:

https://github.com/moerlemans/pytorch/blob/2f5f7ede8d9c2959ad9e6af9fa1f4edc11db46ab/aten/src/ATen/native/TensorAdvancedIndexing.cpp#L692-L704

## Other considered fixes

I've also considered explictly making a new bool which would be propagated, instead of unsqueezing some tensor. However this would create a new variable, which is unnecessary.

# Tests
Two new tests are added which test the true and false cases of this problem. They test it in the same way the bug was presented in the issue.

I ran all tests which came back without errors. I have not run the GPU tests.

# AI policy
This work has been done with the help of Claude Code. Messages in the issues and in this PR are completely written by me. I've also reviewed all code changes and looked for other options than only the LLM suggested. Followed the AI policy and agents.md.