### PR TITLE
[Inductor] Account NonOwningLayout storage in peak-memory planning

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -1,15 +1,18 @@
 # Owner(s): ["module: inductor"]
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 import torch
 from torch._C import FileCheck
 from torch._dynamo.utils import same
-from torch._inductor import config, memory
+from torch._inductor import config, ir, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
+from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import serialTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.utils._ordered_set import OrderedSet
 
 
 try:
@@ -19,6 +22,120 @@ try:
     TRITON_AVAILABLE = True
 except ImportError:
     TRITON_AVAILABLE = False
+
+
+class TestMemoryPlanningAliases(TestCase):
+    def test_non_owning_layout_uses_owner_storage_and_lifetime(self):
+        class SizeVars:
+            @staticmethod
+            def optimization_hint(value, fallback=0):
+                return value
+
+        class Node:
+            def __init__(self, numel, layout):
+                self.numel = numel
+                self.layout = layout
+
+            def get_numel(self):
+                return self.numel
+
+            def get_dtype(self):
+                return torch.float32
+
+        class Buffer:
+            def __init__(self, name, numel, layout, aliases=()):
+                self.name = name
+                self.node = Node(numel, layout)
+                self.aliases = aliases
+
+            def get_name(self):
+                return self.name
+
+            def get_aliases(self):
+                return self.aliases
+
+        class Consumer:
+            unmet_dependencies = [
+                SimpleNamespace(name="slice2"),
+                SimpleNamespace(name="input_view"),
+            ]
+
+            @staticmethod
+            def get_outputs():
+                return []
+
+        class Producer:
+            def __init__(self, output):
+                self.output = output
+
+            def get_outputs(self):
+                return [self.output]
+
+        graph = SimpleNamespace(
+            sizevars=SizeVars(), scheduler=SimpleNamespace(mutation_real_name={})
+        )
+        consumer = Consumer()
+        owner = Buffer("owner", 1000, object())
+        alias1 = Buffer(
+            "slice1", 400, object.__new__(ir.NonOwningLayout), aliases=["owner"]
+        )
+        alias2 = Buffer(
+            "slice2", 100, object.__new__(ir.NonOwningLayout), aliases=["slice1"]
+        )
+        input_view = Buffer(
+            "input_view",
+            100,
+            object.__new__(ir.NonOwningLayout),
+            aliases=["graph_input"],
+        )
+        buffers = {
+            "owner": owner,
+            "slice1": alias1,
+            "slice2": alias2,
+            "input_view": input_view,
+        }
+        with V.set_graph_handler(graph):
+            memory.assign_memory_planning_info_for_scheduler_buffers(
+                [consumer], buffers
+            )
+
+        self.assertEqual(
+            (owner.mpi_buffer.size_alloc, owner.mpi_buffer.size_free), (4000, 4000)
+        )
+        self.assertEqual(
+            (alias1.mpi_buffer.size_alloc, alias1.mpi_buffer.size_free), (0, 0)
+        )
+        self.assertEqual(
+            (alias2.mpi_buffer.size_alloc, alias2.mpi_buffer.size_free), (0, 0)
+        )
+        self.assertEqual(
+            (input_view.mpi_buffer.size_alloc, input_view.mpi_buffer.size_free),
+            (400, 400),
+        )
+        self.assertEqual(owner.mpi_buffer.succ_nodes, {consumer})
+        self.assertEqual(input_view.mpi_buffer.succ_nodes, {consumer})
+        self.assertEqual(
+            memory._normalize_graph_outputs(OrderedSet(["slice2"]), buffers),
+            OrderedSet(["slice2", "owner"]),
+        )
+
+        # Direct timeline/peak-estimator callers must also retain the ultimate
+        # owner when only a transitive alias is a graph output.
+        graph_outputs = OrderedSet(["slice2"])
+        timeline_nodes = [
+            Producer(owner),
+            Producer(alias1),
+            Producer(alias2),
+            consumer,
+        ]
+        timeline, _, _ = memory.compute_memory_timeline(
+            timeline_nodes, {}, graph_outputs
+        )
+        self.assertEqual(graph_outputs, OrderedSet(["slice2", "owner"]))
+        owner_info = next(info for info in timeline if info.buffer is owner)
+        self.assertEqual(owner_info.end_step, -1)
+        peak, _ = memory.estimate_peak_memory(timeline_nodes, {}, graph_outputs)
+        self.assertEqual(peak, 4000)
 
 
 class Foo(torch.nn.Module):

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -12,7 +12,7 @@ from torch._utils_internal import signpost_event
 from torch.utils._ordered_set import OrderedSet
 
 from . import config
-from .ir import MultiOutputLayout, NoneLayout
+from .ir import MultiOutputLayout, NoneLayout, NonOwningLayout
 from .utils import get_dtype_size, is_nonfreeable_buffers
 from .virtualized import V
 
@@ -188,7 +188,18 @@ def compute_size_for_scheduler_buffer(
         if sched_buf.get_name() in V.graph.scheduler.mutation_real_name:
             sched_buf_to_size[sched_buf.get_name()] = (0, 0)
             return 0
-        elif isinstance(sched_buf.node.layout, NoneLayout):
+        if isinstance(sched_buf.node.layout, NonOwningLayout):
+            owner_name = _get_storage_owner_name(sched_buf.get_name(), name_to_buf)
+            if owner_name in name_to_buf:
+                # This buffer is only a name/view into another scheduler
+                # buffer's storage. Its consumers are folded into that owning
+                # buffer's lifetime below.
+                sched_buf_to_size[sched_buf.get_name()] = (0, 0)
+                return 0
+            # A NonOwningLayout may instead view a graph input (for example a
+            # TMA descriptor). Until input-alias lifetime propagation exists,
+            # retain the previous conservative size for such buffers.
+        if isinstance(sched_buf.node.layout, NoneLayout):
             sched_buf_to_size[sched_buf.get_name()] = (0, 0)
             return 0
         elif isinstance(sched_buf.node.layout, MultiOutputLayout):
@@ -223,6 +234,55 @@ def compute_size_for_scheduler_buffer(
     return sched_buf_to_size
 
 
+def _get_storage_owner_name(
+    buf_name: str, name_to_buf: dict[str, SchedulerBuffer]
+) -> str:
+    """Resolve a chain of NonOwningLayout buffers to its storage owner."""
+    seen = OrderedSet[str]()
+    while (
+        buf_name in name_to_buf
+        and isinstance(name_to_buf[buf_name].node.layout, NonOwningLayout)
+    ):
+        if buf_name in seen:
+            raise AssertionError(f"Cycle in NonOwningLayout aliases: {seen}")
+        seen.add(buf_name)
+        owners = name_to_buf[buf_name].get_aliases()
+        if len(owners) != 1:
+            raise AssertionError(
+                f"NonOwningLayout buffer {buf_name} must have one owner, got {owners}"
+            )
+        buf_name = owners[0]
+    return buf_name
+
+
+def _normalize_graph_outputs(
+    graph_outputs: OrderedSet[str], name_to_buf: dict[str, SchedulerBuffer]
+) -> OrderedSet[str]:
+    """Keep the storage owners of output aliases live through graph completion."""
+    result = graph_outputs.copy()
+    for buf_name in graph_outputs:
+        owner_name = _get_storage_owner_name(buf_name, name_to_buf)
+        if owner_name in name_to_buf:
+            result.add(owner_name)
+    return result
+
+
+def _normalize_graph_outputs_from_nodes(
+    nodes: list[BaseSchedulerNode], graph_outputs: OrderedSet[str]
+) -> OrderedSet[str]:
+    """Add storage owners for output aliases discoverable from ``nodes``.
+
+    Update the caller's set as well as returning it.  Memory timeline callers
+    reuse that set in subsequent local estimators (for example combo-kernel
+    region estimates), which must observe the same storage lifetimes.
+    """
+    name_to_buf = {
+        buf.get_name(): buf for node in nodes for buf in node.get_outputs()
+    }
+    graph_outputs.update(_normalize_graph_outputs(graph_outputs, name_to_buf))
+    return graph_outputs
+
+
 def assign_memory_planning_info_for_scheduler_buffers(
     nodes: list[BaseSchedulerNode],
     name_to_buf: dict[str, SchedulerBuffer],
@@ -249,6 +309,20 @@ def assign_memory_planning_info_for_scheduler_buffers(
             dep_name_to_succ_nodes_for_ordering[dep.name].add(node)
             if not (isinstance(dep, WeakDep) and dep.is_fake):
                 dep_name_to_succ_nodes[dep.name].add(node)
+
+    # NonOwningLayout outputs (notably inputs realized directly into slices of
+    # a ConcatKernel) do not own allocation storage. A use of such an alias
+    # must extend the owner's lifetime; otherwise peak-memory reordering may
+    # model the owner as freed while generated code still retains it.
+    for alias_name, sched_buf in name_to_buf.items():
+        if not isinstance(sched_buf.node.layout, NonOwningLayout):
+            continue
+        owner_name = _get_storage_owner_name(alias_name, name_to_buf)
+        if owner_name in name_to_buf:
+            dep_name_to_succ_nodes[owner_name] |= dep_name_to_succ_nodes[alias_name]
+            dep_name_to_succ_nodes_for_ordering[owner_name] |= (
+                dep_name_to_succ_nodes_for_ordering[alias_name]
+            )
 
     # iterate in reverse, so dependencies are picked up transitively.
     for mutating_buf_name, real_buf_name in reversed(
@@ -356,6 +430,12 @@ def compute_memory_timeline(
     Compute buffer allocation and deallocation sizes and map their
     lifetime to the node schedule
     """
+
+    # A graph may return a NonOwningLayout view while its backing allocation is
+    # produced by another scheduler buffer.  Keep that ultimate owner live too.
+    # Doing this at the shared timeline boundary also covers direct estimators
+    # that do not enter through reorder_for_peak_memory().
+    graph_outputs = _normalize_graph_outputs_from_nodes(nodes, graph_outputs)
 
     # get the execution step of each node, this will be used to determine
     # the end_step of buffers
@@ -1031,6 +1111,7 @@ def reorder_for_peak_memory(
     """
 
     torch_log.info("Reordering for peak memory -- %d nodes", len(nodes))
+    graph_outputs = _normalize_graph_outputs(graph_outputs, name_to_buf)
 
     estimated_peak_memory, name_to_freeable_input_buf = prepare_planning_info(
         nodes,


### PR DESCRIPTION
Summary: NonOwningLayout buffers do not allocate independent storage. Count scheduler-owned aliases as zero bytes, transfer their consumers to the ultimate storage owner, and keep owners of graph-output aliases live. Preserve conservative sizing when the owner is a graph input.

Test Plan:
- python3 -m py_compile fbcode/caffe2/torch/_inductor/memory.py fbcode/caffe2/test/inductor/test_memory.py
- arc lint fbcode/caffe2/torch/_inductor/memory.py fbcode/caffe2/test/inductor/test_memory.py
- Direct built test binary: `--regex=non_owning_layout_uses_owner_storage` passed
- buck2 test fbcode//caffe2/test/inductor:memory -- TestMemoryPlanningAliases (build succeeded; test execution timed out at 10:00: exit 32, Pass 0 / Fail 0 / Timeout 1; Buck trace 988a3eb6-d7bd-4fc2-9f33-6c548c9a7fa5, test run 32088147378951187)

Differential Revision: D119732882


