### PR TITLE
[dynamo] Reject a CPU artifact whose kernels this host would compile differently

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import dataclasses
 import functools
 import gc
 import importlib
@@ -22,6 +23,7 @@ from torch._dynamo.package import (
     CompilePackage,
     DiskDynamoStore,
     DynamoCache,
+    SystemInfo,
 )
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.testing import reduce_to_scalar_loss
@@ -33,6 +35,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
     parametrize,
+    subtest,
     TEST_WITH_TORCHDYNAMO,
 )
 from torch.testing._internal.inductor_utils import (
@@ -140,6 +143,80 @@ class TestPackage(torch._inductor.test_case.TestCase):
         self.assertEqual(len(debug_info["backends"]), expected_backends)
         torch._dynamo.reset()
         PrecompileContext.clear()
+
+    # Named codegen targets: (machine, isa, bit width, build macros, simdlen, march).
+    _CODEGEN_TARGETS = {
+        "avx2": ("x86_64", "avx2", 256, ("CPU_CAPABILITY_AVX2",), None, None),
+        "avx512": ("x86_64", "avx512", 512, ("CPU_CAPABILITY_AVX512",), None, None),
+        "neon": (
+            "aarch64",
+            "asimd",
+            128,
+            ("CPU_CAPABILITY_NEON", "AT_BUILD_ARM_VEC256_WITH_SLEEF"),
+            None,
+            None,
+        ),
+        "sve128": ("aarch64", "asimd", 128, ("CPU_CAPABILITY_SVE128",), None, None),
+        "avx2_simdlen": ("x86_64", "avx2", 256, ("CPU_CAPABILITY_AVX2",), 256, None),
+    }
+
+    @parametrize(
+        "cached, host, error",
+        [
+            subtest(("avx2", "avx2", None), name="same_isa"),
+            subtest(
+                ("avx2", "avx512", "generated for vector ISA 'avx2'.*for 'avx512'"),
+                name="wider_host",
+            ),
+            subtest(
+                ("avx512", "avx2", "generated for vector ISA 'avx512'.*for 'avx2'"),
+                name="narrower_host",
+            ),
+            subtest(
+                ("neon", "avx2", "machine 'aarch64', this host is 'x86_64'"),
+                name="other_machine",
+            ),
+            # NEON and SVE128 share both the name "asimd" and a 128-bit width, so
+            # only the build macro tells them apart.
+            subtest(
+                ("neon", "sve128", "vector ISA 'asimd'"), name="same_name_other_macro"
+            ),
+            # simdlen and march are recorded for diagnostics but do not gate:
+            # pick_vec_isa() folds cpp.simdlen (and ATEN_CPU_CAPABILITY) into the
+            # ISA it resolves, and march never reaches it -- it only changes how
+            # the same tiled source is compiled -- so a host that lands on the
+            # same (ISA, width, macro) can rebuild the kernels whatever knob got
+            # it there. An artifact built under cpp.simdlen=256 loads on a host
+            # whose default already picks the same 256-bit ISA; gating on the raw
+            # knob would reject it and make the cpp.simdlen escape hatch trade an
+            # ISA error for a simdlen error.
+            subtest(("avx2_simdlen", "avx2", None), name="simdlen_does_not_gate"),
+            subtest(
+                ("avx2", None, "reports no CPU codegen target"), name="no_host_target"
+            ),
+        ],
+    )
+    def test_cpu_codegen_target_requires_the_host_to_pick_the_same_isa(
+        self, cached, host, error
+    ):
+        # The kernel source is tiled for the ISA picked at codegen and compiled
+        # with the ISA picked on the loading host, so the two must be equal. A
+        # wider host is not a superset: its masked loads zero-fill the lanes the
+        # narrower tiling never touches, and unmasked reductions read them.
+        base = SystemInfo.current(cpu_codegen=False)
+        cached_info = dataclasses.replace(
+            base, cpu_codegen_target=self._CODEGEN_TARGETS[cached]
+        )
+        host_target = None if host is None else self._CODEGEN_TARGETS[host]
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target",
+            return_value=host_target,
+        ):
+            if error is None:
+                cached_info.check_compatibility(SystemInfo.current())
+            else:
+                with self.assertRaisesRegex(RuntimeError, error):
+                    cached_info.check_compatibility(SystemInfo.current())
 
     def test_no_valid_vec_isa_records_no_cpu_codegen_target(self):
         # pick_vec_isa never raises for a missing compiler; it returns

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -71,7 +71,13 @@ class CompileArtifacts:
         # cached info as receiver they skip only when the artifact itself
         # recorded no Triton/GPU, requiring a match otherwise -- the correct
         # direction for a compatibility check.
-        self.system_info.check_compatibility(SystemInfo.current(), self.device_type)
+        current = SystemInfo.current(
+            cpu_codegen=(
+                self.device_type == "cpu"
+                and self.system_info.cpu_codegen_target is not None
+            )
+        )
+        self.system_info.check_compatibility(current, self.device_type)
 
 
 @dataclasses.dataclass

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -801,6 +801,62 @@ def _current_cpu_codegen_target() -> _CpuCodegenTarget | None:
     )
 
 
+def _cpu_codegen_target_problem(
+    cached: _CpuCodegenTarget, current: _CpuCodegenTarget | None
+) -> str | None:
+    """Why code generated for ``cached`` cannot be built and run here, or None.
+
+    The artifact carries kernel source tiled for the ISA pick_vec_isa() made at
+    codegen, and the loading host compiles that source with the flags of its
+    own pick_vec_isa(). The gate is the *resolved* target -- (machine, vec_isa,
+    vec_isa_width, vec_isa_macro) -- because pick_vec_isa() already folds
+    cpp.simdlen and ATEN_CPU_CAPABILITY into the ISA it returns: a simdlen that
+    caps the width picks a narrower ISA, so the width and macro already reflect
+    it. march does not gate for a different reason: it does not change the
+    tiling the kernel source was generated for -- which is what the
+    masked-load/zero-fill hazard across ISAs is about -- it only changes how
+    that same source is compiled, the same class of variation as the compiler
+    version, which is likewise unchecked. (pick_vec_isa() folds in simdlen and
+    ATEN_CPU_CAPABILITY but never reads cpp.march, and the default -march=native
+    is host-specific by definition, so gating on the recorded value would catch
+    nothing anyway.) Comparing the resolved triple is therefore complete, and
+    comparing the raw simdlen/march knobs on top of it is not just
+    redundant, it is wrong -- it rejects an artifact whose kernels this host can
+    reproduce merely because the knob that got there differs (an artifact built
+    under cpp.simdlen=256 is loadable on any host that resolves to the same
+    256-bit ISA, whether via its default or via ATEN_CPU_CAPABILITY), and it
+    makes the escape hatch ineffective, since setting cpp.simdlen to fix an ISA
+    mismatch would only trade it for a simdlen mismatch. The name and width must
+    both agree (VecSVE(128)/VecSVE(256) share the name "asimd"), and the build
+    macros disambiguate further (VecNEON and VecSVE(128) share name and width
+    but compile with different capability macros). A wider host ISA is not a
+    superset: its masked loads zero-fill the lanes the narrower tiling never
+    wrote. simdlen and march stay in the recorded tuple for diagnostics but do
+    not gate.
+    """
+    if current is None:
+        # No current tuple to compare against, so no component-level reason is
+        # available -- the host simply reports no target of its own.
+        return (
+            "This host reports no CPU codegen target (no C++ toolchain, no "
+            "supported vector ISA, or a torch._inductor.config.cpp.simdlen that "
+            "matches no available ISA width), so it cannot reproduce the target "
+            "the artifact's CPU kernels were built for."
+        )
+    machine, vec_isa, vec_isa_width, vec_isa_macro = cached[:4]
+    if machine != current[0]:
+        return f"The artifact was built for machine {machine!r}, this host is {current[0]!r}."
+    if (vec_isa, vec_isa_width, vec_isa_macro) != (current[1], current[2], current[3]):
+        return (
+            f"The artifact's CPU kernels were generated for vector ISA {vec_isa!r} "
+            f"({vec_isa_width}-bit, macros {list(vec_isa_macro)}); this host would "
+            f"compile them for {current[1]!r} ({current[2]}-bit, macros "
+            f"{list(current[3])}). Set ATEN_CPU_CAPABILITY or "
+            "torch._inductor.config.cpp.simdlen so the host picks the same ISA."
+        )
+    return None
+
+
 @dataclasses.dataclass(frozen=True)
 class SystemInfo:
     """
@@ -861,6 +917,20 @@ class SystemInfo:
             raise RuntimeError(
                 f"Compile package was created with a different PyTorch version: {self.torch_version}"
             )
+        # A cached None means the artifact recorded no vector ISA -- it predates
+        # this field (for a release build, every artifact already on disk), or it
+        # was captured with vectorization disabled (cpp.simdlen=1, or any width
+        # no valid ISA has) -- so there is nothing to compare.
+        if device_type == "cpu" and self.cpu_codegen_target is not None:
+            problem = _cpu_codegen_target_problem(
+                self.cpu_codegen_target, other.cpu_codegen_target
+            )
+            if problem is not None:
+                raise RuntimeError(
+                    "Compile package was created for a CPU codegen target this host "
+                    f"cannot run: cached={self.cpu_codegen_target}, "
+                    f"current={other.cpu_codegen_target}. {problem}"
+                )
         if device_type in self.CHECK_GPUS:
             if not getattr(torch, device_type).is_available():
                 raise RuntimeError(f"{device_type} is not available")
@@ -907,7 +977,12 @@ class _DynamoCacheEntry:
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
-        current_system_info = SystemInfo.current()
+        current_system_info = SystemInfo.current(
+            cpu_codegen=(
+                self.device_type == "cpu"
+                and self.system_info.cpu_codegen_target is not None
+            )
+        )
         self.system_info.check_compatibility(current_system_info, self.device_type)
 
     def debug_info(self) -> dict[str, Any]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196833
* #196832
* #196831
* #196830
* __->__ #196829
* #196828
* #196827
* #196826
* #196825
* #196824
* #196823
* #196822
* #196821
* #196820
* #196819
* #196818
* #196817
* #196816
* #196815
* #196814
* #196767
* #196764
* #196756
* #196693
* #196692
* #196691
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683

An artifact carries inductor CPU kernel source tiled for the vector ISA
`pick_vec_isa()` resolved at codegen, and the loading host compiles that source
with the flags of its own `pick_vec_isa()`. Nothing checked that the two agree,
and a wider host ISA is not a safe superset: its masked loads zero-fill the lanes
the narrower tiling never wrote, and unmasked reductions then read them, so the
consequence is wrong numbers rather than a build error.

Gate the load on the recorded target. The comparison is deliberately the
*resolved* target -- machine, ISA name, width, build macros -- and not the raw
knobs, because `pick_vec_isa()` already folds `cpp.simdlen` and
`ATEN_CPU_CAPABILITY` into the ISA it returns, while `cpp.march` never reaches it
at all (march changes how the same source is compiled, the same class of
variation as the compiler version, which is likewise unchecked, and its default
`-march=native` is host-specific by definition). Comparing the knobs on top of
the resolved target would be actively wrong: it rejects an artifact whose kernels
the host can reproduce, and it makes `cpp.simdlen` useless as an escape hatch,
since setting it to fix an ISA mismatch would only trade it for a simdlen
mismatch. Name and width are both needed (VecSVE(128) and VecSVE(256) share the
name "asimd"), and the build macros disambiguate the rest (VecNEON and
VecSVE(128) share name and width).

A recorded `None` means the artifact has nothing to compare -- it predates the
field, or was captured with vectorization off -- so it still loads, and that is
also what keeps both callers from paying for the host probe unless the artifact
is a CPU artifact that actually recorded a target.

Test Plan:

```
python test/dynamo/test_package.py -k test_cpu_codegen_target_requires_the_host_to_pick_the_same_isa
python test/dynamo/test_package.py
python test/dynamo/test_aot_compile.py
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98