### PR TITLE
[docs] Fix reference docstring for linear_cross_entropy on 3D+ inputs

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3722,9 +3722,10 @@ def linear_cross_entropy(
     is equivalent to the following reference implementation of linear_cross_entropy::
 
    logits = linear(input, linear_weight)
-        if logits.ndim > 2:
-            logits = logits.transpose(1, -1)
-        loss = cross_entropy(logits, target, **kwargs)
+      if logits.ndim > 2:
+        # F.cross_entropy expects the class channel at dim=1
+        logits = logits.movedim(-1, 1)
+    loss = cross_entropy(logits, target, **kwargs)
 
     provided that :attr:`ignore_index` is not explicitly set to `None`
     in `kwargs` (since :func:`cross_entropy` does not accept `None`

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3721,8 +3721,10 @@ def linear_cross_entropy(
 
     is equivalent to the following reference implementation of linear_cross_entropy::
 
-      logits = linear(input, linear_weight)
-      loss = cross_entropy(logits, target, **kwargs)
+   logits = linear(input, linear_weight)
+        if logits.ndim > 2:
+            logits = logits.transpose(1, -1)
+        loss = cross_entropy(logits, target, **kwargs)
 
     provided that :attr:`ignore_index` is not explicitly set to `None`
     in `kwargs` (since :func:`cross_entropy` does not accept `None`


### PR DESCRIPTION
Fixes #196749

### Description
The reference docstring for `linear_cross_entropy` previously failed for multi-dimensional inputs (3D+) because `F.linear` places classes at `dim=-1`, while `F.cross_entropy` expects them at `dim=1`. 

Updated the docstring snippet to include `if logits.ndim > 2: logits = logits.transpose(1, -1)` to accurately reflect the function's internal behavior.