### PR TITLE
[dynamo] Exempt a backend that generates no native code from the ISA gate

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -2717,9 +2717,16 @@ from user code:
             with self.assertRaisesRegex(RuntimeError, "different GPU"):
                 make((3, 5), "A100").check_compatibility(make((3, 5), "H100"), "cuda")
             make((3, 5), None).check_compatibility(make((3, 5), "H100"), "cuda")
+            # check_codegen=False skips the toolkit/Triton/GPU-model checks (they
+            # describe generated code) but not device existence.
+            make((3, 5), "A100").check_compatibility(
+                make((3, 5), "H100"), "cuda", check_codegen=False
+            )
         with patch.object(torch.cuda, "is_available", return_value=False):
             with self.assertRaisesRegex(RuntimeError, "cuda is not available"):
-                make((0, 0), None).check_compatibility(make((0, 0), None), "cuda")
+                make((0, 0), None).check_compatibility(
+                    make((0, 0), None), "cuda", check_codegen=False
+                )
 
     def test_graph_device_types_ignores_placeholders_without_a_device(self):
         # Under dynamic shapes the leading placeholder is a SymInt, which has no

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -246,6 +246,69 @@ class TestPackage(torch._inductor.test_case.TestCase):
         self.assertNotEqual(narrow_target[2], wide_target[2])
         self.assertNotEqual(narrow_target, wide_target)
 
+    @torch._dynamo.config.patch(caching_precompile=True, strict_precompile=False)
+    @parametrize("fullgraph", (False, True))
+    def test_eager_backend_entry_is_exempt_from_the_codegen_target(self, fullgraph):
+        # fullgraph=False takes _optimize, fullgraph=True optimize_assert; both
+        # thread native_backend and must agree.
+        def fn(x):
+            return x + 1
+
+        def custom_backend(gm, example_inputs):
+            return gm
+
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target",
+            side_effect=AssertionError("toolchain probe ran for an eager backend"),
+        ) as probe:
+            torch.compile(fn, backend="eager", fullgraph=fullgraph)(torch.randn(3))
+            (entry,) = PrecompileContext._dynamo_cache_entries.values()
+        # side_effect fails at the call site, but Dynamo swallows exceptions on
+        # the compile path, so assert not-called outside the patch too.
+        probe.assert_not_called()
+        self.assertFalse(entry.requires_native_backend_compatibility)
+        self.assertIsNone(entry.system_info.cpu_codegen_target)
+
+        torch._dynamo.reset()
+        PrecompileContext.clear()
+        # A user's own callable may emit anything, so it counts as native and
+        # the probe runs; patch it so the assertion needs no host toolchain.
+        sentinel = ("x86_64", "avx2", 256, ("CPU_CAPABILITY_AVX2",), None, None)
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target",
+            return_value=sentinel,
+        ):
+            torch.compile(fn, backend=custom_backend, fullgraph=fullgraph)(
+                torch.randn(3)
+            )
+        (entry,) = PrecompileContext._dynamo_cache_entries.values()
+        self.assertTrue(entry.requires_native_backend_compatibility)
+        self.assertEqual(entry.system_info.cpu_codegen_target, sentinel)
+
+    def test_loaded_eager_package_stays_exempt_on_resave(self):
+        def fn(x):
+            return x + 1
+
+        package = CompilePackage(fn, requires_native_backend_compatibility=False)
+        torch._dynamo.optimize(backend="eager", package=package)(fn)(torch.randn(3))
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target",
+            side_effect=AssertionError("toolchain probe ran for an eager backend"),
+        ) as probe:
+            entry = package.cache_entry()
+            self.assertFalse(entry.requires_native_backend_compatibility)
+            self.assertIsNone(entry.system_info.cpu_codegen_target)
+            # Reload under an eager session (native_backend=False, as eval_frame
+            # passes it): an eager artifact reloaded to be served again stays
+            # exempt, so the resave never runs the toolchain probe.
+            reloaded = CompilePackage(
+                fn, entry, requires_native_backend_compatibility=False
+            )
+            resaved = reloaded.cache_entry()
+        probe.assert_not_called()
+        self.assertFalse(resaved.requires_native_backend_compatibility)
+        self.assertIsNone(resaved.system_info.cpu_codegen_target)
+
     def test_guarded_code_records_backend_ids_from_bytecode(self):
         def fn(x):
             return x + 1

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1799,6 +1799,18 @@ def optimize(*args: Any, **kwargs: Any) -> OptimizeContext | _NullDecorator:
     return _optimize(rebuild_ctx, *args, **kwargs)
 
 
+def _backend_emits_native_code(backend: str | Callable[..., Any] | None) -> bool:
+    # get_compiler_fn erases the name, and torch.compile hands us a
+    # _TorchCompileWrapper rather than the string the user wrote.
+    from torch._dynamo.package import emits_native_code
+
+    # A user backend that bakes no native code can declare it.
+    user_backend = getattr(backend, "compiler_fn", backend)
+    if getattr(user_backend, "emits_native_code", True) is False:
+        return False
+    return emits_native_code(str(getattr(backend, "compiler_name", backend)))
+
+
 def _optimize(
     rebuild_ctx: Callable[[], OptimizeContext | _NullDecorator],
     backend: str | Callable[..., Any] = "inductor",
@@ -1886,6 +1898,7 @@ def _optimize(
             dynamic_shapes=dynamic_shapes,
         )
 
+    native_backend = _backend_emits_native_code(backend)
     backend = get_compiler_fn(backend)
 
     # Find if backend has any extra context manager
@@ -1900,7 +1913,12 @@ def _optimize(
     if config.caching_precompile and package is None:
         from .package import CompilePackage
 
-        package = CompilePackage(fn=None, dynamo=None, ignore_inlined_sources=False)
+        package = CompilePackage(
+            fn=None,
+            dynamo=None,
+            ignore_inlined_sources=False,
+            requires_native_backend_compatibility=native_backend,
+        )
 
     return _optimize_catch_errors(
         convert_frame.convert_frame(
@@ -2830,6 +2848,7 @@ def _optimize_assert(
     Used for fullgraph=True and export, since we must always error on graph breaks and ignore
     symbolic_convert.error_on_graph_break. Can also be used for testing.
     """
+    native_backend = _backend_emits_native_code(backend)
     backend = get_compiler_fn(backend)
 
     # Find if backend has any extra context manager
@@ -2843,7 +2862,12 @@ def _optimize_assert(
         # and OptimizeContext.
         from .package import CompilePackage
 
-        package = CompilePackage(fn=None, dynamo=None, ignore_inlined_sources=False)
+        package = CompilePackage(
+            fn=None,
+            dynamo=None,
+            ignore_inlined_sources=False,
+            requires_native_backend_compatibility=native_backend,
+        )
 
     return _optimize_catch_errors(
         convert_frame.convert_frame_assert(

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -857,6 +857,31 @@ def _cpu_codegen_target_problem(
     return None
 
 
+# Registered backends that generate no native code, so an artifact of theirs
+# has no baked vector width to protect and must not be gated on one. This is a
+# blacklist on purpose: anything unrecognised -- including a user's own
+# callable, whose compiler_name is just its __name__ -- is assumed to emit
+# code, because a false rejection at load is recoverable and silently running a
+# kernel built for another ISA is not.
+_NO_NATIVE_CODE_BACKENDS = frozenset(
+    {
+        "aot_eager",
+        "aot_eager_decomp_partition",
+        "aot_eager_decomp_partition_crossref",
+        "aot_eager_decomp_partition_with_mode",
+        "aot_eager_default_partitioner",
+        "eager",
+        "eager_debug",
+        "eager_noexcept",
+        "pre_dispatch_eager",
+    }
+)
+
+
+def emits_native_code(backend_name: str) -> bool:
+    return backend_name not in _NO_NATIVE_CODE_BACKENDS
+
+
 @dataclasses.dataclass(frozen=True)
 class SystemInfo:
     """
@@ -902,7 +927,11 @@ class SystemInfo:
         )
 
     def check_compatibility(
-        self, other: "SystemInfo", device_type: str = "cpu"
+        self,
+        other: "SystemInfo",
+        device_type: str = "cpu",
+        *,
+        check_codegen: bool = True,
     ) -> None:
         """
         Check if this SystemInfo is compatible with another SystemInfo.
@@ -921,7 +950,11 @@ class SystemInfo:
         # this field (for a release build, every artifact already on disk), or it
         # was captured with vectorization disabled (cpp.simdlen=1, or any width
         # no valid ISA has) -- so there is nothing to compare.
-        if device_type == "cpu" and self.cpu_codegen_target is not None:
+        if (
+            check_codegen
+            and device_type == "cpu"
+            and self.cpu_codegen_target is not None
+        ):
             problem = _cpu_codegen_target_problem(
                 self.cpu_codegen_target, other.cpu_codegen_target
             )
@@ -932,8 +965,16 @@ class SystemInfo:
                     f"current={other.cpu_codegen_target}. {problem}"
                 )
         if device_type in self.CHECK_GPUS:
+            # Device EXISTENCE is not a native-code question: an artifact
+            # holding cuda tensors cannot run without cuda whatever backend
+            # produced it, so this check stays outside check_codegen. Only the
+            # toolkit/Triton/GPU-model checks below describe generated code and
+            # are skipped for a backend that emits none.
             if not getattr(torch, device_type).is_available():
                 raise RuntimeError(f"{device_type} is not available")
+
+            if not check_codegen:
+                return
 
             if self.toolkit_version != other.toolkit_version:
                 raise RuntimeError(
@@ -968,6 +1009,7 @@ class _DynamoCacheEntry:
     system_info: SystemInfo = dataclasses.field(
         default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
     )
+    requires_native_backend_compatibility: bool = True
     fn_name: str | None = None
     fn_first_lineno: str | None = None
 
@@ -977,13 +1019,17 @@ class _DynamoCacheEntry:
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
+        check_codegen = self.requires_native_backend_compatibility
         current_system_info = SystemInfo.current(
             cpu_codegen=(
-                self.device_type == "cpu"
+                check_codegen
+                and self.device_type == "cpu"
                 and self.system_info.cpu_codegen_target is not None
             )
         )
-        self.system_info.check_compatibility(current_system_info, self.device_type)
+        self.system_info.check_compatibility(
+            current_system_info, self.device_type, check_codegen=check_codegen
+        )
 
     def debug_info(self) -> dict[str, Any]:
         if len(self.codes) == 0:
@@ -1130,6 +1176,8 @@ class CompilePackage:
         fn: Callable[..., Any] | None,
         dynamo: _DynamoCacheEntry | None = None,
         ignore_inlined_sources: bool = False,
+        *,
+        requires_native_backend_compatibility: bool = True,
     ) -> None:
         self._innermost_fn = None
         self._codes: dict[types.CodeType, _DynamoCodeCacheEntry] = {}
@@ -1142,6 +1190,11 @@ class CompilePackage:
         self._installed_globals: dict[types.ModuleType, list[str]] = {}
         # device_type that model compiled with.
         self._device_type = "cpu"
+        # An eager backend bakes no vector width, so it neither pays the C++
+        # toolchain probe at save nor is rejected on ISA skew at load.
+        self._requires_native_backend_compatibility = (
+            requires_native_backend_compatibility
+        )
 
         # For debugging/testing purpose only.
         self._cached_backends: dict[_BackendId, Any] = {}
@@ -1542,7 +1595,15 @@ class CompilePackage:
             device_type=self._device_type,
             # The codegen probe runs the C++ toolchain; only pay for it when the
             # artifact can hold native CPU code.
-            system_info=SystemInfo.current(cpu_codegen=(self._device_type == "cpu")),
+            system_info=SystemInfo.current(
+                cpu_codegen=(
+                    self._requires_native_backend_compatibility
+                    and self._device_type == "cpu"
+                )
+            ),
+            requires_native_backend_compatibility=(
+                self._requires_native_backend_compatibility
+            ),
             fn_name=self._innermost_fn.__qualname__,
             fn_first_lineno=self._innermost_fn.__code__.co_firstlineno,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196833
* #196832
* #196831
* __->__ #196830
* #196829
* #196828
* #196827
* #196826
* #196825
* #196824
* #196823
* #196822
* #196821
* #196820
* #196819
* #196818
* #196817
* #196816
* #196815
* #196814
* #196767
* #196764
* #196756
* #196693
* #196692
* #196691
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683

The CPU codegen gate is about generated kernel source, but it applied to every
CPU artifact, including packages compiled with `backend="eager"` or one of the
`aot_eager` family. Those bake no native code and have no vector width to
protect, so the gate can only reject them for no reason -- and worse, they were
also paying for the `pick_vec_isa()` toolchain probe at save time to record a
target that could never matter.

Mark the package with whether its backend emits native code and thread that
through to both ends: the probe is skipped at save, and `check_versions` passes
`check_codegen=False` at load. The classification is a blacklist of the
recognised no-code backends, deliberately: anything unrecognised -- including a
user's own callable, whose `compiler_name` is just its `__name__` -- is assumed to
emit code, because a false rejection at load is recoverable and silently running
a kernel built for another ISA is not. A user backend can opt out explicitly by
setting `emits_native_code = False` on the callable.

Inside `check_compatibility` the flag deliberately does not cover everything:
device EXISTENCE stays checked, since an artifact holding cuda tensors cannot run
without cuda whoever generated it, while the toolkit/Triton/GPU-model checks
describe generated code and are skipped along with the CPU target.

`_optimize` and `_optimize_assert` both have to resolve this BEFORE
`get_compiler_fn`, which erases the name; `torch.compile` also hands them a
`_TorchCompileWrapper` rather than the string the user wrote, hence the
`compiler_name`/`compiler_fn` unwrapping.

Test Plan:

```
python test/dynamo/test_package.py -k test_eager_backend_entry_is_exempt_from_the_codegen_target
python test/dynamo/test_package.py -k test_loaded_eager_package_stays_exempt_on_resave
python test/dynamo/test_package.py
python test/dynamo/test_aot_compile.py
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98