### PR TITLE
[AOTI cuda graph S1][6/8] Codegen: capture the whole run_impl body

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -13,7 +13,6 @@ from itertools import chain, count
 from typing import Any, Literal, TYPE_CHECKING
 
 import sympy
-
 import torch
 import torch._higher_order_ops.torchbind
 import torch._inductor.async_compile
@@ -1622,9 +1621,21 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar}));"
             )
 
+    def _output_array_name(self) -> str:
+        """Name of the C array `generate_return` writes results into.
+
+        Normally the entry point's `output_handles` parameter. The GPU
+        whole-graph cuda-graph wrapper redirects it to the capture lambda's
+        `out` parameter, whose contents the runtime records and then hands back
+        as views -- the body's local RAII handles are not visible outside the
+        lambda, so it cannot write `output_handles` directly.
+        """
+        return "output_handles"
+
     def generate_return(self, output_refs: list[str]):
         cst_names = V.graph.constants.keys()
         output2idx: dict[str, int] = {}
+        out_arr = self._output_array_name()
 
         # If any output ref represents an rvalue tensor, materialize it to an lvalue
         # RAIIAtenTensorHandle first.  This prevents situations where the code for the
@@ -1654,7 +1665,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 # Need to wrap scalar into tensor as the main function returns a vector of tensors
                 output_tensor = self.codegen_scalar_to_tensor(output)
                 self.wrapper_call.writeline(
-                    f"output_handles[{idx}] = {output_tensor}.release();"
+                    f"{out_arr}[{idx}] = {output_tensor}.release();"
                 )
                 continue
 
@@ -1662,17 +1673,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 # See NOTE(return_constant) above.
                 self.wrapper_call.writeline(
                     "AOTI_TORCH_ERROR_CODE_CHECK("
-                    f"aoti_torch_clone({output}, &output_handles[{idx}]));"
+                    f"aoti_torch_clone({output}, &{out_arr}[{idx}]));"
                 )
             else:
                 if output in output2idx:
                     src_idx = output2idx[output]
                     self.wrapper_call.writeline(
-                        f"output_handles[{idx}] = output_handles[{src_idx}];"
+                        f"{out_arr}[{idx}] = {out_arr}[{src_idx}];"
                     )
                 else:
                     self.wrapper_call.writeline(
-                        f"output_handles[{idx}] = {output}.release();"
+                        f"{out_arr}[{idx}] = {output}.release();"
                     )
 
             if output not in output2idx:

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -7,15 +7,14 @@ import re
 import sys
 from itertools import count, zip_longest
 from typing import Any, cast
-from typing_extensions import Self
 
 import sympy
-
 import torch
 from torch import dtype as torch_dtype
 from torch._inductor.codecache import get_cpp_wrapper_cubin_path_name
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch.utils._ordered_set import OrderedSet
+from typing_extensions import Self
 
 from .. import config
 from ..codecache import CudaKernelParamCache
@@ -1174,6 +1173,187 @@ class CppWrapperGpu(CppWrapperCpu):
             self.header.splice_jit(kernel_driver)
         else:
             self.header.splice(kernel_driver)
