### PR TITLE
[PT2] Normalize AOT-eager preflight backward views

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -23,6 +23,7 @@ import torch.optim as optim
 from torch import nn
 from torch._C import FileCheck
 from torch._dynamo import config
+from torch._dynamo.backends.registry import lookup_backend
 from torch._dynamo.backends.distributed import DDPOptimizer
 from torch._dynamo.comptime import comptime
 from torch._dynamo.device_interface import CudaInterface, DeviceGuard
@@ -1275,6 +1276,122 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
             torch.distributed.all_gather_object(res, len(metrics))
             for r in res[1:]:
                 self.assertEqual(res[0], r)
+
+    @unittest.skipIf(not HAS_GPU, "compiler collectives need multiple GPUs")
+    @config.patch(automatic_dynamic_shapes=True)
+    @config.patch(enable_compiler_collectives=True)
+    def test_compiler_collectives_first_backend_compile_is_dynamic(self):
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+            backend_compile_count = 0
+            backend_symbolic_inputs = []
+            inductor_backend = lookup_backend("inductor")
+
+            def recording_backend(gm, example_inputs):
+                nonlocal backend_compile_count
+                backend_compile_count += 1
+                backend_symbolic_inputs.append(
+                    any(
+                        isinstance(example, torch.SymInt)
+                        or (
+                            isinstance(example, torch.Tensor)
+                            and example.ndim == 2
+                            and any(
+                                isinstance(dim, torch.SymInt)
+                                for dim in example.shape
+                            )
+                        )
+                        for example in example_inputs
+                    )
+                )
+                return inductor_backend(gm, example_inputs)
+
+            @torch.compiler.disable
+            def eager_regroup(x):
+                return x[x[:, 0] > 0]
+
+            @torch.compile(backend=recording_backend)
+            def f(x):
+                regrouped = eager_regroup(x.sin())
+                return (regrouped.cos() + 1).sum(dim=1)
+
+            def make_input(batch_size, regrouped_size):
+                # Citrine C3: create tensors directly on the target GPU.
+                x = -torch.ones(batch_size, 10, device=self.rank)
+                x[:regrouped_size, 0] = 1
+                return x
+
+            first_input = make_input(5 + 2 * self.rank, 3 + 2 * self.rank)
+            expected = (eager_regroup(first_input.sin()).cos() + 1).sum(dim=1)
+            self.assertEqual(f(first_input), expected)
+            self.assertEqual(backend_compile_count, 2)
+            self.assertEqual(backend_symbolic_inputs, [True, True])
+
+            second_input = make_input(8 + 2 * self.rank, 4 + 2 * self.rank)
+            expected = (eager_regroup(second_input.sin()).cos() + 1).sum(dim=1)
+            self.assertEqual(f(second_input), expected)
+            self.assertEqual(backend_compile_count, 2)
+
+    @unittest.skipIf(not HAS_GPU, "compiler collectives need multiple GPUs")
+    @config.patch(automatic_dynamic_shapes=True)
+    @config.patch(enable_compiler_collectives=True)
+    def test_compiler_collectives_many_graph_breaks_first_compile_dynamic(self):
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+            backend_compile_count = 0
+            backend_symbolic_inputs = []
+            inductor_backend = lookup_backend("inductor")
+
+            def recording_backend(gm, example_inputs):
+                nonlocal backend_compile_count
+                backend_compile_count += 1
+                backend_symbolic_inputs.append(
+                    any(
+                        isinstance(example, torch.SymInt)
+                        or (
+                            isinstance(example, torch.Tensor)
+                            and any(
+                                isinstance(dim, torch.SymInt)
+                                for dim in example.shape
+                            )
+                        )
+                        for example in example_inputs
+                    )
+                )
+                return inductor_backend(gm, example_inputs)
+
+            @torch.compiler.disable
+            def eager_trim(x):
+                return x[:-1]
+
+            def model(x):
+                x = eager_trim((x + 1).sin())
+                x = eager_trim((x + 2).cos())
+                x = eager_trim((x + 3).tanh())
+                x = eager_trim((x + 4).sigmoid())
+                x = eager_trim((x + 5).relu())
+                x = eager_trim((x + 6).square())
+                x = eager_trim((x + 7).sqrt())
+                x = eager_trim((x + 8).log1p())
+                return (x + 9).sum(dim=1)
+
+            compiled_model = torch.compile(model, backend=recording_backend)
+
+            # Citrine C3: create inputs directly on the target GPU.
+            first_input = torch.rand(
+                20 + 4 * self.rank,
+                10,
+                device=self.rank,
+            )
+            self.assertEqual(compiled_model(first_input), model(first_input))
+            self.assertEqual(backend_compile_count, 9)
+            self.assertEqual(backend_symbolic_inputs, [True] * 9)
+
+            second_input = torch.rand(
+                28 + 4 * self.rank,
+                10,
+                device=self.rank,
+            )
+            self.assertEqual(compiled_model(second_input), model(second_input))
+            self.assertEqual(backend_compile_count, 9)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @config.patch(enable_compiler_collectives=True)

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1841,6 +1841,45 @@ class DecoratorTests(PytreeRegisteringTestCase):
         # Would have been 4 without stance
         self.assertEqual(cnts.op_count, 2)
 
