### PR TITLE
[DataLoader] Pass device to custom pin_memory methods

### DIFF
--- a/test/test_pin_memory.py
+++ b/test/test_pin_memory.py
@@ -1,0 +1,52 @@
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils.data._utils.pin_memory import pin_memory
+
+
+class TestCustomPinMemory(TestCase):
+    def test_device_argument(self):
+        class Batch:
+            def __init__(self):
+                self.device = None
+
+            def pin_memory(self, device):
+                self.device = device
+                return self
+
+        batch = Batch()
+        result = pin_memory(batch, "xpu")
+
+        self.assertIs(result, batch)
+        self.assertEqual(batch.device, "xpu")
+
+    def test_legacy_no_argument(self):
+        class Batch:
+            def __init__(self):
+                self.called = False
+
+            def pin_memory(self):
+                self.called = True
+                return self
+
+        batch = Batch()
+        result = pin_memory(batch, "xpu")
+
+        self.assertIs(result, batch)
+        self.assertTrue(batch.called)
+
+    def test_legacy_optional_argument(self):
+        class Batch:
+            def __init__(self):
+                self.copy = False
+
+            def pin_memory(self, copy=False):
+                self.copy = copy
+                return self
+
+        batch = Batch()
+        pin_memory(batch, "xpu")
+
+        self.assertFalse(batch.copy)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -7,6 +7,7 @@ static methods.
 
 import collections
 import copy
+import inspect
 import queue
 
 import torch
@@ -57,7 +58,19 @@ def pin_memory(data, device=None):
         return data.pin_memory()
 
     if hasattr(data, "pin_memory"):
-        return data.pin_memory()
+        fn = data.pin_memory
+        try:
+            params = inspect.signature(fn).parameters
+        except (TypeError, ValueError):
+            return fn()
+        param = params.get("device")
+        if param is not None:
+            if param.kind == inspect.Parameter.POSITIONAL_ONLY:
+                return fn(device)
+            return fn(device=device)
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            return fn(device=device)
+        return fn()
 
     if isinstance(data, (str, bytes)):
         return data


### PR DESCRIPTION
Fixes #116403

Pass the selected device to custom `pin_memory` methods when their signature accepts it. Existing no-argument methods keep working.

Tests cover device-aware and legacy custom methods.