### PR TITLE
[refs] Validate pixel_shuffle/pixel_unshuffle shapes like eager does

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3259,6 +3259,48 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(grad_output, grad_output_clone)
 
 
+    def test_pixel_shuffle_unshuffle_decomp_shape_validation(self):
+        """The decompositions must reject bad shapes with eager's messages.
+
+        Without these checks the bad shape reaches view()/reshape() and surfaces
+        as an internal "shape [...] is invalid for input of size N" error, which
+        says nothing about which argument was wrong.
+        """
+        from torch._refs.nn.functional import (
+            pixel_shuffle as pixel_shuffle_decomp,
+            pixel_unshuffle as pixel_unshuffle_decomp,
+        )
+
+        # channel dim not divisible by upscale_factor ** 2
+        x = torch.randn(1, 5, 4, 4)
+        msg = "channel' dimension to be divisible by the square of upscale_factor"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.pixel_shuffle(x, 2)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pixel_shuffle_decomp(x, 2)
+
+        # height / width not divisible by downscale_factor
+        y = torch.randn(1, 4, 5, 5)
+        msg = "height to be divisible by downscale_factor"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.pixel_unshuffle(y, 2)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pixel_unshuffle_decomp(y, 2)
+
+        z = torch.randn(1, 4, 4, 5)
+        msg = "width to be divisible by downscale_factor"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.pixel_unshuffle(z, 2)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            pixel_unshuffle_decomp(z, 2)
+
+        # the dimension count must be reported as a number, not a bound method
+        w = torch.randn(4, 4)
+        with self.assertRaisesRegex(RuntimeError, r"input with 2 dimension\(s\)"):
+            pixel_shuffle_decomp(w, 2)
+        with self.assertRaisesRegex(RuntimeError, r"input with 2 dimension\(s\)"):
+            pixel_unshuffle_decomp(w, 2)
+
     def test_pixel_shuffle_unshuffle(self):
         def _test_pixel_shuffle_unshuffle_helper(num_input_dims, valid_channels_dim=True,
                                                  upscale_factor=None):

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1285,7 +1285,14 @@ def pdist(a: TensorLikeType, p: float = 2) -> TensorLikeType:
 def pixel_shuffle(self: Tensor, upscale_factor: int):
     torch._check(
         self.dim() >= 3,
-        lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
+        lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim()} dimension(s)",
+    )
+    upscale_factor_squared = upscale_factor * upscale_factor
+    torch._check(
+        self.shape[-3] % upscale_factor_squared == 0,
+        lambda: f"pixel_shuffle expects its input's 'channel' dimension to be divisible by the "
+        f"square of upscale_factor, but input.size(-3)={self.shape[-3]} is not divisible by "
+        f"{upscale_factor_squared}",
     )
     batch = self.shape[:-3]
     C_out = self.shape[-3] // upscale_factor**2
@@ -1313,7 +1320,17 @@ def pixel_shuffle(self: Tensor, upscale_factor: int):
 def pixel_unshuffle(self: Tensor, downscale_factor: int):
     torch._check(
         self.dim() >= 3,
-        lambda: f"pixel_unshuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
+        lambda: f"pixel_unshuffle expects input to have at least 3 dimensions, but got input with {self.dim()} dimension(s)",
+    )
+    torch._check(
+        self.shape[-2] % downscale_factor == 0,
+        lambda: f"pixel_unshuffle expects height to be divisible by downscale_factor, but "
+        f"input.size(-2)={self.shape[-2]} is not divisible by {downscale_factor}",
+    )
+    torch._check(
+        self.shape[-1] % downscale_factor == 0,
+        lambda: f"pixel_unshuffle expects width to be divisible by downscale_factor, but "
+        f"input.size(-1)={self.shape[-1]} is not divisible by {downscale_factor}",
     )
     batch = self.shape[:-3]
     C_out = self.shape[-3] * downscale_factor**2


### PR DESCRIPTION
The `_refs` decompositions for `pixel_shuffle` and `pixel_unshuffle` only check the
dimension count. Every other malformed input falls through to the `view()`/`reshape()`
that follows, and surfaces as an internal shape error that names none of the arguments
the caller actually got wrong:

```python
>>> import torch
>>> from torch._refs.nn.functional import pixel_unshuffle
>>> pixel_unshuffle(torch.randn(1, 4, 5, 5), 2)
RuntimeError: shape '[1, 4, 2, 2, 2, 2]' is invalid for input of size 100
```

Eager, for the same call:

```
RuntimeError: pixel_unshuffle expects height to be divisible by downscale_factor,
but input.size(-2)=5 is not divisible by 2
```

`pixel_shuffle` has the same gap on its channel dimension:

```python
>>> from torch._refs.nn.functional import pixel_shuffle
>>> pixel_shuffle(torch.randn(1, 5, 4, 4), 2)
RuntimeError: shape '[1, 1, 2, 2, 4, 4]' is invalid for input of size 80
```

This adds the checks eager already performs in `check_pixel_shuffle_shapes` and
`check_pixel_unshuffle_shapes` (`aten/src/ATen/native/PixelShuffle.h`), using the same
wording: `channel % upscale_factor^2` for `pixel_shuffle`, and `height % downscale_factor`
and `width % downscale_factor` for `pixel_unshuffle`.

It also fixes the dimension-count message in both functions, which interpolated the bound
method instead of calling it:

```
... but got input with <built-in method dim of Tensor object at 0x105e05800> dimension(s)
```

`{self.dim}` -> `{self.dim()}`.

### Testing

New test `TestNN.test_pixel_shuffle_unshuffle_decomp_shape_validation` in
`test/test_nn.py`. It fails on an unpatched build and passes with the change.

```
test/test_nn.py -k pixel        5 passed, 2 skipped
test/test_decomp.py -k pixel   24 passed
test/test_meta.py -k pixel     72 passed
```

`ruff check` and `ruff format` are clean on the changed `_refs` file. `test/test_nn.py`
is in the PYFMT exclude list (`.lintrunner.toml`) and is left unformatted, as it already
fails `ruff format --check` on unmodified main.

### Note on scope

`meta_pixel_shuffle` keeps its own pre-existing wording for the dimension and divisibility
errors, which also differs from eager. That is a larger and more debatable change to
long-standing messages, so it is deliberately left out of this PR.
