### PR TITLE
[AOTI cuda graph S2][7/7] Regional hardening + tests

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -315,12 +315,13 @@ def profiled_ivalue_kinds(code, kernel_name):
         "scalar" if "_scalar_" in entry else "tensor"
         for entry in vector.group(1).split(",")
     ]
-def compile_whole_cudagraph(model, example_inputs, dynamic_shapes=None, **cfg):
-    """Compile and load `model` with whole-graph cuda graph enabled.
+def compile_with_cudagraph(model, example_inputs, dynamic_shapes=None, **cfg):
+    """Compile and load `model` with cuda graph enabled, whole-graph by default.
 
-    Module-level rather than a method because `copy_tests` only copies `test_*`
-    methods into the generated device classes, so a helper method would not
-    exist on them.
+    Pass `**{"aot_inductor.cudagraph_mode": "regional"}` for the partitioned
+    path. Module-level rather than a method because `copy_tests` only copies
+    `test_*` methods into the generated device classes, so a helper method would
+    not exist on them.
     """
     with config.patch({"aot_inductor.cudagraph_mode": "whole", **cfg}), torch.no_grad():
         package_path = AOTIRunnerUtil.compile(
@@ -6325,7 +6326,7 @@ class AOTInductorTestsTemplate:
 
         model = Model().to(self.device)
         example = torch.randn(8, 64, device=self.device)
-        compiled = compile_whole_cudagraph(
+        compiled = compile_with_cudagraph(
             model, (example,), {"x": {0: Dim("b", min=1, max=256)}}
         )
 
@@ -6352,7 +6353,7 @@ class AOTInductorTestsTemplate:
 
         model = Model().to(self.device)
         example = torch.randn(8, 32, device=self.device)
-        compiled = compile_whole_cudagraph(
+        compiled = compile_with_cudagraph(
             model,
             (example,),
             {"x": {0: Dim("b", min=1, max=256)}},
@@ -6380,13 +6381,129 @@ class AOTInductorTestsTemplate:
         model = Model().to(self.device)
         example = torch.randn(8, 64, device=self.device)
         with self.assertRaisesRegex(Exception, "RNG"):
-            compile_whole_cudagraph(model, (example,), None)
+            compile_with_cudagraph(model, (example,), None)
 
-    def test_cudagraph_mode_regional_rejected(self):
-        # "regional" is reserved for the follow-up stack; it must fail loudly
-        # instead of silently behaving like "off".
+    def test_cudagraph_regional_capture_and_replay(self):
+        # Regional splits the graph and captures only the eligible pieces. The
+        # embedding lookup is a partition boundary (index_select), so this model
+        # exercises the partitioned path -- several captures per forward with
+        # eager regions between them -- rather than one big capture.
         if self.device != "cuda":
-            raise unittest.SkipTest("AOTI whole-graph cuda graph requires CUDA")
+            raise unittest.SkipTest("AOTI regional cuda graph requires CUDA")
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear1 = torch.nn.Linear(32, 32)
+                self.linear2 = torch.nn.Linear(32, 32)
+                self.emb1 = torch.nn.Embedding(128, 32)
+                self.emb2 = torch.nn.Embedding(128, 32)
+
+            def forward(self, x, idx):
+                # A gather whose index is derived from earlier compute, so the
+                # graph is not a single straight-line region. In practice the
+                # clusterer still merges this into one capture; see the note on
+                # the assertion below.
+                h = self.linear1(x).relu()
+                sel = (h.argmax(dim=1) + idx) % 128
+                g = self.emb1(sel)
+                return self.linear2(h + g).relu().sum(dim=1)
+
+        model = Model().to(self.device)
+        x = torch.randn(8, 32, device=self.device)
+        idx = torch.randint(0, 128, (8,), device=self.device)
+        dim0 = Dim("b", min=1, max=256)
+
+        # Assert the model really was PARTITIONED and captured. Without this the
+        # test would still pass if regional silently fell back to a single
+        # capture, or to no capture at all -- numerics alone cannot tell.
+        with (
+            config.patch(
+                {
+                    "aot_inductor.cudagraph_mode": "regional",
+                    # These toy partitions are far below the production default
+                    # of 8 nodes, which would demote every one of them to eager.
+                    "aot_inductor.cudagraph_min_partition_size": 1,
+                }
+            ),
+            torch.no_grad(),
+        ):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile,
+                model,
+                (x, idx),
+                dynamic_shapes={"x": {0: dim0}, "idx": {0: dim0}},
+            )
+        # >= 1 is the load-bearing assertion: it separates "regional actually
+        # captured something" from "regional silently captured nothing", which is
+        # a state numerics alone cannot detect and which this check has already
+        # caught once (every partition being demoted by the size threshold).
+        #
+        # NOT asserted: more than one captured partition. The convex clusterer
+        # deliberately merges eligible regions and reorders eager ones out from
+        # between them, so small models collapse to a single capture. That means
+        # CROSS-PARTITION HANDOFF -- a buffer produced by one capture and read by
+        # a later one -- is not covered here, and needs a real model to exercise.
+        self.assertGreaterEqual(
+            code.count("cudagraph_mgr_->run_graph("),
+            1,
+            "regional mode captured nothing at all",
+        )
+
+        compiled = compile_with_cudagraph(
+            model,
+            (x, idx),
+            {"x": {0: dim0}, "idx": {0: dim0}},
+            **{
+                "aot_inductor.cudagraph_mode": "regional",
+                "aot_inductor.cudagraph_min_partition_size": 1,
+            },
+        )
+
+        with torch.no_grad():
+            for batch in (8, 8, 32, 8):
+                x = torch.randn(batch, 32, device=self.device)
+                idx = torch.randint(0, 128, (batch,), device=self.device)
+                self.assertEqual(compiled(x, idx), model(x, idx))
+
+    def test_cudagraph_regional_accepts_model_whole_rejects(self):
+        # The contrast that motivates having two modes: whole-graph FAILS this
+        # model's lowering because RNG cannot be captured, while regional lowers
+        # it by partitioning around the RNG. Numerics are not compared here --
+        # the point is that one mode rejects and the other does not.
+        if self.device != "cuda":
+            raise unittest.SkipTest("AOTI regional cuda graph requires CUDA")
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(64, 64)
+
+            def forward(self, x):
+                h = self.linear(x).relu()
+                return h + torch.rand_like(h)
+
+        model = Model().to(self.device)
+        example = torch.randn(8, 64, device=self.device)
+
+        with self.assertRaisesRegex(Exception, "RNG"):
+            compile_with_cudagraph(model, (example,))
+
+        compiled = compile_with_cudagraph(
+            model,
+            (example,),
+            **{
+                "aot_inductor.cudagraph_mode": "regional",
+                "aot_inductor.cudagraph_min_partition_size": 1,
+            },
+        )
+        with torch.no_grad():
+            self.assertEqual(compiled(example).shape, torch.Size([8, 64]))
+
+    def test_cudagraph_mode_invalid_rejected(self):
+        # An unrecognised mode must fail loudly rather than silently act as off.
+        if self.device != "cuda":
+            raise unittest.SkipTest("AOTI cuda graph requires CUDA")
 
         class Model(torch.nn.Module):
             def forward(self, x):
@@ -6394,8 +6511,8 @@ class AOTInductorTestsTemplate:
 
         model = Model().to(self.device)
         example = torch.randn(8, 64, device=self.device)
-        with self.assertRaisesRegex(Exception, "not implemented yet"):
-            with config.patch({"aot_inductor.cudagraph_mode": "regional"}):
+        with self.assertRaisesRegex(Exception, "not a valid mode"):
+            with config.patch({"aot_inductor.cudagraph_mode": "bogus"}):
                 with torch.no_grad():
                     AOTIRunnerUtil.compile(model, (example,))
 
@@ -10606,6 +10723,14 @@ GPU_LAZY_AUTOTUNE_TEST_FAILURES = {
         ("cuda", "xpu"), is_skip=True
     ),
     "test_cudagraph_whole_rejects_uncapturable_graph": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    # Same reason for regional: only the AOTI body of the two emitted entry
+    # points could be captured.
+    "test_cudagraph_regional_capture_and_replay": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_cudagraph_regional_accepts_model_whole_rejects": fail_gpu(
         ("cuda", "xpu"), is_skip=True
     ),
 }

--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -17,6 +17,7 @@ if IS_WINDOWS and IS_CI:
         sys.exit(0)
     raise unittest.SkipTest("requires sympy/functorch/filelock")
 
+import sympy
 import torch
 from torch._C import FileCheck
 from torch._dynamo.utils import same
@@ -104,6 +105,103 @@ class TestMemoryPlanningOutputGroups(TestCase):
         group = self.compute_single_group(scheduler_buffers=scheduler_buffers)
         self.assertEqual(group.names, ["buf16", "buf48"])
         self.assertTrue(group.is_output)
+
+
+class TestCudagraphSlabGuard(TestCase):
+    """Pure-Python unit tests for the single-max-slab compile-time backstop
+    (guard #1) in AllocationPool._codegen_create_cudagraph_cached. On real
+    inputs the backstop is tautological -- the slab is sized to Max(leaf
+    extents) by construction, so it always covers every leaf -- so these tests
+    INJECT a pool-vs-leaf sizing divergence (a leaf whose finalized offset+size
+    reaches past the frozen slab) to prove the backstop fires, and confirm it
+    stays silent when the slab covers every leaf. Also covers the
+    finite-upper-bound requirement for freezing the slab.
+    """
+
+    class _StopAfterGuard(Exception):
+        """Raised by the fake wrapper's first post-guard call so that a passing
+        (non-firing) guard is observable without a real cpp wrapper."""
+
+    class _FakeWrapper:
+        subgraph_name = None
+
+        def codegen_device(self, device):
+            raise TestCudagraphSlabGuard._StopAfterGuard
+
+    @staticmethod
+    def _make_pool(sym):
+        # One leaf whose byte-size is 4*sym; with sym in [1, 2048] its extent
+        # upper-bounds to 8192 bytes. finalize() assigns it offset 0.
+        from torch._inductor.codegen.memory_planning import (
+            Allocation,
+            AllocationPool,
+            LiveRange,
+            TemporalSplit,
+        )
+
+        node = SimpleNamespace(
+            get_layout=lambda: SimpleNamespace(size=[sym]),
+            get_name=lambda: "buf_test",
+        )
+        leaf = Allocation(
+            node=node,
+            live_range=LiveRange(0, 1),
+            size_hint=64,
+            symbolic_size=sym * 4,
+        )
+        pool = AllocationPool(device=torch.device("cuda"), root=TemporalSplit([leaf]))
+        pool.finalize("pool0")
+        return pool, leaf
+
+    def _run_guard(self, pool, var_to_range, shape, stride):
+        from torch._inductor.utils import IndentedBuffer
+        from torch._inductor.virtualized import V
+
+        fake_graph = SimpleNamespace(
+            sizevars=SimpleNamespace(
+                shape_env=SimpleNamespace(var_to_range=var_to_range)
+            )
+        )
+        with V.set_graph_handler(fake_graph):
+            pool._codegen_create_cudagraph_cached(
+                self._FakeWrapper(),
+                IndentedBuffer(),
+                dtype=torch.uint8,
+                shape=shape,
+                stride=stride,
+            )
+
+    def test_slab_guard_fires_on_leaf_overrun(self):
+        from torch.utils._sympy.value_ranges import ValueRanges
+
+        s0 = sympy.Symbol("s0", positive=True, integer=True)
+        pool, leaf = self._make_pool(s0)
+        # Inject the divergence: push the finalized leaf offset one slab past 0
+        # so its offset+size (8192 + 8192) overruns the frozen slab (8192).
+        leaf.offset = sympy.Integer(8192)
+        with self.assertRaisesRegex(RuntimeError, "would overrun the slab"):
+            self._run_guard(pool, {s0: ValueRanges(1, 2048)}, (s0,), (1,))
+
+    def test_slab_guard_silent_when_slab_covers_leaves(self):
+        from torch.utils._sympy.value_ranges import ValueRanges
+
+        s0 = sympy.Symbol("s0", positive=True, integer=True)
+        pool, _ = self._make_pool(s0)
+        # No injection: the slab (8192) covers the single leaf (offset 0 + 8192),
+        # so the backstop must NOT fire -- codegen proceeds until the fake
+        # wrapper's first post-guard call raises the sentinel.
+        with self.assertRaises(self._StopAfterGuard):
+            self._run_guard(pool, {s0: ValueRanges(1, 2048)}, (s0,), (1,))
+
+    def test_slab_freeze_requires_finite_upper_bound(self):
+        from torch.utils._sympy.numbers import int_oo
+        from torch.utils._sympy.value_ranges import ValueRanges
+
+        s0 = sympy.Symbol("s0", positive=True, integer=True)
+        pool, _ = self._make_pool(s0)
+        # An unbounded slab dim cannot yield a fixed max slab -> hard error.
+        with self.assertRaisesRegex(RuntimeError, "finite dynamic-shape upper"):
+            self._run_guard(pool, {s0: ValueRanges(1, int_oo)}, (s0,), (1,))
 
 
 @requires_gpu()

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -668,6 +668,38 @@ class CppWrapperCpu(PythonWrapperCodegen):
         """Assign symbolic shapes to C++ locals, with replacement aliases."""
         code = self.prefix
 
+        def emit_cg_input_bound_check(sym, ctx):
+            """Reject an input dim above the bound the max slab was frozen for.
+
+            Emitted right where each dynamic symbol is read from its input dim
+            at run_impl entry. Regional cuda graph freezes one max-sized slab
+            from each dynamic dim's compiled upper bound, so a larger input
+            would overrun it silently.
+            """
+            if not (
+                config.aot_inductor.cudagraph_mode == "regional"
+                and V.graph.aot_mode
+                and config.aot_inductor.cudagraph_runtime_input_bounds_check
+            ):
+                return
+            if not isinstance(sym, sympy.Symbol) or symbol_is_type(
+                sym, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT, SymT.FLOAT)
+            ):
+                return
+            upper = self._cudagraph_symbol_finite_upper(sym)
+            if upper is None:
+                return
+            code.writeline(f"if ({sym} > {upper}LL) {{")
+            code.writeline(
+                'throw std::runtime_error("AOTI cuda-graph input-bounds check: '
+                f'{ctx} (symbol {sym}) = " + std::to_string({sym}) + '
+                f'" exceeds the compiled maximum {upper} this model was built for; '
+                "a larger input would overrun the regional cuda-graph slab frozen "
+                "at that max. Re-lower with a higher declared max, or opt out via "
+                'cudagraph_runtime_input_bounds_check.");'
+            )
+            code.writeline("}")
+
         @functools.cache
         def sizeof(name):
             self.codegen_input_size_var_decl(code, name)
@@ -690,6 +722,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     return False
                 code.writeline(f"int64_t {sym_or_exp} = {name_fn(base_name)}[{dim}];")
                 bound_vars.add(sym_or_exp)
+                emit_cg_input_bound_check(sym_or_exp, f"input {base_name} dim {dim}")
                 if symbol_is_type(sym_or_exp, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT)):
                     self.unbacked_symbol_decls.add(str(sym_or_exp))
                 self.maybe_emit_replacement_aliases(sym_or_exp, bound_vars)
@@ -731,6 +764,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                     expr = _rewrite_symbol_solution_for_int_codegen(solution[1])
                     code.writeline(f"int64_t {free_symbol} = {cexpr(expr)};")
                     bound_vars.add(free_symbol)
+                    emit_cg_input_bound_check(free_symbol, f"input {base_name} dim {dim}")
                     if symbol_is_type(
                         free_symbol, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT)
                     ):
@@ -749,6 +783,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 decl = "int64_t"
             code.writeline(f"{decl} {value} = {name};")
             bound_vars.add(value)
+            emit_cg_input_bound_check(value, f"scalar input {name}")
             if symbol_is_type(value, (SymT.UNBACKED_INT, SymT.UNBACKED_FLOAT)):
                 self.unbacked_symbol_decls.add(str(value))
             self.maybe_emit_replacement_aliases(value, bound_vars)
@@ -1620,6 +1655,30 @@ class CppWrapperCpu(PythonWrapperCodegen):
             writer.writeline(
                 f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar}));"
             )
+
+    def _cudagraph_symbol_finite_upper(self, sym: sympy.Symbol) -> int | None:
+        """The finite compiled upper bound (shape_env var_to_range) for a dynamic
+        symbol, or None if unbounded / non-integer."""
+        import math
+
+        from torch.utils._sympy.numbers import int_oo
+
+        sizevars = getattr(V.graph, "sizevars", None)
+        shape_env = getattr(sizevars, "shape_env", None)
+        if shape_env is None:
+            return None
+        vr = shape_env.var_to_range.get(sym)
+        if vr is None:
+            return None
+        upper = vr.upper
+        if upper in (sympy.oo, int_oo) or (
+            isinstance(upper, float) and math.isinf(upper)
+        ):
+            return None
+        try:
+            return int(upper)
+        except (TypeError, ValueError):
+            return None
 
     def _output_array_name(self) -> str:
         """Name of the C array `generate_return` writes results into.

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1213,6 +1213,32 @@ class CppWrapperGpu(CppWrapperCpu):
                 """
             )
 
+        if (
+            self._cudagraph_regional_enabled()
+            and config.aot_inductor.cudagraph_lock_eager_during_capture
+        ):
+            # Only regional has eager regions to protect. The guard holds the
+            # SHARED replay lock across run_impl so eager partitions are
+            # "readers", which a concurrent instance's EXCLUSIVE capture then
+            # excludes -- otherwise an unguarded eager cudaMalloc can corrupt
+            # that capture. The Release guard temporarily drops it around each
+            # run_graph, which takes its own lock, avoiding a same-thread
+            # recursive-shared / upgrade deadlock. Both RAII, so exception-safe.
+            self.header.splice(
+                """
+                namespace {
+                struct AOTIEagerReplayLockGuard {
+                  AOTIEagerReplayLockGuard() { aoti_torch_cuda_graph_replay_lock(); }
+                  ~AOTIEagerReplayLockGuard() { aoti_torch_cuda_graph_replay_unlock(); }
+                };
+                struct AOTIEagerReplayLockRelease {
+                  AOTIEagerReplayLockRelease() { aoti_torch_cuda_graph_replay_unlock(); }
+                  ~AOTIEagerReplayLockRelease() { aoti_torch_cuda_graph_replay_lock(); }
+                };
+                } // namespace
+                """
+            )
+
     def _cudagraph_any_enabled(self) -> bool:
         """True when either cuda-graph mode emits calls into the runtime, so the
         runtime header must be included. Const graphs (`_const_run_impl`) run
@@ -1223,11 +1249,17 @@ class CppWrapperGpu(CppWrapperCpu):
 
     def _cudagraph_regional_enabled(self) -> bool:
         """True when this wrapper emits per-partition captures."""
-        return (
-            config.aot_inductor.cudagraph_mode == "regional"
-            and V.graph.aot_mode
-            and not V.graph.is_const_graph
-        )
+        if config.aot_inductor.cudagraph_mode != "regional":
+            return False
+        if not V.graph.aot_mode or V.graph.is_const_graph:
+            return False
+        if V.graph.is_dual_wrapper_mode:
+            raise RuntimeError(
+                'config.aot_inductor.cudagraph_mode="regional" is not supported '
+                "in dual-wrapper mode, which emits a JIT entry point alongside "
+                "the AOTI one; only the AOTI body can be captured."
+            )
+        return True
 
     def _cudagraph_whole_enabled(self) -> bool:
         """True when this wrapper should capture its whole body as one cuda graph.
@@ -1700,6 +1732,21 @@ class CppWrapperGpu(CppWrapperCpu):
                     f"AOTI_TORCH_ERROR_CODE_CHECK("
                     f"{get_stream}({device_idx}, (void**)&{name}));"
                 )
+
+    def codegen_cudagraph_eager_replay_lock_prologue(self) -> None:
+        # FIX B: emitted (via scheduler _codegen_partitions) at the top of the
+        # partition sequence in run_impl. Holds the SHARED regional-cudagraph
+        # replay lock for the whole forward so eager (non-captured) partition
+        # regions are 'readers' -> a concurrent instance's EXCLUSIVE capture
+        # excludes them, preventing unguarded eager cudaMalloc from corrupting
+        # the capture. Released around each run_graph (see
+        # codegen_partition_call). Gated + AOTI-only; no-op otherwise.
+        if (
+            config.aot_inductor.cudagraph_mode == "regional"
+            and V.graph.aot_mode
+            and config.aot_inductor.cudagraph_lock_eager_during_capture
+        ):
+            self.writeline("AOTIEagerReplayLockGuard __aoti_eager_replay_lock_guard;")
 
     def finalize_prefix(self):
         """Define the triton kernels now that autotuning is finished"""
@@ -2278,6 +2325,16 @@ static inline void ensure_triton_kernel_compiles_started() {{
         def _vec_i32(xs: list[int]) -> str:
             return "std::vector<int32_t>{" + ", ".join(str(x) for x in xs) + "}"
 
+        # FIX B: drop the run_impl-scope shared replay lock around run_graph.
+        # run_graph takes its own lock (EXCLUSIVE to record / SHARED to
+        # replay); holding the shared lock here would self-deadlock (same-thread
+        # recursive-shared on record's upgrade to exclusive). RAII, so a throw in
+        # run_graph re-acquires the shared lock before unwinding.
+        lock_eager = config.aot_inductor.cudagraph_lock_eager_during_capture
+        if lock_eager:
+            self.writeline(
+                "{ AOTIEagerReplayLockRelease __aoti_eager_replay_lock_release;"
+            )
         self.writeline(
             f"this->cudagraph_mgr_->run_graph({shape_key}, "
             f"p{partition_id}_inputs, {num_tensor_inputs}, "
@@ -2294,6 +2351,8 @@ static inline void ensure_triton_kernel_compiles_started() {{
         )
         self.writeline(f"  stream = p{partition_id}_saved;")
         self.writeline("});")
+        if lock_eager:
+            self.writeline("}")
 
         # Unpack outputs. Every output (model or internal) hands off a stable
         # non-owning view of its recorded output address -- no clone. For a
@@ -2310,7 +2369,7 @@ static inline void ensure_triton_kernel_compiles_started() {{
         self._outer_scope_vars.update(input_deallocation.keys())
         passthrough_names = set(input_deallocation.keys())
         # Passthrough outputs (output name == one of this partition's input
-        # names): run_partition returned a NON-OWNING view at output_meta[i],
+        # names): run_graph returned a NON-OWNING view at output_meta[i],
         # which for an eager-copied input is THIS partition's static_inputs[i]
         # address. When THIS partition is the EARLIEST captured passthrough
         # emitter for `name`, reassign outer-scope `name` to that stable

--- a/torch/_inductor/codegen/memory_planning.py
+++ b/torch/_inductor/codegen/memory_planning.py
@@ -576,6 +576,23 @@ class AllocationPool:
                 )
             )
 
+    def _cudagraph_iter_leaf_allocations(self):
+        """Yield every leaf Allocation packed in this pool, recursing the
+        TemporalSplit / SpatialSplit tree. Used by the single-max-slab backstop
+        in _codegen_create_cudagraph_cached to check the frozen slab covers each
+        packed buffer's (offset + size)."""
+        stack = [self.root]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, Allocation):
+                yield node
+            elif isinstance(node, TemporalSplit):
+                stack.extend(node.allocations)
+            elif isinstance(node, SpatialSplit):
+                stack.append(node.left)
+                stack.append(node.right)
+            # Empty (and any other node) has no packed buffer -> skip.
+
     def _codegen_create_cudagraph_cached(
         self, wrapper, code: IndentedBuffer, dtype, shape, stride
     ):
@@ -661,6 +678,60 @@ class AllocationPool:
             # shapes (the per-pool cache key below is a constant).
             shape = tuple(max_shape)
             stride = tuple(max_stride)
+
+            # Defensive backstop for the single-max-slab. The slab is a
+            # COMPILE-TIME constant, but each packed buffer's alloc_from_pool
+            # offset is emitted as a RUNTIME expression, so a buffer whose offset
+            # scales with a dynamic symbol can overrun the frozen slab. Verify the
+            # frozen slab covers the upper bound of every packed buffer's
+            # (offset + size) under the SAME var_to_range, and HARD-ERROR at
+            # compile time instead of silently emitting a slab a captured
+            # partition overruns (the RMSNorm OOB seen with a stale secondary-
+            # symbol range). The slab is sized from self.root.get_symbolic_size()
+            # (== Max(leaf extents) by construction), so this backstop fires on a
+            # pool-vs-leaf sizing DIVERGENCE; a stale symbol range under-bounds
+            # the slab AND the offsets equally and must be fixed by correcting
+            # that symbol's var_to_range. This whole path is cuda-graph-only
+            # (reached only under _cudagraph_slab_cache_enabled), so it never
+            # affects non-cuda-graph lowering.
+            slab_bytes = _const_upper_bound(self.root.get_symbolic_size())
+            worst_name = None
+            worst_extent = None
+            for leaf in self._cudagraph_iter_leaf_allocations():
+                if leaf.offset is None:
+                    continue
+                extent = _const_upper_bound(leaf.offset + leaf.get_symbolic_size())
+                if extent is None:
+                    continue
+                if worst_extent is None or extent > worst_extent:
+                    worst_extent = extent
+                    worst_name = leaf.node.get_name()
+            if (
+                slab_bytes is not None
+                and worst_extent is not None
+                and slab_bytes < worst_extent
+            ):
+                raise RuntimeError(
+                    "AOTI regional cuda-graph max-slab for pool "
+                    f"'{self.name}' is {slab_bytes} bytes but packed buffer "
+                    f"'{worst_name}' reaches offset+size={worst_extent} bytes "
+                    f"(deficit {worst_extent - slab_bytes} bytes): a captured "
+                    "partition would overrun the slab. The frozen slab must cover "
+                    "every packed buffer's runtime extent; this means the pool "
+                    "byte-size and the packed-buffer offsets were bounded "
+                    "inconsistently -- most often a dynamic-shape symbol whose "
+                    "var_to_range upper bound is smaller than the extent its "
+                    "offsets reach. Correct that symbol's upper bound (export "
+                    "Dim(max=...) / dynamic_shapes_strategy) or the pool sizing."
+                )
+            # No separate export-declared Dim(max=...) cross-check here: that max
+            # is baked into var_to_range at export (the same range this freeze
+            # reads), so it would be tautological with the freeze -- it could
+            # never fire. A dropped/stale declared range is instead caught at
+            # serving by the runtime input-bounds check
+            # (cudagraph_runtime_input_bounds_check in cpp_wrapper_cpu.py); an
+            # independent declared-source variant is a possible future follow-up
+            # only if override plumbing ever regresses.
         # Under single-max-slab the per-shape key is always a constant: the slab
         # is sized to the dynamic-shape upper bounds and shared across shapes, so
         # only the per-pool id (folded in below) distinguishes cache slots.

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -4982,6 +4982,13 @@ class PythonWrapperCodegen(CodeGen):
         finally:
             self.pop_codegened_graph()
 
+    def codegen_cudagraph_eager_replay_lock_prologue(self) -> None:
+        """Hook to emit, at the top of the partition sequence in run_impl, the
+        guard that holds the SHARED regional-cuda-graph replay lock across eager
+        (non-captured) partition regions. Default no-op; only the AOTI GPU
+        wrapper emits, and only when regional cuda-graph is on. See
+        cpp_wrapper_gpu.py and config.aot_inductor.cudagraph_lock_eager_during_capture."""
+
     def codegen_partition_call(
         self,
         partition_id: int,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2507,6 +2507,33 @@ class aot_inductor:
         os.environ.get("AOT_INDUCTOR_CUDAGRAPH_CROSS_PARTITION_MEMORY", "0") == "1"
     )
 
+    # Hold the SHARED replay lock across eager (non-captured) partition regions
+    # in the generated run_impl. Root cause of a multi-instance serving IMA:
+    # during one instance's EXCLUSIVE capture, another instance's EAGER
+    # partitions run under NO lock and issue a real unguarded cudaMalloc/cudaFree
+    # (the allocator routes by the CALLING thread's capture status, and
+    # thread-local capture mode does not restrict other threads), which corrupts
+    # the captured graph. Replays already take the lock shared and captures take
+    # it exclusive; only eager regions were unprotected. Steady state stays fully
+    # concurrent -- all readers -- and only a rare new-shape capture stalls eager
+    # regions at a boundary. Regional-only: whole-graph mode has no eager regions.
+    cudagraph_lock_eager_during_capture: bool = (
+        os.environ.get("AOT_INDUCTOR_CUDAGRAPH_LOCK_EAGER_DURING_CAPTURE", "1") == "1"
+    )
+
+    # Reject, at run_impl entry, any input whose dynamic dim exceeds the compiled
+    # upper bound the max slab was frozen for, instead of silently overrunning it.
+    # The compiled .so is only valid for inputs within the ranges it was built
+    # for; a served value above the frozen max corrupts GPU memory and yields
+    # wrong predictions with no error. This turns that whole class -- a stale or
+    # under-sampled dynamic range, e.g. a batch dim compiled to a too-small max --
+    # into an immediate named error. Cost is a few integer compares once per
+    # forward, off the kernel path. Regional-only: it guards the frozen max slab,
+    # which whole-graph does not use. Independent of AOTI_RUNTIME_CHECK_INPUTS.
+    cudagraph_runtime_input_bounds_check: bool = (
+        os.environ.get("AOT_INDUCTOR_CUDAGRAPH_RUNTIME_INPUT_BOUNDS_CHECK", "1") == "1"
+    )
+
     # flag to force weight to be appended to the shared library and mapped by the runtime
     # rather than embedded into the data section. Needed to support 1B+ parameter models
     force_mmap_weights: bool = False

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -12192,6 +12192,10 @@ class Scheduler:
             cudagraph_partition.plan_cudagraph_scratch_slab()
 
         with self.use_default_device_context(partitions, signatures):
+            # Hold the shared replay lock across the eager partition regions, so
+            # a concurrent instance's exclusive capture excludes them. No-op
+            # unless AOTI GPU + regional mode + the gating flag.
+            V.graph.wrapper_code.codegen_cudagraph_eager_replay_lock_prologue()
             for partition, signature in zip(partitions, signatures):
                 if len(partition) < 1:
                     raise AssertionError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196841
* #196840
* #196839
* #196838
* #196837
* #196836
* #196835
* #196785
* #196784
* #196783
* #196782
* #196781
* #196780
* #196779
* #196778

Three safety nets that regional capture needs before it can serve real traffic, plus the end-to-end tests for the mode.

EAGER-LOCK (`cudagraph_lock_eager_during_capture`, on). Root cause of a multi-instance serving IMA: during one instance's EXCLUSIVE capture, another instance's EAGER partitions ran under no lock and issued real unguarded `cudaMalloc`/`cudaFree` -- the allocator routes by the CALLING thread's capture status, and thread-local capture mode does not restrict other threads -- corrupting the captured graph. Replays already took the lock shared and captures took it exclusive; only eager regions were unprotected. `run_impl` now holds the shared lock for the whole forward, releasing it around each `run_graph` (which takes its own, so holding it would self-deadlock on record's upgrade to exclusive). Steady state is all readers and stays fully concurrent. This is regional-only by construction -- whole-graph has no eager regions -- which is why the guards are emitted under the regional gate rather than where the original put them.

INPUT-BOUNDS CHECK (`cudagraph_runtime_input_bounds_check`, on). The max slab is frozen from each dynamic dim's compiled upper bound, so an input above that bound overruns it and corrupts GPU memory with no error. Each dynamic symbol now gets a compare at `run_impl` entry and an input over the bound is rejected by name. A few integer compares per forward, off the kernel path. Regional-only: whole-graph does not use a frozen slab.

SLAB-OVERRUN BACKSTOP (compile time). Verifies the frozen slab covers the upper bound of every packed buffer's offset+size under the same ranges, and hard-errors during lowering rather than emitting a slab a captured partition overruns.

The fp8 exclusion from the same original batch is NOT here -- it is wired as a partition boundary in [3/7], because deferring it would have made [6/7] activate a mode that captures fp8 gemms and faults. It is also unconditional rather than a config flag: capturing an fp8 gemm is always wrong, so an opt-out would only ever select the broken behavior.

Authored with Claude.

Differential Revision: [D118228085](https://our.internmc.facebook.com/intern/diff/D118228085/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo