### PR TITLE
[AOTI cuda graph S1][8/8] Tests for whole-graph capture

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -151,8 +151,6 @@ def use_fa3():
 
 if HAS_GPU:
     import triton  # @manual
-    from triton import language as tl
-
     from torch.testing._internal.triton_utils import (
         add_kernel,
         add_kernel_2d_autotuned,
@@ -174,6 +172,7 @@ if HAS_GPU:
         strange_config_matmul_kernel,
         sub_kernel_autotuned,
     )
+    from triton import language as tl
 
 if IS_WINDOWS and IS_CI:
     sys.stderr.write(
@@ -316,6 +315,18 @@ def profiled_ivalue_kinds(code, kernel_name):
         "scalar" if "_scalar_" in entry else "tensor"
         for entry in vector.group(1).split(",")
     ]
+def compile_whole_cudagraph(model, example_inputs, dynamic_shapes=None, **cfg):
+    """Compile and load `model` with whole-graph cuda graph enabled.
+
+    Module-level rather than a method because `copy_tests` only copies `test_*`
+    methods into the generated device classes, so a helper method would not
+    exist on them.
+    """
+    with config.patch({"aot_inductor.cudagraph_mode": "whole", **cfg}), torch.no_grad():
+        package_path = AOTIRunnerUtil.compile(
+            model, example_inputs, dynamic_shapes=dynamic_shapes
+        )
+    return torch._inductor.aoti_load_package(package_path)
 
 
 class AOTInductorTestsTemplate:
@@ -6297,6 +6308,97 @@ class AOTInductorTestsTemplate:
         mem_after = device_interface.memory_allocated(device)
         self.assertEqual(mem_after, mem_before)
 
+    def test_cudagraph_whole_capture_replay_and_recapture(self):
+        # cudagraph_mode="whole" captures the entire lowered component. The first
+        # call at a shape records, later calls at that shape replay, and a new
+        # shape records a second graph. All three must match eager.
+        if self.device != "cuda":
+            raise unittest.SkipTest("AOTI whole-graph cuda graph requires CUDA")
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(64, 64)
+
+            def forward(self, x):
+                return self.linear(x).relu().sum(dim=1)
+
+        model = Model().to(self.device)
+        example = torch.randn(8, 64, device=self.device)
+        compiled = compile_whole_cudagraph(
+            model, (example,), {"x": {0: Dim("b", min=1, max=256)}}
+        )
+
+        with torch.no_grad():
+            # Shape 8 twice: the second call is a replay of the first capture.
+            for _ in range(2):
+                x = torch.randn(8, 64, device=self.device)
+                self.assertEqual(compiled(x), model(x))
+            # A new shape must record its own graph rather than replay shape 8's.
+            for batch in (32, 8, 32):
+                x = torch.randn(batch, 64, device=self.device)
+                self.assertEqual(compiled(x), model(x))
+
+    def test_cudagraph_whole_capture_cap_falls_back_to_eager(self):
+        # Past cudagraph_max_captures a new shape runs UNCAPTURED. It must still
+        # be correct -- the cap trades the launch saving for bounded pool memory,
+        # never correctness.
+        if self.device != "cuda":
+            raise unittest.SkipTest("AOTI whole-graph cuda graph requires CUDA")
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return (x * 2).sin().sum(dim=1)
+
+        model = Model().to(self.device)
+        example = torch.randn(8, 32, device=self.device)
+        compiled = compile_whole_cudagraph(
+            model,
+            (example,),
+            {"x": {0: Dim("b", min=1, max=256)}},
+            **{"aot_inductor.cudagraph_max_captures": 1},
+        )
+
+        with torch.no_grad():
+            # Shape 8 fills the single capture slot; 16 and 24 exceed it and run
+            # uncaptured. Re-running 8 afterwards must still hit its capture.
+            for batch in (8, 16, 24, 8):
+                x = torch.randn(batch, 32, device=self.device)
+                self.assertEqual(compiled(x), model(x))
+
+    def test_cudagraph_whole_rejects_uncapturable_graph(self):
+        # RNG cannot be captured: capture freezes the philox seed, so replays
+        # would stop advancing. The lowering must fail, naming the blocker,
+        # rather than silently producing a model that repeats one draw forever.
+        if self.device != "cuda":
+            raise unittest.SkipTest("AOTI whole-graph cuda graph requires CUDA")
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x + torch.rand_like(x)
+
+        model = Model().to(self.device)
+        example = torch.randn(8, 64, device=self.device)
+        with self.assertRaisesRegex(Exception, "RNG"):
+            compile_whole_cudagraph(model, (example,), None)
+
+    def test_cudagraph_mode_regional_rejected(self):
+        # "regional" is reserved for the follow-up stack; it must fail loudly
+        # instead of silently behaving like "off".
+        if self.device != "cuda":
+            raise unittest.SkipTest("AOTI whole-graph cuda graph requires CUDA")
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.relu()
+
+        model = Model().to(self.device)
+        example = torch.randn(8, 64, device=self.device)
+        with self.assertRaisesRegex(Exception, "not implemented yet"):
+            with config.patch({"aot_inductor.cudagraph_mode": "regional"}):
+                with torch.no_grad():
+                    AOTIRunnerUtil.compile(model, (example,))
+
     def test_add_complex(self):
         class Model(torch.nn.Module):
             def forward(self, a, b):
@@ -10493,6 +10595,17 @@ GPU_LAZY_AUTOTUNE_TEST_FAILURES = {
     # mode runs the generated JIT wrapper during compile, so it fails before
     # the AOTI package can be loaded.
     "test_aoti_custom_op_bad_fake_dtype_fails_fast": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    # cudagraph_mode="whole" is rejected in dual-wrapper mode: it emits a JIT
+    # entry point alongside the AOTI one and only the latter can be captured.
+    "test_cudagraph_whole_capture_replay_and_recapture": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cudagraph_whole_capture_cap_falls_back_to_eager": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cudagraph_whole_rejects_uncapturable_graph": fail_gpu(
         ("cuda", "xpu"), is_skip=True
     ),
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* #196835
* __->__ #196785
* #196784
* #196783
* #196782
* #196781
* #196780
* #196779
* #196778

GPU tests for the behavior the rest of the stack adds, all under `AOTInductorTestsTemplate` so they run on the CUDA instantiation.

The shared compile helper is a MODULE-LEVEL function, not a method: `copy_tests` only copies `test_*` methods into the generated per-device classes, so a helper method does not exist on them and every test fails with `AttributeError`.

The three whole-graph tests are registered as skips in `GPU_LAZY_AUTOTUNE_TEST_FAILURES`, because `cudagraph_mode="whole"` is deliberately rejected in dual-wrapper mode (it emits a JIT entry point alongside the AOTI one, and only the latter can be captured). `test_cudagraph_mode_regional_rejected` still runs there, since the mode check fires before that rejection.

- `test_cudagraph_whole_capture_replay_and_recapture` -- first call at a shape records, later calls at that shape replay, a second shape records its own graph, and returning to the first shape replays rather than re-records. Every call is compared against eager, so a replay that silently reused the wrong graph's output buffer would fail.
- `test_cudagraph_whole_capture_cap_falls_back_to_eager` -- with `cudagraph_max_captures=1`, shapes past the cap run uncaptured and must still match eager. The cap trades the launch saving for bounded pool memory, never correctness.
- `test_cudagraph_whole_rejects_uncapturable_graph` -- a model with `rand_like` fails the lowering naming RNG, instead of compiling into a graph that repeats one draw on every replay.
- `test_cudagraph_mode_regional_rejected` -- `"regional"` fails loudly rather than silently behaving like `"off"`.

The recapture test is the important one: it is what distinguishes a correct implementation from one that keys shapes wrongly, since a bad key still produces plausible-looking numbers at the shape it was captured for.

Deliberately not tested: the formatting of the multi-blocker error message (grouping and the 5-example cap). A bug there degrades readability, not correctness, and the reject test already proves the error fires and names its reason.

Run with `@fbcode//mode/dev-nosan`: the default asan-ubsan mode cannot initialize CUDA, so these fail at `.to("cuda")` under it.

Authored with Claude.

Differential Revision: [D118228078](https://our.internmc.facebook.com/intern/diff/D118228078/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo