### PR TITLE
[Stable-ABI] Add torch::stable::add for v2.15.

### DIFF
--- a/docs/cpp/source/api/stable/operators.md
+++ b/docs/cpp/source/api/stable/operators.md
@@ -154,6 +154,9 @@ auto tensor = torch::stable::empty(
 ```{doxygenfunction} torch::stable::sum_out
 ```
 
+```{doxygenfunction} torch::stable::add
+```
+
 ```{doxygenfunction} torch::stable::subtract
 ```
 

--- a/test/cpp_extensions/libtorch_agn_2_15_extension/csrc/my_add.cpp
+++ b/test/cpp_extensions/libtorch_agn_2_15_extension/csrc/my_add.cpp
@@ -1,0 +1,17 @@
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+
+using torch::stable::Tensor;
+
+Tensor my_add(const Tensor& self, const Tensor& other, double alpha) {
+  return torch::stable::add(self, other, alpha);
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(STABLE_LIB_NAME, m) {
+  m.def("my_add(Tensor self, Tensor other, float alpha=1.0) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(STABLE_LIB_NAME, CompositeExplicitAutograd, m) {
+  m.impl("my_add", TORCH_BOX(&my_add));
+}

--- a/test/cpp_extensions/libtorch_agn_2_15_extension/libtorch_agn_2_15/__init__.py
+++ b/test/cpp_extensions/libtorch_agn_2_15_extension/libtorch_agn_2_15/__init__.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import torch
+
+
+# The op extension (_C) registers this version's and the inherited 2.9-2.14
+# STABLE_TORCH_LIBRARY ops; load it via load_library like the other libtorch_agn
+# extensions.
+so_files = list(
+    Path(__file__).parent.glob("_C*" + (".pyd" if sys.platform == "win32" else ".so"))
+)
+if len(so_files) != 1:
+    raise AssertionError(f"Expected one _C*.{{so,pyd}} file, found {len(so_files)}")
+torch.ops.load_library(str(so_files[0]))
+
+from . import ops
+
+
+__all__ = [
+    "ops",
+]

--- a/test/cpp_extensions/libtorch_agn_2_15_extension/libtorch_agn_2_15/ops.py
+++ b/test/cpp_extensions/libtorch_agn_2_15_extension/libtorch_agn_2_15/ops.py
@@ -1,0 +1,45 @@
+import torch
+
+
+# =============================================================================
+# Proxy for inherited ops (from libtorch_agn_2_9, 2_10, 2_11, 2_12, 2_13, and
+# 2_14 csrc/)
+#
+# Ops compiled from previous versions' csrc directories are accessible via
+# the module-level __getattr__. For example:
+#     libtorch_agn_2_15.ops.sgd_out_of_place(...)  # from 2.9
+#     libtorch_agn_2_15.ops.my_sum(...)            # from 2.10
+#
+# Ops defined in this package's csrc/ (e.g. my_add) are registered on
+# ``torch.ops.libtorch_agn_2_15`` and wrapped explicitly below.
+# =============================================================================
+
+_NAMESPACE = "libtorch_agn_2_15"
+
+
+def my_add(self, other, alpha=1.0) -> torch.Tensor:
+    """Stable ``add.Tensor`` (2.15+)."""
+    return torch.ops.libtorch_agn_2_15.my_add.default(self, other, alpha)
+
+
+def __getattr__(name):
+    """Proxy for inherited ops from previous versions."""
+    if name.startswith("_"):
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    ops_namespace = getattr(torch.ops, _NAMESPACE)
+    op = getattr(ops_namespace, name, None)
+    if op is None:
+        raise AttributeError(f"No op named '{name}' in {_NAMESPACE}")
+    return op.default
+
+
+def __dir__():
+    """List all available ops (native + inherited)."""
+    native = [
+        name
+        for name in globals()
+        if not name.startswith("_") and callable(globals().get(name))
+    ]
+    ops_namespace = getattr(torch.ops, _NAMESPACE)
+    inherited = [n for n in dir(ops_namespace) if not n.startswith("_")]
+    return sorted(set(native + inherited))

--- a/test/cpp_extensions/libtorch_agn_2_15_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_2_15_extension/setup.py
@@ -1,0 +1,114 @@
+import distutils.command.clean
+import shutil
+from pathlib import Path
+
+from setuptools import find_packages, setup
+
+import torch
+from torch.utils.cpp_extension import (
+    BuildExtension,
+    CppExtension,
+    CUDAExtension,
+    IS_WINDOWS,
+)
+
+
+ROOT_DIR = Path(__file__).parent
+CSRC_DIR = ROOT_DIR / "csrc"
+
+# Include csrc from previous versions for forward compatibility testing
+PREV_CSRC_DIRS = [
+    ROOT_DIR.parent / "libtorch_agn_2_9_extension" / "csrc",
+    ROOT_DIR.parent / "libtorch_agn_2_10_extension" / "csrc",
+    ROOT_DIR.parent / "libtorch_agn_2_11_extension" / "csrc",
+    ROOT_DIR.parent / "libtorch_agn_2_12_extension" / "csrc",
+    ROOT_DIR.parent / "libtorch_agn_2_13_extension" / "csrc",
+    ROOT_DIR.parent / "libtorch_agn_2_14_extension" / "csrc",
+]
+
+
+class clean(distutils.command.clean.clean):
+    def run(self):
+        # Run default behavior first
+        distutils.command.clean.clean.run(self)
+
+        # Remove extension
+        for path in (ROOT_DIR / "libtorch_agn_2_15").glob("**/*.so"):
+            path.unlink()
+        # Remove build and dist and egg-info directories
+        dirs = [
+            ROOT_DIR / "build",
+            ROOT_DIR / "dist",
+            ROOT_DIR / "libtorch_agn_2_15.egg-info",
+        ]
+        for path in dirs:
+            if path.exists():
+                shutil.rmtree(str(path), ignore_errors=True)
+
+
+def get_extension():
+    common_cxx = ["-DTORCH_TARGET_VERSION=0x020f000000000000"]
+    if not IS_WINDOWS:
+        common_cxx.append("-fdiagnostics-color=always")
+
+    all_csrc_dirs = [CSRC_DIR, *PREV_CSRC_DIRS]
+    mps_available = torch.backends.mps.is_available()
+
+    # Op extension (_C): this version's ops + inherited 2.9-2.14 csrc, minus the
+    # interop module.
+    op_sources = [
+        s
+        for d in all_csrc_dirs
+        for s in d.glob("**/*.cpp")
+        if s.name != "pyobject_interop_module.cpp"
+        and (s.parent.name != "mps" or mps_available)
+    ]
+
+    op_cxx = common_cxx + ["-DSTABLE_LIB_NAME=libtorch_agn_2_15"]
+    op_extra = {"cxx": op_cxx}
+    op_extension = CppExtension
+    # allow including <cuda_runtime.h>
+    if torch.cuda.is_available():
+        op_cxx.append("-DLAE_USE_CUDA")
+        op_extra["nvcc"] = [
+            "-O2",
+            "-DUSE_CUDA",
+            "-DTORCH_TARGET_VERSION=0x020f000000000000",
+            "-DSTABLE_LIB_NAME=libtorch_agn_2_15",
+        ]
+        op_extension = CUDAExtension
+        op_sources.extend(CSRC_DIR.glob("**/*.cu"))
+        for prev_dir in PREV_CSRC_DIRS:
+            op_sources.extend(prev_dir.glob("**/*.cu"))
+
+    if mps_available:
+        op_cxx.append("-DUSE_MPS")
+
+    return [
+        op_extension(
+            "libtorch_agn_2_15._C",
+            sources=sorted(str(s) for s in op_sources),
+            py_limited_api=True,
+            extra_compile_args=op_extra,
+            extra_link_args=[],
+        ),
+    ]
+
+
+setup(
+    name="libtorch_agn_2_15",
+    version="0.0",
+    author="PyTorch Core Team",
+    description="Example of libtorch agnostic extension for PyTorch 2.15+",
+    packages=find_packages(exclude=("test",)),
+    package_data={"libtorch_agn_2_15": ["*.dll", "*.dylib", "*.so"]},
+    install_requires=[
+        "torch",
+    ],
+    ext_modules=get_extension(),
+    cmdclass={
+        "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
+        "clean": clean,
+    },
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
+)

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -63,6 +63,7 @@ class TestLibtorchAgnostic(TestCase):
     - libtorch_agn_2_12: Extension built with TORCH_TARGET_VERSION=2.12.0
     - libtorch_agn_2_13: Extension built with TORCH_TARGET_VERSION=2.13.0
     - libtorch_agn_2_14: Extension built with TORCH_TARGET_VERSION=2.14.0
+    - libtorch_agn_2_15: Extension built with TORCH_TARGET_VERSION=2.15.0
 
     Tests should be decorated with @skipIfTorchVersionLessThan to indicate the
     version that they target.
@@ -137,6 +138,16 @@ class TestLibtorchAgnostic(TestCase):
                 )
         else:
             print(f"Skipping 2.14 extension (running on PyTorch {torch.__version__})")
+
+        if (current_major > 2) or (current_major == 2 and current_minor >= 15):
+            try:
+                import libtorch_agn_2_15  # noqa: F401
+            except Exception:
+                install_cpp_extension(
+                    extension_root=base_dir / "libtorch_agn_2_15_extension"
+                )
+        else:
+            print(f"Skipping 2.15 extension (running on PyTorch {torch.__version__})")
 
     @onlyCPU
     def test_slow_sgd(self, device):
@@ -427,6 +438,40 @@ class TestLibtorchAgnostic(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "expected torch.Tensor"):
             libtorch_agnostic._interop.pyobject_roundtrip("not a tensor")
+
+    @skipIfTorchVersionLessThan(2, 15)
+    def test_my_add(self, device):
+        """Test add.Tensor op."""
+        import libtorch_agn_2_15 as libtorch_agnostic
+
+        a = torch.randn(3, 4, device=device)
+        b = torch.randn(3, 4, device=device)
+
+        # Test basic addition (alpha=1.0)
+        result = libtorch_agnostic.ops.my_add(a, b)
+        expected = torch.add(a, b)
+        self.assertEqual(result, expected)
+
+        # Test addition with alpha=2.0
+        result_alpha = libtorch_agnostic.ops.my_add(a, b, alpha=2.0)
+        expected_alpha = torch.add(a, b, alpha=2.0)
+        self.assertEqual(result_alpha, expected_alpha)
+
+        # Test addition with alpha=0.5
+        result_half = libtorch_agnostic.ops.my_add(a, b, alpha=0.5)
+        expected_half = torch.add(a, b, alpha=0.5)
+        self.assertEqual(result_half, expected_half)
+
+        # Test addition with negative alpha
+        result_neg = libtorch_agnostic.ops.my_add(a, b, alpha=-1.0)
+        expected_neg = torch.add(a, b, alpha=-1.0)
+        self.assertEqual(result_neg, expected_neg)
+
+        # Test addition with broadcasting
+        c = torch.randn(4, device=device)
+        result_broadcast = libtorch_agnostic.ops.my_add(a, c)
+        expected_broadcast = torch.add(a, c)
+        self.assertEqual(result_broadcast, expected_broadcast)
 
     # TODO: Debug this:
     # torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors:

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_aten.h
@@ -14,6 +14,9 @@
 extern "C" {
 #endif
 
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_add_Tensor(AtenTensorHandle self, AtenTensorHandle other, double alpha, AtenTensorHandle* ret0);
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_amax(AtenTensorHandle self, const int64_t* dim, int64_t dim_len_, int32_t keepdim, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_aten_fill__Scalar(AtenTensorHandle self, double value);
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0

--- a/torch/csrc/stable/ops.h
+++ b/torch/csrc/stable/ops.h
@@ -1332,4 +1332,33 @@ inline bool is_pinned(const torch::stable::Tensor& self) {
 
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_10_0
 
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
+
+/// Stable version of the add.Tensor op.
+///
+/// Adds the other tensor to self, with an optional scaling factor alpha.
+/// Computes: self + alpha * other.
+///
+/// Minimum compatible version: PyTorch 2.15.
+/// Build time minimum version: PyTorch 2.15.
+///
+/// @note The alpha parameter is typed as double
+///       API uses double for the Scalar parameter.
+///
+/// @param self The input tensor.
+/// @param other The tensor to add.
+/// @param alpha The scaling factor for other. Defaults to 1.0.
+/// @return The result of self + alpha * other.
+inline torch::stable::Tensor add(
+    const torch::stable::Tensor& self,
+    const torch::stable::Tensor& other,
+    double alpha = 1.0) {
+  AtenTensorHandle ret0;
+  STABLE_TORCH_ERROR_CODE_CHECK(
+      aoti_torch_aten_add_Tensor(self.get(), other.get(), alpha, &ret0));
+  return torch::stable::Tensor(ret0);
+}
+
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_15_0
+
 HIDDEN_NAMESPACE_END(torch, stable)

--- a/torch/csrc/stable/version.h
+++ b/torch/csrc/stable/version.h
@@ -39,3 +39,4 @@
 #define TORCH_VERSION_2_12_0 (((0ULL + 2) << 56) | ((0ULL + 12) << 48))
 #define TORCH_VERSION_2_13_0 (((0ULL + 2) << 56) | ((0ULL + 13) << 48))
 #define TORCH_VERSION_2_14_0 (((0ULL + 2) << 56) | ((0ULL + 14) << 48))
+#define TORCH_VERSION_2_15_0 (((0ULL + 2) << 56) | ((0ULL + 15) << 48))

--- a/torchgen/aoti/fallback_ops.py
+++ b/torchgen/aoti/fallback_ops.py
@@ -229,4 +229,5 @@ aten_shimified_ops: dict[str, dict[str, str | dict[str, list[str] | str]]] = {
     "aten.new_zeros.default": {},
     "aten.full.default": {"since": "TORCH_VERSION_2_10_0"},
     "aten.subtract.Tensor": {"since": "TORCH_VERSION_2_10_0"},
+    "aten.add.Tensor": {"since": "TORCH_VERSION_2_15_0"},
 }


### PR DESCRIPTION
Adds `torch::stable::add` to the stable ABI, gated on a new `TORCH_VERSION_2_15_0`. This is needed for the torchvision stable-ABI port, which currently works around the missing op with [subtract(self, other, -1.0)](https://github.com/pytorch/vision/blob/ac8d215f7d45d6601451b62e9f81622dac8aa0b4/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp#L90-L93).

## Summary
- Introduces `torch::stable::add(self, other, double alpha = 1.0)` via the aten C shim (`aoti_torch_aten_add_Tensor`), mirroring [torch::stable::subtract](https://github.com/pytorch/pytorch/blob/879f5e08bd32c01bf8374d7e9cf1c2f5f61468cb/torch/csrc/stable/ops.h#L1065-L1087). 
- Added`TORCH_VERSION_2_15_0` and document the new API in the stable operators docs.
- Added a `libtorch_agn_2_15` extension and new unit tests `test_my_add` (default alpha, alpha=2.0, alpha=0.5, negative alpha, broadcasting)

cc @janeyx99