### PR TITLE
[aot_compile] Record and check the CPU codegen target on an AOT artifact

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_aot_compile.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_aot_compile.md
@@ -159,8 +159,11 @@ Load a previously saved AOT-compiled function from a file.
   that could not be serialized (e.g., `nn.Module` instances). The keys should
   match those passed to `save_compiled_function(external_data=...)`.
 
-**Returns:** A callable with compilation preloaded from disk.
+**Returns:** A callable with compilation preloaded from disk. An artifact that
+may hold native CPU code is also checked against the host's CPU codegen target;
+see {ref}`Choosing a backend <choosing-a-backend>`.
 
+(choosing-a-backend)=
 ## Choosing a backend
 
 `aot_compile()` works with any backend that implements the
@@ -178,6 +181,32 @@ compiled_fn = torch.compile(fn, fullgraph=True, backend="eager").aot_compile(
     ((torch.randn(3, 4),), {})
 )
 ```
+
+The backend also decides where the artifact can be loaded. An artifact from a
+backend that may emit native CPU code -- `"inductor"`, and every other backend
+including a user callable unless it declares `emits_native_code = False` -- records
+the CPU codegen target it was tiled for (the machine, vector ISA, width and
+build macros `pick_vec_isa()` resolved at capture), and loading it on a host
+that resolves a different target fails with `RuntimeError: Compile package was
+created for a CPU codegen target this host cannot run: cached=..., current=...`.
+Kernels tiled for one ISA are not run on another, even a wider one. To load on
+such a host, make it resolve the recorded ISA before loading, with the
+`ATEN_CPU_CAPABILITY` environment variable or the global
+`torch._inductor.config.cpp.simdlen`; `torch.compile(options={"cpp.simdlen":
+...})` does not apply at load time. The target is recorded and checked only
+when the graph names a CPU device (a pure accelerator graph emits no CPU
+kernels). `"eager"`, `"aot_eager"` and the rest of the eager family (the
+`_NO_NATIVE_CODE_BACKENDS` set in `torch/_dynamo/package.py`) bake no
+generated code and are not subject to this check, and neither is a user
+backend that declares the plain attribute `emits_native_code = False` (any
+other value, including a method, counts as native). The attribute is read off
+the object handed to `torch.compile` as `backend` (for a registered backend
+name, off the function that name resolves to), never off anything that object
+wraps: for `aot_autograd(fw_compiler=...)` set it on the object `aot_autograd`
+returns, not on `fw_compiler`. Declaring it on a backend that does emit
+native code disables the only check standing between a mis-targeted artifact
+and a crash or wrong result at first call; opt out only a backend whose
+artifacts hold no compiled kernels.
 
 ## Handling closures and external references
 

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import copy
+import dataclasses
 import functools
 import importlib
 import inspect
@@ -42,7 +43,12 @@ from torch._dynamo.exc import PackageError, Unsupported
 from torch._dynamo.graph_utils import _graph_device_types
 from torch._dynamo.guards import CheckFunctionManager
 from torch._dynamo.output_graph import get_builtins_dict
-from torch._dynamo.package import DynamoCache, load_guards_state, SystemInfo
+from torch._dynamo.package import (
+    _current_cpu_codegen_target,
+    DynamoCache,
+    load_guards_state,
+    SystemInfo,
+)
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._functorch.aot_autograd import (
     aot_compile_joint_with_descriptors,
@@ -2693,6 +2699,116 @@ from user code:
         actual = loaded_fn(x)
         self.assertEqual(expected[0], actual[0])
         self.assertEqual(expected[1], actual[1])
+
+    def test_check_compatibility_compares_artifact_against_current_machine(self):
+        # CompileArtifacts.check_compatibility must invoke the CACHED
+        # SystemInfo's method with the current machine as `other`, the way
+        # _DynamoCacheEntry.check_versions does. Reversed, the "artifact
+        # predates cpu_codegen_target" skip is evaluated against the current
+        # machine -- never None -- so every old artifact is rejected, and every
+        # mismatch message reports the two sides the wrong way round.
+        def fn(x):
+            return x + 1
+
+        compiled = torch.compile(fn, fullgraph=True, backend="eager").aot_compile(
+            ((torch.randn(3, 3),), {})
+        )
+        artifacts = compiled._artifacts
+        self.assertEqual(artifacts.device_type, "cpu")
+        stale = ("mips", "DEFAULT", 128, (), None, "INVALID")
+
+        # An eager artifact holds no generated code, so there is no baked vector
+        # width to protect and the comparison must not run at all -- otherwise
+        # capture-here/serve-there, which is the whole point of the feature,
+        # rejects an artifact over a target it never used. Arm the capture-time
+        # flag so the exemption pinned here is the backend NAME's.
+        self.assertEqual(artifacts.backend_name, "eager")
+        self.assertFalse(artifacts.requires_native_backend_compatibility)
+        artifacts.requires_native_backend_compatibility = True
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=stale
+        )
+        artifacts.check_compatibility()
+
+        # The rest is about the receiver order, which only a native backend
+        # (name and capture-time flag) reaches.
+        artifacts.backend_name = "inductor"
+        current_target = _current_cpu_codegen_target()
+        if current_target is None:
+            # No usable C++ compiler, so there is no current target to compare
+            # against and the skew arms below have nothing to assert. Skipping
+            # rather than failing is the point of the lazy probe.
+            self.skipTest("no CPU codegen target on this host")
+
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=None
+        )
+        artifacts.check_compatibility()
+
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=stale
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            artifacts.check_compatibility()
+        message = str(ctx.exception)
+        self.assertIn(f"cached={stale}", message)
+        self.assertIn(f"current={current_target}", message)
+
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=None, torch_version="0.0.0-fake"
+        )
+        with self.assertRaisesRegex(RuntimeError, "0.0.0-fake"):
+            artifacts.check_compatibility()
+
+    def test_aot_compile_backend_declaring_no_native_code_skips_the_isa_gate(self):
+        # A user backend that emits no native code declares emits_native_code =
+        # False: the artifact records no CPU codegen target and loads on a host
+        # whose ISA differs (or that has no toolchain at all), while a backend
+        # without the declaration is fingerprinted like inductor.
+        from torch._dynamo.aot_compile_types import GraphModuleSerializableCallable
+
+        def python_backend(gm, example_inputs):
+            return GraphModuleSerializableCallable(gm)
+
+        python_backend.emits_native_code = False
+
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(3)
+        target = ("x86_64", "avx2", 256, ("CPU_CAPABILITY_AVX2",), None, None)
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target", return_value=target
+        ):
+            compiled = torch.compile(
+                fn, fullgraph=True, backend=python_backend
+            ).aot_compile(((x,), {}))
+        artifacts = compiled._artifacts
+        self.assertFalse(artifacts.requires_native_backend_compatibility)
+        self.assertIsNone(artifacts.system_info.cpu_codegen_target)
+        # A host that resolves no codegen target at all still loads it, from
+        # the in-memory artifact and from disk alike.
+        compiled.save_compiled_function(self.path())
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target", return_value=None
+        ):
+            artifacts.check_compatibility()
+            with open(self.path(), "rb") as f:
+                loaded = torch.compiler.load_compiled_function(f)
+        self.assertEqual(compiled(x), fn(x))
+        self.assertEqual(loaded(x), fn(x))
+
+        def undeclared_backend(gm, example_inputs):
+            return GraphModuleSerializableCallable(gm)
+
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target", return_value=target
+        ):
+            native = torch.compile(
+                fn, fullgraph=True, backend=undeclared_backend
+            ).aot_compile(((x,), {}))
+        self.assertTrue(native._artifacts.requires_native_backend_compatibility)
+        self.assertEqual(native._artifacts.system_info.cpu_codegen_target, target)
 
     def test_check_compatibility_triton_and_gpu_exempt_off_artifact(self):
         # The Triton/GPU checks must exempt off the ARTIFACT (self), not the

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -18,7 +18,12 @@ import torch
 import torch.fx
 from torch._dynamo.convert_frame import GraphRuntimeEnv
 from torch._dynamo.graph_utils import _graph_device_types
-from torch._dynamo.package import FunctionPicklerBase, SerializedCode, SystemInfo
+from torch._dynamo.package import (
+    emits_native_code,
+    FunctionPicklerBase,
+    SerializedCode,
+    SystemInfo,
+)
 
 from . import convert_frame
 from .aot_compile_types import (
@@ -63,6 +68,10 @@ class CompileArtifacts:
     system_info: SystemInfo = dataclasses.field(
         default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
     )
+    # False for a backend that bakes no native code (the eager family, or a user
+    # backend declaring `emits_native_code = False`), so the ISA gate is skipped.
+    # Defaults True so an artifact saved before the field existed keeps loading.
+    requires_native_backend_compatibility: bool = True
 
     def check_compatibility(self) -> None:
         # The cached info is the receiver so mismatch messages label self
@@ -71,13 +80,20 @@ class CompileArtifacts:
         # cached info as receiver they skip only when the artifact itself
         # recorded no Triton/GPU, requiring a match otherwise -- the correct
         # direction for a compatibility check.
+        check_codegen = (
+            self.requires_native_backend_compatibility
+            and emits_native_code(self.backend_name)
+        )
         current = SystemInfo.current(
             cpu_codegen=(
-                self.device_type == "cpu"
+                check_codegen
+                and self.device_type == "cpu"
                 and self.system_info.cpu_codegen_target is not None
             )
         )
-        self.system_info.check_compatibility(current, self.device_type)
+        self.system_info.check_compatibility(
+            current, self.device_type, check_codegen=check_codegen
+        )
 
 
 @dataclasses.dataclass
@@ -766,7 +782,8 @@ def aot_compile_fullgraph(
         backend_input.graph_module._backend_id = backend_input.backend_id  # type: ignore[assignment]
         # A graph naming no device lowers to CPU code.
         graph_devices = _graph_device_types(backend_input.graph_module.graph)
-        device_type = next((d for d in sorted(graph_devices) if d != "cpu"), "cpu")
+        device_types = graph_devices or frozenset(("cpu",))
+        device_type = next((d for d in sorted(device_types) if d != "cpu"), "cpu")
         if (
             backend_input.fake_mode.shape_env
             is not graph_capture_output.output_graph.shape_env
@@ -838,6 +855,18 @@ def aot_compile_fullgraph(
         for traced_code in graph_capture_output.traced_code:
             source_info.add_code(traced_code)
 
+        backend_name = getattr(backend, "compiler_name", "unknown")
+        # A user backend that bakes no native code can say so (on the callable
+        # torch.compile wrapped); the eager family is exempt by name.
+        user_backend = getattr(backend, "compiler_fn", backend)
+        native_backend = getattr(
+            user_backend, "emits_native_code", True
+        ) is not False and emits_native_code(backend_name)
+        # The codegen probe runs the C++ toolchain; only pay for it when the
+        # artifact can hold native CPU code.
+        system_info = SystemInfo.current(
+            cpu_codegen=(native_backend and "cpu" in device_types)
+        )
         artifacts = CompileArtifacts(
             signature=convert_frame._get_signature(fn),
             guard_manager=check_fn.guard_manager,
@@ -848,7 +877,9 @@ def aot_compile_fullgraph(
             runtime_env=graph_capture_output.get_runtime_env(),
             source_info=source_info,
             device_type=device_type,
-            backend_name=getattr(backend, "compiler_name", "unknown"),
+            backend_name=backend_name,
+            system_info=system_info,
+            requires_native_backend_compatibility=native_backend,
         )
         aot_compiled_fn = AOTCompiledFunction(
             _artifacts=artifacts, _extra_globals=fn.__globals__


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196833
* #196832
* __->__ #196831
* #196830
* #196829
* #196828
* #196827
* #196826
* #196825
* #196824
* #196823
* #196822
* #196821
* #196820
* #196819
* #196818
* #196817
* #196816
* #196815
* #196814
* #196767
* #196764
* #196756
* #196693
* #196692
* #196691
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683

The package path records the CPU codegen target and gates the load on it; an
`aot_compile()` artifact did neither. Its `system_info` came from the dataclass
default, which deliberately skips the toolchain probe, so a function artifact
built with avx512 kernels loaded happily on an avx2 host -- the exact case the
gate exists for.

Record it at capture and check it at load, with the same native-code exemption
the package path has: the eager family by name, plus a user backend that declares
`emits_native_code = False` on the object `torch.compile` was handed. Whether the
graph names a CPU device at all is part of it too, since a pure accelerator graph
emits no CPU kernels and should not pay the probe or carry a target.
`requires_native_backend_compatibility` defaults to True so an artifact saved
before the field existed keeps loading.

The docs get the user-facing half: what the check rejects, the two ways to make a
host resolve the recorded ISA (`ATEN_CPU_CAPABILITY`,
`torch._inductor.config.cpp.simdlen` -- and why `torch.compile(options=...)` is
not one of them), where the attribute is read from for wrapped backends, and that
declaring it on a backend that does emit code removes the only check between a
mis-targeted artifact and a wrong result.

Test Plan:

```
python test/dynamo/test_aot_compile.py -k test_check_compatibility_compares_artifact_against_current_machine
python test/dynamo/test_aot_compile.py -k test_aot_compile_backend_declaring_no_native_code_skips_the_isa_gate
python test/dynamo/test_aot_compile.py
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98