### PR TITLE
[c10d] Fix threaded-PG teardown crash on pg_flight_recorder_hooks

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -17,6 +17,7 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
+from torch.distributed.distributed_c10d import _World
 from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
     skip_if_lt_x_gpu,
@@ -28,6 +29,11 @@ from torch.testing._internal.common_utils import (
     IS_SANDCASTLE,
     run_tests,
     TestCase,
+)
+from torch.testing._internal.distributed.multi_threaded_pg import (
+    _install_threaded_pg,
+    _uninstall_threaded_pg,
+    ThreadLocalWorld,
 )
 
 
@@ -384,6 +390,35 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
         )
         x = MyFunc.apply(x)
         x.sum().backward()
+
+
+class TestThreadLocalWorld(TestCase):
+    def test_mirrors_world_state(self):
+        # ThreadLocalWorld stands in for _World while a threaded PG is
+        # installed, and distributed_c10d reaches for world state by name. A
+        # state attribute added to _World alone makes those reads raise
+        # AttributeError under every MultiThreadedTestCase.
+        missing = sorted(
+            name
+            for name, attr in vars(_World).items()
+            if isinstance(attr, property) and not hasattr(ThreadLocalWorld, name)
+        )
+        self.assertEqual(missing, [])
+
+    def test_destroy_process_group_runs_to_completion(self):
+        world = _install_threaded_pg()
+        try:
+            dist.init_process_group(
+                backend="threaded", rank=0, world_size=1, store=dist.HashStore()
+            )
+            dist.destroy_process_group()
+            # Set by the last statement of destroy_process_group, so a non-zero
+            # count means teardown bailed out partway through.
+            self.assertEqual(world.group_count, 0)
+            self.assertEqual(len(world.pg_map), 0)
+            self.assertEqual(len(world.pg_flight_recorder_hooks), 0)
+        finally:
+            _uninstall_threaded_pg()
 
 
 if __name__ == "__main__":

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -3,7 +3,7 @@
 import sys
 import threading
 import weakref
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial, reduce
 
 import torch
@@ -15,12 +15,18 @@ from torch._C._distributed_c10d import (
     AllToAllOptions,
     BarrierOptions,
     BroadcastOptions,
+    FlightRecorderHook,
     ReduceOp,
     ReduceScatterOptions,
     ScatterOptions,
     Store,
 )
-from torch.distributed.distributed_c10d import _CollOp, _store_based_barrier, P2POp
+from torch.distributed.distributed_c10d import (
+    _CollOp,
+    _store_based_barrier,
+    _World,
+    P2POp,
+)
 from torch.futures import Future
 from torch.utils import _pytree as pytree
 
@@ -619,18 +625,31 @@ dist.Backend.register_backend(
 )
 
 
+# Mirrors the per-world state _World owns. Every field here needs a matching
+# property on ThreadLocalWorld below; distributed_c10d reaches for them by name
+# and does not care which world is installed. Fields default-construct so that
+# adding one cannot silently shift the others.
 @dataclass
 class WorldData:
-    default_pg: dist.ProcessGroup
-    pg_map: dict[dist.ProcessGroup, tuple[str, Store | None]]
-    pg_names: dict[dist.ProcessGroup, str]
-    pg_group_ranks: dict[dist.ProcessGroup, dict[int, int]]
-    pg_backend_config: dict[dist.ProcessGroup, str]
-    group_count: int
-    tags_to_pg: dict[str, list[dist.ProcessGroup]]
-    pg_to_tag: dict[dist.ProcessGroup, str]
-    pg_coalesce_state: dict[dist.ProcessGroup, list[_CollOp | P2POp]]
-    comms: list
+    default_pg: dist.ProcessGroup | None = None
+    pg_map: dict[dist.ProcessGroup, tuple[str, Store | None]] = field(
+        default_factory=dict
+    )
+    pg_names: dict[dist.ProcessGroup, str] = field(default_factory=dict)
+    pg_group_ranks: dict[dist.ProcessGroup, dict[int, int]] = field(
+        default_factory=dict
+    )
+    pg_backend_config: dict[dist.ProcessGroup, str] = field(default_factory=dict)
+    group_count: int = 0
+    tags_to_pg: dict[str, list[dist.ProcessGroup]] = field(default_factory=dict)
+    pg_to_tag: dict[dist.ProcessGroup, str] = field(default_factory=dict)
+    pg_coalesce_state: dict[dist.ProcessGroup, list[_CollOp | P2POp]] = field(
+        default_factory=dict
+    )
+    pg_flight_recorder_hooks: dict[dist.ProcessGroup, FlightRecorderHook] = field(
+        default_factory=dict
+    )
+    comms: list = field(default_factory=list)
 
 
 class ThreadLocalWorld:
@@ -638,9 +657,7 @@ class ThreadLocalWorld:
 
     def _get_world(self) -> WorldData:
         if not hasattr(ThreadLocalWorld._world, "world"):
-            ThreadLocalWorld._world.world = WorldData(
-                None, {}, {}, {}, {}, 0, {}, {}, {}, []
-            )
+            ThreadLocalWorld._world.world = WorldData()
         return ThreadLocalWorld._world.world
 
     @property
@@ -688,8 +705,16 @@ class ThreadLocalWorld:
         return self._get_world().pg_coalesce_state
 
     @property
+    def pg_flight_recorder_hooks(self) -> dict[dist.ProcessGroup, FlightRecorderHook]:
+        return self._get_world().pg_flight_recorder_hooks
+
+    @property
     def comms(self):
         return self._get_world().comms
+
+    # Derived entirely from the state mirrored above, so reuse _World's
+    # property object rather than duplicating its body.
+    pg_config_info = _World.pg_config_info
 
 
 _old_pg_world = None


### PR DESCRIPTION
`_World` grew a `pg_flight_recorder_hooks` dict in #192233, but `ThreadLocalWorld` -- the per-thread stand-in that `_install_threaded_pg()` swaps into `distributed_c10d._world` for `MultiThreadedTestCase` and `spawn_threads_and_init_comms` -- was never taught to mirror it. Every threaded-PG teardown has raised since then:

```
  File "torch/testing/_internal/common_distributed.py", line 1594, in run_test_with_threaded_pg
    c10d.destroy_process_group()
  File "torch/distributed/distributed_c10d.py", line 3181, in destroy_process_group
    _world.pg_flight_recorder_hooks.clear()
AttributeError: 'ThreadLocalWorld' object has no attribute 'pg_flight_recorder_hooks'
```

## Why it matters

`destroy_process_group()` clears world state in a fixed order, and `_world.pg_flight_recorder_hooks.clear()` is third from the end. The groups do get shut down, but the `AttributeError` means `_unregister_all_process_groups()` and the `_world.group_count = 0` reset never run. The exception then escapes the `finally:` in `run_test_with_threaded_pg`, so `perThreadTearDown()` is skipped and the rank's thread dies. `_abort_process_group()` breaks in exactly the same place.

This went unnoticed for a month because each rank runs in its own thread: pytest turns the escaped exception into a `PytestUnhandledThreadExceptionWarning` and the test still reports PASSED. Nothing in CI goes red; it only shows up as warning spam in FSDP, DTensor and `_composable` multithread logs.

For context on how it surfaced: it turned up while reading mi350 trunk logs for an unrelated PR, where several `distributed/_composable/fsdp` tests timed out. Those timeouts did not reproduce locally and this PR is **not** claimed to fix them. The teardown breakage is a real bug on its own and is what this PR fixes.

## Fix

Mirror `pg_flight_recorder_hooks` on `ThreadLocalWorld`. `pg_config_info` had drifted out of the mirror as well, and it has its own live failure: `ExecutionTraceObserver._record_pg_config()` reads `_world.pg_config_info` whenever distributed is initialized, so starting an execution-trace capture under a threaded PG raises `'ThreadLocalWorld' object has no attribute 'pg_config_info'` on `main` today. It is derived entirely from state that is already mirrored, so `ThreadLocalWorld` reuses `_World`'s property object instead of duplicating its body. `WorldData`'s fields now default-construct, so adding a field can no longer silently shift the positional constructor the way it did here.

The new `test_mirrors_world_state` asserts that every `_World` property is reachable on `ThreadLocalWorld`, which is the check that would have caught #192233 at review time. `test_destroy_process_group_runs_to_completion` asserts `group_count == 0` afterwards, i.e. that teardown reached its final statement rather than bailing out midway.

## Test plan

All runs on a 4x MI250X (gfx90a) host, ROCm 7.14, built from this branch.

Both new tests fail on `main` and pass with the fix:

```
python test/distributed/test_multi_threaded_pg.py TestThreadLocalWorld -v
```

Before: `Ran 2 tests ... FAILED (failures=1, errors=1)`. After: `Ran 25 tests in 2.064s / OK` for the whole file.

The four `distributed/_composable/fsdp` files whose logs showed the warning, run with the warning promoted to an error so any surviving thread exception fails the run:

```
python -m pytest distributed/_composable/fsdp/test_fully_shard_extensions.py -m "not multigpu" -p no:xdist -W "error::pytest.PytestUnhandledThreadExceptionWarning"
python -m pytest distributed/_composable/fsdp/test_fully_shard_init.py -m "not multigpu" -p no:xdist -W "error::pytest.PytestUnhandledThreadExceptionWarning"
python -m pytest distributed/_composable/fsdp/test_fully_shard_mixed_precision.py -m "not multigpu" -p no:xdist -W "error::pytest.PytestUnhandledThreadExceptionWarning"
python -m pytest distributed/_composable/fsdp/test_fully_shard_autograd.py -p no:xdist -W "error::pytest.PytestUnhandledThreadExceptionWarning"
```

`5 passed`, `43 passed 1 skipped`, `7 passed`, `5 passed`. On `main` the first three emit the traceback above once per rank per test and still report PASSED.

Wider threaded-PG coverage, same warning-as-error flag:

```
python -m pytest distributed/test_functional_api.py distributed/tensor/test_op_strategy.py distributed/test_functional_differentials.py -p no:xdist -W "error::pytest.PytestUnhandledThreadExceptionWarning"
python -m pytest distributed/_composable/fsdp/ -m "not multigpu" -p no:xdist -W "error::pytest.PytestUnhandledThreadExceptionWarning"
```

`24 passed 17 skipped`, `56 passed`, `176 passed 9 skipped`, and `74 passed 12 skipped` for the whole FSDP directory.

`ExecutionTraceObserver.register_callback()` + `start()` under a threaded PG raises `'ThreadLocalWorld' object has no attribute 'pg_config_info'` before the change and succeeds after it.

The non-threaded `_World` path is unchanged: a plain gloo `init_process_group` / `destroy_process_group` still reports `pg_flight_recorder_hooks == {}`, a populated `pg_config_info`, and `group_count == 0` after teardown.

```
spin quicklint
```

clean on both changed files.

This PR was authored with the assistance of an AI agent (Claude). The root-cause analysis and every test result above were reproduced and verified by hand on the machine described.


cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @kapilsh