+    def test_set_stance_aot_eager_then_compile_uses_native_pgo(self):
+        symbolic_inputs = []
+
+        def backend(gm, example_inputs):
+            symbolic_inputs.append(
+                any(
+                    isinstance(example, torch.SymInt)
+                    or (
+                        isinstance(example, torch.Tensor)
+                        and any(
+                            isinstance(dim, torch.SymInt) for dim in example.shape
+                        )
+                    )
+                    for example in example_inputs
+                )
+            )
+            return gm.forward
+
+        @torch.compile(backend=backend)
+        def fn(x):
+            x = torch.sin(x)
+            torch._dynamo.graph_break()
+            return torch.cos(x)
+
+        with (
+            torch._dynamo.config.patch(
+                automatic_dynamic_shapes=True,
+                automatic_dynamic_local_pgo=False,
+                automatic_dynamic_remote_pgo=False,
+                delayed_compile_use_native_pgo=True,
+            ),
+            torch.compiler.set_stance("aot_eager_then_compile"),
+        ):
+            for size in (2, 3, 4):
+                x = torch.randn(size)
+                self.assertEqual(fn(x), torch.cos(torch.sin(x)))
+
+        self.assertEqual(symbolic_inputs, [True, True])
+
     def test_mark_static_nn_module(self):
         @torch._dynamo.mark_static
         class Mock(torch.nn.Module):

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -15,6 +15,7 @@ from torch._dynamo.eval_frame import (
     _get_total_cache_entry_count,
 )
 from torch._dynamo.exc import FailOnRecompileLimitHit
+from torch.utils._pytree import GetAttrKey, register_pytree_node
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -24,6 +25,19 @@ from torch.testing._internal.logging_utils import kwargs_to_settings, log_settin
 
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
+class _AttrPytree:
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+
+register_pytree_node(
+    _AttrPytree,
+    lambda value: ([value.tensor], None),
+    lambda values, _context: _AttrPytree(values[0]),
+    flatten_with_keys_fn=lambda value: ([(GetAttrKey("tensor"), value.tensor)], None),
 )
 
 
@@ -66,6 +80,40 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
             opt_model(x, i)
 
         self.assertTrue(triggered)