+        if self._cudagraph_whole_enabled():
+            # Whole-graph cuda-graph runtime: one capture per dynamic shape over
+            # a per-instance private pool. See cudagraph_runtime.h.
+            self.header.splice(
+                """
+                #include <cstring>
+                #include <torch/csrc/inductor/aoti_runtime/cudagraph_runtime.h>
+                namespace {
+                // Bit-exact int64 view of a double, for the shape key. A scalar
+                // graph input is read on the host and baked into captured kernel
+                // arguments, so two calls may share a capture only if the scalar
+                // is bit-identical -- a lossy numeric cast could alias two
+                // different values onto one graph.
+                inline int64_t aoti_cg_key_bits(double v) {
+                  int64_t bits = 0;
+                  std::memcpy(&bits, &v, sizeof(bits));
+                  return bits;
+                }
+                } // namespace
+                """
+            )
+
+    def _cudagraph_whole_enabled(self) -> bool:
+        """True when this wrapper should capture its whole body as one cuda graph.
+
+        Mode validity is checked once in `Scheduler._check_cudagraph_mode`; the
+        extra conditions here are the ones only codegen can see. Const graphs
+        (`_const_run_impl`) have no input/output handle arrays to capture around,
+        and are run once at load, so they are simply excluded rather than an
+        error.
+        """
+        if config.aot_inductor.cudagraph_mode != "whole":
+            return False
+        if not V.graph.aot_mode or V.graph.is_const_graph:
+            return False
+        if V.graph.is_dual_wrapper_mode:
+            raise RuntimeError(
+                'config.aot_inductor.cudagraph_mode="whole" is not supported in '
+                "dual-wrapper mode, which emits a JIT entry point alongside the "
+                "AOTI one; only the AOTI body can be captured. Set cudagraph_mode "
+                'to "off" for dual-wrapper builds.'
+            )
+        return True
+
+    def _cudagraph_input_spec(self):
+        """(tensor input names, scalar input names) in graph-input order.
+
+        Scalars are the sympy.Expr inputs, which `_write_input_unpacking` reads
+        into plain C++ locals. They belong in the shape key because their value
+        is baked into captured kernel arguments.
+
+        Anything else (TorchBindObject, GeneratorState, OpaqueObjectState) is a
+        Python-level input with no capturable representation, so it is rejected
+        rather than silently dropped from the key.
+        """
+        tensor_names: list[str] = []
+        scalar_names: list[str] = []
+        for name, value in V.graph.graph_inputs.items():
+            if isinstance(value, sympy.Expr):
+                scalar_names.append(name)
+            elif isinstance(value, TensorBox):
+                tensor_names.append(name)
+            else:
+                raise RuntimeError(
+                    'config.aot_inductor.cudagraph_mode="whole" cannot capture a '
+                    f"graph with the Python-level input {name!r} of type "
+                    f"{type(value).__name__}, whose value cannot be part of the "
+                    "capture key."
+                )
+        return tensor_names, scalar_names
+
+    def _output_array_name(self) -> str:
+        if getattr(self, "_cg_in_capture_lambda", False):
+            return "out"
+        return super()._output_array_name()
+
+    def write_wrapper_decl(self):
+        super().write_wrapper_decl()
+        if self._cudagraph_whole_enabled():
+            self._codegen_cudagraph_prologue()
+
+    def _codegen_cudagraph_prologue(self) -> None:
+        """Open the capture: build the key and the handle arrays, then start the
+        lambda that the rest of run_impl is emitted into.
+
+        Runs at the end of write_wrapper_decl, so input unpacking and symbol
+        reads have already happened on the host and are OUTSIDE the capture --
+        only device work ends up inside it.
+        """
+        code = self.prefix
+        tensor_names, scalar_names = self._cudagraph_input_spec()
+        num_ins = len(tensor_names)
+        # Sized here but written by generate_return, which is driven by
+        # get_output_refs(). The epilogue re-checks the two agree: a mismatch
+        # would write past __cg_outputs rather than fail visibly.
+        num_outs = len(V.graph.graph_outputs)
+        self._cg_num_outputs = num_outs
+
+        code.writeline("if (!this->cudagraph_mgr_) {")
+        code.writeline(
+            "  this->cudagraph_mgr_ = std::make_unique<"
+            "torch::aot_inductor::AOTICUDAGraphManager>(this->device_idx_, "
+            f"{config.aot_inductor.cudagraph_max_captures});"
+        )
+        code.writeline("}")
+
+        # Key on every input dim plus every scalar input value: two calls share a
+        # capture exactly when their inputs have identical shapes and scalars,
+        # which is precisely when replaying the same graph is valid. Keying on
+        # the dynamic symbols instead would miss a scalar input, whose value is
+        # baked into captured kernel args.
+        code.writeline("std::vector<int64_t> __cg_shape_key;")
+        for name in tensor_names:
+            ndim = len(V.graph.graph_inputs[name].get_size())
+            if ndim:
+                code.writeline(f"{{ const int64_t* __s = {name}.sizes();")
+                code.writeline(
+                    f"  __cg_shape_key.insert(__cg_shape_key.end(), __s, __s + {ndim}); }}"
+                )
+        for name in scalar_names:
+            # An integer scalar goes in verbatim; anything else is a double
+            # local, which must go in bit-exact (see aoti_cg_key_bits).
+            if V.graph.graph_inputs[name].is_integer:
+                code.writeline(
+                    f"__cg_shape_key.push_back(static_cast<int64_t>({name}));"
+                )
+            else:
+                code.writeline(f"__cg_shape_key.push_back(aoti_cg_key_bits({name}));")
+
+        handles = ", ".join(f"{name}.get()" for name in tensor_names)
+        code.writeline(
+            f"AtenTensorHandle __cg_inputs[] = {{{handles}}};"
+            if num_ins
+            else "AtenTensorHandle* __cg_inputs = nullptr;"
+        )
+        code.writeline(f"AtenTensorHandle __cg_outputs[{max(num_outs, 1)}] = {{}};")
+        # Every input is staged (there is no earlier capture to chain from) and
+        # every output escapes to the caller.
+        copy_in = "std::vector<int32_t>{" + ", ".join(map(str, range(num_ins))) + "}"
+        escape = "std::vector<int32_t>{" + ", ".join(map(str, range(num_outs))) + "}"
+        code.writeline(
+            f"this->cudagraph_mgr_->run_graph(__cg_shape_key, __cg_inputs, "
+            f"{num_ins}, __cg_outputs, {num_outs}, {copy_in}, {escape}, "
+            "(void*)stream, "
+            "[&](AtenTensorHandle* in, AtenTensorHandle* out, void* cs) {"
+        )
+        # Kernels read the `stream` variable; point it at the capture stream for
+        # the duration of the body and restore it in the epilogue.
+        code.writeline("  auto __cg_saved_stream = stream;")
+        code.writeline("  stream = reinterpret_cast<decltype(stream)>(cs);")
+        # Shadow each input local with the runtime's staged slot, so captured
+        # kernels bake the slot address (refreshed per replay) instead of the
+        # caller's handle, which is a different allocation on every call.
+        for i, name in enumerate(tensor_names):
+            code.writeline(f"  RAIIAtenTensorHandle {name}(in[{i}]);")
+
+    def _codegen_cudagraph_epilogue(self, num_outs: int) -> None:
+        """Close the capture lambda and publish the recorded output views."""
+        sized = getattr(self, "_cg_num_outputs", None)
+        if sized != num_outs:
+            raise RuntimeError(
+                f"AOTI cuda graph: __cg_outputs was sized for {sized} outputs "
+                f"but generate_return produced {num_outs}. Writing them would "
+                "overrun the array."
+            )
+        self.wrapper_call.writeline("stream = __cg_saved_stream;")
+        self.wrapper_call.writeline("});")
+        for idx in range(num_outs):
+            self.wrapper_call.writeline(f"output_handles[{idx}] = __cg_outputs[{idx}];")
+
+    def generate_return(self, output_refs: list[str]):
+        if not self._cudagraph_whole_enabled():
+            return super().generate_return(output_refs)
+        # Inside the lambda the body's RAII handles are local, so results go to
+        # the lambda's `out` array; the epilogue copies them to output_handles.
+        self._cg_in_capture_lambda = True
+        try:
+            super().generate_return(output_refs)
+        finally:
+            self._cg_in_capture_lambda = False
+        self._codegen_cudagraph_epilogue(len(output_refs))
 
     def _generate(self, is_inference):
         # Per-Run()-function state, reset each generation. Do NOT reset


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* #196835
* #196785
* #196784
* __->__ #196783
* #196782
* #196781
* #196780
* #196779
* #196778

