### PR TITLE
[AOTI cuda graph S2][5/7] Runtime: per-forward boundary + slab cache member

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1278,6 +1278,10 @@ class CppWrapperGpu(CppWrapperCpu):
             f"{config.aot_inductor.cudagraph_max_captures});"
         )
         code.writeline("}")
+        # Per-forward boundary: releases the previous forward's uncaptured
+        # outputs. Must be per-forward rather than per-capture, since regional
+        # mode issues several run_graph calls per forward.
+        code.writeline("this->cudagraph_mgr_->begin_forward();")
 
         # Key on every input dim plus every scalar input value: two calls share a
         # capture exactly when their inputs have identical shapes and scalars,

--- a/torch/csrc/inductor/aoti_runtime/cudagraph_runtime.h
+++ b/torch/csrc/inductor/aoti_runtime/cudagraph_runtime.h
@@ -248,7 +248,22 @@ class AOTICUDAGraphManager {
     aoti_torch_cuda_graph_pool_destroy_handle(pool_handle_);
   }
 
-  // Run the whole lowered component for one dynamic shape.
+  // Start of one forward. Frees the PREVIOUS forward's uncaptured outputs,
+  // which is what gives the uncaptured path the same "valid until the next
+  // forward" contract the captured path has.
+  //
+  // This is per-FORWARD, not per-run_graph, because regional mode makes several
+  // run_graph calls per forward and a later partition's uncaptured outputs are
+  // frequently still live as an earlier one's chained inputs. Freeing per call
+  // would be a use-after-free. The generated run_impl calls this once, up front,
+  // in both modes.
+  void begin_forward() {
+    release_uncaptured_outputs();
+  }
+
+  // Run one captured region for one dynamic shape. In whole-graph mode that is
+  // the entire component; in regional mode it is one partition, and the caller
+  // distinguishes them by prepending the partition id to shape_key.
   //   shape_key     : value of every dynamic symbol, in a codegen-fixed order.
   //   copy_in       : input indices staged into node-owned slots and refreshed
   //                   per replay. Whole-graph capture stages every tensor input,
@@ -269,12 +284,6 @@ class AOTICUDAGraphManager {
       const std::vector<int32_t>& escape_outs,
       void* caller_stream,
       const GraphBody& body) {
-    // Free the PREVIOUS call's uncaptured outputs. Deferring the free to here,
-    // rather than to the end of the call that produced them, is what gives the
-    // uncaptured path the same "valid until the next run_graph" contract that
-    // the captured path has.
-    release_uncaptured_outputs();
-
     // Shared (read) lock over capture/replay (see captureMutex in the shim):
     // replay + output reconstruction run concurrently with other instances'
     // replays but are excluded while ANY instance holds the exclusive capture

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -90,6 +90,16 @@ class AOTInductorModel : public AOTInductorModelBase<AOTInductorModel> {
   // for models built without cuda graph. Destroyed with the model (no leak).
   // See cudagraph_runtime.h.
   std::unique_ptr<AOTICUDAGraphManager> cudagraph_mgr_;
+  // Per-instance slab cache for regional cuda graph, keyed by a packed pool id.
+  // Each value owns a persistent slab whose base address captured partitions
+  // bake into their reinterpret_tensor views, so the address stays stable across
+  // forwards; the slab is sized to the dynamic-shape upper bounds and shared
+  // across shapes. Per AOTInductorModel instance (NOT process-static) so
+  // concurrent instances in a container have isolated slabs, and the RAII
+  // handles free them at model destruction. Populated by the generated
+  // memory_planning codegen; unused in whole-graph mode, whose intermediates
+  // live in the graph pool instead.
+  std::unordered_map<int64_t, RAIIAtenTensorHandle> cudagraph_slabs_;
 #endif
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196841
* #196840
* __->__ #196839
* #196838
* #196837
* #196836
* #196835
* #196785
* #196784
* #196783
* #196782
* #196781
* #196780
* #196779
* #196778

The two C++ runtime changes regional capture needs on top of Step 1's manager. Both apply to whole-graph mode as well, so this diff also updates the whole-graph prologue rather than leaving a broken intermediate state.

FIXES A USE-AFTER-FREE THAT REGIONAL WOULD OTHERWISE HIT. Step 1 released the previous call's uncaptured outputs at the top of `run_graph`. With one call per forward that is exactly right. Regional makes N calls per forward, and a later partition's uncaptured outputs are frequently still live as an earlier partition's chained inputs -- so partition k+1 would free memory partition k+2 still reads. The release moves to a new `begin_forward()`, which the generated `run_impl` calls once up front in BOTH modes. The whole-graph prologue is updated in this diff for that reason; deferring it to [6/7] would leave whole-graph never releasing.

RESTORES `cudagraph_slabs_` TO `model.h`. Step 1 dropped this member because whole-graph capture does not need it -- its intermediates are allocated inside the capture and live in the graph pool. Regional does need it: [4/7] emits `this->cudagraph_slabs_` from the memory planner, so without the member the generated code would not compile.

No change to the dispatch key. Step 1's key is already a `std::vector<int64_t>` compared for full equality, so regional distinguishes partitions by PREPENDING the partition id ([6/7] does this). That is deliberately not the original's `encode(partition_id, shape_key)` bit-packing, which could collide two distinct keys and replay the wrong graph; hashing a vector and comparing it in full cannot.

Authored with Claude.

Differential Revision: [D118228083](https://our.internmc.facebook.com/intern/diff/D118228083/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo