### PR TITLE
Intentionally break the example periodic-strict test

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -799,13 +799,13 @@ class TestPeriodicCanary(TestCase):
     @periodic
     @onlyCPU
     def test_cpu_canary(self, device):
-        self.assertEqual(torch.arange(4, device=device).sum().item(), 6)
+        self.assertEqual(torch.arange(4, device=device).sum().item(), 7)
 
     @periodic
     @onlyCUDA
     def test_gpu_canary(self, device):
         x = torch.ones(4, 4, device=device)
-        self.assertEqual(x @ x, torch.full((4, 4), 4.0, device=device))
+        self.assertEqual(x @ x, torch.full((4, 4), 5.0, device=device))
 
 
 instantiate_device_type_tests(TestPeriodicCanary, globals(), only_for=("cpu", "cuda"))


### PR DESCRIPTION
We introduced these in https://github.com/pytorch/pytorch/pull/196644. After letting the test run for a few days, let's force-merge this breaking change to see if autorevert reverts the change.