Activates whole-graph capture. `CppWrapperGpu` wraps the entire generated `run_impl` body in one `run_graph` call, so a forward is a single `cudaGraphLaunch` once its shape has been captured.

Where the seam goes. The prologue is emitted at the end of `write_wrapper_decl`, which is after input unpacking and symbol reads -- so all host-side work (reading input dims, computing symbols, the `aoti_torch_item_*` device-to-host reads for scalar inputs) stays OUTSIDE the capture, and only device work lands inside it. The epilogue closes the lambda at the end of `generate_return`.

Three details worth review:

1. THE SHAPE KEY IS EVERY INPUT DIM PLUS EVERY SCALAR INPUT VALUE, not the list of dynamic symbols. Two calls may share a capture exactly when replaying the same graph is valid, which is when their input shapes AND scalar inputs match. Keying on dynamic symbols alone would miss a scalar graph input, whose value is read on the host and then baked into captured kernel arguments -- a second call with a different scalar would silently replay the first call's constant. Scalars that are not integers go in bit-exact via `aoti_cg_key_bits`, because a lossy numeric cast could alias two different values onto one graph. A Python-level input (TorchBindObject, GeneratorState, OpaqueObjectState) has no representation in the key, so it is rejected rather than dropped.

2. INPUT LOCALS ARE SHADOWED INSIDE THE LAMBDA. `RAIIAtenTensorHandle arg0_1(in[0]);` re-binds each input name to the runtime's staged slot, so captured kernels bake the slot address -- which the runtime refreshes per replay -- rather than the caller's handle, which is a fresh allocation on every call. The body is otherwise emitted unchanged.

3. OUTPUTS GO THROUGH THE LAMBDA. The body's RAII handles are local to the lambda, so `generate_return` cannot assign `output_handles` directly. `CppWrapperCpu.generate_return` now writes to `self._output_array_name()` (still `output_handles` by default, one-line indirection, no behavior change off this path) and the GPU wrapper points it at the lambda's `out` while the body is emitted. The epilogue then copies the runtime's recorded views into `output_handles`.

The epilogue also re-checks that the number of outputs `generate_return` produced matches what the prologue sized `__cg_outputs` for. The two come from different sources (`V.graph.graph_outputs` vs `get_output_refs()`), and a divergence would write past the array instead of failing visibly.

Const graphs (`_const_run_impl`) are excluded: they have no handle arrays to capture around and run once at load. Dual-wrapper mode is rejected, since only the AOTI body of the two emitted entry points could be captured.

Authored with Claude.

Differential Revision: [D118228076](https://our.internmc.facebook.com/intern/diff/D118228076/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo