### PR TITLE
[Inductor] Add stable eager-free peak-memory schedule candidate

### DIFF
--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -1,15 +1,18 @@
 # Owner(s): ["module: inductor"]
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 import torch
 from torch._C import FileCheck
 from torch._dynamo.utils import same
-from torch._inductor import config, memory
+from torch._inductor import config, ir, memory
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_triton_code
+from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import serialTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.utils._ordered_set import OrderedSet
 
 
 try:
@@ -19,6 +22,120 @@ try:
     TRITON_AVAILABLE = True
 except ImportError:
     TRITON_AVAILABLE = False
+
+
+class TestMemoryPlanningAliases(TestCase):
+    def test_non_owning_layout_uses_owner_storage_and_lifetime(self):
+        class SizeVars:
+            @staticmethod
+            def optimization_hint(value, fallback=0):
+                return value
+
+        class Node:
+            def __init__(self, numel, layout):
+                self.numel = numel
+                self.layout = layout
+
+            def get_numel(self):
+                return self.numel
+
+            def get_dtype(self):
+                return torch.float32
+
+        class Buffer:
+            def __init__(self, name, numel, layout, aliases=()):
+                self.name = name
+                self.node = Node(numel, layout)
+                self.aliases = aliases
+
+            def get_name(self):
+                return self.name
+
+            def get_aliases(self):
+                return self.aliases
+
+        class Consumer:
+            unmet_dependencies = [
+                SimpleNamespace(name="slice2"),
+                SimpleNamespace(name="input_view"),
+            ]
+
+            @staticmethod
+            def get_outputs():
+                return []
+
+        class Producer:
+            def __init__(self, output):
+                self.output = output
+
+            def get_outputs(self):
+                return [self.output]
+
+        graph = SimpleNamespace(
+            sizevars=SizeVars(), scheduler=SimpleNamespace(mutation_real_name={})
+        )
+        consumer = Consumer()
+        owner = Buffer("owner", 1000, object())
+        alias1 = Buffer(
+            "slice1", 400, object.__new__(ir.NonOwningLayout), aliases=["owner"]
+        )
+        alias2 = Buffer(
+            "slice2", 100, object.__new__(ir.NonOwningLayout), aliases=["slice1"]
+        )
+        input_view = Buffer(
+            "input_view",
+            100,
+            object.__new__(ir.NonOwningLayout),
+            aliases=["graph_input"],
+        )
+        buffers = {
+            "owner": owner,
+            "slice1": alias1,
+            "slice2": alias2,
+            "input_view": input_view,
+        }
+        with V.set_graph_handler(graph):
+            memory.assign_memory_planning_info_for_scheduler_buffers(
+                [consumer], buffers
+            )
+
+        self.assertEqual(
+            (owner.mpi_buffer.size_alloc, owner.mpi_buffer.size_free), (4000, 4000)
+        )
+        self.assertEqual(
+            (alias1.mpi_buffer.size_alloc, alias1.mpi_buffer.size_free), (0, 0)
+        )
+        self.assertEqual(
+            (alias2.mpi_buffer.size_alloc, alias2.mpi_buffer.size_free), (0, 0)
+        )
+        self.assertEqual(
+            (input_view.mpi_buffer.size_alloc, input_view.mpi_buffer.size_free),
+            (400, 400),
+        )
+        self.assertEqual(owner.mpi_buffer.succ_nodes, {consumer})
+        self.assertEqual(input_view.mpi_buffer.succ_nodes, {consumer})
+        self.assertEqual(
+            memory._normalize_graph_outputs(OrderedSet(["slice2"]), buffers),
+            OrderedSet(["slice2", "owner"]),
+        )
+
+        # Direct timeline/peak-estimator callers must also retain the ultimate
+        # owner when only a transitive alias is a graph output.
+        graph_outputs = OrderedSet(["slice2"])
+        timeline_nodes = [
+            Producer(owner),
+            Producer(alias1),
+            Producer(alias2),
+            consumer,
+        ]
+        timeline, _, _ = memory.compute_memory_timeline(
+            timeline_nodes, {}, graph_outputs
+        )
+        self.assertEqual(graph_outputs, OrderedSet(["slice2", "owner"]))
+        owner_info = next(info for info in timeline if info.buffer is owner)
+        self.assertEqual(owner_info.end_step, -1)
+        peak, _ = memory.estimate_peak_memory(timeline_nodes, {}, graph_outputs)
+        self.assertEqual(peak, 4000)
 
 
 class Foo(torch.nn.Module):

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -137,6 +137,81 @@ class TestMemoryPlanningAliases(TestCase):
         peak, _ = memory.estimate_peak_memory(timeline_nodes, {}, graph_outputs)
         self.assertEqual(peak, 4000)
 
+    def test_eager_free_preserves_baseline_except_for_memory_reducing_nodes(self):
+        class Node:
+            def __init__(self, name, index):
+                self.name = name
+                self.outputs = []
+                self.mpi_node = memory.MemoryPlanningInfoForNode(index=index)
+
+            def get_name(self):
+                return self.name
+
+            def get_outputs(self):
+                return self.outputs
+
+        class Buffer:
+            def __init__(self, name, producer, size, successors):
+                self.name = name
+                self.node = SimpleNamespace(layout=object())
+                self.mpi_buffer = memory.MemoryPlanningInfoForBuffer(
+                    size_alloc=size,
+                    size_free=size,
+                    succ_nodes=OrderedSet(successors),
+                    succ_nodes_for_ordering=OrderedSet(successors),
+                )
+                producer.outputs.append(self)
+
+            def get_name(self):
+                return self.name
+
+        start = Node("start", 0)
+        produce = Node("produce", 1)
+        consume_whole = Node("consume_whole", 2)
+        large_alloc = Node("large_alloc", 3)
+        compact_alias = Node("compact_alias", 4)
+
+        gate = Buffer("gate", start, 0, [produce])
+        owner = Buffer("owner", produce, 1664, [consume_whole, compact_alias])
+        competing = Buffer("competing", produce, 2000, [large_alloc])
+        Buffer("whole_result", consume_whole, 0, [])
+        Buffer("large_result", large_alloc, 1011, [])
+        Buffer("compact_result", compact_alias, 326, [])
+
+        start.mpi_node.succ_nodes = OrderedSet([produce])
+        produce.mpi_node.pred_buffers = OrderedSet([gate])
+        produce.mpi_node.pred_nodes = OrderedSet([start])
+        produce.mpi_node.succ_nodes = OrderedSet(
+            [consume_whole, large_alloc, compact_alias]
+        )
+        produce.mpi_node.size = 3664
+        consume_whole.mpi_node.pred_buffers = OrderedSet([owner])
+        consume_whole.mpi_node.pred_nodes = OrderedSet([produce])
+        consume_whole.mpi_node.succ_nodes = OrderedSet([large_alloc, compact_alias])
+        large_alloc.mpi_node.pred_buffers = OrderedSet([competing])
+        large_alloc.mpi_node.pred_nodes = OrderedSet([produce, consume_whole])
+        large_alloc.mpi_node.size = 1011
+        compact_alias.mpi_node.pred_buffers = OrderedSet([owner])
+        compact_alias.mpi_node.pred_nodes = OrderedSet([produce, consume_whole])
+        compact_alias.mpi_node.size = 326
+
+        nodes = [start, produce, consume_whole, large_alloc, compact_alias]
+        buffers = {
+            buf.get_name(): buf for node in nodes for buf in node.get_outputs()
+        }
+        graph_outputs = OrderedSet(["large_result", "compact_result"])
+        eager_order = memory.topological_sort_eager_free(
+            nodes, {}, buffers, graph_outputs
+        )
+
+        self.assertEqual(
+            [node.get_name() for node in eager_order],
+            ["start", "produce", "consume_whole", "compact_alias", "large_alloc"],
+        )
+        baseline_peak, _ = memory.estimate_peak_memory(nodes, {}, graph_outputs)
+        eager_peak, _ = memory.estimate_peak_memory(eager_order, {}, graph_outputs)
+        self.assertLess(eager_peak, baseline_peak)
+
 
 class Foo(torch.nn.Module):
     """

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -12,7 +12,7 @@ from torch._utils_internal import signpost_event
 from torch.utils._ordered_set import OrderedSet
 
 from . import config
-from .ir import MultiOutputLayout, NoneLayout
+from .ir import MultiOutputLayout, NoneLayout, NonOwningLayout
 from .utils import get_dtype_size, is_nonfreeable_buffers
 from .virtualized import V
 
@@ -188,7 +188,18 @@ def compute_size_for_scheduler_buffer(
         if sched_buf.get_name() in V.graph.scheduler.mutation_real_name:
             sched_buf_to_size[sched_buf.get_name()] = (0, 0)
             return 0
-        elif isinstance(sched_buf.node.layout, NoneLayout):
+        if isinstance(sched_buf.node.layout, NonOwningLayout):
+            owner_name = _get_storage_owner_name(sched_buf.get_name(), name_to_buf)
+            if owner_name in name_to_buf:
+                # This buffer is only a name/view into another scheduler
+                # buffer's storage. Its consumers are folded into that owning
+                # buffer's lifetime below.
+                sched_buf_to_size[sched_buf.get_name()] = (0, 0)
+                return 0
+            # A NonOwningLayout may instead view a graph input (for example a
+            # TMA descriptor). Until input-alias lifetime propagation exists,
+            # retain the previous conservative size for such buffers.
+        if isinstance(sched_buf.node.layout, NoneLayout):
             sched_buf_to_size[sched_buf.get_name()] = (0, 0)
             return 0
         elif isinstance(sched_buf.node.layout, MultiOutputLayout):
@@ -223,6 +234,55 @@ def compute_size_for_scheduler_buffer(
     return sched_buf_to_size
 
 
+def _get_storage_owner_name(
+    buf_name: str, name_to_buf: dict[str, SchedulerBuffer]
+) -> str:
+    """Resolve a chain of NonOwningLayout buffers to its storage owner."""
+    seen = OrderedSet[str]()
+    while (
+        buf_name in name_to_buf
+        and isinstance(name_to_buf[buf_name].node.layout, NonOwningLayout)
+    ):
+        if buf_name in seen:
+            raise AssertionError(f"Cycle in NonOwningLayout aliases: {seen}")
+        seen.add(buf_name)
+        owners = name_to_buf[buf_name].get_aliases()
+        if len(owners) != 1:
+            raise AssertionError(
+                f"NonOwningLayout buffer {buf_name} must have one owner, got {owners}"
+            )
+        buf_name = owners[0]
+    return buf_name
+
+
+def _normalize_graph_outputs(
+    graph_outputs: OrderedSet[str], name_to_buf: dict[str, SchedulerBuffer]
+) -> OrderedSet[str]:
+    """Keep the storage owners of output aliases live through graph completion."""
+    result = graph_outputs.copy()
+    for buf_name in graph_outputs:
+        owner_name = _get_storage_owner_name(buf_name, name_to_buf)
+        if owner_name in name_to_buf:
+            result.add(owner_name)
+    return result
+
+
+def _normalize_graph_outputs_from_nodes(
+    nodes: list[BaseSchedulerNode], graph_outputs: OrderedSet[str]
+) -> OrderedSet[str]:
+    """Add storage owners for output aliases discoverable from ``nodes``.
+
+    Update the caller's set as well as returning it.  Memory timeline callers
+    reuse that set in subsequent local estimators (for example combo-kernel
+    region estimates), which must observe the same storage lifetimes.
+    """
+    name_to_buf = {
+        buf.get_name(): buf for node in nodes for buf in node.get_outputs()
+    }
+    graph_outputs.update(_normalize_graph_outputs(graph_outputs, name_to_buf))
+    return graph_outputs
+
+
 def assign_memory_planning_info_for_scheduler_buffers(
     nodes: list[BaseSchedulerNode],
     name_to_buf: dict[str, SchedulerBuffer],
@@ -249,6 +309,20 @@ def assign_memory_planning_info_for_scheduler_buffers(
             dep_name_to_succ_nodes_for_ordering[dep.name].add(node)
             if not (isinstance(dep, WeakDep) and dep.is_fake):
                 dep_name_to_succ_nodes[dep.name].add(node)
+
+    # NonOwningLayout outputs (notably inputs realized directly into slices of
+    # a ConcatKernel) do not own allocation storage. A use of such an alias
+    # must extend the owner's lifetime; otherwise peak-memory reordering may
+    # model the owner as freed while generated code still retains it.
+    for alias_name, sched_buf in name_to_buf.items():
+        if not isinstance(sched_buf.node.layout, NonOwningLayout):
+            continue
+        owner_name = _get_storage_owner_name(alias_name, name_to_buf)
+        if owner_name in name_to_buf:
+            dep_name_to_succ_nodes[owner_name] |= dep_name_to_succ_nodes[alias_name]
+            dep_name_to_succ_nodes_for_ordering[owner_name] |= (
+                dep_name_to_succ_nodes_for_ordering[alias_name]
+            )
 
     # iterate in reverse, so dependencies are picked up transitively.
     for mutating_buf_name, real_buf_name in reversed(
@@ -356,6 +430,12 @@ def compute_memory_timeline(
     Compute buffer allocation and deallocation sizes and map their
     lifetime to the node schedule
     """
