### PR TITLE
[FSDP2] Simplify all-gather copy grouping

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -32,7 +32,9 @@ from torch.testing._internal.common_fsdp import (
     reduce_scatter_with_assert,
 )
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
     MI300_ARCH,
+    parametrize,
     run_tests,
     skipIfRocmArch,
     skipIfRocmVersionLessThan,
@@ -80,6 +82,7 @@ class KDAStyleTransformer(Transformer):
         return (self.output_norm(output) * decay).flatten(-2).clone()
 
 
+@instantiate_parametrized_tests
 class TestFullyShardMixedPrecisionTraining(FSDPTest):
     @property
     def world_size(self) -> int:
@@ -215,6 +218,64 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
 
             self.assertEqual(fsdp_loss, ref_loss)
             check_sharded_parity(self, ref_model, model)
+
+    @skipIfRocmVersionLessThan((7, 0))
+    @skip_if_lt_x_gpu(2)
+    @parametrize("reshard_after_forward", [True, 2])
+    def test_all_gather_mixed_compute_dtypes(self, reshard_after_forward: bool | int):
+        if reshard_after_forward == 2 and self.world_size != 4:
+            self.skipTest("Partial resharding requires four devices")
+        param_dtypes = (
+            torch.bfloat16,
+            torch.float32,
+            torch.float16,
+            torch.bfloat16,
+            torch.float16,
+        )
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.params = nn.ParameterList(
+                    nn.Parameter(
+                        torch.arange(8 * (i + 1), dtype=torch.float32).view(8, -1) / 32
+                        + i
+                    )
+                    for i in range(len(param_dtypes))
+                )
+
+            def forward(self):
+                return tuple(param.square() for param in self.params)
+
+        model = Model().to(device_type)
+        param_to_dtype = dict(zip(model.parameters(), param_dtypes, strict=True))
+        ref_params = [
+            param.detach().to(dtype).clone().requires_grad_()
+            for param, dtype in param_to_dtype.items()
+        ]
+        fully_shard(
+            model,
+            reshard_after_forward=reshard_after_forward,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.float32,
+                param_dtype_fn=param_to_dtype.get,
+            ),
+        )
+
+        outputs = model()
+        ref_outputs = tuple(param.square() for param in ref_params)
+        self.assertEqual(tuple(output.dtype for output in outputs), param_dtypes)
+        self.assertEqual(outputs, ref_outputs)
+        sum(output.float().sum() for output in outputs).backward()
+        sum(output.float().sum() for output in ref_outputs).backward()
+        for param, ref_param in zip(model.parameters(), ref_params, strict=True):
+            self.assertIsNotNone(param.grad)
+            self.assertIsNotNone(ref_param.grad)
+            self.assertEqual(
+                param.grad.to_local(),
+                ref_param.grad.float().chunk(self.world_size)[self.rank],
+            )
 
     @skipIfRocmVersionLessThan((7, 0))
     @skip_if_lt_x_gpu(2)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -395,17 +395,13 @@ def _get_param_all_gather_inputs(
         )
 
     param_all_gather_inputs: list[list[torch.Tensor]] = [[] for _ in fsdp_params]
-    foreach_copy_indices: list[int] = []
-    foreach_copy_inputs: list[torch.Tensor] = []
-    foreach_copy_input_numels: list[int] = []
-    foreach_copy_dtype_pair: tuple[torch.dtype, torch.dtype] | None = None
-    foreach_copy_dtypes_are_uniform = True
+    copy_groups: dict[
+        tuple[torch.dtype, torch.dtype],
+        tuple[list[int], list[torch.Tensor]],
+    ] = {}
 
-    # 1st pass: for foreach-copy parameters, get inputs and metadata for the
-    # foreach copy, and for the others, actually get their all-gather inputs
     for i, fsdp_param in enumerate(fsdp_params):
         if use_foreach_copy(fsdp_param):
