### PR TITLE
[AOTI cuda graph S1][7/8] Thread-aware pinned execution

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -259,6 +259,43 @@ AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
   return AOTI_RUNTIME_SUCCESS;
 })
 
+AOTIRuntimeError AOTInductorModelContainerRunPinned(
+    AOTInductorModelContainerHandle container_handle,
+    size_t model_idx,
+    AtenTensorHandle* input_handles, // array of input AtenTensorHandle; handles
+                                     // are stolen; the array itself is borrowed
+    size_t num_inputs,
+    AtenTensorHandle*
+        output_handles, // array for writing output AtenTensorHandle; handles
+                        // will be stolen by the caller; the array itself is
+                        // borrowed
+    size_t num_outputs,
+    AOTInductorStreamHandle stream_handle,
+    AOTIProxyExecutorHandle proxy_executor_handle) AOTI_RUNTIME_TRY({
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  AOTI_VECTOR_SIZE_CHECK(num_inputs, container->num_inputs(), "inputs");
+  AOTI_VECTOR_SIZE_CHECK(num_outputs, container->num_outputs(), "outputs");
+
+  auto stream =
+      reinterpret_cast<torch::aot_inductor::DeviceStreamType>(stream_handle);
+  AOTINoGradGuard guard;
+  container->run_pinned(
+      model_idx, input_handles, output_handles, stream, proxy_executor_handle);
+  return AOTI_RUNTIME_SUCCESS;
+})
+
+AOTIRuntimeError AOTInductorModelContainerGetNumModels(
+    AOTInductorModelContainerHandle container_handle,
+    size_t* ret_num_models) AOTI_RUNTIME_TRY({
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  *ret_num_models = container->num_models();
+  return AOTI_RUNTIME_SUCCESS;
+})
+
 AOTIRuntimeError AOTInductorModelContainerGetNumConstants(
     AOTInductorModelContainerHandle container_handle,
     size_t* num_constants) AOTI_RUNTIME_TRY({

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -150,6 +150,36 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
     AOTInductorStreamHandle stream_handle,
     AOTIProxyExecutorHandle proxy_executor_handle);
 
+// Thread-aware variant of AOTInductorModelContainerRun. Runs on the model
+// instance pinned at model_idx (indexed directly, bypassing the
+// available-models queue) so that instance's captured cuda graphs and private
+// graph pool stay warm across requests. Callers map each worker thread to a fixed instance,
+// e.g. model_idx = worker_index % num_models. Concurrent calls with the same
+// model_idx are serialized internally, so oversubscription cannot corrupt
+// execution -- but under cuda graph it can still corrupt RESULTS. Outputs are
+// non-owning views that the next call on the instance overwrites, and that call
+// may begin as soon as this one returns, before the caller has consumed them.
+// Copy outputs out before letting another request reach the same model_idx.
+// See OUTPUT CONTRACT in aoti_runtime/cudagraph_runtime.h.
+AOTI_API AOTIRuntimeError AOTInductorModelContainerRunPinned(
+    AOTInductorModelContainerHandle container_handle,
+    size_t model_idx,
+    AtenTensorHandle* input_handles, // array of input AtenTensorHandle; handles
+                                     // are stolen; the array itself is borrowed
+    size_t num_inputs,
+    AtenTensorHandle*
+        output_handles, // array for writing output AtenTensorHandle; handles
+                        // will be stolen by the caller; the array itself is
+                        // borrowed
+    size_t num_outputs,
+    AOTInductorStreamHandle stream_handle,
+    AOTIProxyExecutorHandle proxy_executor_handle);
+
+// Retrieves the number of model instances (runtimes) held by the container.
+AOTI_API AOTIRuntimeError AOTInductorModelContainerGetNumModels(
+    AOTInductorModelContainerHandle container_handle,
+    size_t* ret_num_models);
+
 // Retrieves the number of constants for the model.
 AOTI_API AOTIRuntimeError AOTInductorModelContainerGetNumConstants(
     AOTInductorModelContainerHandle container_handle,

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 
@@ -313,6 +314,67 @@ class AOTInductorModelContainer {
     }
 
     model->run_single_threaded(
+        input_handles, output_handles, stream, proxy_executor);
+  }
+
+  // Thread-aware variant of run(): executes on the model instance pinned at
+  // model_idx instead of pulling one from the available-models queue, so that
+  // instance's captured cuda graphs and private graph pool stay warm across
+  // requests. Callers map
+  // each worker thread to a fixed instance (e.g. worker_index % num_models()).
+  // Concurrent calls with the same model_idx are serialized by a per-instance
+  // mutex, so their EXECUTION cannot interleave. That mutex does not cover
+  // output consumption: it is released when run_single_threaded() returns,
+  // while under cuda graph the outputs are still non-owning views that the
+  // next call on this instance overwrites. Callers must copy outputs out
+  // before another request reaches the same model_idx. See OUTPUT CONTRACT in
+  // aoti_runtime/cudagraph_runtime.h.
+  void run_pinned(
+      size_t model_idx,
+      AtenTensorHandle*
+          input_handles, // array of input AtenTensorHandle; handles
+                         // are stolen; the array itself is borrowed
+      AtenTensorHandle*
+          output_handles, // array for writing output AtenTensorHandle; handles
+                          // will be stolen by the caller; the array itself is
+                          // borrowed
+      DeviceStreamType stream,
+      AOTIProxyExecutorHandle proxy_executor) {
+    if (model_idx >= models_.size()) {
+      throw std::runtime_error(
+          "run_pinned: model_idx " + std::to_string(model_idx) +
+          " out of range (num_models=" + std::to_string(models_.size()) + ")");
+    }
+
+    // Constant folding is normally already done at container construction, since
+    // loaders typically fold eagerly. Handle a still-INITIALIZED buffer under an
+    // exclusive lock for safety; the steady-state serving path sees FOLDED and
+    // falls straight through to execution.
+    auto& const_folded = active().fold_state;
+    if (const_folded == ConstantState::INITIALIZED) {
+      std::unique_lock constants_folding_lk(model_exec_mutex_);
+      if (active().fold_state == ConstantState::INITIALIZED) {
+        auto* fold_model = models_[model_idx].get();
+        auto folded_const_map = fold_model->run_const_fold(
+            stream, proxy_executor, /* initialization = */ true);
+        update_constant_buffer(
+            std::move(folded_const_map),
+            /* use_inactive = */ false,
+            /* validate_full_update = */ false);
+        active().fold_state = ConstantState::FOLDED;
+      }
+    } else if (const_folded != ConstantState::FOLDED) {
+      throw std::runtime_error(
+          "Unknown constant state: " + toStringConstantState(const_folded));
+    }
+
+    // Execution holds the shared lock for the same reason run() does: a weight
+    // update takes model_exec_mutex_ exclusively, so holding it shared here is
+    // what guarantees the constants are not re-pointed mid-run. Without it a
+    // swap_constant_buffer() could land in the middle of this execution.
+    std::shared_lock model_lk(model_exec_mutex_);
+    std::lock_guard<std::mutex> instance_lk(run_mutex_for(model_idx));
+    models_[model_idx]->run_single_threaded(
         input_handles, output_handles, stream, proxy_executor);
   }
 
@@ -886,6 +948,16 @@ class AOTInductorModelContainer {
       model->update_constants_map(
           active().map, /* remap_constants_array = */ false);
       model->update_constants_array(active().array);
+#ifdef USE_CUDA
+      // Captured cuda graphs baked the addresses of the buffer we just swapped
+      // away from, so replaying them would silently serve stale weights. Safe
+      // to clear here because we hold model_exec_mutex_ exclusively, so no
+      // replay is in flight. (In-place updates via update_constant_buffer keep
+      // the same storage and so keep captures valid; the exception is a
+      // user_managed update of the ACTIVE buffer, which re-points it without
+      // holding this lock -- do not combine that with cuda graph.)
+      model->reset_cuda_graph_captures();
+#endif
     }
   }
 
