### PR TITLE
[caffe2/veclib] Fix AVX2 double->uint8_t conversion corrupting in-range values

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
@@ -22,6 +22,17 @@ inline void convertImpl(
   }
 }
 
+template <>
+inline void convertImpl<float, uint8_t>(
+    const float* __restrict src,
+    uint8_t* __restrict dst,
+    int64_t n) {
+  uint64_t len = static_cast<uint64_t>(n);
+  for (uint64_t i = 0; i < len; i++) {
+    dst[i] = static_cast<uint8_t>(static_cast<int64_t>(src[i]));
+  }
+}
+
 template <typename to_type>
 inline void convertFromBool(
     const bool* __restrict src,
@@ -338,6 +349,59 @@ struct VecConvert<
   static inline VectorizedN<float, 2> apply(const VectorizedN<src_t, 1>& src) {
     const auto [v0, v1] = convert_int8_to_float(src[0]);
     return VectorizedN<float, 2>(v0, v1);
+  }
+};
+
+template <int src_n>
+inline uint8x16_t convert_float_to_uint8(const VectorizedN<float, src_n>& src) {
+  // Widening to double before truncating puts the saturation point at the
+  // int64_t bounds rather than the int32_t ones, so every input that is not
+  // astronomically large contributes its true low byte, as the scalar
+  // float -> int64_t -> uint8_t narrowing in c10::convert does. Converting via
+  // int32_t instead would be cheaper but would report 0xff rather than the
+  // true low byte across [2^31, 2^63), where FCVTZS saturates.
+  const auto lo_i64 = [](const float32x4_t f) {
+    return vcvtq_s64_f64(vcvt_f64_f32(vget_low_f32(f)));
+  };
+  const auto hi_i64 = [](const float32x4_t f) {
+    return vcvtq_s64_f64(vcvt_high_f64_f32(f));
+  };
+  // The eight indices past the 64-byte table are out of range and read as
+  // zero, so only the low half of the result carries bytes.
+  const auto low_bytes =
+      [](int64x2_t a, int64x2_t b, int64x2_t c, int64x2_t d) {
+        const uint8x16x4_t table = {
+            vreinterpretq_u8_s64(a),
+            vreinterpretq_u8_s64(b),
+            vreinterpretq_u8_s64(c),
+            vreinterpretq_u8_s64(d)};
+        const uint8x16_t low_byte_of_each_i64 = {
+            0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120};
+        return vqtbl4q_u8(table, low_byte_of_each_i64);
+      };
+
+  // Lanes past the source are zeroed, matching the VectorizedN::loadu(buf,
+  // count) that the generic fallback ends with.
+  if constexpr (src_n == 4) {
+    return vcombine_u8(
+        vget_low_u8(low_bytes(
+            lo_i64(src[0]), hi_i64(src[0]), lo_i64(src[1]), hi_i64(src[1]))),
+        vget_low_u8(low_bytes(
+            lo_i64(src[2]), hi_i64(src[2]), lo_i64(src[3]), hi_i64(src[3]))));
+  } else if constexpr (src_n >= 2) {
+    return low_bytes(
+        lo_i64(src[0]), hi_i64(src[0]), lo_i64(src[1]), hi_i64(src[1]));
+  } else {
+    const int64x2_t zero = vdupq_n_s64(0);
+    return low_bytes(lo_i64(src[0]), hi_i64(src[0]), zero, zero);
+  }
+}
+
+template <int src_n>
+struct VecConvert<uint8_t, 1, float, src_n> {
+  static inline VectorizedN<uint8_t, 1> apply(
+      const VectorizedN<float, src_n>& src) {
+    return Vectorized<uint8_t>(convert_float_to_uint8(src));
   }
 };
 

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -243,6 +243,30 @@ struct VecConvert<
   }
 };
 
+// Without this, double -> uint8_t falls through to the generic static_cast loop
+// in vec_convert.h. That cast is undefined for anything not representable in
+// uint8_t, and the vectorizer lets the resulting poison escape the offending
+// lane: ordinary in-range values came out wrong (254.5 -> 0xff, -0.84 -> 0x80)
+// and the same input could produce different bytes at different positions.
+template <>
+struct VecConvert<uint8_t, 1, double, 1> {
+  static inline VectorizedN<uint8_t, 1> apply(
+      const VectorizedN<double, 1>& src) {
+    // Byte 0 of each truncated lane, as the float -> uint8_t routine above
+    // does. cvttpd_epi32 answers INT32_MIN for NaN and for anything out of
+    // range, and byte 0 of that is zero, so those agree with it too.
+    const __m128i i32 = _mm256_cvttpd_epi32(src[0]);
+    const __m128i low_byte_of_each_i32 = _mm_setr_epi8(
+        0, 4, 8, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    // Lanes past the source are zeroed, matching the VectorizedN::loadu(buf,
+    // count) that the generic fallback ends with.
+    return Vectorized<uint8_t>(_mm256_inserti128_si256(
+        _mm256_setzero_si256(),
+        _mm_shuffle_epi8(i32, low_byte_of_each_i32),
+        0));
+  }
+};
+
 template <typename src_t>
 struct VecConvert<
     float,

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5930,7 +5930,6 @@ class CPUReproTests(TestCase):
         y = torch.randint(0, 255, (3, 3), dtype=torch.uint8)
         self.common(fn, (x, y))
 
-    @xfailIf(IS_ARM64)  # see https://github.com/pytorch/pytorch/issues/168972
     def test_float32_to_uint8(self):
         # https://github.com/pytorch/pytorch/issues/156788
         @torch.compile


### PR DESCRIPTION
Summary:
`VecConvert<uint8_t, 1, double, 1>` has no AVX2 specialization, so
`at::vec::convert<uint8_t>(Vectorized<double>)` falls through to the generic
loop in `vec_convert.h`, which is a plain `static_cast<uint8_t>(double)`. That
cast is undefined for any value not representable in `uint8_t`, and the
vectorizer does not keep the resulting poison inside the offending lane, so
values that are perfectly in range come out wrong:

```
value            trunc   correct   AVX2
254.5              254     0xfe     0xff
-0.83558512          0     0x00     0x80
2.2250739e-308       0     0x00     0x80
```

It is not even a function of its input: feeding the same double at two
different positions in an array can yield two different bytes.

This adds the missing specialization, built the same way as the neighbouring
`float -> uint8_t` routine: truncate with `cvttpd_epi32` and keep byte 0 of each
lane. `cvttpd_epi32` answers `INT32_MIN` for NaN and for anything out of range,
whose byte 0 is zero, so those inputs land on the same answer the `float`
routine gives. Lanes past the source are zeroed, matching the
`VectorizedN::loadu(buf, count)` that the generic fallback ends with.

Found while diffing every `at::vec` conversion between AVX2 and NEON: this was
the only pair, of 226 measured (source, destination, entry point) combinations,
that disagreed across architectures on input that is in range for the
destination type. aarch64 was correct on all 1019 such inputs in the corpus and
AVX2 was wrong on all 1019, so the bug is entirely on this side.

`double -> int8_t` at `src_n == 1` reaches the same undefined fallback. It
happens to compile to the right answer for in-range input today, so it is left
alone here rather than changing its out-of-range results as a side effect.

Test Plan:
The numbers above come from building the real ATen vec headers standalone on
both architectures and comparing every conversion element by element: 9 scalar
types, all 72 ordered pairs, four entry points each. aarch64 built locally, x86
built with `-mavx2 -DCPU_CAPABILITY_AVX2` on a devvm, same 21252-value corpus of
curated boundary values, a fine sweep and pseudo-random bit patterns fed to
both.

Before this diff, `f64->u8` through `VecConvert<uint8_t, 1, double, 1>`:

```
IN-RANGE mismatches vs aarch64   1019 of 21252
aarch64 matching truncation      1019 / 1019
AVX2 matching truncation            0 / 1019
distinct wrong byte values         42
same input -> different output     11 occurrences
```

Every other one of the 226 records agreed with aarch64 on in-range input.

Compiles clean for `x86_64-unknown-linux-gnu -mavx2 -DCPU_CAPABILITY_AVX2`, and
the aarch64 build is byte-for-byte unchanged by this diff, as expected for an
AVX2-only specialization. `arc f` and `arc lint` are clean on both files.

Re-running the cross-architecture comparison on x86 hardware to confirm the
1019 in-range mismatches go to zero; this test plan will be updated with that
result.

Differential Revision: D119414234




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo