### PR TITLE
[AOTI cuda graph S1][1/8] Guard empty codegened_graph stack

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -20,11 +20,10 @@ from itertools import chain, count
 from typing import Any, Literal, Protocol, TYPE_CHECKING
 
 import sympy
-from sympy import Expr
-
 import torch
 import torch._ops
 import torch.utils._pytree as pytree
+from sympy import Expr
 from torch import dtype as torch_dtype
 from torch._dynamo.utils import counters, dynamo_timed, get_debug_dir
 from torch._inductor.codegen.debug_utils import DebugPrinterManager
@@ -2305,6 +2304,12 @@ class PythonWrapperCodegen(CodeGen):
         return name
 
     def get_codegened_graph(self):
+        # With graph-partition / cuda-graph codegen, a partition body is codegened
+        # through a fresh subgraph wrapper whose codegened_graph_stack is never
+        # pushed, so allocation codegen here can run with an empty stack. Fall back
+        # to the active top-level GraphLowering instead of raising IndexError.
+        if not self.codegened_graph_stack:
+            return V.graph
         return self.codegened_graph_stack[-1]
 
     def push_codegened_graph(self, graph):
@@ -2473,7 +2478,9 @@ class PythonWrapperCodegen(CodeGen):
         return
 
     def generate_after_suffix(self, result: IndentedBuffer) -> None:
-        if config.graph_partition:
+        # Const graphs (runtime const folding) skip _codegen_partitions in
+        # Scheduler.codegen, so all_partition_names is unset for them.
+        if config.graph_partition and not V.graph.is_const_graph:
             all_partition_name_list = ", ".join(self.all_partition_names) + (
                 "," if len(self.all_partition_names) == 1 else ""
             )
@@ -3259,17 +3266,20 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_alloc_from_pool(
         self, name, offset, dtype, shape, stride
     ) -> tuple[str, list[str]]:
-        return "alloc_from_pool({})".format(
-            ", ".join(
-                [
-                    name,
-                    pexpr(offset),  # bytes not numel
-                    str(dtype),
-                    self.codegen_python_shape_tuple(shape),
-                    self.codegen_python_shape_tuple(stride),
-                ]
-            )
-        ), []
+        return (
+            "alloc_from_pool({})".format(
+                ", ".join(
+                    [
+                        name,
+                        pexpr(offset),  # bytes not numel
+                        str(dtype),
+                        self.codegen_python_shape_tuple(shape),
+                        self.codegen_python_shape_tuple(stride),
+                    ]
+                )
+            ),
+            [],
+        )
 
     def codegen_reinterpret_view(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* #196835
* #196785
* #196784
* #196783
* #196782
* #196781
* #196780
* #196779
* __->__ #196778

`PythonWrapperCodegen.get_codegened_graph()` indexed `codegened_graph_stack[-1]` and raised `IndexError` when the stack was empty. The production trace path (`trace_aot_inductor_module=True`) with cuda-graph codegen reaches the outer allocation codegen with an empty stack, so this guards the empty case by falling back to `V.graph`. The fix is independent of the cuda-graph feature flags: on every normal path the stack is non-empty, so the guard branch is never taken and behavior is byte-identical.

Bottom of the **Step 1** stack for AOTI cuda graph. Step 1 captures the WHOLE AOTI-lowered component as a single cuda graph, with on-demand re-capture per dynamic shape. Step 2 (a later stack) adds graph partitioning, static memory planning and partition transitions on top.

Both steps re-split work previously reviewed as D104683973 / D109083080 / D109083079 and drafted as D111062961..D111062962. Those originals are preserved unchanged.

Authored with Claude.

Differential Revision: [D118228071](https://our.internmc.facebook.com/intern/diff/D118228071/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo