### PR TITLE
[AOTI cuda graph S1][2/8] Config: cudagraph_mode + capture cap

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2422,6 +2422,40 @@ class aot_inductor:
     # flag to decide whether to create a submodule for constant graph.
     use_runtime_constant_folding: bool = False
 
+    # CUDA graph mode for AOTI.
+    #
+    #   "off"      -- no cuda graph (default).
+    #   "whole"    -- capture the ENTIRE lowered component as a single cuda
+    #                 graph, re-capturing on demand for each distinct dynamic
+    #                 shape. Requires the whole graph to be capture-safe;
+    #                 lowering hard-errors listing every offending node if it
+    #                 is not.
+    #   "regional" -- partition the graph and capture only eligible regions.
+    #                 Added by the follow-up stack; rejected here.
+    #
+    # Defaults to "off" because "whole" fails the lowering outright on a model
+    # containing anything uncapturable, rather than silently running
+    # uncaptured. It is therefore opted into per model (via
+    # aot_inductor_config) once that model is known to be clean.
+    cudagraph_mode: Literal["off", "whole", "regional"] = os.environ.get(
+        "AOT_INDUCTOR_CUDAGRAPH_MODE", "off"
+    )  # type: ignore[assignment]
+
+    # Maximum number of distinct dynamic shapes captured per model instance.
+    # Every capture reserves memory in that instance's private graph pool, so an
+    # unbounded count lets a model with a variable serving batch reserve without
+    # limit. Past the cap a request at a new shape runs UNCAPTURED -- correct,
+    # just without the launch saving -- and warns once. Raise it for models with
+    # many hot shapes; lower it to cap upfront GPU reservation.
+    #
+    # This is only the DEFAULT baked into the generated .so. The same env var
+    # read here is re-read at serving time by AOTICUDAGraphManager and wins
+    # over the baked value, so an already-published model can be retuned (or,
+    # with 0, have cuda graph switched off) without re-lowering.
+    cudagraph_max_captures: int = int(
+        os.environ.get("AOT_INDUCTOR_CUDAGRAPH_MAX_CAPTURES", "64")
+    )
+
     # flag to force weight to be appended to the shared library and mapped by the runtime
     # rather than embedded into the data section. Needed to support 1B+ parameter models
     force_mmap_weights: bool = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* #196835
* #196785
* #196784
* #196783
* #196782
* #196781
* #196780
* __->__ #196779
* #196778

Adds the two settings Step 1 needs, and nothing else.

`aot_inductor.cudagraph_mode` is a three-state knob (`"off"` / `"whole"` / `"regional"`) rather than a bool, so the Step 2 stack can add regional capture without changing what an existing `"whole"` config means. Step 1 implements `"off"` and `"whole"`; `"regional"` is rejected until Step 2 lands.

Default is `"off"`. Under `"whole"`, a model containing anything uncapturable fails to lower (see [5/8]) instead of silently running uncaptured, so it is opted into per model via `aot_inductor_config` once that model is known to be clean.

`aot_inductor.cudagraph_max_captures` (default 64) bounds how many distinct dynamic shapes one model instance captures. Every capture reserves memory in that instance's private graph pool, so an uncapped count lets a variable-batch model reserve without limit. Past the cap a new shape runs uncaptured -- correct, just without the launch saving -- and warns once.

The value set here is only the DEFAULT baked into the generated `.so`. `cudagraph_max_captures` is the one `cudagraph_*` knob that is also a plain runtime value, so `AOT_INDUCTOR_CUDAGRAPH_MAX_CAPTURES` is re-read by the serving process and wins over the baked default (see [4/8]). The right cap depends on host memory headroom and the live shape distribution, neither of which is known at lowering time. Setting it to `0` at serving time is a cuda-graph kill switch for an already-published model.

No `compile_fx` change is needed here. Whole-graph capture wants a single generated body, which is already what AOTI produces (`graph_partition` is forced off for `cpp_wrapper` / `aot_mode`), and it does not need `memory_planning` because intermediates are allocated inside the capture and live in the graph pool. Both of those become necessary for regional capture and are introduced in Step 2.

Authored with Claude.

Differential Revision: [D118228072](https://our.internmc.facebook.com/intern/diff/D118228072/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo