### PR TITLE
Add the review-time validator, row emitter, and suite CI

### DIFF
--- a/.claude/hooks/pr_review/restrict-write.sh
+++ b/.claude/hooks/pr_review/restrict-write.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# PreToolUse(Write) — the actual boundary on where the model may write.
+#
+# WHY THIS EXISTS RATHER THAN A PATH-QUALIFIED --allowedTools RULE. A rule like
+# `Write(//path/to/file)` depends on how the CLI normalises and globs a path,
+# and when it does not match, the tool call is simply refused with no reason
+# recorded anywhere a workflow can read. Three separate runs were lost to that:
+# the model attempted its write, the call was denied, and the only artefact was
+# `permission_denials_count`. So the allowlist now carries a BARE `Write` and
+# the restriction lives here, where it is an explicit string comparison whose
+# outcome is logged either way.
+#
+# This is a real gate, not advice: a non-matching path is denied via
+# `permissionDecision: "deny"`, which stops the call. It runs BEFORE the tool
+# executes, which is what makes it a boundary rather than a report.
+#
+# It also LOGS every attempt to $PR_REVIEW_HOOK_LOG, which a later workflow step
+# prints. Hook stderr is not reliably surfaced through the action, so a file is
+# the only channel that certainly reaches the job log.
+set -uo pipefail
+
+FINDINGS="${PR_REVIEW_FINDINGS_FILE:-/tmp/pr-review-findings.json}"
+LOG="${PR_REVIEW_HOOK_LOG:-/dev/null}"
+
+input=$(cat)
+target=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // "?"' 2>/dev/null || echo '?')
+
+if [[ "$target" == "$FINDINGS" ]]; then
+  printf 'ALLOW %s -> %s\n' "$tool" "$target" >> "$LOG" 2>/dev/null || true
+  # Emit nothing: no opinion, so the ordinary permission path applies and the
+  # bare `Write` grant lets it through.
+  exit 0
+fi
+
+printf 'DENY  %s -> %s (expected %s)\n' "$tool" "$target" "$FINDINGS" >> "$LOG" 2>/dev/null || true
+jq -n --arg t "$target" --arg f "$FINDINGS" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: ("This job may write exactly one file: " + $f +
+      ". Refused a write to " + (if $t == "" then "(no path given)" else $t end) + ".")
+  }
+}'
+exit 0

--- a/.claude/hooks/pr_review/validate-findings.sh
+++ b/.claude/hooks/pr_review/validate-findings.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Shared validator entry point for the hardened PR review.
+#
+# Both hooks call this. The model CANNOT invoke it directly — Bash is refused in
+# that job — so its on-demand check is the write itself: every Write to the
+# findings file runs this and injects the result back. Rewriting is unlimited,
+# so the loop is the same one a manual command would give, minus the shell.
+#
+# WHAT A PASS MEANS, EXACTLY: the file will publish without losing anything. It
+# is NOT a claim that a finding is correct. A line number that is wrong but
+# happens to fall inside the diff passes here and always will; only anchors that
+# would be DISCARDED are catchable this way.
+#
+# Paths come from the environment so the workflow owns them and nothing here
+# has to guess a workspace layout. Every value has a fallback matching what
+# hardened-pr-review-run.yml sets, so a hand-run outside CI still works.
+#
+# All output goes to STDERR, which is what Claude Code surfaces back to the
+# model. Exit 0 valid, 1 invalid.
+set -uo pipefail
+
+FINDINGS="${PR_REVIEW_FINDINGS_FILE:-/tmp/pr-review-findings.json}"
+DIFF="${PR_REVIEW_DIFF_FILE:-/tmp/pr-diff.txt}"
+SCRIPTS="${PR_REVIEW_SCRIPTS_DIR:-}"
+
+if [[ -z "$SCRIPTS" ]]; then
+  echo "CANNOT VALIDATE: PR_REVIEW_SCRIPTS_DIR is unset." >&2
+  echo "This is a workflow problem, not a problem with your file." >&2
+  exit 1
+fi
+
+# PYTHONPATH rather than a `cd`: validate_findings.py imports extract_verdict as
+# a sibling module, and the model's cwd is the PR checkout, which must not
+# become an import root — a PR carrying its own extract_verdict.py would
+# otherwise be imported and get to define what "valid" means.
+PYTHONPATH="$SCRIPTS" python3 "$SCRIPTS/validate_findings.py" \
+  --findings-file "$FINDINGS" \
+  --diff-file "$DIFF"

--- a/.claude/hooks/pr_review/validate-on-stop.sh
+++ b/.claude/hooks/pr_review/validate-on-stop.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Stop hook — blocking. The session may not end on a findings file that would
+# lose findings at publication.
+#
+# Exit 2 is what Claude Code reads as "do not stop, here is why"; the stderr
+# text becomes the model's next instruction.
+#
+# `stop_hook_active` guards the obvious loop: it is true when the model was
+# already resumed by this hook, so a file the model cannot fix stops the session
+# rather than cycling forever. That trades a lost finding for a terminating run,
+# which is the right way round — `extract_verdict.py` still records exactly what
+# was dropped and why, so the loss is visible in the row rather than silent.
+set -uo pipefail
+
+input=$(cat)
+active=$(printf '%s' "$input" | jq -r '.stop_hook_active // false' 2>/dev/null || echo false)
+if [[ "$active" == "true" ]]; then
+  exit 0
+fi
+
+printf 'STOP hook fired (stop_hook_active=%s)\n' "$active" >> "${PR_REVIEW_HOOK_LOG:-/dev/null}" 2>/dev/null || true
+if ! "$(dirname "$0")/validate-findings.sh"; then
+  echo "Rewrite the findings file so nothing is discarded, then finish." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/pr_review/validate-post-write.sh
+++ b/.claude/hooks/pr_review/validate-post-write.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# PostToolUse(Write) hook — advisory, and the reason the whole loop works.
+#
+# HOW FEEDBACK ACTUALLY REACHES THE MODEL. On exit 0 a hook's stderr goes to the
+# transcript and NOWHERE the model can read, so a validator that merely printed
+# errors and exited 0 would be inert — the model would rewrite nothing because
+# it was never told. The two mechanisms that do reach it are exit 2 (stderr fed
+# back as a tool error) and a `hookSpecificOutput.additionalContext` string on
+# STDOUT, injected as a system message. This uses the second: the write already
+# happened and is not an error, so an error is the wrong shape for it.
+#
+# Still always exits 0. PostToolUse fires after the file is on disk, so failing
+# here could not undo the write; it would only turn a fixable state into a dead
+# step. The Stop hook is what refuses to let the session END badly.
+set -uo pipefail
+
+FINDINGS="${PR_REVIEW_FINDINGS_FILE:-/tmp/pr-review-findings.json}"
+
+emit_nothing() { exit 0; }
+
+input=$(cat)
+written=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+
+# Only speak about the findings file. Write is scoped to that one path anyway,
+# but a write elsewhere would otherwise be answered with a missing-file error
+# about a file the model never claimed to be writing.
+[[ "$written" == "$FINDINGS" ]] || emit_nothing
+
+report=$("$(dirname "$0")/validate-findings.sh" 2>&1)
+status=$?
+printf 'POSTWRITE validate rc=%s\n' "$status" >> "${PR_REVIEW_HOOK_LOG:-/dev/null}" 2>/dev/null || true
+
+if [[ $status -eq 0 ]]; then
+  # Silence on success. Injecting "it is valid" after every write spends
+  # context on the case that needs no action, and trains the model to skim
+  # exactly the channel the failures arrive on.
+  emit_nothing
+fi
+
+jq -n --arg r "$report" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: ("Your findings file is not publishable yet:\n\n" + $r +
+      "\n\nRewrite it with the Write tool. This check runs again on every write.")
+  }
+}'
+exit 0

--- a/.github/workflows/pr-review-scripts-test.yml
+++ b/.github/workflows/pr-review-scripts-test.yml
@@ -1,0 +1,55 @@
+name: "PR review scripts: test"
+
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/pr_review/**"
+      - ".claude/hooks/pr_review/**"
+      - ".github/workflows/hardened-pr-review.yml"
+      - ".github/workflows/hardened-pr-review-run.yml"
+      - ".github/workflows/pr-review-scripts-test.yml"
+  pull_request:
+    paths:
+      - "scripts/pr_review/**"
+      - ".claude/hooks/pr_review/**"
+      - ".github/workflows/hardened-pr-review.yml"
+      - ".github/workflows/hardened-pr-review-run.yml"
+      - ".github/workflows/pr-review-scripts-test.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.repository_owner == 'pytorch'
+    runs-on: ubuntu-latest
+    # The suite runs in under a second; the rest is checkout. Five minutes is
+    # already generous, and it is the window a hostile PR gets a runner for.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Refuse a suppressed or emptied suite
+        run: |
+          python3 -c "
+          import scripts.pr_review as p
+          from scripts.pr_review._suite_manifest import EXPECTED_MODULES, HERE
+          if hasattr(p, 'load_tests'):
+              raise SystemExit('scripts/pr_review/__init__.py defines load_tests, '
+                               'which suppresses discovery of the whole suite')
+          missing = sorted(n for n in EXPECTED_MODULES if not (HERE / n).is_file())
+          if missing:
+              raise SystemExit(f'test module(s) missing from the suite: {missing}')
+          "
+
+      - name: Run the pr_review suite
+        run: python3 -m unittest discover -s scripts/pr_review -t .

--- a/scripts/pr_review/_suite_manifest.py
+++ b/scripts/pr_review/_suite_manifest.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""The suite's own completeness guard, imported by every test module.
+
+`unittest discover` runs what it FINDS, so deleting a test module leaves a green
+run and silently retires whatever that module asserted — up to and including the
+workflow invariants the CI wiring exists to hold.
+
+Each test module imports `TestTheSuiteIsWhole` from here, and `unittest` collects
+imported `TestCase` classes, so every check below runs once per surviving module.
+That redundancy is the mechanism: suppressing a check in one module leaves the
+copies its siblings carry, and those report it.
+
+**Sharing this is safe, and that is measured rather than assumed.** An earlier
+revision copied the guard into each module, reasoning that a shared helper "could
+itself be deleted". It cannot be deleted quietly: every test module imports it at
+module scope, so removing it is an import error in all of them.
+
+## What this does NOT cover, and why the line is here
+
+**Drift and accident, not a hostile committer.** Everything below is checked from
+inside the run it is checking, so anything that controls how the run is BUILT
+gets to act first. Adversarial review found several: a `load_tests` hook that
+deletes itself from `globals()` after suppressing its module, one gated on
+`__package__` or `sys.argv` so it is inert whenever a checker looks, one that
+mutates the shared loader's `testMethodPrefix` before the siblings are collected,
+and one on the package `__init__.py`, which runs before any test exists. They are
+all real. None of them is drift — each takes a deliberately self-concealing edit
+by someone who can already change these files, and someone who can do that can
+equally change the workflow that runs them. That is what branch protection and
+required review are for, and chasing it with more in-suite checks buys the
+appearance of a guarantee rather than the guarantee.
+
+So the honest claim is narrow, and it holds only while every listed module
+imports successfully and at least one of them survives: a module deleted, added,
+renamed, un-wired, or emptied by ORDINARY means is caught, and caught by its
+siblings rather than by itself.
+
+The two cases that break that precondition are checked from OUTSIDE the subtree
+instead, in the workflow's "Refuse a suppressed or emptied suite" step — a
+package-level hook, and a suite with no modules left. Neither can be caught from
+in here, since both stop the suite running at all; and the second is not even
+reliably red on its own, because a zero-test run exits 5 on 3.12 and 0 on older
+interpreters.
+
+Deliberately not named `test_*.py`: it must not be discovered as a module of the
+suite it describes.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+
+EXPECTED_MODULES = {
+    "test_emit_row.py",
+    "test_extract_verdict.py",
+    "test_validate_findings.py",
+}
+
+
+def modules_from(path: Path) -> list:
+    """The modules currently in `sys.modules` whose file is `path`.
+
+    Reads what this run actually imported rather than re-executing the file: a
+    `load_tests` hook can be gated on `__package__` or any other import-context
+    value, and a privately loaded copy does not reproduce that context, so the
+    hook would be invisible here while suppressing the real module. An earlier
+    revision did re-execute, and that blindness was the defect.
+
+    Empty means the file was never imported, or was dropped again — which
+    `unittest` does to a module that raises `SkipTest` while importing.
+    `loaded_modules` turns that into a failure rather than guessing.
+    """
+    target = path.resolve()
+    found = []
+    for mod in list(sys.modules.values()):
+        f = getattr(mod, "__file__", None)
+        if not f:
+            continue
+        try:
+            if Path(f).resolve() == target:
+                found.append(mod)
+        except OSError:
+            continue
+    return found
+
+
+def descendant_packages(root: Path):
+    """Sub-packages and directory symlinks — the only routes below a flat suite.
+
+    `discover` reaches a nested module only through a directory that is a
+    package, so refusing packages at the top level refuses every deeper one too,
+    without walking a `node_modules` or a large data tree to find out. It also
+    covers a nested `__init__.py`, which discovery imports whatever the filename
+    pattern is, and which the `test*.py` manifest check therefore cannot see.
+
+    Plain data directories are untouched: `fixtures/` and `data/` carry no
+    `__init__.py`, so discovery ignores them and so does this.
+    """
+    packages, links = [], []
+    for p in sorted(root.iterdir()):
+        if p.is_symlink() and p.is_dir():
+            links.append(p.name)  # could point discovery at a tree outside this one
+        elif p.is_dir() and (p / "__init__.py").is_file():
+            packages.append(p.name)
+    return packages, links
+
+
+class TestTheSuiteIsWhole(unittest.TestCase):
+    """Runs once per surviving test module, because each one imports it."""
+
+    def loaded_modules(self):
+        """Manifest module -> the module objects this run imported from it.
+
+        A file that is present but NOT imported is a failure, never a skip.
+        `raise unittest.SkipTest` at import time makes `unittest` drop the module
+        from `sys.modules` and report a skip, so the run stays green with that
+        module's assertions retired — measured, and an ordinary pattern rather
+        than a hostile one. Skipping here would make the guard agree with it.
+
+        All of them are collected before failing, so one unimported module does
+        not hide the next.
+        """
+        loaded, unloaded = {}, []
+        for name in sorted(EXPECTED_MODULES):
+            path = HERE / name
+            if not path.is_file():
+                continue  # test_every_expected_module_is_present owns that report
+            found = modules_from(path)
+            if found:
+                loaded[name] = found
+            else:
+                unloaded.append(name)
+        self.assertEqual(
+            unloaded,
+            [],
+            f"module(s) present but never imported by this run: {unloaded} — an import-time "
+            "unittest.SkipTest retires a module's assertions while the run stays green. To "
+            "run one module's tests, run the whole suite: "
+            "python3 -m unittest discover -s scripts/pr_review -t .",
+        )
+        return loaded
+
+    def test_every_expected_module_is_present(self):
+        missing = sorted(n for n in EXPECTED_MODULES if not (HERE / n).is_file())
+        self.assertEqual(
+            missing, [], f"test module(s) deleted from the suite: {missing}"
+        )
+
+    def test_the_manifest_lists_every_discoverable_module(self):
+        """A module absent from the manifest is an unguarded survivor.
+
+        The guard is only wired into the modules named above, so a new
+        `test_*.py` added without updating the manifest need not carry it — and
+        once such a module exists, deleting all the named ones can be green
+        again, since it keeps the run non-empty. Discovery reality, not the
+        manifest, is what this compares against.
+        """
+        self.assertEqual(
+            {p.name for p in HERE.glob("test*.py")},
+            EXPECTED_MODULES,
+            "a test module was added or removed without updating EXPECTED_MODULES",
+        )
+
+    def test_the_suite_has_no_descendant_packages(self):
+        """The glob above sees this directory only; `discover` also walks packages.
+
+        A test module in a subpackage is discovered and run while staying
+        invisible to the manifest — the same unguarded survivor by another route
+        — and a nested `__init__.py` is imported whatever it is called. The suite
+        is flat, so refusing sub-packages outright closes both. `__pycache__` is
+        not exempted: a directory of that name can hold a package as easily as a
+        cache.
+        """
+        packages, links = descendant_packages(HERE)
+        self.assertEqual(
+            packages,
+            [],
+            f"sub-package(s) extend discovery past the manifest: {packages}",
+        )
+        self.assertEqual(
+            links, [], f"symlinked director(ies) can extend discovery off-tree: {links}"
+        )
+
+    def test_every_manifest_module_is_wired_to_this_guard(self):
+        """A listed module that stopped importing the guard is an unguarded survivor.
+
+        The manifest check stops an UNLISTED module appearing; this stops a listed
+        one drifting out of the wiring, or shadowing the shared class with a
+        private lookalike that can disagree with the manifest its siblings hold.
+        """
+        for name, mods in self.loaded_modules().items():
+            for mod in mods:
+                with self.subTest(module=name, loaded_as=mod.__name__):
+                    guard = getattr(mod, "TestTheSuiteIsWhole", None)
+                    self.assertTrue(
+                        isinstance(guard, type)
+                        and issubclass(guard, unittest.TestCase),
+                        f"{name} has no TestTheSuiteIsWhole TestCase bound at module scope, "
+                        "so deleting the modules that do would stay green",
+                    )
+                    # Compared by defining FILE, resolved: imported bare and as a
+                    # package submodule, this file yields two equivalent class
+                    # objects and both are correct wiring, while a same-named
+                    # file elsewhere on sys.path is not.
+                    self.assertEqual(
+                        Path(inspect.getfile(guard)).resolve(),
+                        (HERE / "_suite_manifest.py").resolve(),
+                        f"{name} binds its own guard instead of the shared one; a private "
+                        "copy can drift from the manifest the others enforce",
+                    )
+
+    def test_no_module_hides_its_tests_behind_load_tests(self):
+        """A `load_tests` hook drops a module's collected tests from the suite.
+
+        It would retire that module's assertions without deleting the file, so
+        the presence check above cannot see it. This lives in the SHARED guard on
+        purpose: held by one module alone, a hook on that same file would remove
+        this check together with everything it protects. Carried by every module,
+        a surviving sibling still reports it — and it reads the module DISCOVERY
+        imported, so a hook defined only under the real import context is still
+        visible.
+        """
+        for name, mods in self.loaded_modules().items():
+            for mod in mods:
+                with self.subTest(module=name, loaded_as=mod.__name__):
+                    self.assertFalse(
+                        hasattr(mod, "load_tests"),
+                        f"{name} defines load_tests, which can silently drop its tests "
+                        "from the suite unittest builds",
+                    )

--- a/scripts/pr_review/emit_row.py
+++ b/scripts/pr_review/emit_row.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Build the ClickHouse telemetry row for one hardened PR review attempt.
+
+Two rows are written per attempt, and the pair is what makes the record
+readable:
+
+  * ``started`` — written by the prepare job before any model call. It exists so
+    that a run which is cancelled, times out, or dies on the runner still leaves
+    a trace.
+  * a terminal row — written by the publish job under ``if: always()``, carrying
+    the real outcome.
+
+That gives three distinguishable states, which a single row cannot express:
+
+  | rows present            | meaning                                        |
+  |-------------------------|------------------------------------------------|
+  | none                    | no review was ever triggered, or prepare failed|
+  | started, no terminal    | cancelled, superseded, or the runner died —    |
+  |                         | reconcilable from the Actions API              |
+  | started + terminal      | the attempt ran; `status` says how it ended    |
+
+``verdict`` is only ever populated when ``status == 'succeeded'``. A failed
+review must never surface as ``changes_requested``, because a reader cannot tell
+a real objection from an infrastructure hiccup.
+
+The empty row is the one a consumer must render explicitly. Stage 1's workflow
+file comes from the PR's own ref, so a PR author can rename its ``name:``, leave
+``workflow_run`` with nothing to match, and produce no review and no rows at all.
+A surface that shows only what it finds renders that suppression as "clean".
+
+The row is deliberately keyed and versioned for reuse: the interim GitHub
+Actions harness and the credential-less sandbox that replaces it write the SAME
+shape, distinguished by ``harness``, so the two eras stay comparable. ``extra``
+is the escape hatch for anything we learn we need later without re-cutting the
+table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+
+# `model` is the one string in this row that we do not construct ourselves. It
+# comes from the usage file's modelUsage keys, which the review job extracts
+# with jq from the action's execution log — in a job that reads untrusted PR
+# code. Influence over it is marginal, but every other string crossing this
+# boundary is validated, and an unvalidated one reaching a ClickHouse row is
+# worth less than the two lines it costs to bound. Out-of-charset or over-length
+# becomes empty rather than failing: telemetry never breaks a review.
+_MODEL_CHARS = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+# Terminal statuses. Anything not in this set is a bug in the caller.
+TERMINAL = {
+    "succeeded",
+    "schema_invalid",
+    "sanitizer_rejected",
+    "model_error",
+    # RESERVED, and unreachable from the GitHub Actions harness: a step timeout
+    # surfaces as outcome `failure`, which `extract_verdict.downgrade()` maps to
+    # model_error. It is kept for the sandbox harness, which can tell the two
+    # apart. Nothing may read its absence as "reviews never time out".
+    "timed_out",
+    "skipped_stale",
+    "skipped_too_large",
+    "blocked",
+}
+
+
+def env(name: str, default: str = "") -> str:
+    return (os.environ.get(name) or default).strip()
+
+
+def as_int(value: str, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def as_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return default
+
+
+def safe_model(value: object) -> str:
+    text = value if isinstance(value, str) else ""
+    return text if _MODEL_CHARS.match(text) else ""
+
+
+def base_row(phase: str) -> dict:
+    """Fields common to both rows — the identity of the attempt."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "phase": phase,
+        # Which execution substrate produced this row. The sandbox will write
+        # 'sandbox' here; without it the two eras' data cannot be compared,
+        # which is the whole reason this table outlives the interim workflow.
+        "harness": env("HARNESS", "gha-interim"),
+        "harness_version": env("HARNESS_VERSION"),
+        "repo": env("REPO"),
+        "pr_number": as_int(env("PR_NUMBER")),
+        "head_sha": env("HEAD_SHA"),
+        "base_sha": env("BASE_SHA"),
+        "is_fork": env("IS_FORK", "false") == "true",
+        "trigger_event": env("TRIGGER_EVENT"),
+        "trigger_label": env("TRIGGER_LABEL"),
+        "trigger_run_id": as_int(env("TRIGGER_RUN_ID")),
+        "review_run_id": as_int(env("GITHUB_RUN_ID")),
+        "review_run_attempt": as_int(env("GITHUB_RUN_ATTEMPT"), 1),
+        # Content hash of the trusted prompt + skill files, not a hand-maintained
+        # version string: those rot within a week of the first hotfix.
+        "prompt_hash": env("PROMPT_HASH"),
+        "trusted_sha": env("TRUSTED_SHA"),
+        "timestamp": env("ROW_TIMESTAMP"),
+    }
+
+
+def read_json(path: str) -> dict:
+    if not path:
+        return {}
+    try:
+        loaded = json.loads(Path(path).read_text())
+    except (OSError, ValueError) as exc:
+        print(f"warning: could not read {path}: {exc}", file=sys.stderr)
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def usage_metrics(path: str) -> dict:
+    """Pull cost/latency from the usage file, if present.
+
+    Accepts BOTH shapes on purpose:
+      * a bare result object — what the review job extracts and hands over in
+        the artifact, so that only numbers cross a world-readable boundary;
+      * claude-code-action's full execution file (a list of turns) — still the
+        shape if this is ever pointed at the raw file directly.
+
+    Best-effort by design: telemetry must never be the reason a review fails.
+    """
+    try:
+        loaded = json.loads(Path(path).read_text())
+    except (OSError, ValueError):
+        return {}
+    if isinstance(loaded, dict):
+        last = loaded
+    elif isinstance(loaded, list):
+        results = [
+            t for t in loaded if isinstance(t, dict) and t.get("type") == "result"
+        ]
+        if not results:
+            return {}
+        last = results[-1]
+    else:
+        return {}
+    if not last:
+        return {}
+    usage = last.get("usage") if isinstance(last.get("usage"), dict) else {}
+    model_usage = last.get("modelUsage")
+    return {
+        "duration_ms": as_int(str(last.get("duration_ms", 0))),
+        "num_turns": as_int(str(last.get("num_turns", 0))),
+        # as_float, not float(): this line sits OUTSIDE the try above, so a
+        # non-numeric cost would raise and take the whole row down — breaking
+        # the "telemetry must never be the reason a review fails" promise in
+        # this function's own docstring.
+        "total_cost_usd": as_float(last.get("total_cost_usd")),
+        "input_tokens": as_int(str(usage.get("input_tokens", 0))),
+        "output_tokens": as_int(str(usage.get("output_tokens", 0))),
+        "cache_read_input_tokens": as_int(str(usage.get("cache_read_input_tokens", 0))),
+        "cache_creation_input_tokens": as_int(
+            str(usage.get("cache_creation_input_tokens", 0))
+        ),
+        # Alphabetically first when several models appear, which is arbitrary
+        # but deterministic. Practically there is one: the review makes a single
+        # model call. If sub-agents ever land, this needs a real rule.
+        "model": safe_model(
+            sorted(model_usage)[0]
+            if isinstance(model_usage, dict) and model_usage
+            else ""
+        ),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--phase", required=True, choices=["started", "terminal"])
+    ap.add_argument(
+        "--verdict-file", default="", help="verdict.json from extract_verdict.py"
+    )
+    ap.add_argument(
+        "--usage-file", default="", help="claude-code-action execution file"
+    )
+    ap.add_argument(
+        "--status",
+        default="",
+        help="override the terminal status (e.g. skipped_stale) when no verdict file exists",
+    )
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    row = base_row(args.phase)
+
+    if args.phase == "started":
+        row["status"] = "started"
+        row["verdict"] = None
+    else:
+        verdict = read_json(args.verdict_file)
+        status = args.status or verdict.get("status") or "model_error"
+        if status not in TERMINAL:
+            print(
+                f"warning: unknown terminal status {status!r}, recording as model_error",
+                file=sys.stderr,
+            )
+            status = "model_error"
+        row["status"] = status
+        # Only a succeeded review carries a verdict. A failed one must not look
+        # like an objection to the change.
+        row["verdict"] = verdict.get("verdict") if status == "succeeded" else None
+        row["summary"] = verdict.get("summary", "") if status == "succeeded" else ""
+        row["findings_count"] = len(verdict.get("findings") or [])
+        row["findings_dropped"] = as_int(str(verdict.get("findings_dropped", 0)))
+        row["failure_detail"] = verdict.get("failure_detail", "")
+        row["reasoning_uri"] = env("REASONING_URI")
+        row.update(usage_metrics(args.usage_file))
+
+    row["extra"] = {}
+
+    Path(args.out).write_text(json.dumps(row, ensure_ascii=True) + "\n")
+    print(
+        f"{args.phase} row: status={row['status']} verdict={row.get('verdict')}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_review/test_emit_row.py
+++ b/scripts/pr_review/test_emit_row.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Tests for the telemetry row builder's one attacker-adjacent string.
+
+`model` is the only value in the row we do not construct ourselves: it is a key
+from the usage file's `modelUsage`, produced by a jq pass in the job that reads
+untrusted PR code. Influence over it is marginal — but it was the single string
+crossing that boundary without validation, and it lands in ClickHouse.
+
+Run: python3 -m unittest discover -s scripts/pr_review -t .
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Collected as a test of THIS module, so the suite notices if this file is the
+# one deleted. See _suite_manifest for why the guard is shared, not copied.
+from _suite_manifest import TestTheSuiteIsWhole  # noqa: E402,F401
+from emit_row import safe_model, usage_metrics  # noqa: E402
+
+
+class TestSafeModel(unittest.TestCase):
+    def test_real_bedrock_model_ids_survive(self):
+        for good in (
+            "global.anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+            "claude-opus-4-8",
+        ):
+            self.assertEqual(safe_model(good), good)
+
+    def test_rendering_and_injection_shapes_are_dropped(self):
+        for bad in (
+            "claude\nrow_injected: true",  # newline — JSONEachRow record split
+            "claude<script>alert(1)</script>",  # markup, if a dashboard renders it
+            "claude sonnet",  # space is not in the charset
+            "modelo-éé",  # non-ASCII
+            "‮model",  # RTL override
+            "x" * 129,  # over the length bound
+        ):
+            self.assertEqual(safe_model(bad), "", f"{bad!r} should not survive")
+
+    def test_non_strings_and_empty_become_empty(self):
+        for value in (None, 42, {"a": 1}, ["x"], ""):
+            self.assertEqual(safe_model(value), "")
+
+
+class TestUsageMetricsAppliesIt(unittest.TestCase):
+    """The validator has to be wired in, not merely defined."""
+
+    def _write(self, tmp, payload):
+        import json
+
+        p = Path(tmp) / "usage.json"
+        p.write_text(json.dumps(payload))
+        return str(p)
+
+    def test_hostile_model_key_does_not_reach_the_row(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, {"modelUsage": {"evil\nphase: started": {"in": 1}}})
+            self.assertEqual(usage_metrics(path)["model"], "")
+
+    def test_benign_model_key_still_reaches_the_row(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(
+                tmp, {"modelUsage": {"global.anthropic.claude-sonnet-4-6": {}}}
+            )
+            self.assertEqual(
+                usage_metrics(path)["model"], "global.anthropic.claude-sonnet-4-6"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pr_review/test_extract_verdict.py
+++ b/scripts/pr_review/test_extract_verdict.py
@@ -26,6 +26,9 @@ from pathlib import Path
 SCRIPT = Path(__file__).with_name("extract_verdict.py")
 sys.path.insert(0, str(SCRIPT.parent))
 
+# Collected as a test of THIS module, so the suite notices if this file is the
+# one deleted. See _suite_manifest for why the guard is shared, not copied.
+from _suite_manifest import TestTheSuiteIsWhole  # noqa: E402,F401
 from extract_verdict import (  # noqa: E402
     build,
     check_charset,

--- a/scripts/pr_review/test_validate_findings.py
+++ b/scripts/pr_review/test_validate_findings.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Tests for the in-session findings validator.
+
+The validator's whole justification is that it answers with the SAME verdict the
+publishing sanitizer will reach. So the tests here are mostly agreement tests: a
+file the validator passes must survive `extract_verdict.py` with nothing dropped,
+and a file it rejects must be one that really would lose something. A validator
+that is merely "roughly right" is worse than none, because it tells the model its
+file is fine and the findings vanish anyway — which is the exact failure that
+motivated it.
+
+Run: python3 -m unittest discover -s scripts/pr_review -t .
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate_findings.py")
+sys.path.insert(0, str(SCRIPT.parent))
+
+from _suite_manifest import TestTheSuiteIsWhole  # noqa: F401,E402
+
+
+# A new 6-line file, so new-side lines 1..6 are anchorable and 7+ are not.
+DIFF = """\
+diff --git a/pkg/sample.py b/pkg/sample.py
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/pkg/sample.py
+@@ -0,0 +1,6 @@
++import os
++
++
++def run(cmd):
++    os.system(cmd)
++    return 0
+"""
+
+
+def _finding(line: int, path: str = "pkg/sample.py") -> dict:
+    return {
+        "path": path,
+        "line": line,
+        "severity": "major",
+        "message": "shell injection",
+    }
+
+
+def _verdict(findings: list[dict]) -> dict:
+    return {
+        "verdict": "changes_requested",
+        "summary": "One issue worth fixing before review.",
+        "findings": findings,
+    }
+
+
+class ValidatorHarness(unittest.TestCase):
+    def run_validator(self, payload, diff: str = DIFF):
+        """Run the validator as a subprocess; return (exit_code, stderr)."""
+        with tempfile.TemporaryDirectory() as td:
+            findings = Path(td) / "findings.json"
+            if payload is not None:
+                findings.write_text(
+                    payload if isinstance(payload, str) else json.dumps(payload)
+                )
+            diff_file = Path(td) / "diff.txt"
+            diff_file.write_text(diff)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--findings-file",
+                    str(findings),
+                    "--diff-file",
+                    str(diff_file),
+                ],
+                capture_output=True,
+                text=True,
+                env={"PYTHONPATH": str(SCRIPT.parent), "PATH": "/usr/bin:/bin"},
+            )
+        return proc.returncode, proc.stderr
+
+
+class TestAgreesWithThePublishingSanitizer(ValidatorHarness):
+    """The claim the model is asked to trust: pass here means nothing is lost."""
+
+    def test_a_correctly_anchored_finding_passes(self):
+        code, err = self.run_validator(_verdict([_finding(5)]))
+        self.assertEqual(code, 0, err)
+        self.assertIn("VALID", err)
+        self.assertIn("none discarded", err)
+
+    def test_an_empty_findings_list_passes_when_the_verdict_is_positive(self):
+        payload = _verdict([])
+        payload["verdict"] = "ready_for_human_review"
+        code, err = self.run_validator(payload)
+        self.assertEqual(code, 0, err)
+
+    def test_changes_requested_with_no_findings_is_refused(self):
+        """An objection with no evidence. Caught here rather than at publication,
+        where it would discard the whole review instead of one finding."""
+        code, err = self.run_validator(_verdict([]))
+        self.assertEqual(code, 1)
+        self.assertIn("no publishable finding", err)
+
+    def test_a_line_past_the_end_of_the_file_fails(self):
+        """The exact shape of the bug this exists to catch: diff-row numbering."""
+        code, err = self.run_validator(_verdict([_finding(11)]))
+        self.assertEqual(code, 1)
+        self.assertIn("line_not_in_diff", err)
+
+    def test_the_failure_names_the_lines_that_would_work(self):
+        """A rejection the model cannot act on is a rejection it will repeat."""
+        code, err = self.run_validator(_verdict([_finding(11)]))
+        self.assertEqual(code, 1)
+        self.assertIn("1-6", err)
+        self.assertIn("pkg/sample.py", err)
+
+    def test_a_file_the_pr_never_touched_fails_and_lists_the_real_files(self):
+        code, err = self.run_validator(_verdict([_finding(1, "pkg/other.py")]))
+        self.assertEqual(code, 1)
+        self.assertIn("path_not_in_diff", err)
+        self.assertIn("pkg/sample.py", err)
+
+    def test_passing_the_validator_means_extract_verdict_drops_nothing(self):
+        """Agreement, asserted rather than assumed — same input, both paths."""
+        from extract_verdict import build, parse_diff
+
+        payload = _verdict([_finding(4), _finding(5)])
+        code, err = self.run_validator(payload)
+        self.assertEqual(code, 0, err)
+        result = build(payload, parse_diff(DIFF))
+        self.assertEqual(result["findings_dropped"], 0)
+        self.assertEqual(len(result["findings"]), 2)
+
+    def test_failing_the_validator_means_extract_verdict_really_would_drop(self):
+        from extract_verdict import build, parse_diff
+
+        payload = _verdict([_finding(4), _finding(99)])
+        code, _ = self.run_validator(payload)
+        self.assertEqual(code, 1)
+        result = build(payload, parse_diff(DIFF))
+        self.assertEqual(result["findings_dropped"], 1)
+
+
+class TestUnusableInputIsBlamedOnTheRightThing(ValidatorHarness):
+    """A model told its own file is broken, when the workflow is, cannot recover."""
+
+    def test_a_missing_file_says_write_it(self):
+        code, err = self.run_validator(None)
+        self.assertEqual(code, 1)
+        self.assertIn("does not exist", err)
+        self.assertIn("Write tool", err)
+
+    def test_malformed_json_is_reported_as_such(self):
+        code, err = self.run_validator("{not json")
+        self.assertEqual(code, 1)
+        self.assertIn("INVALID", err)
+
+    def test_an_unreadable_diff_is_not_blamed_on_the_findings_file(self):
+        """Otherwise every finding reads as unanchorable and the model rewrites
+        a file that was already correct."""
+        with tempfile.TemporaryDirectory() as td:
+            findings = Path(td) / "findings.json"
+            findings.write_text(json.dumps(_verdict([_finding(5)])))
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--findings-file",
+                    str(findings),
+                    "--diff-file",
+                    str(Path(td) / "absent.txt"),
+                ],
+                capture_output=True,
+                text=True,
+                env={"PYTHONPATH": str(SCRIPT.parent), "PATH": "/usr/bin:/bin"},
+            )
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("CANNOT VALIDATE", proc.stderr)
+        self.assertIn("workflow problem", proc.stderr)
+
+    def test_an_empty_diff_is_never_silently_treated_as_no_files(self):
+        """An empty diff anchors nothing, so it must not read as a clean pass."""
+        code, err = self.run_validator(_verdict([_finding(5)]), diff="")
+        self.assertEqual(code, 1)
+        self.assertIn("path_not_in_diff", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pr_review/validate_findings.py
+++ b/scripts/pr_review/validate_findings.py
@@ -1,0 +1,187 @@
+"""Validate the findings file the review model writes, and say what is wrong.
+
+The model writes its verdict to a JSON file instead of returning it as the
+action's structured output, so that it can be checked WHILE the session is still
+running and corrected. Two hooks call this: a PostToolUse hook after every Write
+(advisory — the model reads the errors and rewrites) and a Stop hook (blocking —
+the session cannot end on an invalid file).
+
+THE POINT OF SHARING CODE WITH `extract_verdict.py`. Every check below runs
+through that module's own `load_structured` / `parse_diff` / `build`, so the
+answer the model is given is produced by the code that will actually publish.
+A separate reimplementation would drift, and the direction it drifts in is the
+bad one: the model is told its file is fine, and the sanitizer silently drops
+findings anyway. That is exactly the failure this exists to end — the first live
+run published two findings anchored to blank lines and dropped the most valuable
+one, and nothing in the loop knew.
+
+WHAT IT DOES NOT DO. It is not a security boundary and must never be treated as
+one. It runs inside the model's own session, on a file the model controls, and a
+prompt-injected model can simply not call it. The boundary is still the separate
+`extract_verdict.py` step that runs after the action exits, plus the upstream
+role scoping. This only makes the honest failure mode — a model that miscounts —
+visible and fixable while there is still a turn left to fix it.
+
+Exit 0 when the file would publish exactly what it says. Exit 1 otherwise, with
+every problem on stderr in the order a reader would fix them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from extract_verdict import (
+    build,
+    load_structured,
+    parse_diff,
+    Rejected,
+    sanitize_findings,
+)
+
+
+MAX_REPORTED_LINES = 12
+
+
+def _ranges(lines: set[int]) -> str:
+    """Render a line set as compact ranges: {1,2,3,7} -> '1-3, 7'."""
+    if not lines:
+        return "(none — this file has no anchorable lines)"
+    out: list[str] = []
+    ordered = sorted(lines)
+    start = prev = ordered[0]
+    for n in ordered[1:]:
+        if n == prev + 1:
+            prev = n
+            continue
+        out.append(f"{start}-{prev}" if start != prev else f"{start}")
+        start = prev = n
+    out.append(f"{start}-{prev}" if start != prev else f"{start}")
+    if len(out) > MAX_REPORTED_LINES:
+        return ", ".join(out[:MAX_REPORTED_LINES]) + f", … ({len(out)} ranges total)"
+    return ", ".join(out)
+
+
+def _report_drops(dropped: list[dict], touched: dict[str, set[int]]) -> None:
+    """Explain each dropped finding, and for an anchor miss say what WOULD work."""
+    print(
+        f"{len(dropped)} finding(s) would be DISCARDED before publication:",
+        file=sys.stderr,
+    )
+    for d in dropped:
+        path = d.get("path")
+        reason = d.get("reason", "unknown")
+        where = f"{path}:{d['line']}" if d.get("line") is not None else str(path)
+        print(f"  - {where} — {reason}", file=sys.stderr)
+        if reason == "line_not_in_diff" and path in touched:
+            print(
+                f"      `line` must be a line number in the file at the head commit.\n"
+                f"      Lines this PR touches in {path}: {_ranges(touched[path])}",
+                file=sys.stderr,
+            )
+        elif reason == "path_not_in_diff":
+            known = ", ".join(sorted(touched)) or "(the diff touches no files)"
+            print(f"      Files this PR changed: {known}", file=sys.stderr)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--findings-file", required=True)
+    ap.add_argument("--diff-file", required=True)
+    args = ap.parse_args()
+
+    findings_path = Path(args.findings_file)
+    if not findings_path.exists():
+        print(f"INVALID: {findings_path} does not exist yet.", file=sys.stderr)
+        print(
+            "Write your verdict there with the Write tool before finishing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    obj, problem = load_structured(findings_path)
+    if obj is None:
+        status, _, detail = problem.partition(":")
+        print(f"INVALID ({status}): {detail}", file=sys.stderr)
+        return 1
+
+    try:
+        diff_text = Path(args.diff_file).read_bytes().decode("utf-8", "replace")
+    except OSError as exc:
+        # The diff is workflow-provided. If it is unreadable the model cannot
+        # act on anything reported here, so say so rather than blaming the file
+        # the model just wrote — and do NOT fall back to an empty diff, which
+        # would report every finding as unanchorable.
+        print(
+            f"CANNOT VALIDATE: the diff at {args.diff_file} is unreadable: {exc}",
+            file=sys.stderr,
+        )
+        print(
+            "This is a workflow problem, not a problem with your file.", file=sys.stderr
+        )
+        return 1
+
+    touched = parse_diff(diff_text)
+
+    # ANCHORING IS REPORTED BEFORE ANYTHING ELSE, and the ordering is the point.
+    # `build()` raises `Rejected` when a `changes_requested` verdict is left with
+    # no publishable finding — which is exactly what happens when the model's
+    # only finding is mis-anchored. Running `build()` first therefore answers the
+    # single most common failure with "the whole review is discarded" and not one
+    # word about WHICH line was wrong or which would work. Draining the drops
+    # first turns that back into an actionable message.
+    raw = obj.get("findings")
+    if isinstance(raw, list):
+        try:
+            _, dropped_first = sanitize_findings(raw, touched)
+        except (ValueError, TypeError):
+            dropped_first = []  # a shape problem; `build()` below names it properly
+        if dropped_first:
+            _report_drops(dropped_first, touched)
+            print(
+                "Fix these and write the file again. A discarded finding is not "
+                "published at all — it is not downgraded, it is lost.",
+                file=sys.stderr,
+            )
+            return 1
+
+    try:
+        result = build(obj, touched)
+    except Rejected as exc:
+        print(f"INVALID (sanitizer_rejected): {exc}", file=sys.stderr)
+        print(
+            "The WHOLE review is discarded when this fires, not one finding.",
+            file=sys.stderr,
+        )
+        return 1
+    except (ValueError, TypeError) as exc:
+        print(f"INVALID (schema_invalid): {exc}", file=sys.stderr)
+        return 1
+    except RecursionError:
+        print(
+            "INVALID (schema_invalid): the file nests too deeply to parse.",
+            file=sys.stderr,
+        )
+        return 1
+
+    dropped = result.get("dropped_detail") or []
+    if dropped:
+        _report_drops(dropped, touched)
+        print(
+            "Fix these and write the file again. A discarded finding is not "
+            "published at all — it is not downgraded, it is lost.",
+            file=sys.stderr,
+        )
+        return 1
+
+    kept = len(result.get("findings", []))
+    print(
+        f"VALID: verdict={result.get('verdict')}, {kept} finding(s), none discarded.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196845
* __->__ #196844
* #196843

`validate_findings.py` runs inside the review as a Claude Code hook, rejecting
findings the sanitizer would later drop so the model can correct them while it
still has the context to do so. `emit_row.py` renders an attempt as the
ClickHouse telemetry row shape — two rows per attempt, so a run that dies on the
runner is distinguishable from one that was never triggered. The
`.claude/hooks/pr_review/` scripts wire the validator into the agent's write and
stop events.

`_suite_manifest.py` is a completeness guard imported by every test module:
`unittest discover` runs what it finds, so deleting a module would otherwise
retire its assertions and leave the run green. `pr-review-scripts-test.yml` runs
the suite on any change under `scripts/pr_review/` or `.claude/hooks/pr_review/`.

Test Plan:

```
python3 -m unittest discover -s scripts/pr_review -t .   # 110 tests, OK
BASE=HEAD~1 bash .github/scripts/pr-sanity-check.sh      # PR SIZE is 1159
```

Authored with Claude Code.