@@ -976,6 +1048,21 @@ class AOTInductorModelContainer {
     auto* result = available_models_.back();
     available_models_.pop_back();
     return result;
+  }
+
+  // Per-instance mutexes for run_pinned(). Lazily sized to num_models on first
+  // use so both constructors stay untouched. Each pinned instance runs under
+  // its own mutex, so concurrent run_pinned() calls that map to the same
+  // instance (more worker threads than instances) serialize instead of racing
+  // on one model's single-threaded run state.
+  std::once_flag model_run_mutexes_init_flag_;
+  std::unique_ptr<std::mutex[]> model_run_mutexes_;
+
+  std::mutex& run_mutex_for(size_t model_idx) {
+    std::call_once(model_run_mutexes_init_flag_, [this]() {
+      model_run_mutexes_ = std::make_unique<std::mutex[]>(models_.size());
+    });
+    return model_run_mutexes_[model_idx];
   }
 
   // This mutex is used to protect execution of model.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* #196835
* #196785
* __->__ #196784
* #196783
* #196782
* #196781
* #196780
* #196779
* #196778

Lets a serving worker thread reuse one model instance, so that instance's captured cuda graphs and private graph pool stay warm across requests.

The default container path (`AOTInductorModelContainerRun`) pulls whichever instance is free from the available-models queue. Under cuda graph that is actively harmful: each instance owns its own private pool and its own captures, so a request bouncing between instances keeps landing on cold ones and re-capturing shapes another instance already has. With N instances and M hot shapes the fleet converges on N*M captures instead of M.

