### PR TITLE
[native] Drop CuTeDSL <= 4.5.x from known-good versions

### DIFF
--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -28,9 +28,6 @@ _CUTEDSL_DSL_NAME = "cutedsl"
 _CUTEDSL_REQUIRED_VERSIONS: set[Version] = {
     # Current version - Note Version.from_part(release=(4.4.1)) is better
     #                   but > v26 of packaging.
-    Version("4.4.1"),
-    Version("4.4.2"),
-    Version("4.5.2"),
     Version("4.6.2"),
     Version("4.7.1"),
 }


### PR DESCRIPTION
Summary:
Forward fix for D119588085 (pytorch/pytorch#192662), which re-vendored QuACK
0.6.4. That QuACK imports cutlass.utils.block_copy / SmemPartition,
cutlass.cute.experimental.iket and cutlass.pipeline.alloc_reserved_mbarrier,
which only exist in nvidia-cutlass-dsl >= 4.6 (upstream QuACK pins ==4.6.2).

The internal default nvidia-cutlass-dsl is 4.4.2, but torch/_native still
listed 4.4.1/4.4.2/4.5.2 as known-good, so the CuTeDSL rms_norm override was
registered and the first eager torch.nn.functional.rms_norm call died with
ImportError: cannot import name block_copy from cutlass.utils
(fbcode//pytorch/tritonbench/test/test_gpu:test_gpu -
test_gpu_tritonbench_fused_norm_matmul_norm).

Restrict the known-good set to the versions the vendored QuACK supports so
older CuTeDSL builds fall back to the eager kernels instead of registering
overrides that cannot import. TORCH_NATIVE_SKIP_VERSION_CHECK=1 still forces
registration for local testing.

Test Plan:
Stacked on D119588085; rerun
buck2 test fbcode//pytorch/tritonbench/test/test_gpu:test_gpu -- test_gpu_tritonbench_fused_norm_matmul_norm

Reviewed By: izaitsevfb

Differential Revision: D119738197


