### PR TITLE
[dynamo] Exempt the Triton/GPU compatibility checks off the artifact, not the host

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -9,6 +9,7 @@ import io
 import multiprocessing as mp
 import os
 import pickle
+import platform
 import sys
 import tempfile
 import threading
@@ -41,7 +42,7 @@ from torch._dynamo.exc import PackageError, Unsupported
 from torch._dynamo.graph_utils import _graph_device_types
 from torch._dynamo.guards import CheckFunctionManager
 from torch._dynamo.output_graph import get_builtins_dict
-from torch._dynamo.package import DynamoCache, load_guards_state
+from torch._dynamo.package import DynamoCache, load_guards_state, SystemInfo
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._functorch.aot_autograd import (
     aot_compile_joint_with_descriptors,
@@ -2692,6 +2693,33 @@ from user code:
         actual = loaded_fn(x)
         self.assertEqual(expected[0], actual[0])
         self.assertEqual(expected[1], actual[1])
+
+    def test_check_compatibility_triton_and_gpu_exempt_off_artifact(self):
+        # The Triton/GPU checks must exempt off the ARTIFACT (self), not the
+        # host (other). An artifact built with Triton must be rejected on a
+        # Triton-less host -- it would otherwise fail later at kernel load --
+        # while an artifact built without Triton bakes in no Triton code and
+        # loads anywhere. Same for gpu_name: only an artifact that recorded a
+        # GPU pins the model.
+        def make(triton, gpu):
+            return SystemInfo(
+                python_version=platform.python_version(),
+                torch_version=torch.__version__,
+                toolkit_version="12.0",
+                triton_version=triton,
+                gpu_name=gpu,
+            )
+
+        with patch.object(torch.cuda, "is_available", return_value=True):
+            with self.assertRaisesRegex(RuntimeError, "Triton version"):
+                make((3, 5), "A100").check_compatibility(make((0, 0), "A100"), "cuda")
+            make((0, 0), "A100").check_compatibility(make((3, 5), "A100"), "cuda")
+            with self.assertRaisesRegex(RuntimeError, "different GPU"):
+                make((3, 5), "A100").check_compatibility(make((3, 5), "H100"), "cuda")
+            make((3, 5), None).check_compatibility(make((3, 5), "H100"), "cuda")
+        with patch.object(torch.cuda, "is_available", return_value=False):
+            with self.assertRaisesRegex(RuntimeError, "cuda is not available"):
+                make((0, 0), None).check_compatibility(make((0, 0), None), "cuda")
 
     def test_graph_device_types_ignores_placeholders_without_a_device(self):
         # Under dynamic shapes the leading placeholder is a SymInt, which has no

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -62,8 +62,13 @@ class CompileArtifacts:
     system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
 
     def check_compatibility(self) -> None:
-        current_system = SystemInfo.current()
-        current_system.check_compatibility(self.system_info, self.device_type)
+        # The cached info is the receiver so mismatch messages label self
+        # "cached", matching _DynamoCacheEntry.check_versions. It also sets
+        # which side the triton_version/gpu_name checks exempt off: with the
+        # cached info as receiver they skip only when the artifact itself
+        # recorded no Triton/GPU, requiring a match otherwise -- the correct
+        # direction for a compatibility check.
+        self.system_info.check_compatibility(SystemInfo.current(), self.device_type)
 
 
 @dataclasses.dataclass

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -829,16 +829,20 @@ class SystemInfo:
                     f"Compile package was created with a different toolkit version: {self.toolkit_version}"
                 )
 
+            # Exempt off the artifact (self), not the host: an artifact built
+            # without Triton (self == (0, 0)) bakes in no Triton-specific code,
+            # but one built with Triton must match, even on a Triton-less host
+            # (which would otherwise fail later at kernel load).
             if (
-                other.triton_version != (0, 0)
+                self.triton_version != (0, 0)
                 and self.triton_version != other.triton_version
             ):
                 raise RuntimeError(
                     f"Compile package was created with a different Triton version: {self.triton_version}"
                 )
 
-            # Check GPU name if CUDA/XPU was used
-            if other.gpu_name is not None and self.gpu_name != other.gpu_name:
+            # Check GPU name if the artifact recorded one (self, not the host).
+            if self.gpu_name is not None and self.gpu_name != other.gpu_name:
                 raise RuntimeError(
                     f"Compile package was created with different GPU: "
                     f"cached={self.gpu_name}, current={other.gpu_name}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196833
* #196832
* #196831
* #196830
* #196829
* #196828
* __->__ #196827
* #196826
* #196825
* #196824
* #196823
* #196822
* #196821
* #196820
* #196819
* #196818
* #196817
* #196816
* #196815
* #196814
* #196767
* #196764
* #196756
* #196693
* #196692
* #196691
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683

`SystemInfo.check_compatibility` is written with `self` as the info recorded in
the artifact and `other` as the current machine -- that is how
`_DynamoCacheEntry.check_versions` calls it, and what the `cached=...` in its
messages means. Two of the checks were written the other way round: the Triton
check skipped when `other` (the host) had no Triton, and the GPU check skipped
when the host reported no GPU. So an artifact built WITH Triton loaded happily on
a Triton-less host and then failed much later, at kernel load, and an artifact
that recorded a GPU loaded on a host with a different one. The exemption belongs
on the artifact: an artifact built without Triton or without a GPU bakes in no
code that needs either, so it runs anywhere, while one that recorded them
requires them.

`CompileArtifacts.check_compatibility` compounded it by calling with the
receivers swapped -- current machine as `self` -- which labelled the host as
"cached" in every message and inverted the two exemptions relative to the
package path. Both changes have to land together: flipping the checks while the
AOT path still passed the host as the receiver would leave that path exempting
off the host as before.

Test Plan:

```
python test/dynamo/test_aot_compile.py -k test_check_compatibility_triton_and_gpu_exempt_off_artifact
python test/dynamo/test_aot_compile.py
python test/dynamo/test_package.py
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98