### PR TITLE
[AOTI cuda graph S1][3/8] C ABI shims

### DIFF
--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -620,6 +620,84 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_caching_allocator_raw_alloc(
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_cuda_caching_allocator_raw_delete(void* ptr);
 
+struct AOTICudaGraphOpaque;
+using AOTICudaGraphHandle = AOTICudaGraphOpaque*;
+
+// Create/destroy a per-manager (per-AOTInductorModel) graph pool handle: an
+// opaque owner of one PRIVATE graph mempool + capture stream. Each tree manager
+// creates one in its constructor and destroys it in its destructor, so concurrent
+// model instances in a model_container are fully isolated (no shared pool/stream).
+// destroy_handle also reclaims the pool (releasePool) and clears the stream's
+// cuBLAS workspace. The cuda-graph functions below operate on this handle's pool.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_pool_create(int32_t device_index, void** ret_handle);
+
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_pool_destroy_handle(void* pool_handle);
+
+// Process-global capture lock: the tree runtime serializes record_node across
+// concurrent model instances (cuda-graph capture is unsafe to interleave on a
+// device). Replay (the hot path) never takes it.
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_capture_lock();
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_capture_unlock();
+// Shared (read) lock for replay + output reconstruction (concurrent across
+// instances; excluded only while some instance holds the exclusive capture lock).
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_replay_lock();
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_replay_unlock();
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_create(
+    AOTICudaGraphHandle* ret_handle,
+    void* pool_handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_begin_capture(
+    AOTICudaGraphHandle handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_end_capture(
+    AOTICudaGraphHandle handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_replay(
+    AOTICudaGraphHandle handle);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_get_stream(
+    AOTICudaGraphHandle handle,
+    void** ret_stream);
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_destroy(
+    AOTICudaGraphHandle handle);
+
+// Materialize the (empty) private graph pool so releasePool at teardown has a
+// real pool to release even when no partition is ever captured, and so the
+// manager's matching pool use ref balances the destructor's drop. Operates on
+// the caller's per-manager pool handle (aoti_torch_cuda_graph_pool_create).
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cuda_graph_pool_ensure_created(
+    void* pool_handle);
+
+// Synchronize the device and order the shared capture stream after the caller's
+// stream before recording a partition (mirrors cudagraph_trees' pre-record
+// synchronize + wait_stream). Required because all partitions share one capture
+// stream and one cuBLAS workspace slot.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_sync_before_record(int32_t device_index);
+
+// Clear cuBLAS's per-(handle,stream) workspace cache. cuBLAS workspaces are
+// caching-allocator allocations that land in the graph pool during capture; the
+// runtime clears them after each capture (mirroring cudagraph_trees'
+// clear_cublas_manager) so teardown does not double-free a block the cuBLAS
+// workspace map still references.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_clear_cublas_workspaces(void* pool_handle);
+
+// Debug instrumentation: total in-use GPU bytes (total - free) on the device.
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cuda_graph_device_used_bytes(int32_t device_index, int64_t* ret_bytes);
+
+// Neutralize a tensor's storage deleter so destroying the handle does NOT free
+// the underlying graph-pool block (the captured graph still references that
+// address). The pool is freed wholesale via aoti_torch_cuda_graph_pool_destroy_handle
+// at teardown. This is the AOTI analog of cudagraph_trees' removeStorageDeleterFns.
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_storage_set_noop_deleter(
+    AtenTensorHandle tensor);
+
 #endif // USE_CUDA
 
 // See `ProxyExecutor Design Note` in ir.py for more details

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -532,6 +532,13 @@ AOTITorchError aoti_torch_create_tensor_from_blob(
                                 .strides(strides)
                                 .storage_offset(storage_offset)
                                 .options(options)
+                                // Set the device explicitly so make_tensor()
+                                // skips getDeviceFromPtr (cudaPointerGetAttributes):
+                                // that driver query is illegal during CUDA graph
+                                // capture and a needless round-trip on the hot
+                                // path. The device is caller-provided and already
+                                // required to match opts above.
+                                .target_device(device)
                                 .make_tensor()
                           : at::empty_strided(sizes, strides, options));
   });

--- a/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cuda.cpp
@@ -2,9 +2,106 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGraph.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+
+#include <shared_mutex>
+
+namespace {
+// No-op deleter: leaves the underlying graph-pool block alone so destroying a
+// captured tensor handle does not free a block the captured graph still
+// references. Such blocks are reclaimed wholesale via releasePool at teardown.
+void noopDeleter(void*) {}
+
+// Per-manager (per-AOTInductorModel) graph state: a PRIVATE graph mempool plus a
+// single capture stream. Each AOTInductorModel instance owns one (created via
+// aoti_torch_cuda_graph_pool_create, freed via ..._pool_destroy_handle), so
+// concurrent instances in a model_container never share pool memory or a capture
+// stream -- full isolation. Mirrors cudagraph_trees' per-tree-manager pool +
+// self.stream. One capture stream per manager keeps a SINGLE cuBLAS workspace
+// (keyed by (handle,stream)) for all of that manager's captures, avoiding
+// per-node-stream workspace bloat; replay is stream-independent so this stream
+// only affects recording.
+struct AOTICudaGraphPool {
+  c10::cuda::MempoolId_t pool;
+  c10::cuda::CUDAStream stream;
+  int32_t device_index;
+  explicit AOTICudaGraphPool(int32_t dev)
+      : pool(at::cuda::graph_pool_handle()),
+        stream(c10::cuda::getStreamFromPool(false, dev)),
+        device_index(dev) {}
+};
+
+// One captured graph, bound to its manager's pool (borrowed, not owned).
+struct AOTICudaGraphContext {
+  at::cuda::CUDAGraph graph;
+  std::unique_ptr<c10::cuda::CUDAStreamGuard> stream_guard;
+  AOTICudaGraphPool* pool;
+
+  explicit AOTICudaGraphContext(AOTICudaGraphPool* p) : pool(p) {}
+};
+
+// Process-global READER-WRITER lock coordinating cuda-graph capture vs replay
+// across all manager instances on a device. CAPTURE takes it EXCLUSIVE (write);
+// REPLAY + output reconstruction take it SHARED (read). Two reasons concurrency
+// here is unsafe: (1) the caching allocator's per-device capture bookkeeping
+// (markCaptureBegin/beginAllocateToPool/...) and device-global capture state
+// can't interleave across instances; (2) while one instance captures, another
+// instance's replay must NOT run capture-unsafe CUDA queries -- output
+// reconstruction calls getDeviceFromPtr (cudaPointerGetAttributes), which faults
+// during a concurrent capture. So: at most one capture at a time AND no replay
+// during a capture, but MANY replays run concurrently (shared). Capture is rare
+// (warmup); steady-state serving only ever takes the shared lock, so concurrent
+// inference across instances stays parallel.
+std::shared_mutex& captureMutex() {
+  static std::shared_mutex m;
+  return m;
+}
+} // namespace
+
+AOTITorchError aoti_torch_cuda_graph_pool_create(
+    int32_t device_index,
+    void** ret_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(
+      { *ret_handle = new AOTICudaGraphPool(device_index); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_pool_destroy_handle(void* handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* p = reinterpret_cast<AOTICudaGraphPool*>(handle);
+    // Drop this manager's capture-stream cuBLAS workspace BEFORE releasing the
+    // pool (matching CUDAGraph::reset order): releasePool frees the pool segments
+    // once use_count hits 0, so clearing the workspace afterwards would free an
+    // already-freed block. Per-stream, so a concurrent manager is untouched.
+    at::cuda::clearCublasWorkspacesForStream(p->stream.stream());
+    c10::cuda::CUDACachingAllocator::releasePool(
+        static_cast<c10::DeviceIndex>(p->device_index), p->pool);
+    delete p;
+  });
+}
+
+// Acquire/release the process-global capture/replay lock (see captureMutex). The
+// tree runtime wraps record_node in capture_lock/unlock (EXCLUSIVE write) and
+// wraps replay + output reconstruction in replay_lock/unlock (SHARED read).
+AOTITorchError aoti_torch_cuda_graph_capture_lock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().lock(); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_capture_unlock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().unlock(); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_replay_lock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().lock_shared(); });
+}
+
+AOTITorchError aoti_torch_cuda_graph_replay_unlock() {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({ captureMutex().unlock_shared(); });
+}
 
 AOTITorchError aoti_torch_create_cuda_guard(
     int32_t device_index,
@@ -81,5 +178,132 @@ AOTITorchError aoti_torch_cuda_caching_allocator_raw_delete(void* ptr) {
     if (ptr != nullptr) {
       c10::cuda::CUDACachingAllocator::raw_delete(ptr);
     }
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_create(
+    AOTICudaGraphHandle* ret_handle,
+    void* pool_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = new AOTICudaGraphContext(
+        reinterpret_cast<AOTICudaGraphPool*>(pool_handle));
+    *ret_handle = reinterpret_cast<AOTICudaGraphHandle>(ctx);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_begin_capture(
+    AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    auto stream = ctx->pool->stream;
+    stream.synchronize();
+    ctx->stream_guard = std::make_unique<c10::cuda::CUDAStreamGuard>(stream);
+    // ThreadLocal (not the default Global) capture mode: serialized against other
+    // captures by the global capture lock, this avoids disrupting other model
+    // instances' concurrent replays on other threads.
+    ctx->graph.capture_begin(ctx->pool->pool, cudaStreamCaptureModeThreadLocal);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_end_capture(
+    AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    ctx->graph.capture_end();
+    ctx->stream_guard.reset();
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_replay(AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    ctx->graph.replay();
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_get_stream(
+    AOTICudaGraphHandle handle,
+    void** ret_stream) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto* ctx = reinterpret_cast<AOTICudaGraphContext*>(handle);
+    *(cudaStream_t*)(ret_stream) = ctx->pool->stream.stream();
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_destroy(AOTICudaGraphHandle handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    delete reinterpret_cast<AOTICudaGraphContext*>(handle);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_pool_ensure_created(void* pool_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    // Materialize this manager's PrivatePool (empty) so releasePool at teardown
+    // has a real pool to release even when no partition is ever captured, and so
+    // the constructor's matching pool use ref balances the destructor's drop. A
+    // no-op begin/end allocation scope creates the pool via create_or_incref_pool
+    // without allocating anything. This adds one pool use ref (only raises
+    // use_count, never drives it negative), so the pool may stay reserved until
+    // process exit; harmless for inference.
+    auto* p = reinterpret_cast<AOTICudaGraphPool*>(pool_handle);
+    auto dev = static_cast<c10::DeviceIndex>(p->device_index);
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        dev, p->pool, [](cudaStream_t) { return false; });
+    c10::cuda::CUDACachingAllocator::endAllocateToPool(dev, p->pool);
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_sync_before_record(int32_t device_index) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    // Mirror cudagraph_trees' pre-record torch.cuda.synchronize(). The single
+    // shared capture stream means every partition reuses one cuBLAS workspace
+    // slot; without ordering, a previous partition's first-replay on the caller's
+    // stream and this partition's warmup/capture on the capture stream would race
+    // on that workspace. A full device sync serializes all prior work before we
+    // touch the pool or capture, which subsumes ordering the capture stream after
+    // the caller's stream (everything is idle afterward). Recording-only.
+    c10::cuda::CUDAGuard guard(static_cast<c10::DeviceIndex>(device_index));
+    C10_CUDA_CHECK(cudaDeviceSynchronize());
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_clear_cublas_workspaces(void* pool_handle) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    // Drop this manager's capture-stream cuBLAS workspace after capture. cuBLAS
+    // allocates its matmul workspace through the caching allocator, so during
+    // capture it lands in the graph pool and is tracked in a per-(handle,stream)
+    // global map. Clearing this stream's entry stops the map from referencing a
+    // block that teardown frees, which would double-free at teardown
+    // (CUDAGraph::reset -> clearCublasWorkspacesForStream). Per-stream (not the
+    // global clear) so a concurrent manager's workspace is left intact. Mirrors
+    // cudagraph_trees' clear_cublas_manager (clear after each recording).
+    auto* p = reinterpret_cast<AOTICudaGraphPool*>(pool_handle);
+    at::cuda::clearCublasWorkspacesForStream(p->stream.stream());
+  });
+}
+
+AOTITorchError aoti_torch_cuda_graph_device_used_bytes(
+    int32_t device_index,
+    int64_t* ret_bytes) {
+  // Debug/instrumentation only: total GPU bytes in use on the device
+  // (total - free). On an otherwise-idle benchmark GPU this reflects this
+  // process's reservation, so the delta across recorded shapes isolates the
+  // graph-pool growth (the cross-shape memory-sharing signal).
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    c10::cuda::CUDAGuard guard(device_index);
+    size_t free_bytes = 0;
+    size_t total_bytes = 0;
+    C10_CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
+    *ret_bytes = static_cast<int64_t>(total_bytes - free_bytes);
+  });
+}
+
+AOTITorchError aoti_torch_storage_set_noop_deleter(AtenTensorHandle tensor) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    at::Tensor* t = reinterpret_cast<at::Tensor*>(tensor);
+    c10::DataPtr& data_ptr =
+        t->storage().unsafeGetStorageImpl()->mutable_data_ptr();
+    // expected == current deleter, so the swap always succeeds; ignore result.
+    (void)data_ptr.compare_exchange_deleter(data_ptr.get_deleter(), &noopDeleter);
   });
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* #196835
* #196785
* #196784
* #196783
* #196782
* #196781
* __->__ #196780
* #196779
* #196778

The C ABI foundation for the AOTI cuda-graph runtime: `shim.h` declares the opaque `AOTICudaGraphHandle` type and the cuda-graph shim entry points (pool lifetime, capture/replay locks, capture/replay, workspace/device helpers); `shim_cuda.cpp` implements them against ATen/c10 (with local `AOTICudaGraphPool` / `AOTICudaGraphContext` helpers); `shim_common.cpp` adds `target_device` to the create-tensor-from-blob path so it skips the capture-illegal `getDeviceFromPtr`. Also wires `:benchmark_lowered_utils` into the benchmark BUCK target.

These are additive ABI symbols with no callers yet -- the runtime that uses them lands in [4/8]. `shim_cuda.cpp` does not depend on the runtime header, so this stands alone as a foundation.

Unchanged from the original D111062964: every shim here is needed for whole-graph capture too, so this diff is carried across the Step 1 / Step 2 re-split verbatim.

Authored with Claude.

Differential Revision: [D118228073](https://our.internmc.facebook.com/intern/diff/D118228073/)