### PR TITLE
Memoize AliasDb::tryGetOrCreateWildcard by TypePtr to cut redundant wildcard resolution (#196842)

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -1902,13 +1902,20 @@ bool AliasDb::mayAliasWildcard(const at::ArrayRef<Value*> vs) const {
 }
 
 std::optional<Element*> AliasDb::tryGetOrCreateWildcard(const TypePtr& type) {
+  auto cache_it = wildcardTypeCache_.find(type);
+  if (cache_it != wildcardTypeCache_.end()) {
+    return cache_it->second;
+  }
+
   auto maybe_mut_types = mapTypeToAliasTypeSetPtr(type);
   if (!maybe_mut_types) {
+    wildcardTypeCache_.emplace(type, std::nullopt);
     return std::nullopt;
   }
   auto mut_type = toSingleType(*maybe_mut_types);
   auto existing_wildcard = wildcardIndex_.find(*mut_type);
   if (existing_wildcard != wildcardIndex_.end()) {
+    wildcardTypeCache_.emplace(type, existing_wildcard->second);
     return existing_wildcard->second;
   }
 
@@ -1919,6 +1926,7 @@ std::optional<Element*> AliasDb::tryGetOrCreateWildcard(const TypePtr& type) {
   } else {
     addContainedTypesToFreshElement(wildcard_elem, *maybe_mut_types);
   }
+  wildcardTypeCache_.emplace(type, wildcard_elem);
   return wildcard_elem;
 }
 

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -282,6 +282,9 @@ class AliasDb {
   ska::flat_hash_map<const Value*, Element*> elementMap_;
   // All wildcard Elements (one for each unique mutable type)
   ska::flat_hash_map<TypePtr, Element*, HashType, EqualType> wildcardIndex_;
+  // Caches the resolved wildcard Element per declared type (keyed by TypePtr
+  // identity) to avoid re-resolving the mutable-type set on repeat lookups.
+  ska::flat_hash_map<TypePtr, std::optional<Element*>> wildcardTypeCache_;
   Element* getWildcard(const TypePtr& type) const;
   std::optional<Element*> tryGetOrCreateWildcard(const TypePtr& type);
   void addContainedTypesToFreshElement(


### PR DESCRIPTION
Summary:

This diff is created by PerfAICT to optimize `torch::jit::AliasDb::analyze` in "fbcode/caffe2/torch/csrc/jit/ir/alias_analysis.cpp", by reducing CPU cycles spent in this function.

### Optimization Details

Added a per-`AliasDb` memoization cache (`wildcardTypeCache_`, a `ska::flat_hash_map<TypePtr, std::optional<Element*>>` keyed by `TypePtr` pointer identity) in `AliasDb::tryGetOrCreateWildcard`. On a repeat lookup for the same `TypePtr` instance, the function returns the already-resolved wildcard `Element*` immediately, short-circuiting the entire body. This eliminates the previously-uncached hot work performed on every call — `toSingleType`/`UnionType::create` rebuilding a fresh union key, the full `mapTypeToAliasTypeSetPtr` call, and the structural `wildcardIndex_.find` lookup. The element-creation path still runs on a genuine miss, so behavior is unchanged: wildcard resolution is deterministic per type, `wildcardIndex_` is monotonic (insert-only, never cleared), and the cache holds a `shared_ptr` copy of the key so the type cannot be freed while cached. The change was applied identically to the fbcode and xplat copies, and the header field comment was tightened to a concise description.

Reviewed By: yfeldblum

Differential Revision: D114166992


