### PR TITLE
[FX][FlyDSL] Add an opaque operator boundary

### DIFF
--- a/docs/source/library.md
+++ b/docs/source/library.md
@@ -165,6 +165,7 @@ relationships.
 
 ```{eval-rst}
 .. autofunction:: custom_op
+.. autofunction:: flydsl_op
 .. autofunction:: triton_op
 .. autofunction:: wrap_triton
 .. autofunction:: wrap_flydsl

--- a/test/inductor/flydsl_aot/test_flydsl_capture.py
+++ b/test/inductor/flydsl_aot/test_flydsl_capture.py
@@ -18,6 +18,7 @@ from torch._higher_order_ops.flydsl_kernel_wrap import (
     TraceableFlyDSLLauncher,
 )
 from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch._library.utils import get_layout_constraint_tag
 from torch.testing._internal.common_utils import TestCase
 
 
@@ -472,6 +473,196 @@ class FlyDSLCaptureTest(TestCase):
                 (0, 1),
                 (0,),
             )
+
+    def test_flydsl_op_is_opaque_to_symbolic_trace(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::symbolic_trace",
+            mutates_args=(),
+        )
+        def flydsl_add(inp: torch.Tensor) -> torch.Tensor:
+            if inp.shape[1] != 8:
+                raise ValueError("expected width eight")
+            out = torch.empty_like(inp)
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_add(inp)
+
+        traced = torch.fx.symbolic_trace(Model())
+
+        nodes = traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.test_flydsl_capture.symbolic_trace.default,
+        )
+        self.assertEqual(1, len(nodes))
+
+    def test_flydsl_op_preserves_exact_strides_by_default(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::exact_strides",
+            mutates_args=(),
+        )
+        def flydsl_add(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+
+        self.assertEqual(
+            torch._C.Tag.needs_exact_strides,
+            get_layout_constraint_tag(
+                torch.ops.test_flydsl_capture.exact_strides.default
+            ),
+        )
+
+        example = torch.randn(8, 4).t()
+        self.assertEqual((1, 4), example.stride())
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_add(inp)
+
+        exported = torch.export.export(Model(), (example,))
+        custom_op_node = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.test_flydsl_capture.exact_strides.default,
+        )[0]
+        input_node = custom_op_node.args[0]
+        self.assertIsInstance(input_node, torch.fx.Node)
+        self.assertEqual(example.stride(), input_node.meta["val"].stride())
+
+    def test_flydsl_op_decomposes_for_export(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::export",
+            mutates_args=(),
+        )
+        def flydsl_add(inp: torch.Tensor) -> torch.Tensor:
+            if inp.shape[1] != 8:
+                raise ValueError("expected width eight")
+            out = torch.empty_like(inp)
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_add(inp)
+
+        batch = torch.export.Dim("batch", min=1, max=32)
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(4, 8),),
+            dynamic_shapes=({0: batch},),
+        )
+
+        custom_op_nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.test_flydsl_capture.export.default,
+        )
+        self.assertEqual(1, len(custom_op_nodes))
+
+        decomposed = exported.run_decompositions()
+        flydsl_nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        self.assertEqual(1, len(flydsl_nodes))
+
+    def test_flydsl_op_preserves_mutation_when_decomposed(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::mutation",
+            mutates_args={"out"},
+        )
+        def flydsl_copy(out: torch.Tensor, inp: torch.Tensor) -> None:
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                flydsl_copy(out, inp)
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        decomposed = exported.run_decompositions()
+
+        nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        self.assertEqual(1, len(nodes))
+        self.assertEqual((0,), nodes[0].kwargs["mutated_arg_indices"])
+
+    def test_flydsl_op_decomposes_multiple_launchers_and_aten(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::composed",
+            mutates_args=(),
+        )
+        def composed(inp: torch.Tensor) -> torch.Tensor:
+            intermediate = torch.empty_like(inp)
+            captured_launcher(
+                out=intermediate,
+                inp=inp,
+                rows=inp.numel(),
+            )
+            shifted = intermediate + 1
+            out = torch.empty_like(inp)
+            captured_launcher(
+                out=out,
+                inp=shifted,
+                rows=shifted.numel(),
+            )
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return composed(inp)
+
+        batch = torch.export.Dim("batch", min=1, max=32)
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(4, 8),),
+            dynamic_shapes=({0: batch},),
+        )
+        decomposed = exported.run_decompositions()
+
+        flydsl_nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        aten_nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.aten.add.Tensor,
+        )
+        self.assertEqual(2, len(flydsl_nodes))
+        self.assertEqual(1, len(aten_nodes))
+        for node in flydsl_nodes:
+            rows = node.kwargs["args"][2]
+            self.assertIsInstance(rows, torch.fx.Node)
+            self.assertIsInstance(rows.meta["val"], torch.SymInt)
 
 
 if __name__ == "__main__":

--- a/torch/_library/__init__.py
+++ b/torch/_library/__init__.py
@@ -3,5 +3,5 @@ import torch._library.fake_impl
 import torch._library.simple_registry
 import torch._library.utils
 from torch._library.fake_class_registry import register_fake_class
-from torch._library.flydsl import wrap_flydsl
+from torch._library.flydsl import flydsl_op, wrap_flydsl
 from torch._library.triton import capture_triton, triton_op, wrap_triton

--- a/torch/_library/flydsl.py
+++ b/torch/_library/flydsl.py
@@ -5,6 +5,86 @@ from typing import Any
 
 from torch.utils._exposed_in import exposed_in
 
+from .custom_ops import custom_op, CustomOpDef
+from .infer_schema import infer_schema
+
+
+@exposed_in("torch.library")
+def flydsl_op(
+    name: str,
+    fn: Callable | None = None,
+    /,
+    *,
+    mutates_args: str | Iterable[str],
+    schema: str | None = None,
+) -> Callable:
+    """Create a custom operator backed by one or more wrapped FlyDSL launchers.
+
+    Use this boundary when a FlyDSL-backed operation contains Python control flow
+    that should remain opaque to frontend tracing. The function body may contain
+    PyTorch-understood operations and launchers returned by :func:`wrap_flydsl`.
+    It must otherwise remain traceable when its implementation is decomposed for
+    compilation and must not rely on unsupported external Python side effects.
+
+    Args:
+        name: A stable operator name in ``"namespace::name"`` form.
+        mutates_args: Names of arguments mutated by the outer operator, or
+            ``"unknown"`` to conservatively mark all inputs as mutated.
+        schema: An optional operator schema. By default it is inferred from the
+            function annotations.
+
+    Example::
+
+        wrapped_launcher = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+
+        @torch.library.flydsl_op("mylib::add_one", mutates_args=())
+        def add_one(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            wrapped_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+    """
+
+    def dec(fn: Callable[..., object]) -> CustomOpDef:
+        result = custom_op(
+            name,
+            fn,
+            mutates_args=mutates_args,
+            schema=(
+                schema
+                if schema is not None
+                else infer_schema(fn, mutates_args=mutates_args)
+            ),
+        )
+        result.register_fake(fn)
+
+        from .._subclasses.functional_tensor import FunctionalTensorMode
+
+        def functional_decomp(mode, op, types, args, kwargs):
+            import torch._subclasses
+
+            unrecognized_types = [
+                typ
+                for typ in types
+                if not issubclass(typ, torch._subclasses.FakeTensor)
+                and typ
+                not in (
+                    torch.Tensor,
+                    torch._subclasses.functional_tensor.FunctionalTensor,
+                )
+            ]
+            if unrecognized_types:
+                return NotImplemented
+            with mode:
+                return fn(*args, **kwargs)
+
+        result.register_torch_dispatch(FunctionalTensorMode, functional_decomp)
+        return result
+
+    if fn is None:
+        return dec
+    return dec(fn)
+
 
 @exposed_in("torch.library")
 def wrap_flydsl(

--- a/torch/library.py
+++ b/torch/library.py
@@ -19,7 +19,7 @@ from torch._library.custom_ops import (
     device_types_t,
 )
 from torch._library.effects import EffectType
-from torch._library.flydsl import wrap_flydsl
+from torch._library.flydsl import flydsl_op, wrap_flydsl
 from torch._library.infer_schema import infer_schema
 from torch._library.triton import triton_op, wrap_triton
 from torch._ops import OpOverload
@@ -39,6 +39,7 @@ __all__ = [
     "get_ctx",
     "get_kernel",
     "custom_op",
+    "flydsl_op",
     "wrap_flydsl",
     "triton_op",
     "wrap_triton",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196810
* #196809
* #196808
* __->__ #196807
* #196806
* #196805


Add `torch.library.flydsl_op`, the FlyDSL counterpart to `torch.library.triton_op`, for compilation pipelines that run classic FX tracing before `torch.export`. `wrap_flydsl` is a per-launcher Python callable and only materializes a FlyDSL HOP once Dynamo/export traces its body; classic FX otherwise enters launcher Python and can fail on ordinary control flow. `torch.fx.wrap` is limited to module-level functions and does not naturally carry per-instance launcher objects, while maintaining application-specific leaf-module allowlists does not scale to arbitrary FlyDSL-backed operators.

`flydsl_op` creates a reusable dispatcher boundary that classic FX preserves. Its body can compose PyTorch operations and one or more `wrap_flydsl` launchers, declares mutations explicitly, and decomposes before Inductor so the final AOTI package contains native FlyDSL launches rather than a Python or custom-op runtime fallback. Eager execution continues through the existing `wrap_flydsl` path; this change does not add a second launcher execution path.

Like `torch.library.custom_op` and `triton_op`, an untagged `flydsl_op` inherits the default `needs_exact_strides` layout contract. Coverage verifies the effective tag and preservation of non-contiguous input stride metadata through export.

Differential Revision: [D116865847](https://our.internmc.facebook.com/intern/diff/D116865847/)

Differential Revision: [D116865847](https://our.internmc.facebook.com/intern/diff/D116865847)