-            foreach_copy_indices.append(i)
             all_gather_input = (
                 fsdp_param._sharded_param_data
                 if fsdp_param.sharded_state == ShardedState.SHARDED
@@ -414,52 +410,25 @@ def _get_param_all_gather_inputs(
             param_dtype = fsdp_param.param_dtype
             if param_dtype is None:
                 raise AssertionError("Expected param_dtype to not be None")
-            foreach_copy_inputs.append(all_gather_input)
-            foreach_copy_input_numels.append(all_gather_input.numel())
-            dtype_pair = (all_gather_input.dtype, param_dtype)
-            if foreach_copy_dtype_pair is None:
-                foreach_copy_dtype_pair = dtype_pair
-            elif dtype_pair != foreach_copy_dtype_pair:
-                foreach_copy_dtypes_are_uniform = False
+            indices, inputs = copy_groups.setdefault(
+                (all_gather_input.dtype, param_dtype), ([], [])
+            )
+            indices.append(i)
+            inputs.append(all_gather_input)
         else:
             param_all_gather_inputs[i] = fsdp_param.all_gather_inputs
 
-    # 2nd pass: use foreach copy to compute the remaining all-gather inputs
-    if foreach_copy_inputs and foreach_copy_dtypes_are_uniform:
-        fsdp_param_0 = fsdp_params[foreach_copy_indices[0]]
-        param_dtype, device = fsdp_param_0.param_dtype, fsdp_param_0.device
+    for (_, target_dtype), (indices, inputs) in copy_groups.items():
+        input_numels = [t.numel() for t in inputs]
         flat_foreach_copy_input = torch.empty(
-            (sum(foreach_copy_input_numels),), device=device, dtype=param_dtype
+            (sum(input_numels),),
+            device=inputs[0].device,
+            dtype=target_dtype,
         )
-        splits = torch.split(flat_foreach_copy_input, foreach_copy_input_numels)
-        torch._foreach_copy_(splits, foreach_copy_inputs)
-        for i, split in zip(foreach_copy_indices, splits):
+        splits = torch.split(flat_foreach_copy_input, input_numels)
+        torch._foreach_copy_(splits, inputs)
+        for i, split in zip(indices, splits):
             param_all_gather_inputs[i] = [split]
-    elif foreach_copy_inputs:
-        copy_groups: dict[
-            tuple[torch.dtype, torch.dtype],
-            tuple[list[int], list[torch.Tensor]],
-        ] = {}
-        for i, inp in zip(foreach_copy_indices, foreach_copy_inputs):
-            target_dtype = fsdp_params[i].param_dtype
-            if target_dtype is None:
-                raise AssertionError("Expected param_dtype to not be None")
-            indices, inputs = copy_groups.setdefault(
-                (inp.dtype, target_dtype), ([], [])
-            )
-            indices.append(i)
-            inputs.append(inp)
-        for (_, target_dtype), (indices, inputs) in copy_groups.items():
-            input_numels = [t.numel() for t in inputs]
-            flat_foreach_copy_input = torch.empty(
-                (sum(input_numels),),
-                device=inputs[0].device,
-                dtype=target_dtype,
-            )
-            splits = torch.split(flat_foreach_copy_input, input_numels)
-            torch._foreach_copy_(splits, inputs)
-            for i, split in zip(indices, splits):
-                param_all_gather_inputs[i] = [split]
 
     return param_all_gather_inputs
 
@@ -559,7 +528,7 @@ def foreach_all_gather_copy_out(
 def foreach_reduce(
     fsdp_params: list[FSDPParam],
     unsharded_grads: list[torch.Tensor],
-    reduce_scatter_group: dist.ProcessGroup,
+    reduce_scatter_group: dist.ProcessGroup | None,
     reduce_scatter_stream: torch.Stream,
     reduce_scatter_comm: ReduceScatter,
     orig_dtype: torch.dtype | None,
@@ -658,7 +627,7 @@ def foreach_reduce(
             device=device,
         )
         _div_if_needed(reduce_scatter_input, predivide_factor)
-        if world_size > 1:
+        if reduce_scatter_group is not None and world_size > 1:
             reduce_scatter_comm(
                 output_tensor=reduce_output,
                 input_tensor=reduce_scatter_input,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196803

> Follow-up to #196626. Group all-gather staging inputs by their actual source dtype and resolved parameter dtype in the existing input scan, then use one copy loop per group. This removes the uniformity flags, redundant metadata lists, and duplicate staging paths while preserving parameter order and the FP32 bypass.
>
> Also correct the optional reduce-scatter process-group annotation and narrow its existing collective guard so type checking passes.
>
> Test Plan
>
> Four focused tests passed on four H100 GPUs, including mixed compute dtypes and partial post-forward resharding. Lint passed.
>
> ```bash
> python test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py -k test_all_gather_mixed_compute_dtypes
> python test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py TestFullyShardMixedPrecisionTraining.test_compute_dtype TestFullyShardMixedPrecisionTraining.test_per_param_mixed_precision
> lintrunner -a torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
> ```
>
> A local H100 staging-helper benchmark across 8/64/256 parameters and 4K/64K elements per parameter found uniform BF16 cases approximately 4-6% slower and mixed BF16/FP16/FP32 cases approximately 4-14% faster. Measurements include host overhead and synchronization, and exclude communication and model execution.
>
> Authored with assistance from Codex.