### PR TITLE
[autograd] Add grad_input_buffer for fused input-gradient accumulation

### DIFF
--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -234,6 +234,7 @@ When creating a new {class}`Function`, the following methods are available to `c
     function.FunctionCtx.mark_non_differentiable
     function.FunctionCtx.save_for_backward
     function.FunctionCtx.set_materialize_grads
+    function.FunctionCtx.grad_input_buffer
 ```
 
 ## Custom Function utilities

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -233,6 +233,35 @@ class ModuleWithGradFunc(torch.nn.Module):
 
 
 class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
+    @parametrize("backend", ["eager", "aot_eager"])
+    def test_grad_input_buffer_fallback(self, backend):
+        class Scale(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, factor):
+                ctx.factor = factor
+                return x * factor
+
+            @staticmethod
+            def backward(ctx, grad):
+                buffer, _ = ctx.grad_input_buffer
+                if buffer is None:
+                    return grad * ctx.factor, None
+                buffer.add_(grad, alpha=ctx.factor)
+                return None, None
+
+        def fn(leaf):
+            x = leaf * 2
+            return (Scale.apply(x, 5) + x * 3).sum()
+
+        compiled = torch.compile(fn, backend=backend, fullgraph=True)
+        for _ in range(2):
+            leaf = torch.randn(8, requires_grad=True)
+            with torch.autograd.set_multithreading_enabled(False):
+                result = compiled(leaf)
+                result.backward()
+            self.assertEqual(result, fn(leaf))
+            self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+
     # Sound behaviors, tested for working capture
     def test_function_ctx_does_not_instantiate_function(self):
         class Foo(torch.autograd.Function):

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1728,6 +1728,32 @@ main()
 
         self.check_output_and_recompiles(fn)
 
+    def test_custom_fn_grad_input_buffer_fallback(self):
+        class Scale(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, factor):
+                ctx.factor = factor
+                return x * factor
+
+            @staticmethod
+            def backward(ctx, grad):
+                buffer, _ = ctx.grad_input_buffer
+                if buffer is None:
+                    return grad * ctx.factor, None
+                buffer.add_(grad, alpha=ctx.factor)
+                return None, None
+
+        def fn():
+            for _ in range(2):
+                leaf = torch.randn(8, requires_grad=True)
+                x = leaf * 2
+                (Scale.apply(x, 5) + x * 3).sum().backward()
+                yield leaf.grad
+
+        self.check_output_and_recompiles(
+            fn, count=[1, 0], compiler_fn=make_compiler_fn(backend="eager")
+        )
+
     def test_custom_fn_saved_multiple_tensors(self):
         def fn():
             class MyFn(torch.autograd.Function):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13798,6 +13798,390 @@ class TestAutogradForwardMode(TestCase):
 
 
 # Generic device type autograd tests.
+class TestGradInputBuffer(TestCase):
+    def _scale(self, x, factor, seen):
+        class Scale(Function):
+            @staticmethod
+            def forward(ctx, x, factor):
+                ctx.factor = factor
+                return x * factor
+
+            @staticmethod
+            def backward(ctx, grad):
+                buffers = ctx.grad_input_buffer
+                self.assertIs(buffers, ctx.grad_input_buffer)
+                buffer, non_tensor = buffers
+                self.assertIsNone(non_tensor)
+                seen.append(buffer is not None)
+                if buffer is None:
+                    return grad * ctx.factor, None
+                buffer.add_(grad, alpha=ctx.factor)
+                return None, None
+
+        return Scale.apply(x, factor)
+
+    @parametrize("use_grad", [False, True])
+    @parametrize("custom_first", [False, True])
+    def test_grad_input_buffer_accumulation(self, device, use_grad, custom_first):
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        seen = []
+        if custom_first:
+            custom = self._scale(x, 5, seen)
+            ordinary = x * 3
+        else:
+            ordinary = x * 3
+            custom = self._scale(x, 5, seen)
+        loss = (custom + ordinary).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            if use_grad:
+                (grad,) = torch.autograd.grad(loss, leaf)
+            else:
+                loss.backward()
+                grad = leaf.grad
+        self.assertEqual(grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [custom_first])
+
+    @parametrize("multithreading", [False, True])
+    def test_grad_input_buffer_leaf(self, device, multithreading):
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        leaf.grad = torch.full_like(leaf, 7)
+        seen = []
+        loss = (self._scale(leaf, 5, seen) + leaf * 3).sum()
+        with torch.autograd.set_multithreading_enabled(multithreading):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 15))
+        self.assertEqual(seen, [False])
+
+    def test_grad_input_buffer_multithreading_fallback(self, device):
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        seen = []
+        loss = (self._scale(x, 5, seen) + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(True):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [False])
+
+    @parametrize("alias", ["tensor", "storage", "expanded"])
+    def test_grad_input_buffer_preserves_aliases(self, device, alias):
+        retained = []
+
+        class OtherBranch(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * 3
+
+            @staticmethod
+            def backward(ctx, grad):
+                if alias == "expanded":
+                    result = torch.full((), 3.0, device=device).expand_as(grad)
+                else:
+                    result = grad * 3
+                retained.append(result if alias == "tensor" else result.view(-1))
+                return result
+
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        seen = []
+        loss = (self._scale(x, 5, seen) + OtherBranch.apply(x)).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(retained[0], torch.full_like(retained[0], 3))
+        self.assertEqual(seen, [False])
+
+    def test_grad_input_buffer_higher_order(self, device):
+        seen = []
+
+        class Square(Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                return x.square()
+
+            @staticmethod
+            def backward(ctx, grad):
+                # The graph's create_graph setting must remain authoritative.
+                with torch.no_grad():
+                    seen.append(ctx.grad_input_buffer)
+                (x,) = ctx.saved_tensors
+                return grad * 2 * x
+
+        leaf = torch.randn(8, device=device, dtype=torch.double, requires_grad=True)
+        x = leaf * 2
+        loss = (Square.apply(x) + x.square()).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            (first,) = torch.autograd.grad(loss, leaf, create_graph=True)
+            (second,) = torch.autograd.grad(first.sum(), leaf)
+        self.assertEqual(first, leaf * 16)
+        self.assertEqual(second, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [(None,)])
+
+    def test_grad_input_buffer_backward_hook(self, device):
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        seen, hooked = [], []
+        custom = self._scale(x, 5, seen)
+
+        def hook(grad_inputs, grad_outputs):
+            hooked.append(grad_inputs[0].clone())
+            return (grad_inputs[0] * 2,)
+
+        custom.grad_fn.register_hook(hook)
+        loss = (custom + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 26))
+        self.assertEqual(hooked, [torch.full_like(leaf, 5)])
+        self.assertEqual(seen, [False])
+
+    def test_grad_input_buffer_consumer_hooks(self, device):
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        seen, hooked = [], []
+        x.retain_grad()
+        x.register_hook(lambda grad: hooked.append(grad.clone()))
+        loss = (self._scale(x, 5, seen) + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(x.grad, torch.full_like(x, 8))
+        self.assertEqual(hooked, [torch.full_like(x, 8)])
+        self.assertEqual(seen, [True])
+
+    def test_grad_input_buffer_repeated_inputs(self, device):
+        seen = []
+
+        class Add(Function):
+            @staticmethod
+            def forward(ctx, x, y):
+                return x + y
+
+            @staticmethod
+            def backward(ctx, grad):
+                outputs = []
+                for buffer in ctx.grad_input_buffer:
+                    seen.append(buffer is not None)
+                    if buffer is None:
+                        outputs.append(grad.clone())
+                    else:
+                        buffer.add_(grad)
+                        outputs.append(None)
+                return tuple(outputs)
+
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        loss = (Add.apply(x, x) + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 10))
+        self.assertEqual(seen, [True, False])
+
+    def test_grad_input_buffer_repeated_backward(self, device):
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        seen = []
+        loss = (self._scale(x, 5, seen) + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            for _ in range(3):
+                (grad,) = torch.autograd.grad(loss, leaf, retain_graph=True)
+                self.assertEqual(grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [True] * 3)
+
+    def test_grad_input_buffer_multiple_edges(self, device):
+        class Join(Function):
+            @staticmethod
+            def forward(ctx, unused, x, y, constant):
+                return x * 5 + y * 7 + constant
+
+            @staticmethod
+            def backward(ctx, grad):
+                unused, dx, dy, constant = ctx.grad_input_buffer
+                self.assertIsNone(unused)
+                self.assertIsNone(constant)
+                self.assertIsNotNone(dx)
+                self.assertIsNotNone(dy)
+                dx.add_(grad, alpha=5)
+                dy.add_(grad, alpha=7)
+                return None, None, None, None
+
+        leaf = torch.randn(2, 8, device=device, requires_grad=True)
+        x, y = (leaf * 2).unbind()
+        constant = torch.ones_like(x)
+        loss = (Join.apply("unused", x, y, constant) + x * 3 + y * 11).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        expected = torch.stack((torch.full_like(x, 16), torch.full_like(y, 36)))
+        self.assertEqual(leaf.grad, expected)
+
+    def test_grad_input_buffer_vmap_fallback(self, device):
+        seen = []
+
+        class Scale(Function):
+            generate_vmap_rule = True
+
+            @staticmethod
+            def forward(x):
+                return x * 5
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                pass
+
+            @staticmethod
+            def backward(ctx, grad):
+                seen.append(ctx.grad_input_buffer)
+                return grad * 5
+
+        leaf = torch.randn(3, 8, device=device, requires_grad=True)
+        x = leaf * 2
+        loss = (torch.vmap(Scale.apply)(x) + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [(None,)])
+
+    def test_grad_input_buffer_nested_backward(self, device):
+        seen = []
+
+        class Reentrant(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * 5
+
+            @staticmethod
+            def backward(ctx, grad):
+                buffers = ctx.grad_input_buffer
+                (buffer,) = buffers
+                self.assertIsNotNone(buffer)
+                with torch.enable_grad():
+                    inner_leaf = torch.ones(8, device=device, requires_grad=True)
+                    inner = inner_leaf * 2
+                    loss = (self._scale(inner, 5, seen) + inner * 3).sum()
+                    loss.backward()
+                self.assertEqual(inner_leaf.grad, torch.full_like(inner_leaf, 16))
+                self.assertIs(buffers, ctx.grad_input_buffer)
+                buffer.add_(grad, alpha=5)
+                return None
+
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        loss = (Reentrant.apply(x) + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [True])
+
+    def test_grad_input_buffer_concurrent_backward(self, device):
+        from concurrent.futures import ThreadPoolExecutor
+
+        barrier = threading.Barrier(2)
+
+        class Concurrent(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * 5
+
+            @staticmethod
+            def backward(ctx, grad):
+                buffers = ctx.grad_input_buffer
+                (buffer,) = buffers
+                self.assertIsNotNone(buffer)
+                barrier.wait(timeout=30)
+                self.assertIs(buffers, ctx.grad_input_buffer)
+                buffer.add_(grad, alpha=5)
+                return None
+
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        loss = (Concurrent.apply(x) + x * 3).sum()
+
+        def backward():
+            with torch.autograd.set_multithreading_enabled(False):
+                return torch.autograd.grad(loss, leaf, retain_graph=True)[0]
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(backward) for _ in range(2)]
+            for future in futures:
+                self.assertEqual(future.result(), torch.full_like(leaf, 16))
+
+    @onlyCUDA
+    def test_grad_input_buffer_stream_fallback(self, device):
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        seen = []
+        default = torch.cuda.current_stream()
+        stream = torch.cuda.Stream()
+        stream.wait_stream(default)
+        with torch.cuda.stream(stream):
+            custom = self._scale(x, 5, seen)
+        default.wait_stream(stream)
+        loss = (custom + x * 3).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [False])
+
+    @parametrize("reentrant", [False, True])
+    def test_grad_input_buffer_checkpoint(self, device, reentrant):
+        seen = []
+
+        def block(leaf):
+            x = leaf * 2
+            return self._scale(x, 5, seen) + x * 3
+
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        loss = checkpoint(block, leaf, use_reentrant=reentrant).sum()
+        with torch.autograd.set_multithreading_enabled(False):
+            loss.backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [True])
+
+    @parametrize("violation", ["return_grad", "register_hook"])
+    def test_grad_input_buffer_scope_and_errors(self, device, violation):
+        contexts = []
+
+        class Invalid(Function):
+            @staticmethod
+            def forward(ctx, x):
+                contexts.append(ctx)
+                with self.assertRaisesRegex(RuntimeError, "only available"):
+                    _ = ctx.grad_input_buffer
+                return x * 5
+
+            @staticmethod
+            def backward(ctx, grad):
+                (buffer,) = ctx.grad_input_buffer
+                self.assertIsNotNone(buffer)
+                buffer.add_(grad, alpha=5)
+                if violation == "return_grad":
+                    return grad * 5
+                ctx.register_hook(lambda *args: None)
+                return None
+
+        leaf = torch.randn(8, device=device, requires_grad=True)
+        x = leaf * 2
+        loss = (Invalid.apply(x) + x * 3).sum()
+        error = (
+            "must return None for input 0"
+            if violation == "return_grad"
+            else "Cannot register a backward hook"
+        )
+        with torch.autograd.set_multithreading_enabled(False):
+            with self.assertRaisesRegex(RuntimeError, error):
+                loss.backward()
+            seen = []
+            y = leaf * 2
+            (self._scale(y, 5, seen) + y * 3).sum().backward()
+        self.assertEqual(leaf.grad, torch.full_like(leaf, 16))
+        self.assertEqual(seen, [True])
+        with self.assertRaisesRegex(RuntimeError, "only available"):
+            _ = contexts[0].grad_input_buffer
+        with self.assertRaises(AttributeError):
+            contexts[0].grad_input_buffer = ()
+
+
 class TestAutogradDeviceType(TestCase):
     def test_min_max_aminmax_median_backprops_to_all_values(self, device):
         # 1) Test min/max/median/nanmedian on both a non NaN and all NaN tensor
@@ -18396,6 +18780,7 @@ from autograd.test_logging import TestAutogradLogging  # noqa: F401
 
 # e.g., TestAutogradDeviceTypeCPU and TestAutogradDeviceTypeCUDA
 instantiate_device_type_tests(TestAutogradDeviceType, globals(), except_for=None)
+instantiate_device_type_tests(TestGradInputBuffer, globals(), only_for=("cpu", "cuda"))
 
 instantiate_device_type_tests(
     TestAutogradMultipleDispatch,

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -273,6 +273,8 @@ class _FunctionBase:
     _raw_saved_tensors: tuple[Any]
     next_functions: tuple[tuple[Any, _int], ...]
     needs_input_grad: tuple[_bool]
+    @property
+    def _grad_input_buffer(self) -> tuple[Tensor | None, ...]: ...
     metadata: dict
     _materialize_non_diff_grads: _bool
     # skip adding type hints for the fields that have wrappers defined

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -114,6 +114,8 @@ class FakeBackwardCFunction:
         self.saved_tensors = saved_tensors
 
     def __getattr__(self, name: str) -> Any:
+        if name == "grad_input_buffer":
+            return (None,) * len(self.real.needs_input_grad)
         if name == "saved_variables":
             warnings.warn(
                 "'saved_variables' is deprecated; use 'saved_tensors'",

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1731,6 +1731,11 @@ class AutogradFunctionContextVariable(UserDefinedObjectVariable):
             return variables.TupleVariable(list(self.dirty_tensors))
         if name == "saved_tensors" and self.saved_tensors is not None:
             return variables.TupleVariable(list(self.saved_tensors.tensors))
+        if name == "_grad_input_buffer":
+            needs_grad = self.tp_getattro_impl(tx, "needs_input_grad")
+            return ConstantVariable.create(
+                (None,) * len(needs_grad.unpack_var_sequence(tx))
+            )
 
         return super().tp_getattro_impl(tx, name)
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -37,6 +37,39 @@ _P = ParamSpec("_P")
 # Formerly known as: _ContextMethodMixin
 class FunctionCtx:
     output_grad_dtypes: "tuple[torch.dtype | None, ...] | None"
+    _grad_input_buffer: tuple[torch.Tensor | None, ...]
+
+    @property
+    def grad_input_buffer(self) -> tuple[torch.Tensor | None, ...]:
+        r"""Acquire existing input gradients for fused accumulation in backward.
+
+        Returns a tuple with one entry for each argument to :meth:`Function.forward`,
+        including ``None`` entries for non-Tensor arguments. A Tensor contains
+        contributions already computed by other branches of this backward pass.
+        Add this Function's contribution to that Tensor in place and return
+        ``None`` for the corresponding input gradient. Do not retain the buffer
+        beyond this backward call or change its shape, dtype, device, or storage.
+        Repeated reads during the same call return the same tuple.
+
+        For ``None`` entries, compute and return the gradient normally. Reuse
+        requires exclusively owned, dense intermediate gradients, first-order
+        backward, and unchanged streams. Run backward inside
+        ``with torch.autograd.set_multithreading_enabled(False):`` to enable it.
+        Leaf inputs, Functions with backward hooks, traced backwards, and
+        :mod:`torch.func` transforms use the ordinary path. This property never
+        exposes a parameter's ``.grad`` and is only available during backward.
+
+        For example, a backward for ``forward(ctx, x): return x * 2`` can use::
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (buffer,) = ctx.grad_input_buffer
+                if buffer is None:
+                    return grad_output * 2
+                buffer.add_(grad_output, alpha=2)
+                return None
+        """
+        return self._grad_input_buffer
 
     def save_for_backward(self, *tensors: torch.Tensor):
         r"""Save given tensors for a future call to :func:`~Function.backward`.

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/autograd/engine.h>
 
 #include <torch/csrc/autograd/anomaly_mode.h>
+#include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/grad_mode.h>
 #include <torch/csrc/autograd/variable.h>
@@ -415,6 +416,32 @@ bool get_current_graph_task_keep_graph() {
   return current_graph_task ? current_graph_task->keep_graph_ : true;
 }
 
+variable_list take_current_grad_input_buffers(Node* fn) {
+  variable_list buffers(fn->num_outputs());
+  const auto& task = current_graph_task;
+  if (!task || get_current_node().get() != fn ||
+      !task->can_fuse_grad_accumulation_ || at::GradMode::is_enabled() ||
+      c10::AutogradState::get_tls_state().get_multithreading_enabled() ||
+      !fn->post_hooks().empty()) {
+    return buffers;
+  }
+
+  std::lock_guard<std::mutex> lock(task->mutex_);
+  for (const auto i : c10::irange(fn->num_outputs())) {
+    const auto& edge = fn->next_edge(i);
+    if (!edge.is_valid() ||
+        dynamic_cast<AccumulateGrad*>(edge.function.get())) {
+      continue;
+    }
+    auto it = task->not_ready_.find(edge.function.get());
+    if (it != task->not_ready_.end()) {
+      buffers[i] = it->second.take_for_accumulation(
+          edge.input_nr, fn->stream(), edge.function->stream());
+    }
+  }
+  return buffers;
+}
+
 void add_node_to_current_graph_task_exec_info(Node* fn) {
   current_graph_task->exec_info_[fn].needed_ = true;
 }
@@ -660,6 +687,9 @@ GraphTask::GraphTask(
     c10::SmallVector<Node*, 4> graph_roots,
     bool exit_on_error)
     : keep_graph_(keep_graph),
+      can_fuse_grad_accumulation_(
+          !grad_mode &&
+          !c10::AutogradState::get_tls_state().get_multithreading_enabled()),
       graph_roots_(std::move(graph_roots)),
 
       reentrant_depth_(reentrant_depth),

--- a/torch/csrc/autograd/graph_task.h
+++ b/torch/csrc/autograd/graph_task.h
@@ -23,6 +23,7 @@ struct GraphTask : std::enable_shared_from_this<GraphTask> {
   std::atomic_bool future_completed_{false};
   // It is safe to read keep_graph_ without synchronization
   bool keep_graph_;
+  const bool can_fuse_grad_accumulation_;
 
   // To protect reads/writes to not_ready_, dependencies_, captured_vars_,
   // has_error_, future_result_, cpu_ready_queue_, and leaf_streams.
@@ -226,6 +227,7 @@ get_current_graph_task_nodes_in_graph();
 TORCH_API bool get_current_graph_task_keep_graph();
 TORCH_API std::vector<Node*> get_current_graph_task_execution_order();
 TORCH_API int get_current_graph_task_id();
+TORCH_API variable_list take_current_grad_input_buffers(Node* fn);
 void add_node_to_current_graph_task_exec_info(Node* fn);
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -130,6 +130,34 @@ bool can_accumulate_inplace(const Variable& v) {
 }
 } // anonymous namespace
 
+Variable InputBuffer::take_for_accumulation(
+    size_t pos,
+    const std::optional<c10::Stream>& producer_stream,
+    const std::optional<c10::Stream>& consumer_stream) {
+  auto& var = buffer.at(pos);
+  if (!var.defined() || !can_accumulate_inplace(var)) {
+    return {};
+  }
+  if (at::accelerator::isAccelerator(var.device().type())) {
+    if (!producer_stream || producer_stream != consumer_stream ||
+        producer_stream != opt_accum_streams[pos] ||
+        producer_stream != ready_streams[pos] ||
+        *producer_stream !=
+            at::accelerator::getCurrentStream(var.device().index())) {
+      return {};
+    }
+  } else if (producer_stream || consumer_stream) {
+    return {};
+  }
+
+  // A reentrant backward may deliver another contribution while this buffer
+  // is in use. Leave an empty slot that can accept a new first producer.
+  opt_accum_streams[pos].reset();
+  ready_events[pos].reset();
+  ready_streams[pos].reset();
+  return std::exchange(var, Variable());
+}
+
 static void accumulate(
     std::vector<Variable>& buffer,
     const size_t pos,

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -57,6 +57,13 @@ struct InputBuffer {
       const std::optional<c10::Stream>& opt_consumer_stream,
       Node* fn);
 
+  // Move out an exclusively owned buffer when accumulation needs no stream
+  // sync.
+  TORCH_API Variable take_for_accumulation(
+      size_t pos,
+      const std::optional<c10::Stream>& producer_stream,
+      const std::optional<c10::Stream>& consumer_stream);
+
   Variable operator[](size_t pos) {
     return buffer[pos];
   }

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -4,6 +4,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/SequenceNumber.h>
+#include <c10/util/ScopeExit.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/irange.h>
 #include <pybind11/pybind11.h>
@@ -63,6 +64,13 @@ PyObject* THPGradientEdgeClass = nullptr;
 
 // Anonymous namespace for helpful functions used in this file
 namespace {
+
+struct GradInputBufferState {
+  THPFunction* function;
+  THPObjectPtr buffers;
+};
+
+C10_DEFINE_TLS_static(GradInputBufferState*, tls_grad_input_buffers);
 
 inline void check_legacy_fn_attr_access(
     const c10::intrusive_ptr<torch::autograd::Node>& cdata,
@@ -174,6 +182,11 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
   pybind11::gil_scoped_acquire gil;
   at::OptionalDeviceGuard _device_guard;
   auto* py_fn = reinterpret_cast<THPFunction*>(pyobj());
+  GradInputBufferState grad_input_buffers{py_fn, {}};
+  auto* previous =
+      std::exchange(tls_grad_input_buffers.get(), &grad_input_buffers);
+  auto restore_buffers = c10::make_scope_exit(
+      [previous] { tls_grad_input_buffers.get() = previous; });
 
   // Massage a C++ variable_list into a Python arguments tuple
   THPObjectPtr pyInputs(to_py_args(inputs, &_device_guard));
@@ -247,7 +260,33 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
       ")");
 
   // Massage the Python results tuple back into a C++ variable_list
-  return to_variable_list(r.get(), is_variable_input);
+  auto outputs = to_variable_list(r.get(), is_variable_input);
+  if (grad_input_buffers.buffers) {
+    size_t output_idx = 0;
+    for (const auto i : c10::irange(num_forward_inputs)) {
+      if (!is_variable_input[i]) {
+        continue;
+      }
+      auto* buffer = PyTuple_GET_ITEM(grad_input_buffers.buffers.get(), i);
+      if (!Py_IsNone(buffer)) {
+        TORCH_CHECK(
+            Py_IsNone(PyTuple_GET_ITEM(r.get(), i)),
+            "function ",
+            name(),
+            " must return None for input ",
+            i,
+            " after acquiring its grad_input_buffer");
+        TORCH_CHECK(
+            post_hooks().empty(),
+            "Cannot register a backward hook after acquiring grad_input_buffer");
+        // Return the accumulated value through the normal engine path. Taking
+        // the old buffer out of InputBuffer avoids adding it a second time.
+        outputs[output_idx] = THPVariable_Unpack(buffer);
+      }
+      ++output_idx;
+    }
+  }
+  return outputs;
 }
 
 auto PyNode::apply_with_saved_impl(
@@ -2183,6 +2222,38 @@ PyObject* getNeedsInputGrad(PyObject* obj, void* _unused) {
   return materialize_needs_input_grad(self);
 }
 
+PyObject* getGradInputBuffer(PyObject* obj, void* _unused) {
+  HANDLE_TH_ERRORS
+  auto* self = reinterpret_cast<THPFunction*>(obj);
+  auto* state = tls_grad_input_buffers.get();
+  TORCH_CHECK(
+      state && state->function == self,
+      "grad_input_buffer is only available while this Function's backward is executing");
+  if (!state->buffers) {
+    auto buffers = are_functorch_transforms_active()
+        ? variable_list(self->cdata->num_outputs())
+        : take_current_grad_input_buffers(self->cdata.get());
+    const auto& is_variable = self->is_variable_input;
+    THPObjectPtr result(
+        PyTuple_New(static_cast<Py_ssize_t>(is_variable.size())));
+    if (!result) {
+      throw_python_error();
+    }
+    size_t tensor_idx = 0;
+    for (const auto i : c10::irange(is_variable.size())) {
+      PyObject* value = is_variable[i] ? THPVariable_Wrap(buffers[tensor_idx++])
+                                       : Py_NewRef(Py_None);
+      if (!value) {
+        throw_python_error();
+      }
+      PyTuple_SET_ITEM(result.get(), i, value);
+    }
+    state->buffers = std::move(result);
+  }
+  return Py_NewRef(state->buffers.get());
+  END_HANDLE_TH_ERRORS
+}
+
 int setNeedsInputGrad(PyObject* obj, PyObject* value, void* _unused) {
   auto self = (THPFunction*)obj;
   if (Py_IsNone(value)) {
@@ -2265,6 +2336,7 @@ static struct PyGetSetDef THPFunction_properties[] = {
      &setNeedsInputGrad,
      nullptr,
      nullptr},
+    {"_grad_input_buffer", &getGradInputBuffer, nullptr, nullptr, nullptr},
     {"requires_grad", getRequiresGrad, nullptr, nullptr, nullptr},
     {"metadata", (getter)THPFunction_metadata, nullptr, nullptr, nullptr},
     {"_input_metadata",


### PR DESCRIPTION
Added an API/standard for combined gradient computation/accumulation for custom backward. Custom backward now adds contributions directly into buffer and returns none. Engine forwards the accumulated result without adding the previous contribution twice. Enables an alternative to manual gradient passing. Related to issue #196312. This implementation supports eager, first-order backward with disabled multithreading for autograd. Any compilation or other unsupported cases will use ordinary gradient computation. Hopefully this will help others (as it has helped me during some phd work and personal research).

AI was only used for implementing my idea


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98