### PR TITLE
[CUDA] Skip grouped_mm u64 indexing on SM100 CUDA 13.0

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -42,7 +42,7 @@ from torch.testing._internal.common_dtype import (
     all_types, all_types_and_complex_and, floating_and_complex_types, integral_types,
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
-from torch.testing._internal.common_cuda import BF16X9_SUPPORTED, CDNA2OrLater, CDNA5OrLater, SM80OrLater, SM90OrLater, tf32_enabled, tf32_on_and_off, _get_magma_version, \
+from torch.testing._internal.common_cuda import BF16X9_SUPPORTED, CDNA2OrLater, CDNA5OrLater, IS_SM100, SM80OrLater, SM90OrLater, tf32_enabled, tf32_on_and_off, _get_magma_version, \
     _get_torch_cuda_version, TEST_MULTIGPU, PLATFORM_SUPPORTS_FP8, blas_library_context, ROCM_VERSION
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
@@ -11750,6 +11750,10 @@ class TestGroupedMM(TestCase):
 
     @onlyOn(["cuda", "mps"])
     @skipCUDAIf(not SM80OrLater, "Grouped gemm supported only on SM80 or greater")
+    @skipCUDAIf(
+        IS_SM100 and _get_torch_cuda_version() == (13, 0),
+        "CUDA 13.0 grouped_mm can cause an illegal memory access on SM100",
+    )
     @serialTest()
     @largeTensorTest("6GB")
     @largeMPSBufferTest((2**31 + 8) * torch.float16.itemsize)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196775

Human Notes:

Unable to repro on OSDC node w/`615.71.09` driver, even with downloaded build artefact
from PR with currently failing CI test...

Codex:

The CUDA 13.0 B200 smoke lane on driver 580.173.02 consistently faults with an illegal memory access in the grouped_mm u64 indexing test. The same CI wheel and cuBLAS 13.1.1.3 pass on driver 615.71.09, isolating this to the older CUDA driver stack.

Skip only the CUDA variant on SM100 when PyTorch is built with CUDA 13.0. MPS and other CUDA toolkit versions continue to exercise the test.

Test Plan:

```
python test/test_linalg.py TestGroupedMMCUDA.test_grouped_mm_u64_indexing_cuda_float16
```

Authored with assistance from OpenAI Codex.