Three pieces:

- `AOTInductorModelContainerRunPinned` / `AOTInductorModelContainerGetNumModels`: new C ABI entry points. `run_pinned` indexes `models_[model_idx]` directly instead of taking from the queue, under a per-instance mutex, so oversubscription (more worker threads than instances) serializes EXECUTION rather than racing on one model's single-threaded run state. That mutex does NOT extend to output consumption -- see the caveat below. The per-instance mutex array is lazily sized on first use, leaving both container constructors untouched. Constant folding is handled under the exclusive lock exactly as the queue path does; the steady state sees FOLDED and falls straight through.

- `AOTInductorModelImpl` loads both symbols with `LOAD_SYMBOL_WARN`, so a model compiled before this diff simply lacks them and transparently falls back to the existing path.

- `run_pinned` holds `model_exec_mutex_` in SHARED mode for the execution, exactly as `run()` does. This is what makes a weight update safe: `swap_constant_buffer()` takes the same mutex exclusively, so holding it shared here guarantees the constants cannot be re-pointed mid-run. An earlier version of this diff took only the per-instance mutex, which left that race open -- a correctness bug for pinned serving independent of cuda graph.

- `swap_constant_buffer()` now also calls `reset_cuda_graph_captures()` on every model. A captured graph baked the addresses of the buffer being swapped away from, so without this a replay after a weight update silently serves stale weights. Safe at that point because the exclusive lock means no replay is in flight. In-place updates through `update_constant_buffer` keep the same storage and so keep captures valid; the exception is a `user_managed` update of the ACTIVE buffer, which re-points it without taking this lock and must not be combined with cuda graph.

- gflag `--aot_inductor_cudagraph_thread_aware` (also settable via `AOT_INDUCTOR_CUDAGRAPH_THREAD_AWARE=1`), DEFAULT OFF. Each thread claims a stable index on first use and maps to `index % num_models`, so a fixed thread pool lands deterministically on instances.

Off by default and gated on the symbols being present, so this is a no-op for every existing model until it is explicitly turned on.

**CAVEAT on the [4/8] output contract.** Pinning does NOT by itself make that contract safe, and an earlier version of this description claimed it did. Outputs are non-owning views valid only until the next call on the instance. `run_pinned` releases its per-instance mutex when execution finishes, which is BEFORE `AOTInductorModelImpl::forward` steals the handles and passes the tensors onward -- and `processOutputs` only materializes a copy when `floatingPointOutputDtype_` forces a real dtype change, so in general the view escapes intact. If two live threads map to the same instance, the second one's replay overwrites the first one's results: wrong numbers, no crash. That happens whenever worker threads outnumber instances, threads churn, or several models share the process-global worker index used here. Pinning narrows the window; closing it is the serving layer's job -- copy outputs out (D2D or D2H) before another request reaches the instance. Documented at all three sites (`cudagraph_runtime.h`, `interface.h` / `model_container.h`, `AOTInductorModelImpl.cpp`) rather than fixed here, since the copy belongs at the predictor layer where the device-vs-host choice is known.


One rebase-compatibility note: the two new entry points use the trailing `AOTI_RUNTIME_TRY({ ... return AOTI_RUNTIME_SUCCESS; })` idiom that the rest of `interface.cpp` now uses. They were originally written against the older `CONVERT_EXCEPTION_TO_ERROR_CODE({ ... })` wrapper, which upstream has since removed; the rebase merged the additions textually but left them calling a macro that no longer exists, so every generated wrapper failed to compile until they were converted.

Authored with Claude.

Differential Revision: [D118228077](https://our.internmc.facebook.com/intern/diff/D118228077/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo