### PR TITLE
[AOTI cuda graph S2][1/7] Unblock "regional" mode: config + gating

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -21,7 +21,6 @@ from inspect import currentframe
 from itertools import count
 from operator import attrgetter
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
-from typing_extensions import Never, override, ParamSpec, Protocol, TypedDict, Unpack
 from unittest import mock
 
 import torch._inductor.async_compile
@@ -109,6 +108,7 @@ from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymExpr
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.monitor import _WaitCounter
 from torch.utils._ordered_set import OrderedSet
+from typing_extensions import Never, override, ParamSpec, Protocol, TypedDict, Unpack
 
 from .._dynamo.exc import ShortenTraceback, SkipFrame
 from ..fx._lazy_graph_module import _use_lazy_graph_module
@@ -932,9 +932,12 @@ def maybe_disable_graph_partition(
     cpp_wrapper: bool, aot_mode: bool
 ) -> AbstractContextManager[None, None]:
     """
-    graph partition does not support cpp_wrapper and aot_mode yet.
+    graph partition does not support cpp_wrapper and aot_mode yet, except under
+    AOTI regional cuda graph, which is built on top of it.
     """
-    if cpp_wrapper or aot_mode:
+    if config.aot_inductor.cudagraph_mode == "regional" and aot_mode:
+        return config.patch(graph_partition=True)
+    elif cpp_wrapper or aot_mode:
         return config.patch(graph_partition=False)
     else:
         return contextlib.nullcontext()
@@ -2439,6 +2442,22 @@ def compile_fx_aot(
 
     config_patches = maybe_aoti_standalone_config(config_patches)
 
+    # Regional cuda graph relies on memory planning to place captured-partition
+    # boundary buffers in an address-stable slab; without it a capture would
+    # replay against reallocated addresses. Auto-enable so the two stay in sync.
+    # (Whole-graph mode does not need this: its intermediates are allocated
+    # inside the capture and live in the graph pool.)
+    cudagraph_mode = config_patches.get(
+        "aot_inductor.cudagraph_mode", config.aot_inductor.cudagraph_mode
+    )
+    memory_planning = config_patches.get("memory_planning", config.memory_planning)
+    if cudagraph_mode == "regional" and not memory_planning:
+        log.warning(
+            "Enabling config.memory_planning because "
+            'config.aot_inductor.cudagraph_mode="regional" requires it.'
+        )
+        config_patches["memory_planning"] = True
+
     extern_node_serializer = config_patches.pop("extern_node_serializer", None)
     saved_compile_id = model_.meta.get("dynamo_compile_id", None)
     saved_compile_context = torch._guards.CompileContext(saved_compile_id)
@@ -2607,9 +2626,18 @@ def get_cpp_wrapper_config(log_cudagraph_skip: bool = True) -> dict[str, object]
     return {
         "triton.autotune_at_compile_time": autotune_at_compile_time,
         "triton.autotune_cublasLt": not autotune_at_compile_time,
+        # Regional cuda graph drives Inductor's partitioner, whose
+        # should_partition only does real work when triton.cudagraphs is on, so
+        # it must stay on for AOT compilation in that mode.
         "triton.cudagraphs": (
-            config.triton.cudagraphs
-            and not V.aot_compilation
+            (
+                config.triton.cudagraphs
+                or config.aot_inductor.cudagraph_mode == "regional"
+            )
+            and (
+                not V.aot_compilation
+                or config.aot_inductor.cudagraph_mode == "regional"
+            )
             and not config.graph_partition
         ),
         "triton.store_cubin": True,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2456,6 +2456,57 @@ class aot_inductor:
         os.environ.get("AOT_INDUCTOR_CUDAGRAPH_MAX_CAPTURES", "64")
     )
 
+    # Every cudagraph_* knob below is read at LOWERING time only. Each one
+    # decides what code or what memory layout gets emitted, so its env var has
+    # no effect on an already-built .so -- changing one means re-lowering.
+    # cudagraph_max_captures above is the sole exception: it is a plain runtime
+    # value, so the serving process re-reads it and wins over the baked default.
+
+    # --- regional-mode-only knobs (cudagraph_mode="regional") ---
+
+    # Minimum number of post-fusion scheduler nodes (a fused node counts as 1,
+    # NOT emitted kernels) in a cudagraph-eligible partition for it to be
+    # captured; smaller eligible clusters are demoted to eager. Capturing a tiny
+    # partition costs per-replay staging + launch overhead that outweighs the
+    # kernel-launch saving over only a few kernels, and each captured partition
+    # also costs a persistent slab. Distinct from
+    # triton.cudagraph_min_partition_size (which counts kernels for JIT
+    # cudagraph-trees). Values below 3 are pathological -- tiny partitions
+    # explode the partition count so boundary copy-in + replay-dispatch overhead
+    # dominates; higher values trade a little capture coverage for less memory.
+    # Tune per model. Default 8 favors lower CG memory (fewer, larger captured
+    # partitions -> fewer persistent slabs); set 4 to favor capture coverage on
+    # models with hot small partitions.
+    cudagraph_min_partition_size: int = 8
+
+    # Drop eager-transient (non-boundary) outer-wrapper buffers from the
+    # persistent regional-cudagraph slab. With regional capture on, the OUTER
+    # wrapper's MemoryPlanner slab-caches EVERY pool into a persistent,
+    # per-instance, address-stable slab. Only boundary buffers (inputs/outputs of
+    # captured partitions) actually need that address stability; eager-transient
+    # buffers (used only in eager regions, never read/written by a captured
+    # graph) are wastefully persisted. When on, those are routed into ordinary
+    # transient pools (normal empty_strided, freed each forward) so the
+    # per-instance slab shrinks. ON by default: without it the persistent slab is
+    # dominated by eager-transient buffers (~38% larger on measured models), and
+    # the exclusion is latency-neutral and IMA-clean on the validated
+    # architectures. Set False to opt out if a new architecture surfaces a
+    # boundary-classification gap.
+    cudagraph_exclude_eager_transient: bool = (
+        os.environ.get("AOT_INDUCTOR_CUDAGRAPH_EXCLUDE_EAGER_TRANSIENT", "1") == "1"
+    )
+
+    # Cross-partition memory planning: intra-partition scratch of captured
+    # partitions shares ONE global slab (partition-interval liveness, offsets
+    # frozen to max) instead of a disjoint slab per partition, dropping runtime
+    # peak from SUM-of-per-partition toward the global working set. Off =
+    # per-partition-disjoint (byte-identical to not having this). Measured a NET
+    # memory LOSS on top of cudagraph_exclude_eager_transient, which already
+    # subsumes its target, so it stays off unless a model shows otherwise.
+    cudagraph_cross_partition_memory: bool = (
+        os.environ.get("AOT_INDUCTOR_CUDAGRAPH_CROSS_PARTITION_MEMORY", "0") == "1"
+    )
+
     # flag to force weight to be appended to the shared library and mapped by the runtime
     # rather than embedded into the data section. Needed to support 1B+ parameter models
     force_mmap_weights: bool = False

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -11600,13 +11600,7 @@ class Scheduler:
         mode = config.aot_inductor.cudagraph_mode
         if mode == "off":
             return
-        if mode == "regional":
-            raise RuntimeError(
-                'config.aot_inductor.cudagraph_mode="regional" is not implemented '
-                "yet -- it is added by the follow-up regional cuda-graph stack. "
-                'Use "whole" or "off".'
-            )
-        if mode != "whole":
+        if mode not in ("whole", "regional"):
             raise RuntimeError(
                 f"config.aot_inductor.cudagraph_mode={mode!r} is not a valid mode; "
                 'expected "off", "whole" or "regional".'
@@ -11615,12 +11609,15 @@ class Scheduler:
             V.graph.aot_mode and V.graph.cpp_wrapper and is_gpu(V.graph.device_type)
         ):
             raise RuntimeError(
-                'config.aot_inductor.cudagraph_mode="whole" requires an '
+                f'config.aot_inductor.cudagraph_mode="{mode}" requires an '
                 "AOTInductor GPU compile, but this graph has "
                 f"aot_mode={V.graph.aot_mode}, cpp_wrapper={V.graph.cpp_wrapper}, "
                 f"device_type={V.graph.device_type!r}."
             )
-        cudagraph_capture.check_whole_graph_capturable(self.nodes)
+        if mode == "whole":
+            cudagraph_capture.check_whole_graph_capturable(self.nodes)
+        # "regional" needs no whole-graph scan: it partitions AROUND the
+        # uncapturable nodes instead of rejecting the model for having them.
 
     def _codegen_partition_wrapper(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* __->__ #196835
* #196785
* #196784
* #196783
* #196782
* #196781
* #196780
* #196779
* #196778

Opens `cudagraph_mode="regional"` and adds the three knobs regional capture needs. Inert on its own -- nothing implements regional until [6/7] activates the codegen -- but it is what the rest of the stack gates on.

Bottom of the **Step 2** stack. Step 1 (whole-graph capture) shipped `cudagraph_mode` with `"regional"` rejected at validation; this removes that rejection. Both modes are kept: `"whole"` stays the simple path for clean models and upstream, `"regional"` is what ads models opt into once they contain something uncapturable.

`Scheduler._check_cudagraph_mode` no longer rejects `"regional"`, and the whole-graph capture scan is now gated to `"whole"` only. That difference is the heart of the two modes: whole-graph FAILS the lowering on an uncapturable node, regional partitions AROUND it.

Three regional-only knobs, all carried over from the original stack with their measured defaults:
- `cudagraph_min_partition_size` (8) -- eligible clusters smaller than this are demoted to eager, since capture staging plus a persistent slab outweighs the launch saving over a few kernels.
- `cudagraph_exclude_eager_transient` (ON) -- keeps buffers that no captured graph touches out of the persistent slab; worth ~38% of slab size on measured models.
- `cudagraph_cross_partition_memory` (OFF) -- measured a net memory LOSS on top of the exclusion above, which already subsumes its target.

These, and every `cudagraph_*` knob added later in the stack, are read at LOWERING time only: each decides what code or what memory layout gets emitted, so its env var has no effect on an already-built `.so`. A note at the top of the section says so, because the names look like runtime knobs and `cudagraph_max_captures` (Step 1) genuinely is one.

`compile_fx` gating, all three conditioned on `"regional"` specifically:
- `maybe_disable_graph_partition` now patches `graph_partition=True` instead of False, since regional capture is built on Inductor's partitioner.
- `memory_planning` is auto-enabled, because captured-partition boundary buffers need an address-stable slab. Whole-graph deliberately does NOT need this (its intermediates live in the graph pool), which is why Step 1 had no compile_fx change at all.
- `triton.cudagraphs` is forced on for AOT compilation, because `should_partition` only does real work when it is set.

Authored with Claude.

Differential Revision: [D118228079](https://our.internmc.facebook.com/intern/diff/D118228079/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo