### PR TITLE
[aot_compile] Warn about dropped hooks; pin both shapes forward can take

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -376,6 +376,11 @@ class SimpleLinearModule(torch.nn.Module):
         return self.linear(x)
 
 
+class ScaleModule(torch.nn.Module):
+    def forward(self, x):
+        return x * 2
+
+
 GLOBAL_POOLING_CONFIG = {"pooling": "sum"}
 
 
@@ -1559,6 +1564,50 @@ from user code:
             with _set_pooling(mode):
                 self.assertEqual(reloaded(x), expected[mode])
 
+    def test_aot_compile_module_scope_resolves_through_forward_hook(self):
+        # A registered forward hook makes get_traced_fn(model) return
+        # Module._wrapped_call_impl, whose globals are torch/nn/modules/module.py.
+        # The guard scope has to come from what was actually traced, model.forward.
+        #
+        # The hook is deliberately the identity: aot_compile_module traces
+        # model.forward directly and never runs hooks, so a hook with an effect
+        # would simply be dropped from the compiled result. This pins the guard
+        # SCOPE resolution on a hooked module, not hook support.
+        mod = GlobalConfigModule()
+        mod.register_forward_hook(lambda m, i, o: o)
+        model = torch.compile(
+            mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        x = torch.randn(4, 8)
+        expected = {}
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                expected[mode] = mod(x)
+
+        model._aot_compile(
+            [
+                ModelInput(args=(x,), kwargs={}, contexts=[_set_pooling(m)])
+                for m in ("sum", "mean")
+            ]
+        )
+        data = model._save_aot_compiled_module()
+        torch._dynamo.reset()
+        reloaded_mod = GlobalConfigModule()
+        reloaded_mod.register_forward_hook(lambda m, i, o: o)
+        reloaded = torch.compile(
+            reloaded_mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        reloaded._load_aot_compiled_module(data)
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                self.assertEqual(reloaded(x), expected[mode])
+
     def test_aot_compile_fn_guards_track_rebound_global(self):
         # Function artifacts get their guard scope from load_compiled_function's
         # f_globals. Same contract as the module test above: the live dict, not
@@ -1657,6 +1706,26 @@ from user code:
         for alias, module_name in import_sources.items():
             if alias != kept_alias:
                 self.assertIs(scope[alias], importlib.import_module(module_name))
+
+    def test_aot_compile_module_partial_forward_falls_back_loudly(self):
+        # A forward that is neither a function nor a bound method has no live
+        # scope to resolve guards against. The artifact still loads, against the
+        # reconstructed scope, but that has to be a warning: it is the one case
+        # where a guarded global does not track the loading process.
+        model = torch.compile(ScaleModule(), fullgraph=True, backend="eager")
+        x = torch.randn(3, 3)
+        model._aot_compile([ModelInput(args=(x,), kwargs={}, contexts=[])])
+        data = model._save_aot_compiled_module()
+        torch._dynamo.reset()
+
+        mod = ScaleModule()
+        mod.forward = functools.partial(ScaleModule.forward, mod)
+        with self.assertLogs("torch._dynamo.aot_compile", level="WARNING") as logs:
+            reloaded = AOTCompiledModel.deserialize(mod, data)
+        (line,) = logs.output
+        self.assertIn("ScaleModule.forward is functools.partial(", line)
+        self.assertIn("no live guard scope", line)
+        self.assertEqual(reloaded(x), x * 2)
 
     def test_aot_module_simplified_serializable_autograd(self):
         mod = SimpleLinearModule()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196896
* #196909
* #196908
* #196904
* #196897
* #196826
* #196825
* #196824
* #197001
* #196823
* #196929
* #196895
* #196821
* #196820
* __->__ #196819
* #196818

Mostly tests for the guard-scope resolution the previous commit added, plus the
behaviour changes writing them turned up. `aot_compile_module` traces
`model.forward` directly, so `nn.Module`'s dispatch in `_call_impl` never runs
and every forward or backward hook registered on `model` itself is dropped from
the compiled callable. That is a silently different answer rather than an
error:

```python
class M(torch.nn.Module):
    def forward(self, x):
        return x * 2

m = M()
m.register_forward_hook(lambda mod, args, out: out + 1)
m(x)                                                   # eager: x * 2 + 1
aot_compile_module(m, [ModelInput((x,), {}, [])])(x)   # x * 2 -- the hook never ran, nothing raised
```

## Warn about dropped hooks, worded per group

`_warn_dropped_module_dispatch(model)` runs at the top of both
`aot_compile_module` and `AOTCompiledModel.deserialize`, since a hook present
only in the loading process is dropped just as thoroughly, and the tests pin one
record per path. It warns whenever any of the four per-instance hook dicts
`_call_impl` dispatches on is non-empty, naming the kind of hook ("forward
pre-hooks", "backward hooks") rather than the private dict a caller who used
`register_forward_pre_hook` never sees:

```
M has forward hooks registered; the AOT compiled forward calls M.forward directly, so those
hooks do NOT run and its result may differ from eager -- to keep them, AOT compile
torch.compile(model).forward instead, which traces __call__ and runs them; call the artifact
it returns with the module as its first argument if you define forward yourself; ...
```

Those four are the per-instance subset of the eight dicts `_call_impl` tests;
the four `_global_*` ones are deliberately left out, because an artifact served
through `OptimizedModule` still runs them on the wrapper's own `_call_impl`, so
warning about them would be a false positive on that path.
`test_aot_compile_module_global_hooks_are_not_warned_about` pins that by
registering a global forward hook and asserting the load stays silent while the
hook still fires through the wrapper. A direct `AOTCompiledModel` really does
drop them, and without a warning, which `deserialize`'s docstring now says
rather than a fifth warning that would claim the loss for both paths. Only the
dicts of `model` itself are polled: a hook or a `__call__` override that a
SUBMODULE carries only in the loading process is dropped with no warning at
all, because the graph baked in whatever the capture traced through that
submodule's `nn.Module.__call__`, so a `model.modules()` walk would be a false
positive for the ordinary capture-and-load-with-the-same-hooks case. The
docstring states that boundary next to the `_global_*` one. One record per
GROUP, not per dict: the forward and backward wordings each name every hook kind
in their group, and `test_aot_compile_module_warns_one_record_per_group`
registers all four kinds on a module that also overrides `__call__` and pins
the three records that come out.

The forward dicts and the backward dicts are worded separately, because the
redirect is unconditional only for the forward ones. AOT compiling
`torch.compile(model).forward` traces `_wrapped_call_impl`, which runs the
forward hooks; the same capture refuses a module-level backward hook unless
compiled autograd is enabled around it, and the flag the graph break's own hint
names does nothing here:

```python
m.register_full_backward_hook(hook)
torch.compile(m).forward.aot_compile(((x,), {}))
# Unsupported: Module-level backwards hooks require compiled autograd

torch._dynamo.config.compiled_autograd = True                  # still refuses: aot_compile never
torch.compile(m).forward.aot_compile(((x,), {}))               # enters the dynamo context that reads it

with torch._dynamo.compiled_autograd._enable(torch.compile):   # private; the capture succeeds
    art = torch.compile(m).forward.aot_compile(((x,), {}))
art(m, x).sum().backward()      # reproduces eager's hooked gradient exactly
art.save_compiled_function(p)   # saves
load_compiled_function(p)       # raises: the artifact cannot round-trip
```

What differs from eager differs too: a dropped backward hook leaves the forward
result bit-identical and changes the gradients, so a reader who checked outputs
against a "result may differ" warning would conclude it was spurious. The
backward message therefore says the hooks do not run, that the gradients may
differ while the forward result does not, and that the redirect keeps them only
under compiled autograd and only for an artifact that is never reloaded; it
calls `_enable` private, because without the word a warning naming an
underscored function reads as a supported API.
`test_aot_compile_module_dropped_hook_advice` follows the advice rather than
only reading it: for the forward dicts it registers a hook with an effect and
asserts the redirect's artifact reproduces eager, and for the backward dicts it
asserts all three legs above, so the text cannot drift back to denying a
redirect that works or promising one that round-trips.

The forward-hook warning gets a tail for a `LazyModuleMixin` module: its
initializer is registered as a forward pre-hook, so every uninitialized lazy
module lands in the warning, and while it does `OptimizedModule._initialize`
pins the wrapper's forward to `_call_lazy_check`, which has no `aot_compile`, so
the redirect says to call the module once and wrap it again.
`test_aot_compile_module_lazy_hook_advice_says_to_wrap_again` pins that pin and
its release.

## Warn about an overridden `__call__`, probed the way eager dispatches

Hooks are not the only thing tracing `model.forward` skips: a `__call__` the
module overrides is dropped the same way, because eager dispatches through
`type(model).__call__` while the artifact calls what `forward` compiled to, and
since no hook dict records it, that case was silent. It gets a warning of its
own, with the redirect, which does work for an override. The probe is the same
type lookup eager does:

```python
class Logged(torch.nn.Module):
    def __call__(self, *a, **k):
        print("called"); return super().__call__(*a, **k)
    def forward(self, x): return x

aot_compile_module(Logged(), ...)   # warns: Logged overrides __call__ ...

m2 = M(); m2.__call__ = lambda *a: ...   # an instance attribute: CPython resolves a special
aot_compile_module(m2, ...)              # method on the type, eager ignores it, the artifact matches -- silent
```

That lookup is not the whole probe. `fx.GraphModule` installs a wrapper as its
per-instance class's `__call__` on every `GraphModule.recompile`, and
`recompile` always runs from `__init__`, so the lookup alone calls every
GraphModule an override, a plain `symbolic_trace` GraphModule included (an
`ExportedProgram.module()` never gets this far: its local-scope
`GraphModuleImpl` fails the save with `PackageError`). That wrapper is not an
override: with no class `__call__` to wrap it only prettifies `eval_with_key`
tracebacks and delegates to `super(cls, obj).__call__`, so eager runs the hooks
and the artifact matches. So the probe walks `type(model).__mro__` and skips
every class whose own `__call__` is FX's wrapper, taking the next `__call__` the
MRO offers, which is the one that delegation reaches:

```python
def is_fx_wrapper(c):
    fn, wrapped = vars(c)["__call__"], vars(c).get("_wrapped_call")
    return ((fn.__module__, fn.__qualname__) == ("torch.fx.graph_module", "GraphModule.recompile.<locals>.call_wrapped")
            and isinstance(wrapped, _WrappedCall) and wrapped.cls_call is None)

call = next(vars(c)["__call__"] for c in type(model).__mro__
            if "__call__" in vars(c) and not is_fx_wrapper(c))
```

The wrapper is told apart by its def site, since `call_wrapped` is a closure
`recompile` mints anew on every run and leaves no one function to compare by
identity, with the `_WrappedCall` that `recompile` installs beside it on the
same class still carrying a `None` `cls_call`. Identifying it by its function
rather than by one class identity matters twice. `recompile` installs it on
whatever `type(self)` is at the time, and `parametrize`, `fully_shard` and
`replicate` all rebind `module.__class__` to a fresh subclass after the trace,
so a recompile after that swap leaves TWO wrapper classes on the MRO
(`recompile` reads `vars(cls)`, which does not see the inherited
`_wrapped_call`, so the fresh subclass gets one of its own), and the capture
itself performs that recompile: serializing the guards pickles the GraphModule,
whose `__reduce__` recompiles it onto the swapped class, so every probe after
the first capture, a load included, sees both, and a probe keyed on one class
identity calls the inner one an override (measured: `ParametrizedLinear
overrides __call__`; eager on that module is FX's own version of the same
mistake, a `RecursionError` between the two wrappers, so there is no override
to report). And a real `__call__` assigned onto the per-instance class
afterwards sits on the very class FX wrapped, so skipping that class by identity
dropped a genuine override that eager runs. Skipping the class rather than
starting the walk past it is what keeps an override sitting AHEAD of it
visible; a test traces an `nn.Linear`, parametrizes its weight and pins that
the capture stays silent while the artifact still matches eager. A wrapper
whose `cls_call` was set is the one shape that does not delegate to `super`;
`functional_export` sets it for a hooked root, and a test pins that this stays
an override, both on the class that owns it and behind a `__class__` swap that
leaves the fresh subclass owning neither attribute. Walking rather than
trusting `cls_call` is what makes this safe rather than merely quiet:
`cls_call` is `None` for a `GraphModule` subclass that declares `__call__` too,
because FX reads the declaration off the per-instance class, where a subclass's
does not live, so calling `cls_call is None` not-an-override would have dropped
a real one. `test_aot_compile_module_fx_call_wrapper_is_not_warned_about` pins
both halves, that a traced GraphModule stays silent on the capture and the load
and that such a subclass still warns. `_LazyGraphModule` defers that recompile
to the first call or code access, so until then no class on its MRO owns a
`__call__` and the probe is silent for want of a wrapper rather than by
skipping one; the test pins both states.

## Which arguments the redirect's artifact takes

All three redirects say which arguments the artifact they produce takes,
because getting it wrong ends on the first call in a guard failure:

```python
art = torch.compile(m).forward.aot_compile(((x,), {}))
art(m, x)   # forward you define yourself: the module first (AOTCompiledModel.__call__ hides this
            # convention by passing self.model for the user)
art(x)      # forward defined in a file Dynamo skips, as torch.nn's stock modules are, or under
            # config.wrap_top_frame: only the forward arguments
```

The branch is the one `OptimizedModule._initialize` took, and the discriminator
is `trace_rules.check(mod.forward)`, which resolves on the FILE `forward` is
defined in rather than on the class, so a subclass that inherits `forward`
unoverridden counts as skipped too. The clause names that predicate,
`OptimizedModule._forward_has_skip_rule(model)`, rather than a list, because no
list spells the rule: `check_file` consults `LEGACY_MOD_INLINELIST` before
`MOD_SKIPLIST`, so a file inside a skipped directory can still be inlined
(measured, `QuantStub`'s forward under `torch/ao/` is, so its artifact takes
the module first), and a wording that enumerated `MOD_SKIPLIST` would answer
wrongly there and rot with the list. Without the clause, following the advice
ends in `GuardManager check failed` for the hook wordings, whose trace of
`_wrapped_call_impl(self, *args, **kwargs)` absorbs the shifted argument and
then fails the recorded `len(L['args']) == 1` guard, and, for the third, in a
`TypeError` naming the override's own parameter when the override declares one,
or that same guard failure when it takes `*args`. The tests assert the clause on
all three wordings: the two hook ones through the parametrization rather than
on the forward pair alone, since a module carrying only a backward hook gets
the backward warning and no other, and the override wording in the test for
that warning. `test_aot_compile_module_redirect_arg_clause_is_conditional` pins
the branch rule itself, on a Linear, on a subclass that inherits `forward`, on
one that overrides it and on a `QuantStub`, which the inline list rescues from
the skipped directory it lives in; it pins that the inheriting subclass's
artifact takes only the forward arguments and refuses the module-first call, so
the predicate cannot drift from the branch `_initialize` takes, and that the
clause names the predicate and no list.

## The capture path unwraps too, and has to REBIND

Handed the wrapper `torch.compile` returned, `aot_compile_module` traced
`OptimizedModule.forward`, which is eval_frame's `compile_wrapper`:

```python
aot_compile_module(torch.compile(m), [ModelInput((x,), {}, [])])
# parent: Unsupported: Attempted to call function marked as skipped ... set_eval_frame
```

So the wrapper-caller path this commit documents and warns for could not reach
an artifact at all. Had it traced, `AOTCompiledModel` would have kept the
wrapper as `self.model`, which `prepare_f_locals` hands the guards as
`L['self']`, so any forward that reads `self` would report no match on every
call: measured, `___check_type_id(L['self'], ...) type=<class 'M'>` answers
false for the wrapper and true for the module. One rebind, through the
`_unwrap_optimized_module` the previous commit added, fixes both halves, and
`test_aot_compile_module_capture_warns_about_the_traced_module` now hands in a
real `ModelInput` and asserts the artifact answers and holds the module rather
than the wrapper. It counts every record rather than filtering for the hook
one, since warning about the wrapper emits exactly one record too, and joins
them into the assertion's message, which `assertEqual` otherwise drops for not
being a string. With `inputs=[]` that test stopped at "Expected at least one
compiled result", raised after the warning and before the capture, which is why
neither half showed up.

## Both shapes `forward` can take, for scope resolution

The hook case is also what discriminates `model` from `model.forward` for the
scope resolution #196818 added: a registered forward hook makes
`get_traced_fn(model)` return the `Module._wrapped_call_impl` function, whose
globals are `torch/nn/modules/module.py`, and the scope must still come out as
the module definition's namespace.
`test_aot_compile_module_scope_resolves_through_forward_hook` pins that; its
hook is deliberately the identity, precisely because hooks are dropped, so it
pins scope resolution on a hooked module rather than hook support, and it
leaves the warning count to the parametrized test that owns it.

A `functools.partial` forward is not such a case (`get_traced_fn` raises the
same "Unsupported model code type" for both spellings), so
`test_aot_compile_module_fallback_scope_hint_names_the_forward` pins the
fallback instead: the artifact loads, the warning names the object and the
consequence, and a call reports the missing global and points at the rebuilt
scope rather than at a module to define the name in. Asserting that report was
chosen over promising the fallback works: nothing on this path puts a user
global into the rebuilt scope, whose extra names are the recorded imports and
the backend id, so the honest contract is the one that runs, which keeps
#196818's choice to warn rather than refuse an unresolvable forward pinned, the
one case here with no capture to redirect to.
`test_aot_compile_module_fallback_scope_runs_without_global_guards` sits beside
it and pins the two things that half silently relied on: that the guards really
did fall back to the reconstructed scope, and that with no global guard to
satisfy nothing warns. The module dispatch body #196818's test spelled inline
becomes a helper parameterized by module factory and mode setter; both the test
it came from and the hooked-module test above call it, and the containment
#196818 added for the globals a capture leaks into this module's dict moves
with the body, to the top of the helper, where one call covers every caller.

Test Plan:

```
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_dispatches_on_global_guard
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_scope_resolves_through_forward_hook
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_warns_on_dropped_hooks
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_dropped_hook_advice
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_global_hooks_are_not_warned_about
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_capture_warns_about_the_traced_module
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_warns_on_custom_call
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_warns_one_record_per_group
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_instance_call_is_not_warned_about
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_fx_call_wrapper_is_not_warned_about
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_fallback_scope_hint_names_the_forward
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_fallback_scope_runs_without_global_guards
python test/dynamo/test_aot_compile.py -k test_aot_compile_fn_missing_global_hint_names_f_globals
python test/dynamo/test_aot_compile.py -k test_aot_compile_fn_missing_global_hint_names_the_tracing_scope
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_lazy_hook_advice_says_to_wrap_again
python test/dynamo/test_aot_compile.py -k test_aot_compile_module_redirect_arg_clause_is_conditional
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## FAQ

> **FAQ: the three warnings fire unconditionally on every capture and every load
> with nothing deduping them -- for a module with both a forward and a backward
> hook plus a GraphModule-style `__call__` that is three multi-line warnings per
> load, so is repeat emission in a serving loop worth a `warn_once`?** Measured: a
> load of a module carrying a forward pre-hook, a forward hook and a backward hook
> emits 2 records totalling 1600 bytes, and 1000 subsequent calls of the loaded
> artifact emit 0 more bytes. The count is 2 rather than 3 because the forward and
> backward wordings each name every hook kind in their group in one record, and the
> GraphModule `__call__` is no longer one of them after this round's narrowing --
> three records now needs a module that both overrides `__call__` for real and
> carries both hook kinds. The emission is per `deserialize`, not per call, so a
> serving loop that loads once and serves many times pays it once; `warn_once`
> would buy nothing there and would cost the thing the tests pin, that a hook
> present only in the loading process is reported in that process too.

> **FAQ: the three-leg backward assertion calls `redirected.aot_compile(...)`
> three times on the same object relying on the first two raising and the third
> succeeding -- wouldn't a `torch._dynamo.reset()` between legs make the third
> leg's success attributable to the context manager rather than to accumulated
> Dynamo state?** Measured in both directions, and no state is doing any work.
> Leg 3 alone in a fresh process, with no preceding legs at all, succeeds and
> its artifact reproduces eager's hooked gradient (`LEG3 STANDALONE SUCCEEDS:
> True`, `grad matches eager: True`), so the context manager is sufficient on
> its own. Reversing the order -- the context-manager leg first, then the two
> refusal legs on the same `redirected` -- both refusal legs still raise
> `Module-level backwards hooks require compiled autograd`, so a successful
> capture leaves nothing behind that lifts the refusal either. A `reset()`
> between legs would change no observed outcome.

> **FAQ: `test_aot_compile_module_capture_warns_about_the_traced_module`
> asserts `len(logs.output) == 1` on the whole logger unlike its siblings which
> filter by substring first -- shouldn't it filter the same way so an unrelated
> `torch._dynamo.aot_compile` warning added later doesn't fail it with a
> confusing diff?** The diff was confusing, and that half is fixed; the filter
> is declined. Measured by adding a stray `log.warning` to
> `aot_compile_module`: the failure read only `Expected 1 but got 2`, because
> PyTorch's `assertEqual` appends the `msg` argument only `if isinstance(msg,
> str)` (`common_utils.py:4959`) and `logs.output` is a list, so the records
> were dropped. Joining them restores it -- the same mutation now prints
> `SOME UNRELATED FUTURE WARNING` and the `ScaleModule has forward hooks`
> record verbatim. Filtering instead would give up what the total count is
> for: this is the only assertion in the file that the capture path is
> otherwise quiet, and it is not redundant with the substring check, since
> warning about the wrapper rather than the module it wraps also emits exactly
> one record (measured: `OptimizedModule overrides __call__`, with no hook
> record, because the wrapper carries 0 forward hooks and 0 pre-hooks).

> **FAQ: `ParameterList`/`ParameterDict` override `__call__` to raise
> unconditionally, so warning that the result "may differ from eager" for a
> module that cannot be called at all is noise -- should the probe skip them
> too?** Declined, and unlike the GraphModule case the warning is not wrong
> here: eager dispatch really does reach `ParameterList.__call__`
> (`container.py:796`), so the type lookup reports a genuine override. What
> makes it moot is measurable -- the module cannot be AOT compiled either:
> `torch.compile(ParameterList([...]))._aot_compile([...])` raises
> `Unsupported: Observed exception` off `Module.forward`, so no artifact ever
> exists for the warning's claim to be wrong about. Excluding the two
> classes by name would add a special case that only ever fires on a path that
> is already an error, whereas the GraphModule narrowing removes a claim that
> is false about a module that captures, loads and answers correctly.

> **FAQ: `assertIn("takes only the forward arguments", naming[0])` cannot
> fail -- that substring is a fixed literal inside the module-level
> `_REDIRECT_CALL` which all three warnings emit unconditionally, so it pins
> nothing about conditionality, and the two `"with the module as its first
> argument"` assertions have the same shape; shouldn't they be replaced with
> something branch-dependent?** Measured, all three do fail, under exactly
> the drift they exist for. Deleting the clause's qualification tail fails
> the first one (`AssertionError: 'takes only the forward arguments' not
> found in '...call the artifact it returns with the module as its first
> argument'`), and rewording the leading clause to "with the module first"
> fails the other two -- all four parametrized hook legs plus the override
> test (`FAILED (failures=4)` and `FAILED (failures=1)`). What they pin is
> the wording of advice a caller follows verbatim, which is the part that
> rots. Conditionality is pinned separately in the same test, by the
> `wrap_top_frame` capture whose artifact raises `GuardManager check failed`
> when called with the module first, and this round adds the half that
> really was missing: that the branch is chosen by the FILE `forward` is
> DEFINED in (`OptimizedModule._forward_has_skip_rule`,
> `eval_frame.py:492-495`). Measured, that is `True` for `nn.Linear`, `True`
> for a user subclass that inherits `forward` and `False` for one that
> overrides it, and the artifacts agree: the inheriting subclass's takes
> only the forward arguments and refuses the module-first call, the
> overriding one's is the other way round.

> **FAQ: `issubclass(type(model), getattr(fx_wrapper, "cls", type(None)))` closes
> the post-hoc `__class__`-swap hole in the `__call__` probe -- why wasn't that
> one-liner taken?** Because measured, it does not close it. With exactly that
> substitution, a traced `nn.Linear` whose `weight` is then parametrized -- which
> is where `parametrize.py:384-386` rebinds `__class__` to a direct subclass --
> still emits `ParametrizedLinear overrides __call__`, so the new test leg fails
> the same way it does unfixed. The entry test was never the whole problem: the
> body walked `type(model).__mro__[1:]`, and after the swap the class FX wrapped is
> no longer element 0 of that MRO but element 1, so the walk finds `call_wrapped`
> on it anyway. The probe now walks the whole MRO and skips every class whose own
> `__call__` is the wrapper FX's `graph_module.py` installs (`call_wrapped`,
> `:1007-1010`) while its `_WrappedCall.cls_call` (`:453-456`) is `None`, which
> survives the swap, survives a `recompile()` after it (which puts a second wrapper
> class on the MRO), keeps a `__call__` assigned onto the per-instance class
> visible, and also keeps a real override sitting AHEAD of those classes visible --
> the wrapper base that `_fsdp_init.py:426-427` and `replicate.py:247` put there
> (`parametrize.py:384-386` subclasses the traced class directly, so its leg is
> silent because the FX class survives as MRO element 1, not because a wrapper sits
> ahead). Your `issubclass` relation is kept as an assertion in the test, pinning
> the shape the swap produces.

> **FAQ: `test_aot_compile_module_redirect_arg_clause_is_conditional` captures
> without the `_hide_leaked_dynamo_globals()` its siblings call, so it leaks
> Dynamo's generated globals into the test module dict -- masked today, but
> shouldn't the call be added for consistency?** Declined, and measured rather than
> assumed. The test does leak, 6 minted names, but so does nearly every capture in
> this file: 68 of the 89 test methods that capture do not hide first (58 of 80 in
> the parent), so hiding is not a convention this test departs from. It is what a
> test that asserts an exact minted-global set does FOR ITSELF -- the helper pops
> the live minted names for the duration of the test and restores them in cleanup
> (`test_aot_compile.py:1719`) -- so those tests are correct no matter who ran
> before them. Run in one process, the redirect test leaks its 6 names and both
> exact-set tests then pass, leaking 4 and 2 of their own. Even the sibling's call
> is not load-bearing: deleting it and running the whole file gives `Ran 163 tests
> ... OK (skipped=6)`. A line that changes no outcome anywhere, and that cannot
> protect a future exact-set test which fails to hide for itself, is not worth
> adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98