### PR TITLE
[xpu][test] Port 3 distributed tests (fsdp folder)  cases on Intel GPUs

### DIFF
--- a/test/distributed/fsdp/test_checkpoint_wrapper.py
+++ b/test/distributed/fsdp/test_checkpoint_wrapper.py
@@ -24,7 +24,7 @@ from torch.utils.checkpoint import checkpoint
 _SAVED_PREFIX = "_saved_"
 GRAD_FN_NEXT_FUNCTIONS = "next_functions"
 
-device_type = torch.device(get_devtype())
+device = torch.device(get_devtype())
 
 
 class CheckpointWrapperTest(TestCase):
@@ -189,12 +189,12 @@ class CheckpointWrapperTest(TestCase):
                 use_checkpointing,
                 use_wrapper=use_wrapper,
                 use_reentrant=use_reentrant,
-            ).to(device_type.type)
-            x = torch.randn(10000, 256, requires_grad=True).to(device_type.type)
-            torch.get_device_module(device_type.type).reset_peak_memory_stats()
+            ).to(device.type)
+            x = torch.randn(10000, 256, requires_grad=True).to(device.type)
+            torch.get_device_module(device.type).reset_peak_memory_stats()
             loss = a(x).sum()
             loss.backward()
-            return torch.get_device_module(device_type.type).max_memory_allocated()
+            return torch.get_device_module(device.type).max_memory_allocated()
 
         functional_no_reentrant = test(
             use_checkpointing=True, use_wrapper=False, use_reentrant=False
@@ -345,7 +345,7 @@ class CheckpointWrapperTest(TestCase):
             nn.Linear(10, 10),
             nn.Linear(10, 10),
             nn.Linear(10, 10),
-        ).to(device_type.type)
+        ).to(device.type)
 
         # Patch saved_tensor_hooks to make the unpack keep the tensor on CPU for
         # testing, otherwise the tensor access during the DFS will cause orig
@@ -364,7 +364,7 @@ class CheckpointWrapperTest(TestCase):
 
         model = offload_wrapper(model)
 
-        inp = torch.randn(3, 10, device=device_type.type)
+        inp = torch.randn(3, 10, device=device.type)
         loss = model(inp).sum()
 
         # All autograd saved tensors should be offloaded to CPU.
@@ -391,7 +391,7 @@ class CheckpointWrapperTest(TestCase):
 
         torch.autograd.graph.saved_tensors_hooks.__init__ = orig_init
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    @unittest.skipIf(not torch.accelerator.is_available(), "requires accelerator")
     def test_checkpoint_wrapper_with_block_mask(self):
         """Test that BlockMask can be passed through checkpoint_wrapper."""
         from torch.nn.attention.flex_attention import BlockMask, create_block_mask
@@ -414,8 +414,8 @@ class CheckpointWrapperTest(TestCase):
             def forward(self, x, mask):
                 return x * 2
 
-        model = checkpoint_wrapper(Block()).cuda()
-        x = torch.randn(4, 128, device="cuda")
+        model = checkpoint_wrapper(Block()).to(device.type)
+        x = torch.randn(4, 128, device=device.type)
         result = model(x, block_mask)
         self.assertEqual(result, x * 2)
 

--- a/test/distributed/fsdp/test_fsdp_grad_acc.py
+++ b/test/distributed/fsdp/test_fsdp_grad_acc.py
@@ -39,6 +39,8 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+
 
 @dataclass
 class _GradAccConfig:
@@ -133,7 +135,7 @@ class TestGradAcc(FSDPTestContinuous):
             deterministic=True,
             add_bn=False,  # disable BN since the test uses varying batch sizes
         )