+
+    def test_aot_eager_then_compile_tracks_attr_pytree_dynamism(self):
+        def model(features):
+            return features.tensor.sin()
+
+        compile_counter = torch._dynamo.testing.CompileCounter()
+        compiled_model = torch.compile(model, backend=compile_counter)
+
+        with (
+            torch._dynamo.config.patch(delayed_compile_use_native_pgo=True),
+            torch.compiler.set_stance("aot_eager_then_compile"),
+        ):
+            compiled_model(_AttrPytree(torch.randn(2)))
+            compiled_model(_AttrPytree(torch.randn(3)))
+
+        compiled_model(_AttrPytree(torch.randn(4)))
+        self.assertEqual(compile_counter.frame_count, 1)
+
+    def test_aot_eager_then_compile_recompiles_static_frame(self):
+        def model(features):
+            return features.sin()
+
+        compile_counter = torch._dynamo.testing.CompileCounter()
+        compiled_model = torch.compile(model, backend=compile_counter)
+
+        with (
+            torch._dynamo.config.patch(delayed_compile_use_native_pgo=True),
+            torch.compiler.set_stance("aot_eager_then_compile"),
+        ):
+            compiled_model(torch.randn(2))
+            compiled_model(torch.randn(2))
+
+        compiled_model(torch.randn(2))
+        self.assertEqual(compile_counter.frame_count, 1)
 
     def test_loop_torture(self):
         def loop_torture(input, iters):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -870,6 +870,15 @@ automatic_dynamic_remote_pgo: bool | None = get_tristate_env(
     "TORCH_DYNAMO_AUTOMATIC_DYNAMIC_REMOTE_PGO"
 )
 
+# Opt in to letting the "aot_eager_then_compile" stance derive dynamism from
+# automatic-dynamic PGO instead of diffing two f_locals snapshots. PGO also sees
+# nested inputs (attributes, dict entries) that the snapshot walk misses, but it
+# only records what Dynamo actually traces, so the preflight cache entry has to
+# be discarded for the production compile to count as a second observation.
+# Off by default: it changes preflight cache lifetime and starts writing warmup
+# observations to the persistent PGO cache.
+delayed_compile_use_native_pgo: bool = False
+
 # temporary config to kill later
 _unsafe_skip_fsdp_module_guards = (
     os.environ.get("UNSAFE_SKIP_FSDP_MODULE_GUARDS", "0") == "1"

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -428,6 +428,24 @@ def _delayed_compile_uses_native_pgo(stance: StanceStr) -> bool:
     return stance == "aot_eager_then_compile" and config.delayed_compile_use_native_pgo
 
 
+def _aot_eager_safe_backward_compiler(
+    graph_module: torch.fx.GraphModule,
+    example_inputs: list[torch.Tensor],
+) -> Callable[..., Any]:
+    # AOT eager executes this graph verbatim, without Inductor's unconditional
+    # view-to-reshape normalization. Runtime kernels can return a different
+    # stride than FakeTensor predicted, making an otherwise traced view invalid.
+    for node in graph_module.graph.find_nodes(
+        op="call_function",
+        target=torch.ops.aten.view.default,
+    ):
+        node.target = torch.ops.aten.reshape.default
+
+    from .backends.debugging import boxed_nop
+
+    return boxed_nop(graph_module, example_inputs)
+
+
 def _create_delayed_compile_callback(
     callback: DynamoCallback, stance: StanceStr
 ) -> Callable[..., Any]:
@@ -438,7 +456,10 @@ def _create_delayed_compile_callback(
             phase = _get_delayed_compile_phase(frame)
             if phase == 1:
                 if stance == "aot_eager_then_compile":
-                    aot_eager_fn = get_compiler_fn("aot_eager")
+                    aot_eager_fn = functools.partial(
+                        get_compiler_fn("aot_eager"),
+                        bw_compiler=_aot_eager_safe_backward_compiler,
+                    )
                     result = _create_wrapped_callback(aot_eager_fn)(*args, **kwargs)
                     if result.guarded_code is not None:
                         _record_delayed_compile_cache_code(frame.f_code)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -255,6 +255,46 @@ def get_example_inputs(key: str) -> list[Any]:
     return _EXAMPLE_INPUTS[key]
 
 
+_DELAYED_COMPILE_CACHE_SCOPES = threading.local()
+
+
+@dataclass
+class _DelayedCompileCacheScope:
+    cache_codes: set[types.CodeType]
+    observed_codes: set[types.CodeType]
+
+
+def _enter_delayed_compile_cache_scope() -> None:
+    scopes = getattr(_DELAYED_COMPILE_CACHE_SCOPES, "scopes", None)
+    if scopes is None:
+        scopes = []
+        _DELAYED_COMPILE_CACHE_SCOPES.scopes = scopes
+    scopes.append(_DelayedCompileCacheScope(set(), set()))
+
+
+def _record_delayed_compile_cache_code(code: types.CodeType) -> None:
+    scopes = getattr(_DELAYED_COMPILE_CACHE_SCOPES, "scopes", None)
+    if scopes:
+        scopes[-1].cache_codes.add(code)
+
+
+def _record_delayed_compile_observation(code: types.CodeType) -> bool:
+    scopes = getattr(_DELAYED_COMPILE_CACHE_SCOPES, "scopes", None)
+    if not scopes:
+        return True
+    if code in scopes[-1].observed_codes:
+        return False
+    scopes[-1].observed_codes.add(code)
+    return True
+
+
+def _exit_delayed_compile_cache_scope() -> None:
+    scopes = _DELAYED_COMPILE_CACHE_SCOPES.scopes
+    scope = scopes.pop()
+    for code in scope.cache_codes:
+        reset_code(code)
+
+
 @contextlib.contextmanager
 def _set_in_optimized_module() -> Generator[None, None, None]:
     # Set in dynamo's OptimizedModule forward, to have better coverage than is_compiling().
@@ -373,26 +413,52 @@ def _get_or_add_example_inputs(frame: DynamoFrameType) -> list[Any]:
     return example_inputs
 
 
+def _get_delayed_compile_phase(frame: DynamoFrameType) -> int:
+    context = code_context.get_context(frame.f_code)
+    phase = context.setdefault("delayed_compile_phase", 0)
+    if phase < 2 and _record_delayed_compile_observation(frame.f_code):
+        phase += 1
+        context["delayed_compile_phase"] = phase
+    return phase
+
+
+def _delayed_compile_uses_native_pgo(stance: StanceStr) -> bool:
+    # "eager_then_compile" never traces its first invocation, so native PGO has
+    # nothing to observe there; it always uses the legacy snapshot diff.
+    return stance == "aot_eager_then_compile" and config.delayed_compile_use_native_pgo
+
+
 def _create_delayed_compile_callback(
     callback: DynamoCallback, stance: StanceStr
 ) -> Callable[..., Any]:
     def callback_fn(*args: Any, **kwargs: Any) -> convert_frame.ConvertFrameReturn:
         frame = args[0]
-        example_inputs = _get_or_add_example_inputs(frame)
 
-        if len(example_inputs) == 1:
-            if stance == "eager_then_compile":
-                return ConvertFrameReturn(
-                    frame_exec_strategy=FrameExecStrategy(
-                        FrameAction.DEFAULT, FrameAction.DEFAULT
+        if _delayed_compile_uses_native_pgo(stance):
+            phase = _get_delayed_compile_phase(frame)
+            if phase == 1:
+                if stance == "aot_eager_then_compile":
+                    aot_eager_fn = get_compiler_fn("aot_eager")
+                    result = _create_wrapped_callback(aot_eager_fn)(*args, **kwargs)
+                    if result.guarded_code is not None:
+                        _record_delayed_compile_cache_code(frame.f_code)
+                    return result
+        else:
+            example_inputs = _get_or_add_example_inputs(frame)
+            if len(example_inputs) == 1:
+                if stance == "eager_then_compile":
+                    return ConvertFrameReturn(
+                        frame_exec_strategy=FrameExecStrategy(
+                            FrameAction.DEFAULT, FrameAction.DEFAULT
+                        )
                     )
-                )
-            elif stance == "aot_eager_then_compile":
-                aot_eager_fn = get_compiler_fn("aot_eager")
-                return _create_wrapped_callback(aot_eager_fn)(*args, **kwargs)
+                elif stance == "aot_eager_then_compile":
+                    aot_eager_fn = get_compiler_fn("aot_eager")
+                    return _create_wrapped_callback(aot_eager_fn)(*args, **kwargs)
 
-        dynamism = track_dynamism_across_examples(example_inputs)
-        code_context.get_context(frame.f_code)["dynamism"] = dynamism
+            dynamism = track_dynamism_across_examples(example_inputs)
+            code_context.get_context(frame.f_code)["dynamism"] = dynamism
+
         compiler_fn = callback._torchdynamo_orig_backend._torchdynamo_orig_backend  # type: ignore[union-attr]
         return _create_wrapped_callback(compiler_fn)(*args, **kwargs)
 
@@ -1255,6 +1321,11 @@ class _TorchDynamoContext:
                 # balanced even if the inner finally itself raises (e.g. the
                 # fullgraph "found no compiled frames" error).
                 torch._C._dynamo_save_local_dispatch_key_set()
+                delayed_compile_cache_scope = _delayed_compile_uses_native_pgo(
+                    _stance.stance
+                )
+                if delayed_compile_cache_scope:
+                    _enter_delayed_compile_cache_scope()
                 try:
                     call_succeeded = False
                     try:
@@ -1316,6 +1387,8 @@ class _TorchDynamoContext:
                     # outer finally so it runs even if the inner finally raised,
                     # keeping the save/restore stack balanced.
                     torch._C._dynamo_restore_local_dispatch_key_set()
+                    if delayed_compile_cache_scope:
+                        _exit_delayed_compile_cache_scope()
                 return result
             finally:
                 if fullgraph_count_enabled:


### PR DESCRIPTION
Summary:
Rewrite `aten.view` to `aten.reshape` in the backward graph of the AOT-eager
preflight used by the native-PGO path of `aot_eager_then_compile`.

AOT eager executes the traced graph verbatim, without Inductor's unconditional
view-to-reshape normalization. A custom op whose runtime kernel returns a
different stride than its FakeTensor rule predicted therefore produces a
backward `view` that is valid at trace time but invalid at runtime. Inductor
never hits this because it normalizes; the preflight does.

This only touches the preflight backward compiler, so the production backend is
unchanged. It is also reached only when `delayed_compile_use_native_pgo` is on —
the legacy path keeps the plain `get_compiler_fn("aot_eager")` with no
`bw_compiler` override, so existing `aot_eager_then_compile` users are
unaffected.

Test Plan:
New unit test `test_aot_eager_then_compile_normalizes_backward_views` builds the
failure directly: a custom op whose fake rule predicts a contiguous output while
the real kernel returns a transposed clone, consumed by an autograd Function
whose backward does `.view(ctx.input_shape)`. Without the rewrite the backward
raises on the stride mismatch; with it the gradient matches
`grad_output.transpose(-2, -1).reshape_as(x)` and the production backend is
never invoked (`production_backend_calls == 0`).

  buck2 test fbcode//apf/plugin/tests:pt2_warmup_compiler_collectives_gpu_test
  buck2 test fbcode//apf/plugin/tests:pt2_warmup_controller_test
  -> Pass 24. Fail 0.

  buck2 build fbcode//caffe2/test/dynamo:test_dynamo
  ./test_dynamo.par test_decorators.py test_recompile_ux.py \
      -k "eager_then_compile or infers_dynamism"
  -> 16 passed, 4 skipped, 2 errors (skips and errors both pre-existing; see
     D119219611's test plan)

  arc lint -a on changed files: clean

Also exercised in production as part of the stack: f1141720095 (native PGO on,
SUCCEEDED) runs this preflight backward compiler on every warmup batch.

Differential Revision: D119219614




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98