### PR TITLE
[ROCm][UT] Enable sparse CSR add tests on RDNA

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -57,7 +57,8 @@ from torch.testing._internal.common_utils import (
     load_tests,
     parametrize,
     run_tests,
-    skipIfRocm,
+    NAVI_ARCH,
+    runOnRocmArch,
     skipIfTorchDynamo,
     subtest,
     suppress_warnings,
@@ -2365,7 +2366,7 @@ class TestSparseCSR(TestCase):
                         self.assertEqual(res_in, res_in_dense)
                         self.assertEqual(res_out, res_in)
 
-    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/167783")
+    @runOnRocmArch(NAVI_ARCH)
     @skipCPUIfNoMklSparse
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
     def test_sparse_add(self, device, dtype):


### PR DESCRIPTION
Part of #196583

## Summary

`test_sparse_add` was disabled on all ROCm by:

```python
@skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/167783")
```

The skip was bulk-inlined by #185013. The original auto-disable was related
to flaky sparse CSR numerical failures in #167783. The relevant hipSPARSE
`csrgeam2` issue was addressed by #171435, and the test already contains the
ROCm-specific `nnz >= 1` workaround.

Replace the blanket ROCm skip with:

```python
@runOnRocmArch(NAVI_ARCH)
```

This enables the test on RDNA while automatically keeping non-NAVI ROCm
architectures skipped. The test body and the existing `nnz` workaround are
unchanged.

## Validation

Validated against the current `origin/main` test source:

- gfx1100: 50/50 iterations passed
- gfx1151: 50/50 iterations passed
- gfx1200: 50/50 iterations passed
- 4 dtypes per iteration
- 600/600 counted test cases passed
- 0 failures, errors, or counted skips


MI200, MI300, and MI350 were not available locally. Please run the appropriate
ROCm CI jobs for MI coverage.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang