### PR TITLE
[dynamo] Record the CPU codegen target in SystemInfo

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import types
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch._dynamo.testing
@@ -16,11 +17,17 @@ import torch._inductor.test_case
 import torch.onnx.operators
 import torch.utils.cpp_extension
 from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
-from torch._dynamo.package import CompilePackage, DiskDynamoStore, DynamoCache
+from torch._dynamo.package import (
+    _current_cpu_codegen_target,
+    CompilePackage,
+    DiskDynamoStore,
+    DynamoCache,
+)
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.testing import reduce_to_scalar_loss
 from torch._dynamo.utils import CleanupManager
 from torch._functorch import config as functorch_config
+from torch._inductor import cpu_vec_isa
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -133,6 +140,34 @@ class TestPackage(torch._inductor.test_case.TestCase):
         self.assertEqual(len(debug_info["backends"]), expected_backends)
         torch._dynamo.reset()
         PrecompileContext.clear()
+
+    def test_no_valid_vec_isa_records_no_cpu_codegen_target(self):
+        # pick_vec_isa never raises for a missing compiler; it returns
+        # invalid_vec_isa, which must read as "no target", not as a target
+        # named INVALID_VEC_ISA that only an equally broken host would match.
+        # Patch pick_vec_isa directly, not valid_vec_isa_list: in fbcode on x86
+        # pick_vec_isa returns VecAVX2 before ever consulting the list, so
+        # emptying the list would leave this assertion inert there.
+        with patch.object(
+            cpu_vec_isa, "pick_vec_isa", return_value=cpu_vec_isa.invalid_vec_isa
+        ):
+            self.assertIsNone(_current_cpu_codegen_target())
+
+    def test_sve_widths_do_not_collide_in_the_codegen_fingerprint(self):
+        # VecSVE(128) and VecSVE(256) both stringify to "asimd", so the ISA name
+        # alone cannot tell a 128-bit tiling from a 256-bit one. The fingerprint
+        # records bit_width() so the two do not compare equal and a kernel tiled
+        # for one width is refused on a host that picks the other.
+        narrow = cpu_vec_isa.VecSVE(_bit_width=128)
+        wide = cpu_vec_isa.VecSVE(_bit_width=256)
+        self.assertEqual(str(narrow), str(wide))
+        with patch.object(cpu_vec_isa, "pick_vec_isa", return_value=narrow):
+            narrow_target = _current_cpu_codegen_target()
+        with patch.object(cpu_vec_isa, "pick_vec_isa", return_value=wide):
+            wide_target = _current_cpu_codegen_target()
+        self.assertEqual(narrow_target[1], wide_target[1])
+        self.assertNotEqual(narrow_target[2], wide_target[2])
+        self.assertNotEqual(narrow_target, wide_target)
 
     def test_guarded_code_records_backend_ids_from_bytecode(self):
         def fn(x):

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -1,5 +1,6 @@
 import builtins
 import dataclasses
+import functools
 import importlib
 import inspect
 import io
@@ -59,7 +60,9 @@ class CompileArtifacts:
     source_info: "SourceInfo"
     device_type: str
     backend_name: str
-    system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
+    system_info: SystemInfo = dataclasses.field(
+        default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
+    )
 
     def check_compatibility(self) -> None:
         # The cached info is the receiver so mismatch messages label self

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -764,10 +764,47 @@ def _get_code_source(code: types.CodeType) -> tuple[str, str]:
     return toplevel.__qualname__, code_source.strip(".")
 
 
+_CpuCodegenTarget = tuple[str, str, int, tuple[str, ...], int | None, str | None]
+
+
+def _current_cpu_codegen_target() -> _CpuCodegenTarget | None:
+    """(machine, vec_isa, vec_isa_width, vec_isa_macro, simdlen, march): the CPU codegen context.
+
+    ``pick_vec_isa`` dry-compiles a probe with the C++ toolchain, so call this
+    only when the artifact can hold native CPU code. None means the host has no
+    usable CPU codegen target: the probe raised, or it picked no valid vector
+    ISA (``pick_vec_isa`` never raises for a missing compiler; it returns
+    ``invalid_vec_isa``), so it can neither produce nor run a vectorized
+    inductor CPU kernel.
+    """
+    from torch._inductor import config as inductor_config, cpu_vec_isa
+
+    try:
+        vec_isa = cpu_vec_isa.pick_vec_isa()
+    except Exception:
+        logger.warning(
+            "Could not determine the CPU vector ISA, so no CPU codegen target "
+            "is recorded and none will be checked.",
+            exc_info=True,
+        )
+        return None
+    if isinstance(vec_isa, cpu_vec_isa.InvalidVecISA):
+        return None
+
+    return (
+        platform.machine(),
+        str(vec_isa),
+        vec_isa.bit_width(),
+        tuple(vec_isa.build_macro()),
+        inductor_config.cpp.simdlen,
+        inductor_config.cpp.march,
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class SystemInfo:
     """
-    System information including Python, PyTorch, and GPU details.
+    System information including Python, PyTorch, CPU codegen, and GPU details.
     This information is used to ensure compiled artifacts can only be loaded
     with compatible system configurations.
     """
@@ -777,13 +814,16 @@ class SystemInfo:
     toolkit_version: str | None
     triton_version: tuple[int, int] | None
     gpu_name: str | None
+    cpu_codegen_target: _CpuCodegenTarget | None = None
     CHECK_GPUS = ("cuda", "xpu")
 
     @classmethod
-    def current(cls) -> "SystemInfo":
-        """Create a SystemInfo instance with current system information."""
-        # Get GPU name if CUDA or XPU is available
-        gpu_name = None
+    def current(cls, *, cpu_codegen: bool = True) -> "SystemInfo":
+        """Create a SystemInfo instance with current system information.
+
+        ``cpu_codegen=False`` skips the C++ toolchain probe behind
+        ``cpu_codegen_target``.
+        """
         from torch.utils._triton import get_triton_version
 
         gpu_name, toolkit_version = None, None
@@ -802,6 +842,7 @@ class SystemInfo:
             toolkit_version=toolkit_version,
             triton_version=get_triton_version((0, 0)),
             gpu_name=gpu_name,
+            cpu_codegen_target=_current_cpu_codegen_target() if cpu_codegen else None,
         )
 
     def check_compatibility(
@@ -854,7 +895,9 @@ class _DynamoCacheEntry:
     codes: list[_DynamoCodeCacheEntry]
     source_info: SourceInfo
     device_type: str
-    system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
+    system_info: SystemInfo = dataclasses.field(
+        default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
+    )
     fn_name: str | None = None
     fn_first_lineno: str | None = None
 
@@ -1422,6 +1465,9 @@ class CompilePackage:
             codes=list(self._codes.values()),
             source_info=self._source_info,
             device_type=self._device_type,
+            # The codegen probe runs the C++ toolchain; only pay for it when the
+            # artifact can hold native CPU code.
+            system_info=SystemInfo.current(cpu_codegen=(self._device_type == "cpu")),
             fn_name=self._innermost_fn.__qualname__,
             fn_first_lineno=self._innermost_fn.__code__.co_firstlineno,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196833
* #196832
* #196831
* #196830
* #196829
* __->__ #196828
* #196827
* #196826
* #196825
* #196824
* #196823
* #196822
* #196821
* #196820
* #196819
* #196818
* #196817
* #196816
* #196815
* #196814
* #196767
* #196764
* #196756
* #196693
* #196692
* #196691
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683

A precompile artifact holding inductor CPU kernels is tied to the vector ISA the
kernels were tiled for, but `SystemInfo` recorded nothing about CPU codegen, so
nothing could be checked. Record it: `(machine, vec_isa, vec_isa_width,
vec_isa_macro, simdlen, march)`, resolved by `_current_cpu_codegen_target()`.

The width and the build macro are in there because the ISA name alone does not
identify the tiling: NEON and SVE128 both call themselves "asimd" and are both
128-bit, and only the build macro tells them apart. `simdlen` and `march` are
recorded for diagnostics.

`pick_vec_isa()` dry-compiles a probe with the C++ toolchain, which is far too
expensive to run unconditionally, so `SystemInfo.current()` takes a keyword to
skip it and the two dataclass defaults (used when a field is absent from a
deserialized artifact) skip it too. Only `CompilePackage.cache_entry` pays for it,
and only for a CPU artifact. A `None` target means the host has no usable CPU
codegen target at all -- the probe raised, or it resolved no valid vector ISA,
which is also what a missing compiler looks like since `pick_vec_isa` returns
`invalid_vec_isa` rather than raising.

This commit only records the target; nothing checks it yet.

Test Plan:

```
python test/dynamo/test_package.py -k test_no_valid_vec_isa_records_no_cpu_codegen_target
python test/dynamo/test_package.py -k test_sve_widths_do_not_collide_in_the_codegen_fingerprint
python test/dynamo/test_package.py
python test/dynamo/test_aot_compile.py
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98