-        device = torch.device("cuda")
+        device = torch.device(device_type)
         optim = torch.optim.SGD(
             fsdp_model.parameters(),
             lr=0.01,

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -935,8 +935,10 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
             def __init__(self, rank):
                 super().__init__()
                 self.rank = rank
-                self.a = nn.Linear(1, 1).cuda(self.rank)
-                self.b = nn.Linear(1, 1).cuda((self.rank + 1) % dist.get_world_size())
+                self.a = nn.Linear(1, 1).to(torch.device(device_type, self.rank))
+                self.b = nn.Linear(1, 1).to(
+                    torch.device(device_type, (self.rank + 1) % dist.get_world_size())
+                )
 
         with self.assertRaisesRegex(
             RuntimeError, "FSDP only supports single device modules"
@@ -969,7 +971,8 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
         context = (
             (
                 self.assertRaisesRegex(
-                    ValueError, f"Inconsistent.*cuda:{self.rank} vs cuda:0"
+                    ValueError,
+                    f"Inconsistent.*{device_type}:{self.rank} vs {device_type}:0",
                 )
             )
             if self.rank != 0
@@ -1151,7 +1154,7 @@ class TestFSDPMiscWorldSize1(FSDPTestMultiThread):
         with self.assertRaisesRegex(
             RuntimeError,
             "An FSDP-managed module unexpectedly has parameters on cpu. Make "
-            "sure to move the module to cuda:0 before training.",
+            f"sure to move the module to {device_type}:0 before training.",
         ):
             fsdp_model(inp)
 
@@ -1163,8 +1166,8 @@ class TestFSDPMiscWorldSize1(FSDPTestMultiThread):
         with self.assertRaisesRegex(
             RuntimeError,
             "An FSDP-managed module with parameter CPU offloading enabled has "
-            "parameters on cuda:0. Make sure to not move the module from CPU "
-            "when offloading parameters.",
+            f"parameters on {device_type}:0. Make sure to not move the module from "
+            "CPU when offloading parameters.",
         ):
             fsdp_model(inp)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -661,8 +661,12 @@ class ModuleWithDelay(FSDPTestModel):
     def get_loss(self, input, output):
         loss = self.module.get_loss(input, output)  # type: ignore[operator]
         if self.delay_after_loss_ms > 0:
-            if TEST_HPU or TEST_XPU:
+            if TEST_HPU:
                 time.sleep(self.delay_after_loss_ms / 1000)
+            elif TEST_XPU:
+                torch.xpu._sleep(
+                    int(self.delay_after_loss_ms * get_cycles_per_ms("xpu"))
+                )
             elif TEST_CUDA:
                 torch.cuda._sleep(int(self.delay_after_loss_ms * get_cycles_per_ms()))
 
@@ -677,7 +681,11 @@ class ModuleWithDelay(FSDPTestModel):
                     torch.cuda._sleep(
                         int(self.delay_before_reduction_ms * get_cycles_per_ms())
                     )
-                elif TEST_HPU or TEST_XPU:
+                elif TEST_XPU:
+                    torch.xpu._sleep(
+                        int(self.delay_before_reduction_ms * get_cycles_per_ms("xpu"))
+                    )
+                elif TEST_HPU:
                     time.sleep(self.delay_before_reduction_ms / 1000)
             return orig_reduce_scatter(*args, **kwargs)
 
@@ -810,7 +818,11 @@ class MixtureOfExperts(NestedWrappedModule):
                         torch.cuda._sleep(
                             int(self.delay_before_free_ms * get_cycles_per_ms())
                         )
-                    elif TEST_HPU or TEST_XPU:
+                    elif TEST_XPU:
+                        torch.xpu._sleep(
+                            int(self.delay_before_free_ms * get_cycles_per_ms("xpu"))
+                        )
+                    elif TEST_HPU:
                         time.sleep(self.delay_before_free_ms / 1000)
 
                     return orig_reshard(*args, **kwargs)


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU.
We will enable Intel GPU with following methods and keep the original code styles:

Example: "torch.accelerator.current_accelerator()" to determine the accelerator backend

enabled XPU for the following files:

1. test/distributed/fsdp/test_checkpoint_wrapper.py
2. test/distributed/fsdp/test_fsdp_grad_acc.py
3. test/distributed/fsdp/test_fsdp_misc.py
4. torch/testing/_internal/common_fsdp.py

cc @newtdms, @guangyey, @etaf, @CuiYifeng, @liangan1, @astachowiczhabana, @pbielak.