### PR TITLE
[Export][FlyDSL] Add independent custom-op decomposition control

### DIFF
--- a/test/inductor/flydsl_aot/test_flydsl_capture.py
+++ b/test/inductor/flydsl_aot/test_flydsl_capture.py
@@ -575,12 +575,159 @@ class FlyDSLCaptureTest(TestCase):
         )
         self.assertEqual(1, len(custom_op_nodes))
 
-        decomposed = exported.run_decompositions()
+        preserved = exported.run_decompositions(
+            decomp_table={},
+            decompose_custom_triton_ops=True,
+        )
+        self.assertEqual(
+            1,
+            len(
+                preserved.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=torch.ops.test_flydsl_capture.export.default,
+                )
+            ),
+        )
+        self.assertEqual(
+            [],
+            preserved.graph_module.graph.find_nodes(
+                op="call_function",
+                target=flydsl_kernel_wrapper_functional,
+            ),
+        )
+
+        with torch._functorch.config.patch(decompose_custom_flydsl_ops=False):
+            decomposed = exported.run_decompositions(
+                decomp_table={},
+                decompose_custom_triton_ops=False,
+                decompose_custom_flydsl_ops=True,
+            )
         flydsl_nodes = decomposed.graph_module.graph.find_nodes(
             op="call_function",
             target=flydsl_kernel_wrapper_functional,
         )
         self.assertEqual(1, len(flydsl_nodes))
+
+    def test_flydsl_op_decomposes_for_torch_compile_by_default(self):
+        from torch._dynamo.testing import AotEagerAndRecordGraphs
+
+        captured = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::compile_default",
+            mutates_args=(),
+        )
+        def flydsl_copy(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            captured(out, inp, inp.numel())
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_copy(inp)
+
+        backend = AotEagerAndRecordGraphs()
+        inp = torch.randn(8)
+
+        def invoke(_, args):
+            args[0].copy_(args[1])
+
+        with mock.patch(
+            "torch._higher_order_ops.flydsl_kernel_wrap.invoke_flydsl_launcher",
+            side_effect=invoke,
+        ):
+            actual = torch.compile(
+                Model(),
+                backend=backend,
+                fullgraph=True,
+            )(inp)
+
+        torch.testing.assert_close(actual, inp)
+        self.assertEqual(1, len(backend.fw_graphs))
+        graph = backend.fw_graphs[0].graph
+        self.assertEqual(
+            1,
+            len(
+                graph.find_nodes(
+                    op="call_function",
+                    target=flydsl_kernel_wrapper_functional,
+                )
+            ),
+        )
+        self.assertEqual(
+            [],
+            graph.find_nodes(
+                op="call_function",
+                target=torch.ops.test_flydsl_capture.compile_default.default,
+            ),
+        )
+
+    def test_flydsl_op_preserved_in_joint_export(self):
+        from torch.export.experimental import _export_forward_backward
+
+        captured = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::joint_export",
+            mutates_args=(),
+        )
+        def flydsl_copy(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            captured(out, inp, inp.numel())
+            return out
+
+        def backward(ctx, grad):
+            return grad
+
+        flydsl_copy.register_autograd(backward)
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_copy(inp).sum()
+
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(8, requires_grad=True),),
+        )
+        joint = _export_forward_backward(exported)
+
+        self.assertEqual(
+            1,
+            len(
+                joint.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=torch.ops.test_flydsl_capture.joint_export.default,
+                )
+            ),
+        )
+        self.assertEqual(
+            [],
+            joint.graph_module.graph.find_nodes(
+                op="call_function",
+                target=flydsl_kernel_wrapper_functional,
+            ),
+        )
+
+        decomposed = joint.run_decompositions(
+            decomp_table={},
+            decompose_custom_flydsl_ops=True,
+        )
+        self.assertEqual(
+            [],
+            decomposed.graph_module.graph.find_nodes(
+                op="call_function",
+                target=torch.ops.test_flydsl_capture.joint_export.default,
+            ),
+        )
+        self.assertEqual(
+            1,
+            len(
+                decomposed.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=flydsl_kernel_wrapper_functional,
+                )
+            ),
+        )
 
     def test_flydsl_op_preserves_mutation_when_decomposed(self):
         captured_launcher = torch.library.wrap_flydsl(
@@ -602,7 +749,7 @@ class FlyDSLCaptureTest(TestCase):
                 return out
 
         exported = torch.export.export(Model(), (torch.randn(8),))
-        decomposed = exported.run_decompositions()
+        decomposed = exported.run_decompositions(decompose_custom_flydsl_ops=True)
 
         nodes = decomposed.graph_module.graph.find_nodes(
             op="call_function",
@@ -647,7 +794,7 @@ class FlyDSLCaptureTest(TestCase):
             (torch.randn(4, 8),),
             dynamic_shapes=({0: batch},),
         )
-        decomposed = exported.run_decompositions()
+        decomposed = exported.run_decompositions(decompose_custom_flydsl_ops=True)
 
         flydsl_nodes = decomposed.graph_module.graph.find_nodes(
             op="call_function",

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -46,6 +46,9 @@ debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", "0") != "0"
 # See # NOTE [Export custom triton op]
 decompose_custom_triton_ops = True
 
+# Controls functional decomposition for torch.library.flydsl_op.
+decompose_custom_flydsl_ops: bool = True
+
 static_weight_shapes = True
 
 # See https://github.com/pytorch/pytorch/issues/141881

--- a/torch/_library/flydsl.py
+++ b/torch/_library/flydsl.py
@@ -61,6 +61,11 @@ def flydsl_op(
         from .._subclasses.functional_tensor import FunctionalTensorMode
 
         def functional_decomp(mode, op, types, args, kwargs):
+            from torch.export._trace import custom_flydsl_ops_decomposition_disabled
+
+            if custom_flydsl_ops_decomposition_disabled():
+                return mode.__torch_dispatch__(op, types, args, kwargs)
+
             import torch._subclasses
 
             unrecognized_types = [

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -223,6 +223,26 @@ def custom_triton_ops_decomposition_disabled():
     return not torch._functorch.config.decompose_custom_triton_ops
 
 
+@contextmanager
+def _set_custom_flydsl_op_functional_decomposition(enabled: bool):
+    old = torch._functorch.config.decompose_custom_flydsl_ops
+    try:
+        torch._functorch.config.decompose_custom_flydsl_ops = enabled
+        yield torch._functorch.config.decompose_custom_flydsl_ops
+    finally:
+        torch._functorch.config.decompose_custom_flydsl_ops = old
+
+
+@contextmanager
+def _disable_custom_flydsl_op_functional_decomposition():
+    with _set_custom_flydsl_op_functional_decomposition(False) as enabled:
+        yield enabled
+
+
+def custom_flydsl_ops_decomposition_disabled():
+    return not torch._functorch.config.decompose_custom_flydsl_ops
+
+
 def _fixup_key(x):
     return "L__self__" + _strip_root(x)
 
@@ -1020,9 +1040,9 @@ def _export_to_torch_ir(
     # them here.
     args, kwargs = pytree.tree_map_only(
         _IntWrapper,
-        lambda a: a.val
-        if a.dynamism is None or a.dynamism.type == _DimHintType.STATIC
-        else a,
+        lambda a: (
+            a.val if a.dynamism is None or a.dynamism.type == _DimHintType.STATIC else a
+        ),
         (args, kwargs),
     )
 
@@ -1177,6 +1197,7 @@ def _export_to_aten_ir(
     decomp_table=None,
     _prettify_placeholder_names: bool = True,
     decompose_custom_triton_ops: bool = False,
+    decompose_custom_flydsl_ops: bool = False,
 ) -> ATenExportArtifact:
     custom_triton_ops_decomposition_ctx = (
         nullcontext
@@ -1199,6 +1220,9 @@ def _export_to_aten_ir(
         stack.enter_context(_ignore_backend_decomps())
         stack.enter_context(_compiling_state_context())
         stack.enter_context(custom_triton_ops_decomposition_ctx())
+        stack.enter_context(
+            _set_custom_flydsl_op_functional_decomposition(decompose_custom_flydsl_ops)
+        )
         stack.enter_context(torch.no_grad())
 
         gm, graph_signature = transform(_aot_export_joint_with_descriptors)(
@@ -1562,9 +1586,11 @@ def _process_export_inputs(
     mod: torch.nn.Module,
     args: tuple[object, ...],
     kwargs: dict[str, object] | None,
-    dynamic_shapes: _DynamicShapesInput
-    | torch.export.AdditionalInputs
-    | torch.export.ShapesCollection,
+    dynamic_shapes: (
+        _DynamicShapesInput
+        | torch.export.AdditionalInputs
+        | torch.export.ShapesCollection
+    ),
 ) -> tuple[
     tuple[object, ...],
     dict[str, object],

--- a/torch/export/experimental/__init__.py
+++ b/torch/export/experimental/__init__.py
@@ -78,10 +78,10 @@ def _export_forward_backward(
         cia_to_decomp={},
         python_decomp_table=core_aten_decompositions(),
         joint_loss_index=joint_loss_index,
-        # For serialization purpose, we don't want to decompose custom triton ops.
-        # If users would like to decompose custom triton ops, they could do it
-        # with run_decompositions() API.
+        # Preserve custom kernel ops for serialization. Users can opt into
+        # decomposition with run_decompositions().
         decompose_custom_triton_ops=False,
+        decompose_custom_flydsl_ops=False,
     )
     gm, new_graph_signature = _copy_graph_module_and_signature(ep)
     _remove_detach_pass(gm, new_graph_signature)

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -335,6 +335,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
     python_decomp_table: dict[torch._ops.OperatorBase, Callable],
     joint_loss_index: int | None,
     decompose_custom_triton_ops,
+    decompose_custom_flydsl_ops=False,
 ):
     from torch._export.passes.lift_constants_pass import _materialize_and_lift_constants
     from torch._functorch.aot_autograd import aot_export_module
@@ -342,6 +343,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
         _disable_custom_triton_op_functional_decomposition,
         _export_to_aten_ir,
         _ignore_backend_decomps,
+        _set_custom_flydsl_op_functional_decomposition,
         _verify_nn_module_stack,
         _verify_placeholder_names,
         _verify_stack_trace,
@@ -489,6 +491,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
                     decomp_table=python_decomp_table,
                     _prettify_placeholder_names=False,
                     decompose_custom_triton_ops=decompose_custom_triton_ops,
+                    decompose_custom_flydsl_ops=decompose_custom_flydsl_ops,
                 )
 
                 # aten_export_artifact.constants contains only fake script objects, we need to map them back
@@ -601,6 +604,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
         fake_mode_ctx,
         _override_composite_implicit_decomp(cia_to_decomp),
         custom_triton_ops_decomposition_ctx(),
+        _set_custom_flydsl_op_functional_decomposition(decompose_custom_flydsl_ops),
     ):
         gm, graph_signature = aot_export_module(
             ep.graph_module,
@@ -1018,6 +1022,7 @@ def _decompose_exported_program(
     python_decomp_table: dict[torch._ops.OperatorBase, Callable],
     joint_loss_index: int | None,
     decompose_custom_triton_ops: bool,
+    decompose_custom_flydsl_ops: bool = False,
 ):
     (
         gm,
@@ -1030,6 +1035,7 @@ def _decompose_exported_program(
         python_decomp_table=python_decomp_table,
         joint_loss_index=joint_loss_index,
         decompose_custom_triton_ops=decompose_custom_triton_ops,
+        decompose_custom_flydsl_ops=decompose_custom_flydsl_ops,
     )
 
     # The signatures of ep.module_call_graph refer to input / output nodes of
@@ -1516,6 +1522,7 @@ class ExportedProgram:
         self,
         decomp_table: dict[torch._ops.OperatorBase, Callable] | None = None,
         decompose_custom_triton_ops: bool = False,
+        decompose_custom_flydsl_ops: bool = False,
     ) -> "ExportedProgram":
         """
         Run a set of decompositions on the exported program and returns a new
@@ -1530,6 +1537,10 @@ class ExportedProgram:
              An optional argument that specifies decomp behaviour for Aten ops
              (1) If None, we decompose to core aten decompositions
              (2) If empty, we don't decompose any operator
+            decompose_custom_flydsl_ops:
+             Whether to decompose :func:`torch.library.flydsl_op` operators into
+             their wrapped FlyDSL launchers. Defaults to ``False`` independently
+             of ``decompose_custom_triton_ops``.
 
 
         Some examples:
@@ -1580,6 +1591,7 @@ class ExportedProgram:
             python_decomp_table=python_decomp_table,
             joint_loss_index=None,
             decompose_custom_triton_ops=decompose_custom_triton_ops,
+            decompose_custom_flydsl_ops=decompose_custom_flydsl_ops,
         )
 
     def _transform_do_not_use(self, *passes: PassType) -> "ExportedProgram":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196810
* #196809
* __->__ #196808
* #196807
* #196806
* #196805


Add `decompose_custom_flydsl_ops` as the FlyDSL-specific counterpart to `decompose_custom_triton_ops` on `ExportedProgram.run_decompositions`. Keep both controls independent: exported programs preserve opaque FlyDSL operators by default, while callers preparing a graph for Inductor can explicitly expose their PyTorch bodies and `wrap_flydsl` launchers.

Thread the option through export and AOTDispatcher contexts and make `torch.library.flydsl_op` consult only the FlyDSL flag. This keeps the public FX boundary stable without coupling FlyDSL behavior to Triton configuration. Tests exercise default preservation, explicit FlyDSL decomposition, independent Triton/FlyDSL settings, functionalization, and experimental forward/backward export.

Differential Revision: [D117007670](https://our.internmc.facebook.com/intern/diff/D117007670/)

Differential Revision: [D117007670](https://our.internmc.facebook.com/intern/diff/D117007670)