### PR TITLE
[dynamo] Carry every device an artifact targets, not just the winning one

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -2844,6 +2844,29 @@ from user code:
                     make((0, 0), None), "cuda", check_codegen=False
                 )
 
+    def test_inductor_cpu_capture_records_cpu_codegen_target(self):
+        # Pins the recording side: a regression that records None silently
+        # disarms check_compatibility via its predates-the-field skip.
+        if _current_cpu_codegen_target() is None:
+            self.skipTest("no CPU codegen target on this host")
+
+        def fn(x):
+            return x + 1
+
+        compiled = torch.compile(fn, fullgraph=True, backend="inductor").aot_compile(
+            ((torch.randn(3, 3),), {})
+        )
+        artifacts = compiled._artifacts
+        self.assertEqual(artifacts.device_types, frozenset(("cpu",)))
+        self.assertIsNotNone(artifacts.system_info.cpu_codegen_target)
+
+        stale = ("mips", "DEFAULT", 128, (), None, "INVALID")
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=stale
+        )
+        with self.assertRaisesRegex(RuntimeError, "CPU codegen target"):
+            artifacts.check_compatibility()
+
     def test_graph_device_types_ignores_placeholders_without_a_device(self):
         # Under dynamic shapes the leading placeholder is a SymInt, which has no
         # device. Reading only the first meta value reported "cpu" for this
@@ -2898,6 +2921,32 @@ from user code:
         graph.call_method("to", (x, "mps"))
         graph.call_function(torch.ops.aten.ones.default, ([2],), {"device": "cuda"})
         self.assertEqual(_graph_device_types(graph), frozenset(("mps", "cuda")))
+
+    @unittest.skipIf(not HAS_GPU, "requires gpu")
+    def test_mixed_device_graph_arms_cpu_codegen_target(self):
+        # A mixed cpu+accelerator graph collapses device_type to the
+        # accelerator, but inductor still emits native CPU kernels for the cpu
+        # half, so the codegen target must be recorded and compared anyway.
+        if _current_cpu_codegen_target() is None:
+            self.skipTest("no CPU codegen target on this host")
+
+        def fn(x, y):
+            return x + 1, y + 1
+
+        compiled = torch.compile(fn, fullgraph=True, backend="inductor").aot_compile(
+            ((torch.randn(4), torch.randn(4, device=GPU_TYPE)), {})
+        )
+        artifacts = compiled._artifacts
+        self.assertEqual(artifacts.device_type, GPU_TYPE)
+        self.assertIn("cpu", artifacts.device_types)
+        self.assertIsNotNone(artifacts.system_info.cpu_codegen_target)
+
+        stale = ("mips", "DEFAULT", 128, (), None, "INVALID")
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=stale
+        )
+        with self.assertRaisesRegex(RuntimeError, "CPU codegen target"):
+            artifacts.check_compatibility()
 
     @unittest.skipIf(not HAS_GPU, "requires gpu")
     def test_cross_aot_compile(self):

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -144,6 +144,39 @@ class TestPackage(torch._inductor.test_case.TestCase):
         torch._dynamo.reset()
         PrecompileContext.clear()
 
+    def test_mixed_device_capture_records_cpu_codegen_target(self):
+        # A mixed cpu+accelerator capture still holds native CPU code, so the
+        # codegen target must be recorded and compared even though the
+        # collapsed device_type reads as the accelerator. The graph is
+        # fabricated (never run), so no accelerator is needed.
+        if _current_cpu_codegen_target() is None:
+            self.skipTest("no CPU codegen target on this host")
+
+        def fn(x):
+            return x + 1
+
+        package = CompilePackage(fn)
+        graph = torch.fx.Graph()
+        node = graph.placeholder("x")
+        node.meta["val"] = torch.empty(2)
+        graph.call_function(
+            torch.ops.aten.ones.default, ((2,),), {"device": torch.device("cuda")}
+        )
+        package.update_device_type(graph)
+        self.assertEqual(package._device_types, {"cpu", "cuda"})
+
+        entry = package.cache_entry()
+        self.assertEqual(entry.device_type, "cuda")
+        self.assertEqual(entry.device_types, frozenset(("cpu", "cuda")))
+        self.assertIsNotNone(entry.system_info.cpu_codegen_target)
+
+        stale = ("mips", "DEFAULT", 128, ("INVALID",), None, "INVALID")
+        entry.system_info = dataclasses.replace(
+            entry.system_info, cpu_codegen_target=stale
+        )
+        with self.assertRaisesRegex(RuntimeError, "CPU codegen target"):
+            entry.check_versions()
+
     # Named codegen targets: (machine, isa, bit width, build macros, simdlen, march).
     _CODEGEN_TARGETS = {
         "avx2": ("x86_64", "avx2", 256, ("CPU_CAPABILITY_AVX2",), None, None),

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -68,6 +68,9 @@ class CompileArtifacts:
     system_info: SystemInfo = dataclasses.field(
         default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
     )
+    # device_type keeps the collapsed accelerator-wins value for BC; a mixed
+    # cpu+accelerator graph still emits native CPU code, so keep the full set.
+    device_types: frozenset[str] = frozenset()
     # False for a backend that bakes no native code (the eager family, or a user
     # backend declaring `emits_native_code = False`), so the ISA gate is skipped.
     # Defaults True so an artifact saved before the field existed keeps loading.
@@ -80,6 +83,7 @@ class CompileArtifacts:
         # cached info as receiver they skip only when the artifact itself
         # recorded no Triton/GPU, requiring a match otherwise -- the correct
         # direction for a compatibility check.
+        device_types = self.device_types or frozenset((self.device_type,))
         check_codegen = (
             self.requires_native_backend_compatibility
             and emits_native_code(self.backend_name)
@@ -87,13 +91,14 @@ class CompileArtifacts:
         current = SystemInfo.current(
             cpu_codegen=(
                 check_codegen
-                and self.device_type == "cpu"
+                and "cpu" in device_types
                 and self.system_info.cpu_codegen_target is not None
             )
         )
-        self.system_info.check_compatibility(
-            current, self.device_type, check_codegen=check_codegen
-        )
+        for device_type in sorted(device_types):
+            self.system_info.check_compatibility(
+                current, device_type, check_codegen=check_codegen
+            )
 
 
 @dataclasses.dataclass
@@ -880,6 +885,7 @@ def aot_compile_fullgraph(
             backend_name=backend_name,
             system_info=system_info,
             requires_native_backend_compatibility=native_backend,
+            device_types=device_types,
         )
         aot_compiled_fn = AOTCompiledFunction(
             _artifacts=artifacts, _extra_globals=fn.__globals__

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -1009,6 +1009,9 @@ class _DynamoCacheEntry:
     system_info: SystemInfo = dataclasses.field(
         default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
     )
+    # device_type keeps the collapsed accelerator-wins value for BC; a mixed
+    # cpu+accelerator capture still holds native CPU code, so keep the full set.
+    device_types: frozenset[str] | None = None
     requires_native_backend_compatibility: bool = True
     fn_name: str | None = None
     fn_first_lineno: str | None = None
@@ -1019,17 +1022,22 @@ class _DynamoCacheEntry:
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
+        device_types = self.device_types or frozenset((self.device_type,))
         check_codegen = self.requires_native_backend_compatibility
         current_system_info = SystemInfo.current(
             cpu_codegen=(
                 check_codegen
-                and self.device_type == "cpu"
+                and "cpu" in device_types
                 and self.system_info.cpu_codegen_target is not None
             )
         )
-        self.system_info.check_compatibility(
-            current_system_info, self.device_type, check_codegen=check_codegen
-        )
+        # cpu first, so a codegen-target refusal is not masked by a GPU error.
+        for device_type in sorted(device_types):
+            self.system_info.check_compatibility(
+                current_system_info,
+                device_type,
+                check_codegen=check_codegen,
+            )
 
     def debug_info(self) -> dict[str, Any]:
         if len(self.codes) == 0:
@@ -1188,8 +1196,8 @@ class CompilePackage:
         # earlier, installed variant of the same code object still needs.
         self._current_backend_ids: list[_BackendId] = []
         self._installed_globals: dict[types.ModuleType, list[str]] = {}
-        # device_type that model compiled with.
-        self._device_type = "cpu"
+        # Empty means no graph named a device; cache_entry records that as cpu.
+        self._device_types: set[str] = set()
         # An eager backend bakes no vector width, so it neither pays the C++
         # toolchain probe at save nor is rejected on ISA skew at load.
         self._requires_native_backend_compatibility = (
@@ -1259,6 +1267,8 @@ class CompilePackage:
                         function_names=list(code.function_names),
                         import_sources=dict(code.import_sources),
                     )
+            # Restored so a re-save keeps checking what the capture targeted.
+            self._device_types = set(dynamo.device_types or (dynamo.device_type,))
         else:
             self._add_function(
                 self._innermost_fn.__code__, self._innermost_fn.__module__
@@ -1370,8 +1380,7 @@ class CompilePackage:
             self._source_info.add_code(code)
 
     def update_device_type(self, graph: torch.fx.Graph | None) -> None:
-        devices = _graph_device_types(graph)
-        self._device_type = next((d for d in sorted(devices) if d != "cpu"), "cpu")
+        self._device_types.update(_graph_device_types(graph))
 
     def bypass_current_compile(self) -> None:
         """Drop the backend ids the current compile registered on its entry.
@@ -1589,16 +1598,22 @@ class CompilePackage:
         self.validate()
         if self._innermost_fn is None:
             raise AssertionError("_innermost_fn is not set in cache_entry")
+        device_types = frozenset(self._device_types or ("cpu",))
+        device_type = next(
+            (device for device in sorted(device_types) if device != "cpu"),
+            "cpu",
+        )
         return _DynamoCacheEntry(
             codes=list(self._codes.values()),
             source_info=self._source_info,
-            device_type=self._device_type,
+            device_type=device_type,
+            device_types=device_types,
             # The codegen probe runs the C++ toolchain; only pay for it when the
             # artifact can hold native CPU code.
             system_info=SystemInfo.current(
                 cpu_codegen=(
                     self._requires_native_backend_compatibility
-                    and self._device_type == "cpu"
+                    and "cpu" in device_types
                 )
             ),
             requires_native_backend_compatibility=(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #196833
* __->__ #196832
* #196831
* #196830
* #196829
* #196828
* #196827
* #196826
* #196825
* #196824
* #196823
* #196822
* #196821
* #196820
* #196819
* #196818
* #196817
* #196816
* #196815
* #196814
* #196767
* #196764
* #196756
* #196693
* #196692
* #196691
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683

Both artifact kinds collapsed their devices to a single "accelerator wins" value.
A graph that mixes cpu and cuda work therefore recorded `device_type="cuda"`, and
the CPU codegen target was neither recorded at save nor checked at load -- even
though such an artifact really does hold native CPU kernels, which is exactly what
the ISA gate protects. The collapse also meant only one device was version-checked
per artifact, so a mixed artifact could not verify cuda availability and the CPU
target.

Keep the whole set. `device_type` stays as it was, holding the collapsed value, so
an artifact written before this commit still loads and anything reading that field
is unaffected; the new `device_types` is the authoritative set, and both check
paths fall back to `{device_type}` when it is absent. The checks then run once per
device, sorted so cpu goes first and a codegen-target refusal is not masked by a
GPU error.

`CompilePackage.update_device_type` accumulates instead of overwriting, which it
had to for a package holding several graphs: the last graph's devices used to win.
The collapse to a single value now happens where the entry is built, and a restored
entry repopulates the set so a re-save keeps checking what the original capture
targeted.

Test Plan:

```
python test/dynamo/test_package.py -k test_mixed_device_capture_records_cpu_codegen_target
python test/dynamo/test_aot_compile.py -k test_mixed_device_graph_arms_cpu_codegen_target
python test/dynamo/test_aot_compile.py -k test_inductor_cpu_capture_records_cpu_codegen_target
python test/dynamo/test_package.py
python test/dynamo/test_aot_compile.py
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98