### PR TITLE
[AOTI][FlyDSL] Test composed packaged launchers

### DIFF
--- a/test/inductor/flydsl_aot/flydsl_aoti_test_models.py
+++ b/test/inductor/flydsl_aot/flydsl_aoti_test_models.py
@@ -1,0 +1,245 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+import torch
+from caffe2.test.inductor.flydsl_aot.flydsl_test_kernels import (
+    _relu_kernel,
+    ELEMENTWISE_BLOCK,
+    gemm_launcher,
+    GEMM_M,
+    GEMM_N,
+    relu_launcher,
+    RMS_N,
+    rms_norm_launcher,
+)
+
+
+RELU_SCALE = 0.75
+
+
+@flyc.kernel
+def _vector_add_kernel(
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    out: fx.Tensor,
+    block_dim: fx.Constexpr[int],
+):
+    block = fx.block_idx.x
+    thread = fx.thread_idx.x
+
+    lhs = fx.rocdl.make_buffer_tensor(lhs)
+    rhs = fx.rocdl.make_buffer_tensor(rhs)
+    out = fx.rocdl.make_buffer_tensor(out)
+    tiled_lhs = fx.slice(
+        fx.logical_divide(lhs, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    tiled_rhs = fx.slice(
+        fx.logical_divide(rhs, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    tiled_out = fx.slice(
+        fx.logical_divide(out, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    tiled_lhs = fx.logical_divide(tiled_lhs, fx.make_layout(1, 1))
+    tiled_rhs = fx.logical_divide(tiled_rhs, fx.make_layout(1, 1))
+    tiled_out = fx.logical_divide(tiled_out, fx.make_layout(1, 1))
+
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Float32)
+    lhs_register = fx.make_rmem_tensor(1, fx.Float32)
+    rhs_register = fx.make_rmem_tensor(1, fx.Float32)
+    out_register = fx.make_rmem_tensor(1, fx.Float32)
+    fx.copy_atom_call(copy_atom, fx.slice(tiled_lhs, (None, thread)), lhs_register)
+    fx.copy_atom_call(copy_atom, fx.slice(tiled_rhs, (None, thread)), rhs_register)
+    value = fx.arith.addf(
+        fx.memref_load_vec(lhs_register),
+        fx.memref_load_vec(rhs_register),
+    )
+    fx.memref_store_vec(value, out_register)
+    fx.copy_atom_call(copy_atom, out_register, fx.slice(tiled_out, (None, thread)))
+
+
+@flyc.jit
+def _vector_add_launcher(
+    out: fx.Tensor,
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    elements: fx.Int32,
+    block_dim: fx.Constexpr[int],
+):
+    grid = (elements + block_dim - 1) // block_dim
+    _vector_add_kernel(lhs, rhs, out, block_dim).launch(
+        grid=(grid, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+
+
+@flyc.jit
+def _two_stage_add_launcher(
+    out: fx.Tensor,
+    workspace: fx.Tensor,
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    elements: fx.Int32,
+    block_dim: fx.Constexpr[int],
+):
+    grid = (elements + block_dim - 1) // block_dim
+    _vector_add_kernel(lhs, rhs, workspace, block_dim).launch(
+        grid=(grid, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+    _vector_add_kernel(workspace, rhs, out, block_dim).launch(
+        grid=(grid, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+
+
+class _BoundReluLauncher:
+    @flyc.jit
+    def launch(
+        self,
+        inp: fx.Tensor,
+        out: fx.Tensor,
+        elements: fx.Int32,
+        block_dim: fx.Constexpr[int],
+        *,
+        scale: fx.Float32,
+    ):
+        blocks = (elements + block_dim - 1) // block_dim
+        _relu_kernel(inp, out, scale, block_dim).launch(
+            grid=(blocks, 1, 1),
+            block=(block_dim, 1, 1),
+        )
+
+
+_bound_relu_launcher = _BoundReluLauncher()
+_captured_vector_add = torch.library.wrap_flydsl(
+    _vector_add_launcher,
+    mutates_args={"out"},
+)
+_captured_two_stage_add = torch.library.wrap_flydsl(
+    _two_stage_add_launcher,
+    mutates_args={"out", "workspace"},
+)
+_captured_gemm = torch.library.wrap_flydsl(
+    gemm_launcher,
+    mutates_args={"out"},
+)
+_captured_relu = torch.library.wrap_flydsl(
+    relu_launcher,
+    mutates_args={"out"},
+)
+_captured_rms_norm = torch.library.wrap_flydsl(
+    rms_norm_launcher,
+    mutates_args={"out"},
+)
+_captured_bound_relu = torch.library.wrap_flydsl(
+    _bound_relu_launcher.launch,
+    mutates_args={"out"},
+)
+
+
+def _two_stage_add(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    workspace = torch.empty_like(lhs)
+    out = torch.empty_like(lhs)
+    _captured_two_stage_add(
+        out,
+        workspace,
+        lhs,
+        rhs,
+        lhs.numel(),
+        ELEMENTWISE_BLOCK,
+    )
+    return out
+
+
+class VectorAddModel(torch.nn.Module):
+    def forward(self, lhs, rhs):
+        out = torch.empty_like(lhs)
+        _captured_vector_add(
+            out,
+            lhs,
+            rhs,
+            lhs.numel(),
+            256,
+        )
+        return out
+
+
+class TwoStageAddModel(torch.nn.Module):
+    def forward(self, lhs, rhs):
+        return torch.sin(_two_stage_add(lhs, rhs))
+
+
+class BoundReluModel(torch.nn.Module):
+    def forward(self, inp):
+        out = torch.empty_like(inp)
+        _captured_bound_relu(
+            inp,
+            out,
+            inp.numel(),
+            ELEMENTWISE_BLOCK,
+            scale=RELU_SCALE,
+        )
+        return out
+
+
+def _composed(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    bias: torch.Tensor,
+    weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    gemm_out = torch.empty(
+        (GEMM_M, GEMM_N),
+        device=lhs.device,
+        dtype=lhs.dtype,
+    )
+    _captured_gemm(lhs, rhs, gemm_out)
+
+    biased = gemm_out + bias
+    flat_biased = biased.flatten()
+    flat_activated = torch.empty_like(flat_biased)
+    _captured_relu(
+        flat_biased,
+        flat_activated,
+        flat_biased.numel(),
+        RELU_SCALE,
+        ELEMENTWISE_BLOCK,
+    )
+    activated = flat_activated.view(GEMM_M, GEMM_N)
+
+    mixed = activated + torch.sin(activated) * 0.25
+    normalized = torch.empty_like(mixed)
+    _captured_rms_norm(
+        mixed,
+        weight,
+        normalized,
+        GEMM_M,
+        RMS_N,
+    )
+    final = normalized * 1.5 - 0.5
+    return final, gemm_out, activated, normalized
+
+
+class ComposedModel(torch.nn.Module):
+    def forward(self, lhs, rhs, bias, weight):
+        return _composed(lhs, rhs, bias, weight)
+
+
+class DynamicRMSNormModel(torch.nn.Module):
+    def forward(self, inp, weight):
+        out = torch.empty_like(inp)
+        _captured_rms_norm(
+            inp,
+            weight,
+            out,
+            inp.shape[0],
+            RMS_N,
+        )
+        return out

--- a/test/inductor/flydsl_aot/flydsl_test_kernels.py
+++ b/test/inductor/flydsl_aot/flydsl_test_kernels.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Small kernels adapted from the upstream FlyDSL examples."""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import full
+
+
+GEMM_M = 64
+GEMM_N = 64
+GEMM_K = 8
+ELEMENTWISE_BLOCK = 256
+RMS_N = 64
+RMS_EPS = 1e-5
+
+
+@flyc.kernel
+def _gemm_kernel(
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    out: fx.Tensor,
+):
+    thread = fx.thread_idx.x
+    block = fx.block_idx.x
+
+    lhs = fx.rocdl.make_buffer_tensor(lhs)
+    rhs = fx.rocdl.make_buffer_tensor(rhs)
+    out = fx.rocdl.make_buffer_tensor(out)
+
+    block_lhs = fx.slice(
+        fx.zipped_divide(lhs, (GEMM_M, GEMM_K)),
+        (None, block),
+    )
+    block_rhs = fx.slice(
+        fx.zipped_divide(rhs, (GEMM_N, GEMM_K)),
+        (None, block),
+    )
+    block_out = fx.slice(
+        fx.zipped_divide(out, (GEMM_M, GEMM_N)),
+        (None, block),
+    )
+
+    mma_atom = fx.make_mma_atom(fx.rocdl.MFMA(16, 16, 4, fx.Float32))
+    tiled_mma = fx.make_tiled_mma(
+        mma_atom,
+        fx.make_layout((2, 2, 1), (1, 2, 0)),
+    )
+    thread_mma = tiled_mma.thr_slice(thread)
+
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
+    thread_copy_lhs = fx.make_tiled_copy_A(copy_atom, tiled_mma).get_slice(thread)
+    thread_copy_rhs = fx.make_tiled_copy_B(copy_atom, tiled_mma).get_slice(thread)
+    thread_copy_out = fx.make_tiled_copy_C(copy_atom, tiled_mma).get_slice(thread)
+
+    lhs_fragment = thread_mma.make_fragment_A(block_lhs)
+    rhs_fragment = thread_mma.make_fragment_B(block_rhs)
+    out_fragment = thread_mma.make_fragment_C(block_out)
+
+    fx.copy(
+        copy_atom,
+        thread_copy_lhs.partition_S(block_lhs),
+        thread_copy_lhs.retile(lhs_fragment),
+        pred=None,
+    )
+    fx.copy(
+        copy_atom,
+        thread_copy_rhs.partition_S(block_rhs),
+        thread_copy_rhs.retile(rhs_fragment),
+        pred=None,
+    )
+    out_fragment.fill(0)
+    fx.gemm(mma_atom, out_fragment, lhs_fragment, rhs_fragment, out_fragment)
+    fx.copy(
+        copy_atom,
+        thread_copy_out.retile(out_fragment),
+        thread_copy_out.partition_S(block_out),
+        pred=None,
+    )
+
+
+@flyc.jit
+def gemm_launcher(
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    out: fx.Tensor,
+):
+    _gemm_kernel(lhs, rhs, out).launch(
+        grid=(1, 1, 1),
+        block=(256, 1, 1),
+    )
+
+
+@flyc.kernel
+def _relu_kernel(
+    inp: fx.Tensor,
+    out: fx.Tensor,
+    scale: fx.Float32,
+    block_dim: fx.Constexpr[int],
+):
+    block = fx.block_idx.x
+    thread = fx.thread_idx.x
+    inp = fx.rocdl.make_buffer_tensor(inp)
+    out = fx.rocdl.make_buffer_tensor(out)
+    block_inp = fx.slice(
+        fx.logical_divide(inp, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    block_out = fx.slice(
+        fx.logical_divide(out, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    block_inp = fx.logical_divide(block_inp, fx.make_layout(1, 1))
+    block_out = fx.logical_divide(block_out, fx.make_layout(1, 1))
+
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Float32)
+    register = fx.make_rmem_tensor(1, fx.Float32)
+    fx.copy_atom_call(copy_atom, fx.slice(block_inp, (None, thread)), register)
+    value = fx.memref_load_vec(register)[0]
+    activated = value.maximumf(fx.Float32(0.0)) * scale
+    fx.memref_store_vec(full(1, activated, fx.Float32), register)
+    fx.copy_atom_call(copy_atom, register, fx.slice(block_out, (None, thread)))
+
+
+@flyc.jit
+def relu_launcher(
+    inp: fx.Tensor,
+    out: fx.Tensor,
+    elements: fx.Int32,
+    scale: fx.Float32,
+    block_dim: fx.Constexpr[int],
+):
+    blocks = (elements + block_dim - 1) // block_dim
+    _relu_kernel(inp, out, scale, block_dim).launch(
+        grid=(blocks, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+
+
+@flyc.kernel
+def _rms_norm_kernel(
+    inp: fx.Tensor,
+    weight: fx.Tensor,
+    out: fx.Tensor,
+    columns: fx.Constexpr[int],
+):
+    row = fx.block_idx.x
+    thread = fx.thread_idx.x
+    inp = fx.rocdl.make_buffer_tensor(inp)
+    weight = fx.rocdl.make_buffer_tensor(weight)
+    out = fx.rocdl.make_buffer_tensor(out)
+
+    row_inp = fx.logical_divide(
+        fx.slice(inp, (row, None)),
+        fx.make_layout(1, 1),
+    )
+    row_out = fx.logical_divide(
+        fx.slice(out, (row, None)),
+        fx.make_layout(1, 1),
+    )
+    divided_weight = fx.logical_divide(weight, fx.make_layout(1, 1))
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Float32)
+
+    inp_register = fx.make_rmem_tensor(1, fx.Float32)
+    weight_register = fx.make_rmem_tensor(1, fx.Float32)
+    out_register = fx.make_rmem_tensor(1, fx.Float32)
+    fx.copy_atom_call(copy_atom, fx.slice(row_inp, (None, thread)), inp_register)
+    fx.copy_atom_call(
+        copy_atom,
+        fx.slice(divided_weight, (None, thread)),
+        weight_register,
+    )
+    value = fx.memref_load_vec(inp_register)[0]
+    weight_value = fx.memref_load_vec(weight_register)[0]
+
+    sum_of_squares = value * value
+    for offset in (32, 16, 8, 4, 2, 1):
+        sum_of_squares = sum_of_squares + sum_of_squares.shuffle_xor(
+            offset,
+            columns,
+        )
+    inverse_rms = fmath.rsqrt(
+        sum_of_squares / fx.Float32(float(columns)) + fx.Float32(RMS_EPS)
+    )
+    normalized = value * inverse_rms * weight_value
+    fx.memref_store_vec(full(1, normalized, fx.Float32), out_register)
+    fx.copy_atom_call(
+        copy_atom,
+        out_register,
+        fx.slice(row_out, (None, thread)),
+    )
+
+
+@flyc.jit
+def rms_norm_launcher(
+    inp: fx.Tensor,
+    weight: fx.Tensor,
+    out: fx.Tensor,
+    rows: fx.Int32,
+    columns: fx.Constexpr[int],
+):
+    _rms_norm_kernel(inp, weight, out, columns).launch(
+        grid=(rows, 1, 1),
+        block=(columns, 1, 1),
+    )

--- a/test/inductor/flydsl_aot/test_flydsl_aoti_e2e.py
+++ b/test/inductor/flydsl_aot/test_flydsl_aoti_e2e.py
@@ -1,0 +1,376 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+import torch
+from torch._higher_order_ops.flydsl_kernel_wrap import flydsl_kernel_wrapper_mutation
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch._inductor.utils import fresh_cache, run_and_get_cpp_code
+from torch.autograd import DeviceType
+from torch.testing._internal.common_utils import TestCase
+
+
+HAS_FLYDSL = torch.cuda.is_available() and runtime_available()
+if HAS_FLYDSL:
+    from caffe2.test.inductor.flydsl_aot.flydsl_aoti_test_models import (
+        BoundReluModel,
+        ComposedModel,
+        DynamicRMSNormModel,
+        RELU_SCALE,
+        TwoStageAddModel,
+        VectorAddModel,
+    )
+    from caffe2.test.inductor.flydsl_aot.flydsl_test_kernels import (
+        GEMM_K,
+        GEMM_M,
+        GEMM_N,
+        RMS_EPS,
+        RMS_N,
+    )
+
+RELOCATED_PACKAGE_LOADER_SCRIPT = """
+import sys
+
+import torch
+
+package_path = sys.argv[1]
+lhs = torch.arange(1024, device="cuda", dtype=torch.float32)
+rhs = torch.arange(1024, device="cuda", dtype=torch.float32).flip(0)
+loader = torch._C._aoti.AOTIModelPackageLoader(
+    package_path,
+    "model",
+    False,
+    1,
+    -1,
+)
+actual = loader.run([lhs, rhs])[0]
+torch.cuda.synchronize()
+torch.testing.assert_close(actual, lhs + rhs)
+"""
+
+
+@unittest.skipUnless(HAS_FLYDSL, "FlyDSL is not available")
+class FlyDSLAOTIEndToEndTest(TestCase):
+    def _assert_package_runs_after_relocation(
+        self,
+        package_path: str,
+        root: Path,
+    ) -> None:
+        relocated_dir = root / "relocated"
+        relocated_dir.mkdir()
+        relocated_package = relocated_dir / "renamed_model.pt2"
+        shutil.move(package_path, relocated_package)
+        Path(package_path).parent.rmdir()
+
+        child_cache = root / "child_cache"
+        child_cache.mkdir()
+        env = os.environ.copy()
+        env["TORCHINDUCTOR_CACHE_DIR"] = str(child_cache)
+        env["TRITON_CACHE_DIR"] = str(child_cache / "triton")
+        env["PYTHONPATH"] = os.pathsep.join(path for path in sys.path if path)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                RELOCATED_PACKAGE_LOADER_SCRIPT,
+                str(relocated_package),
+            ],
+            cwd=relocated_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        self.assertEqual(
+            0,
+            result.returncode,
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_vector_add_runs_from_package(self):
+        lhs = torch.randn(1024, device="cuda", dtype=torch.float32)
+        rhs = torch.randn_like(lhs)
+        exported = torch.export.export(VectorAddModel(), (lhs, rhs), strict=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            producer_dir = root / "producer"
+            producer_dir.mkdir()
+            with fresh_cache(dir=tmpdir):
+                producer_cache = Path(os.environ["TORCHINDUCTOR_CACHE_DIR"])
+                package_path, generated_code = run_and_get_cpp_code(
+                    torch._inductor.aoti_compile_and_package,
+                    exported,
+                    package_path=str(producer_dir / "flydsl_vector_add.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+            self.assertFalse(producer_cache.exists())
+            self.assertNotIn("aoti_torch_clone", generated_code)
+            self.assertNotIn("aoti_torch_copy_", generated_code)
+            self.assertNotIn("triton_poi", generated_code)
+            with zipfile.ZipFile(package_path) as package:
+                packaged_files = package.namelist()
+            self.assertTrue(
+                any(path.endswith("/libfly_jit_runtime.so") for path in packaged_files),
+                packaged_files,
+            )
+            self.assertTrue(
+                any(
+                    Path(path).name.startswith("libmlir_c_runner_utils.so")
+                    for path in packaged_files
+                ),
+                packaged_files,
+            )
+            loader = torch._C._aoti.AOTIModelPackageLoader(
+                package_path,
+                "model",
+                False,
+                1,
+                -1,
+            )
+            actual = loader.run([lhs, rhs])[0]
+            torch.testing.assert_close(actual, lhs + rhs)
+
+            stream = torch.cuda.Stream()
+            self.assertNotEqual(
+                stream.cuda_stream,
+                torch.cuda.default_stream().cuda_stream,
+            )
+            marker = torch.empty_like(lhs)
+            with torch.cuda.stream(stream):
+                torch.add(lhs, rhs, out=marker)
+                loader.run([lhs, rhs])
+            torch.cuda.synchronize()
+
+            with torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CUDA],
+            ) as prof:
+                with torch.cuda.stream(stream):
+                    torch.add(lhs, rhs, out=marker)
+                    stream_actual = loader.run([lhs, rhs])[0]
+                torch.cuda.synchronize()
+            gpu_events = [
+                event for event in prof.events() if event.device_type == DeviceType.CUDA
+            ]
+            self.assertGreaterEqual(len(gpu_events), 2)
+            self.assertEqual(
+                1,
+                len({event.device_resource_id for event in gpu_events}),
+                [(event.name, event.device_resource_id) for event in gpu_events],
+            )
+            torch.testing.assert_close(stream_actual, lhs + rhs)
+
+            del loader
+            self._assert_package_runs_after_relocation(package_path, root)
+
+    def test_multi_kernel_launcher_runs_from_package(self):
+        lhs = torch.randn(1024, device="cuda", dtype=torch.float32)
+        rhs = torch.randn_like(lhs)
+        exported = torch.export.export(TwoStageAddModel(), (lhs, rhs), strict=True)
+        self.assertEqual(
+            1,
+            len(
+                exported.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=flydsl_kernel_wrapper_mutation,
+                )
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_two_stage_add.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                actual = compiled(lhs, rhs)
+
+        torch.testing.assert_close(actual, torch.sin(lhs + rhs + rhs))
+
+    def test_bound_launcher_runs_eager_and_from_package(self):
+        inp = torch.randn(1024, device="cuda", dtype=torch.float32)
+        model = BoundReluModel()
+        expected = torch.relu(inp) * RELU_SCALE
+
+        eager_actual = model(inp)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(eager_actual, expected)
+
+        exported = torch.export.export(model, (inp,), strict=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_bound_relu.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                aoti_actual = compiled(inp)
+
+        torch.testing.assert_close(aoti_actual, expected)
+
+    def test_dynamic_rms_norm_runs_multiple_row_counts(self):
+        inp = torch.randn(4, RMS_N, device="cuda", dtype=torch.float32)
+        weight = torch.randn(RMS_N, device="cuda", dtype=torch.float32)
+        rows = torch.export.Dim("rows", min=1, max=32)
+        exported = torch.export.export(
+            DynamicRMSNormModel(),
+            (inp, weight),
+            dynamic_shapes=({0: rows}, None),
+            strict=True,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_dynamic_rms_norm.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                loader = torch._C._aoti.AOTIModelPackageLoader(
+                    package_path,
+                    "model",
+                    False,
+                    1,
+                    -1,
+                )
+                for row_count in (1, 4, 17, 32):
+                    test_inp = torch.randn(
+                        row_count,
+                        RMS_N,
+                        device="cuda",
+                        dtype=torch.float32,
+                    )
+                    actual = loader.run([test_inp, weight])[0]
+                    expected = (
+                        test_inp
+                        * torch.rsqrt(
+                            test_inp.square().mean(dim=-1, keepdim=True) + RMS_EPS
+                        )
+                        * weight
+                    )
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        atol=2e-4,
+                        rtol=2e-4,
+                    )
+
+    def test_non_contiguous_rms_norm_runs_from_package(self):
+        rows = 4
+        inp = (
+            torch.arange(
+                rows * RMS_N,
+                device="cuda",
+                dtype=torch.float32,
+            )
+            .reshape(RMS_N, rows)
+            .transpose(0, 1)
+        )
+        weight = torch.randn(RMS_N, device="cuda", dtype=torch.float32)
+        self.assertFalse(inp.is_contiguous())
+        self.assertEqual((1, rows), inp.stride())
+        exported = torch.export.export(
+            DynamicRMSNormModel(),
+            (inp, weight),
+            strict=True,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(
+                        Path(tmpdir) / "flydsl_non_contiguous_rms_norm.pt2"
+                    ),
+                    inductor_configs={"compile_threads": 1},
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                runtime_inp = torch.randn(
+                    RMS_N,
+                    rows,
+                    device="cuda",
+                    dtype=torch.float32,
+                ).transpose(0, 1)
+                self.assertEqual(inp.stride(), runtime_inp.stride())
+                actual = compiled(runtime_inp, weight)
+
+        expected = (
+            runtime_inp
+            * torch.rsqrt(runtime_inp.square().mean(dim=-1, keepdim=True) + RMS_EPS)
+            * weight
+        )
+        torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+
+    def test_composes_multiple_flydsl_and_pytorch_ops(self):
+        torch.manual_seed(0)
+        lhs = torch.randn(GEMM_M, GEMM_K, device="cuda", dtype=torch.float32)
+        rhs = torch.randn(GEMM_N, GEMM_K, device="cuda", dtype=torch.float32)
+        bias = torch.randn(GEMM_N, device="cuda", dtype=torch.float32)
+        weight = torch.randn(RMS_N, device="cuda", dtype=torch.float32)
+        inputs = (lhs, rhs, bias, weight)
+        exported = torch.export.export(ComposedModel(), inputs, strict=True)
+        flydsl_nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+        self.assertEqual(3, len(flydsl_nodes))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_composed.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                with zipfile.ZipFile(package_path) as package:
+                    packaged_files = package.namelist()
+                self.assertEqual(
+                    1,
+                    sum(
+                        path.endswith("/libfly_jit_runtime.so")
+                        for path in packaged_files
+                    ),
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                actual = compiled(*inputs)
+
+        expected_gemm = lhs @ rhs.T
+        expected_activation = torch.relu(expected_gemm + bias) * RELU_SCALE
+        mixed = expected_activation + torch.sin(expected_activation) * 0.25
+        expected_normalized = (
+            mixed
+            * torch.rsqrt(mixed.square().mean(dim=-1, keepdim=True) + RMS_EPS)
+            * weight
+        )
+        expected = (
+            expected_normalized * 1.5 - 0.5,
+            expected_gemm,
+            expected_activation,
+            expected_normalized,
+        )
+        for actual_value, expected_value in zip(actual, expected):
+            torch.testing.assert_close(
+                actual_value,
+                expected_value,
+                atol=2e-4,
+                rtol=2e-4,
+            )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torch/_inductor/codegen/flydsl/README.md
+++ b/torch/_inductor/codegen/flydsl/README.md
@@ -1,0 +1,265 @@
+# FlyDSL launchers in AOTInductor
+
+This document describes how to use a user-authored FlyDSL launcher with
+AOTInductor (AOTI), and how PyTorch captures, compiles, packages, and invokes
+that launcher. This is the FlyDSL counterpart of wrapping a user-defined Triton
+kernel: the user writes FlyDSL Python and a Python call site, while Inductor
+generates the C++ invocation and packages the compiled artifacts.
+
+## User contract
+
+A user defines one or more `@flyc.kernel` device kernels and calls them from an
+`@flyc.jit` launcher. The launcher can contain any launch logic that FlyDSL can
+trace successfully, including multiple kernel launches such as a split-K GEMM
+followed by a workspace reduction.
+
+For capture and AOTI packaging:
+
+- The launcher returns `None` and writes results to explicit tensor arguments.
+- Output and workspace tensors are allocated by PyTorch code and passed to the
+  launcher. This lets Export and Inductor model their lifetimes and mutations.
+- Mutated tensors are declared through `mutates_args`. If it is omitted, every
+  runtime tensor argument is conservatively treated as mutated.
+- `Constexpr` and FlyDSL type parameters are normal launcher arguments, but are
+  captured as specialization values and omitted from the runtime ABI.
+- Runtime arguments must be graphable PyTorch values. The supported AOT ABI
+  covers tensors, pointers, numeric scalars, and an implicit stream.
+- The launcher must not declare a FlyDSL `Stream` parameter. AOTI supplies the
+  scheduler's current stream when invoking the compiled launcher.
+
+`torch.library.wrap_flydsl()` creates a traceable launcher:
+
+```python
+@flyc.jit
+def split_k_launcher(
+    out: fx.Tensor,
+    workspace: fx.Tensor,
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    rows: fx.Int32,
+    block_size: fx.Constexpr[int],
+):
+    split_k_kernel(...).launch(...)
+    reduce_workspace_kernel(...).launch(...)
+
+
+captured_split_k = torch.library.wrap_flydsl(
+    split_k_launcher,
+    mutates_args={"out", "workspace"},
+)
+```
+
+The model allocates the mutated tensors and invokes the captured launcher:
+
+```python
+def split_k(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    out = torch.empty((lhs.shape[0], rhs.shape[0]), device=lhs.device)
+    workspace = torch.empty(..., device=lhs.device)
+    captured_split_k(out, workspace, lhs, rhs, lhs.shape[0], 256)
+    return out
+```
+
+## End-to-end flow
+
+```mermaid
+flowchart TD
+    subgraph User["User Python"]
+        K["@flyc.kernel device kernels"]
+        L["@flyc.jit launcher<br/>one or multiple launches"]
+        W["torch.library.wrap_flydsl<br/>mutation and signature contract"]
+        K --> L --> W
+    end
+
+    subgraph Export["Export and functionalization"]
+        S["launcher and call-spec side tables"]
+        MH["flydsl_kernel_wrapper_mutation HOP"]
+        FH["flydsl_kernel_wrapper_functional HOP"]
+        S --> MH --> FH
+    end
+
+    subgraph Inductor["Inductor"]
+        D["post-grad functional-HOP decomposition"]
+        I["UserDefinedFlyDSLKernel"]
+        A["restore compile-time arguments<br/>and construct example arguments"]
+        D --> I --> A
+    end
+
+    subgraph Compiler["FlyDSL AOT compiler"]
+        M["trace complete launcher into MLIR"]
+        C["compile embedded GPU device code"]
+        P["emit PIC host object and ABI metadata"]
+        M --> C --> P
+    end
+
+    subgraph Package["AOTI package"]
+        G["generated C++ call site"]
+        R["FlyDSL runtime shared libraries"]
+        SO["linked model shared object"]
+        G --> SO
+        P --> SO
+        R --> SO
+    end
+
+    O --> S
+    W --> S
+    FH --> D
+    A --> M
+```
+
+## Capture and graph representation
+
+`wrap_flydsl()` validates that the input is a FlyDSL `JitFunction`, resolves
+its signature, and records:
+
+- The launcher and an optional bound `self` object.
+- Which tensor arguments may be mutated.
+- Which argument positions are `Constexpr` or type parameters.
+- The FlyDSL helpers used to identify streams and preconstructed JIT arguments.
+
+Runtime tensor and scalar values become FX operands. Compile-time values are
+stored in a call-spec side table and represented in the graph by an integer ID.
+Registrations and equivalent call specifications are deduplicated within the
+process.
+
+The FX graph contains `flydsl_kernel_wrapper_mutation`. Functionalization
+rewrites it to `flydsl_kernel_wrapper_functional`, cloning only the mutated
+tensors that require functional outputs. Aliased arguments that would make
+independent cloning incorrect are rejected. Inductor's post-grad pass later
+decomposes the functional form back into a mutation-aware node for lowering.
+
+The two FlyDSL higher-order operators are deliberately non-cacheable. Their
+launcher and call-spec IDs refer to process-local side tables, so persistent FX
+or AOTAutograd cache reuse would otherwise restore invalid IDs.
+
+## Inductor lowering
+
+`lower_flydsl_kernel()` creates a `UserDefinedFlyDSLKernel`, an Inductor
+`ExternKernel` that owns:
+
+- Realized tensor inputs and runtime scalar or symbolic arguments.
+- Mutation outputs for the declared mutated tensors.
+- The launcher ID and compile-time call-spec ID.
+- Representative meta-tensor arguments used to specialize compilation.
+- The selected device and scheduler stream.
+
+The same IR node supports two wrapper modes:
+
+- A Python wrapper creates a cached `FlyDSLPythonLauncher`, restores the
+  compile-time arguments, and invokes FlyDSL through Python.
+- An AOTI C++ wrapper compiles the launcher to an object, registers it with the
+  AOT link, and emits a packed C ABI call.
+
+The post-grad detection and decomposition pass is guarded by the presence of a
+FlyDSL HOP, including HOPs in nested subgraphs. Graphs without captured FlyDSL
+launchers do not construct or run the FlyDSL-specific pass.
+
+## FlyDSL AOT compilation
+
+`compile_aot()` follows FlyDSL's normal JIT argument conversion instead of
+reimplementing kernel semantics in PyTorch:
+
+1. Bind positional, keyword-only, bound-method, `Constexpr`, and type
+   arguments using the FlyDSL launcher signature.
+2. Convert runtime values through FlyDSL's JIT argument protocol.
+3. Add an implicit stream argument when the launcher does not declare one.
+4. Construct the MLIR function arguments and invoke the original launcher body
+   under FlyDSL's tracing context.
+5. Compile the resulting MLIR module using FlyDSL's configured backend.
+6. Derive declarative ABI metadata from the converted JIT arguments.
+
+The complete `@flyc.jit` body is traced into one exported C entry point. A
+launcher containing multiple device launches therefore remains one Inductor
+external-kernel node and one AOTI call, while the generated launcher performs
+the individual device launches internally.
+
+`CompiledAOTLauncher.export_to_c()` then:
+
+- Gives every exported definition and GPU module loader a unique symbol.
+- Emits a position-independent object through FlyDSL's MLIR execution engine.
+- Renames the generic module initialization and load symbols with `objcopy`.
+- Discovers and copies FlyDSL-owned runtime-library dependencies.
+
+This resembles Triton's packaged-kernel flow at the user and Inductor levels,
+but the artifact is different. The current FlyDSL backend produces a
+relocatable host object containing the C launcher and GPU module-loading
+interface, with the compiled device image embedded in that object; it is not
+only a standalone cubin or HSACO file.
+
+## Runtime ABI and invocation
+
+```mermaid
+sequenceDiagram
+    participant S as Inductor scheduler
+    participant W as Generated AOTI C++ wrapper
+    participant H as Per-artifact module holder
+    participant L as FlyDSL C launcher
+    participant G as GPU runtime
+
+    S->>W: execute external-kernel node
+    W->>H: ensure module loaded on current device
+    alt first invocation
+        H->>G: initialize and load embedded GPU module
+        G-->>H: module handle
+    end
+    W->>W: pack tensor, layout, scalar, and pointer slots
+    W->>W: append scheduler current stream
+    W->>L: launcher(void** packed_args)
+    L->>G: issue one or more device launches
+```
+
+The generated wrapper packs slots in FlyDSL's declared C ABI order:
+
+| FlyDSL argument | Runtime ABI |
+| --- | --- |
+| Tensor or memref | Data pointer, followed by dynamic shape and stride bytes when required |
+| Pointer | `void*` |
+| Integer or Boolean scalar | Fixed-width signed or unsigned value |
+| FP16 or BF16 scalar | Raw 16-bit representation |
+| FP32 or FP64 scalar | `float` or `double` |
+| `Constexpr` or type parameter | No runtime slot; restored from the call spec before compilation |
+| Stream | One implicit current-stream pointer |
+
+For a scheduled auxiliary stream, the generated call uses that scheduler
+stream. Otherwise it queries the current PyTorch device stream. No Python
+stream object crosses Export or the packaged-model boundary.
+
+Each compiled launcher has a DSO-static module holder guarded by
+`std::once_flag`. The holder loads the embedded GPU module once, remembers the
+device that owns it, and unloads it when the model shared object is destroyed.
+An invocation on another device is rejected rather than silently using a
+module loaded for the wrong GPU.
+
+## Linking and package relocation
+
+The generated object is registered in `ROCmCodeCache.aot_kernels_o` for the
+normal AOTI link. FlyDSL runtime libraries are added through the wrapper's
+graph-local `external_kernel_libs` and `additional_files` collections. The
+package uses an `$ORIGIN` runtime search path so the copied libraries remain
+loadable after moving the `.pt2` package away from the compilation cache.
+
+Runtime-library publication is atomic and rejects a same-name collision when
+the existing file has different contents. Dependencies are limited to shared
+libraries located within the FlyDSL distribution instead of copying arbitrary
+system libraries.
+
+## Current limitations
+
+- FlyDSL is an optional dependency. Common PyTorch and Inductor imports do not
+  import it; availability is checked only when FlyDSL is selected or wrapped.
+- Captured-launcher AOT requires FlyDSL 0.2.3 or newer, a ROCm-enabled PyTorch
+  build, and at least one tensor launcher argument.
+- The launcher must return `None`; outputs and workspaces must be explicit
+  tensor arguments.
+- Explicit FlyDSL stream parameters are unsupported. Eager calls through a
+  wrapped launcher currently require the default stream, while AOTI calls use
+  the scheduler's current stream.
+- Mutated tensor aliases that require independent functionalization clones are
+  unsupported.
+- Custom or composite FlyDSL JIT arguments without a declarative ABI are
+  unsupported.
+- Python post-load processors and extern-linked launchers combined with
+  FlyDSL's external binary codegen are unsupported.
+- `aot_inductor.package_cpp_only=True` is unsupported because the generated
+  object and runtime libraries must be linked and packaged.
+- A loaded artifact is owned by one GPU device for the lifetime of its AOTI
+  model instance.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196810
* #196809
* #196808
* #196807
* #196806
* #196805


Add MI350 end-to-end coverage for packaged FlyDSL launchers through the native AOTI package loader. Verify vector add packages the FlyDSL and MLIR runtime libraries, avoids clone/copy and Triton fallback code, and executes correctly on both the default and a non-default current stream.

Cover a launcher that emits two device kernels with an explicit workspace, a dynamically exported RMSNorm package that runs multiple row counts through one native loader, and a composed model containing FlyDSL GEMM, ReLU, RMSNorm, and intervening PyTorch operations. Add a packaged RMSNorm case using different transposed tensors for export and execution to verify that the decomposed `wrap_flydsl` path carries non-contiguous strides through the AOTI memref ABI. These tests use `wrap_flydsl` directly and verify the exported FlyDSL HOPs without requiring an outer custom-op boundary.

Differential Revision: [D116840784](https://our.internmc.facebook.com/intern/diff/D116840784/)

Differential Revision: [D116840784](https://our.internmc.facebook.com/intern/diff/D116840784)