+
+    # A graph may return a NonOwningLayout view while its backing allocation is
+    # produced by another scheduler buffer.  Keep that ultimate owner live too.
+    # Doing this at the shared timeline boundary also covers direct estimators
+    # that do not enter through reorder_for_peak_memory().
+    graph_outputs = _normalize_graph_outputs_from_nodes(nodes, graph_outputs)
 
     # get the execution step of each node, this will be used to determine
     # the end_step of buffers
@@ -1031,6 +1111,7 @@ def reorder_for_peak_memory(
     """
 
     torch_log.info("Reordering for peak memory -- %d nodes", len(nodes))
+    graph_outputs = _normalize_graph_outputs(graph_outputs, name_to_buf)
 
     estimated_peak_memory, name_to_freeable_input_buf = prepare_planning_info(
         nodes,

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -856,6 +856,91 @@ def topological_sort_lpmf(
     return schedule
 
 
+def topological_sort_eager_free(
+    nodes: list[BaseSchedulerNode],
+    name_to_freeable_input_buf: dict[str, FreeableInputBuffer],
+    name_to_buf: dict[str, SchedulerBuffer],
+    graph_outputs: OrderedSet[str],
+) -> list[BaseSchedulerNode]:
+    """Stably pull ready nodes that reduce live memory ahead of baseline order.
+
+    This is deliberately more conservative than LPMF: absent a currently-ready
+    node whose last-use frees exceed its output allocations, the original node
+    order is retained.
+    """
+
+    class NodeInfo(TypedDict):
+        indegree: int
+        memory_to_free: int
+
+    node_info: dict[BaseSchedulerNode, NodeInfo] = {
+        node: {
+            "indegree": len(node.mpi_node.pred_nodes),
+            "memory_to_free": 0,
+        }
+        for node in nodes
+    }
+    buf_outdegree = {
+        buf: len(buf.mpi_buffer.succ_nodes)
+        + (1 if buf.get_name() in graph_outputs else 0)
+        for buf in list(name_to_buf.values())
+        + list(name_to_freeable_input_buf.values())
+    }
+    nodes_to_schedule = OrderedSet(
+        node for node in nodes if node_info[node]["indegree"] == 0
+    )
+
+    for node in nodes:
+        for buf in node.mpi_node.pred_buffers:
+            if buf_outdegree[buf] == 1:
+                node_info[node]["memory_to_free"] += buf.mpi_buffer.size_free
+        for buf in node.get_outputs():
+            if buf_outdegree[buf] == 0:
+                node_info[node]["memory_to_free"] += buf.mpi_buffer.size_free
+
+    schedule: list[BaseSchedulerNode] = []
+    while nodes_to_schedule:
+        eager_nodes = [
+            node
+            for node in nodes_to_schedule
+            if node.mpi_node.size - node_info[node]["memory_to_free"] < 0
+        ]
+        if eager_nodes:
+            selected_node = min(
+                eager_nodes,
+                key=lambda node: (
+                    node.mpi_node.size - node_info[node]["memory_to_free"],
+                    node.mpi_node.index,
+                ),
+            )
+        else:
+            selected_node = min(
+                nodes_to_schedule, key=lambda node: node.mpi_node.index
+            )
+
+        nodes_to_schedule.remove(selected_node)
+        schedule.append(selected_node)
+
+        for succ_node in selected_node.mpi_node.succ_nodes:
+            node_info[succ_node]["indegree"] -= 1
+            if node_info[succ_node]["indegree"] == 0:
+                nodes_to_schedule.add(succ_node)
+
+        for buf in selected_node.mpi_node.pred_buffers:
+            buf_outdegree[buf] -= 1
+            if buf_outdegree[buf] == 1:
+                for succ_node in buf.mpi_buffer.succ_nodes:
+                    node_info[succ_node]["memory_to_free"] += (
+                        buf.mpi_buffer.size_free
+                    )
+
+    if len(schedule) != len(nodes):
+        raise RuntimeError(
+            f"Failed to schedule, scheduled {len(schedule)} of {len(nodes)} nodes"
+        )
+    return schedule
+
+
 def topological_sort_bfs(nodes: list[BaseSchedulerNode]) -> list[BaseSchedulerNode]:
     """
     A BFS topological sort that selects nodes whose dependencies are executed the
@@ -1101,6 +1186,7 @@ def reorder_for_peak_memory(
     graph_outputs: OrderedSet[str],
     methods: list[Callable[..., list[BaseSchedulerNode]]] = [  # noqa: B006
         topological_sort_lpmf,
+        topological_sort_eager_free,
         topological_sort_bfs,
         topological_sort_dfs,
     ],
@@ -1150,7 +1236,7 @@ def reorder_for_peak_memory(
     # other methods
     for method in methods:
         try:
-            if method is topological_sort_lpmf:
+            if method in (topological_sort_lpmf, topological_sort_eager_free):
                 order = method(
                     nodes, name_to_freeable_input_buf, name_to_buf, graph_outputs
                 )


### PR DESCRIPTION
Summary: Add a baseline-seeded topological candidate that preserves the existing order unless a ready node frees more memory than it allocates. The existing peak estimator selects it only when its modeled peak is lower than baseline.

Test Plan:
- python3 -m py_compile fbcode/caffe2/torch/_inductor/memory.py fbcode/caffe2/test/inductor/test_memory.py
- arc lint fbcode/caffe2/torch/_inductor/memory.py fbcode/caffe2/test/inductor/test_memory.py
- buck2 test fbcode//caffe2/test/inductor:memory -- TestMemoryPlanningAliases (build succeeded; test execution timed out at 10:00: exit 32, Pass 0 / Fail 0 / Timeout 1; Buck trace e5dc6c17-6d0b-4ba1-bca2-f8ffbcaf61c7, test run 14073749033303484)
- Recompiled the 4.7k-node IG CTR graph: modeled peak decreased from 24,636,331,988 to 23,912,503,916 bytes; generated wrapper passed the 69.25 GiB ballast replay that baseline OOMed

Differential Revision: D119733040




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo