### PR TITLE
[aot_compile] Sample the codegen target under the backend's inductor config

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -2760,6 +2760,31 @@ from user code:
         with self.assertRaisesRegex(RuntimeError, "0.0.0-fake"):
             artifacts.check_compatibility()
 
+    def test_aot_compile_samples_the_codegen_target_under_the_wrappers_config(self):
+        # torch.compile(options={"cpp.simdlen": ...}) patches inductor config
+        # only while the backend runs; aot_compile re-applies it while sampling
+        # the fingerprint so the recorded simdlen is the one the kernels were
+        # tiled for, and the ambient config is untouched afterwards.
+        def fake_target():
+            simdlen = torch._inductor.config.cpp.simdlen
+            return ("x86_64", "avx2", 256, ("CPU_CAPABILITY_AVX2",), simdlen, None)
+
+        def fn(x):
+            return x + 1
+
+        self.assertIsNone(torch._inductor.config.cpp.simdlen)
+        with patch(
+            "torch._dynamo.package._current_cpu_codegen_target",
+            side_effect=fake_target,
+        ):
+            compiled = torch.compile(
+                fn, fullgraph=True, backend="inductor", options={"cpp.simdlen": 256}
+            ).aot_compile(((torch.randn(3, 3),), {}))
+        target = compiled._artifacts.system_info.cpu_codegen_target
+        self.assertIsNotNone(target)
+        self.assertEqual(target[4], 256)
+        self.assertIsNone(torch._inductor.config.cpp.simdlen)
+
     def test_aot_compile_backend_declaring_no_native_code_skips_the_isa_gate(self):
         # A user backend that emits no native code declares emits_native_code =
         # False: the artifact records no CPU codegen target and loads on a host

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -861,35 +861,50 @@ def aot_compile_fullgraph(
             source_info.add_code(traced_code)
 
         backend_name = getattr(backend, "compiler_name", "unknown")
+        # The codegen probe runs the C++ toolchain; only pay for it when the
+        # artifact can hold native CPU code. torch.compile(options={...}) builds a
+        # _TorchCompileInductorWrapper that patches inductor config (e.g.
+        # cpp.simdlen) only for the duration of backend(); that scope has exited
+        # by now, so re-apply the wrapper's config while sampling. Otherwise the
+        # fingerprint records the ambient ISA rather than the one the kernels were
+        # actually tiled for, and the load-time gate rejects the matching host and
+        # accepts a wider one.
+        codegen_config_ctx: AbstractContextManager[Any] = nullcontext()
+        if isinstance(backend, torch._TorchCompileInductorWrapper):
+            codegen_config_ctx = torch._inductor.config.patch(backend.config)
         # A user backend that bakes no native code can say so (on the callable
         # torch.compile wrapped); the eager family is exempt by name.
         user_backend = getattr(backend, "compiler_fn", backend)
         native_backend = getattr(
             user_backend, "emits_native_code", True
         ) is not False and emits_native_code(backend_name)
-        # The codegen probe runs the C++ toolchain; only pay for it when the
-        # artifact can hold native CPU code.
-        system_info = SystemInfo.current(
-            cpu_codegen=(native_backend and "cpu" in device_types)
-        )
-        artifacts = CompileArtifacts(
-            signature=convert_frame._get_signature(fn),
-            guard_manager=check_fn.guard_manager,
-            guards_state=check_fn.guards_state,
-            backend_id=backend_input.backend_id,
-            compiled_fn=compiled_fn,
-            original_code=fn.__code__,
-            runtime_env=graph_capture_output.get_runtime_env(),
-            source_info=source_info,
-            device_type=device_type,
-            backend_name=backend_name,
-            system_info=system_info,
-            requires_native_backend_compatibility=native_backend,
-            device_types=device_types,
-        )
-        aot_compiled_fn = AOTCompiledFunction(
-            _artifacts=artifacts, _extra_globals=fn.__globals__
-        )
+        with codegen_config_ctx:
+            system_info = SystemInfo.current(
+                cpu_codegen=(native_backend and "cpu" in device_types)
+            )
+            # Build the artifact under the same config the fingerprint was
+            # sampled under: AOTCompiledFunction.__post_init__ runs
+            # check_compatibility(), whose SystemInfo.current() must see the same
+            # inductor config (e.g. cpp.simdlen) or the artifact rejects its own
+            # build.
+            artifacts = CompileArtifacts(
+                signature=convert_frame._get_signature(fn),
+                guard_manager=check_fn.guard_manager,
+                guards_state=check_fn.guards_state,
+                backend_id=backend_input.backend_id,
+                compiled_fn=compiled_fn,
+                original_code=fn.__code__,
+                runtime_env=graph_capture_output.get_runtime_env(),
+                source_info=source_info,
+                device_type=device_type,
+                backend_name=backend_name,
+                system_info=system_info,
+                requires_native_backend_compatibility=native_backend,
+                device_types=device_types,
+            )
+            aot_compiled_fn = AOTCompiledFunction(
+                _artifacts=artifacts, _extra_globals=fn.__globals__
+            )
 
     return aot_compiled_fn
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #196833
* #196832
* #196831
* #196830
* #196829
* #196828
* #196827
* #196826
* #196825
* #196824
* #196823
* #196822
* #196821
* #196820
* #196819
* #196818
* #196817
* #196816
* #196815
* #196814
* #196767
* #196764
* #196756
* #196693
* #196692
* #196691
* #196688
* #196687
* #196686
* #196685
* #196684
* #196683

`torch.compile(options={"cpp.simdlen": ...})` builds a
`_TorchCompileInductorWrapper` that patches inductor config only for the duration
of the `backend()` call. By the time the artifact is assembled that scope has
exited, so `SystemInfo.current()` sampled the AMBIENT ISA instead of the one the
kernels had just been tiled for. The recorded fingerprint then describes a
machine configuration that never generated this code, and the load-time gate
inverts: it rejects the host that would compile the kernels correctly and accepts
one that would not.

Re-apply the wrapper's config while sampling, and build the artifact inside the
same scope -- `AOTCompiledFunction.__post_init__` calls `check_compatibility()`,
whose own `SystemInfo.current()` has to see the same config or the artifact
rejects its own build on the spot.

Test Plan:

```
python test/dynamo/test_aot_compile.py -k test_aot_compile_samples_the_codegen_target_under_the_wrappers_config
python test/dynamo/test_aot_compile.py
python test/dynamo/test_package.py
```

Authored with the assistance of Claude Code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98