### PR TITLE
[Inductor] Support rank-3 TMA stores in Blackwell BMM

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -563,15 +563,65 @@ class TestMaxAutotune(TestCase):
 
     @unittest.skipIf(not SM100OrLater, "Blackwell BMM template requires SM100+")
     @unittest.skipUnless(meta_ws_enabled(), "2CTA Blackwell BMM requires MetaWS")
-    def test_blackwell_bmm_template_2cta_requires_tma_output(self) -> None:
-        bsz, m, k, n = 2, 256, 8193, 128
+    @parametrize("epilogue_subtile", (1, 2, 4))
+    def test_blackwell_bmm_template_2cta_rank3_output(
+        self, epilogue_subtile: int
+    ) -> None:
+        bsz, m, k, n = 3, 129, 4104, 136
         a = torch.randn(bsz, m, k, device=GPU_TYPE, dtype=torch.bfloat16)
         b = torch.randn(bsz, k, n, device=GPU_TYPE, dtype=torch.bfloat16)
-        self._assert_blackwell_bmm_2cta_rejected(
-            a,
-            b,
-            flatten_output=False,
-        )
+
+        class Rank3Output2CTABlackwellBMMHeuristic(
+            CUDABlackwellBMMTemplateConfigHeuristic
+        ):
+            bmm_configs = (
+                BlackwellBMMConfig(
+                    128,
+                    128,
+                    64,
+                    4,
+                    8,
+                    epilogue_subtile=epilogue_subtile,
+                    two_ctas=True,
+                ),
+            )
+
+        def lowering(a_node, b_node):
+            choices = V.choices.get_template_configs(
+                MMKernelInputs([a_node, b_node]),
+                [blackwell_ws_persistent_tma_bmm_template],
+                "bmm",
+            )
+            self.assertEqual(len(choices), 1)
+            return choices[0].output_node()
+
+        with (
+            override_template_heuristics(
+                device_type=GPU_TYPE,
+                template_op_pairs=[
+                    (blackwell_ws_persistent_tma_bmm_template.uid, "bmm")
+                ],
+                override_heuristic_class=Rank3Output2CTABlackwellBMMHeuristic,
+            ),
+            mock.patch.dict(
+                lowerings,
+                {torch.ops.inductor_test.blackwell_bmm.default: lowering},
+            ),
+            config.patch(
+                compile_threads=1,
+                **{"triton.enable_template_tma_store": True},
+            ),
+        ):
+            compiled = torch.compile(blackwell_bmm, fullgraph=True)
+            actual, codes = run_and_get_code(compiled, a, b)
+            for _ in range(20):
+                actual = compiled(a, b)
+
+        torch.testing.assert_close(actual, torch.bmm(a, b), atol=1e-2, rtol=1e-2)
+        self.assertIn("TWO_CTAS : tl.constexpr = True", codes[0])
+        self.assertIn("RANK3_TMA_OUTPUT : tl.constexpr = True", codes[0])
+        self.assertIn("ctas_per_cga=(2, 1, 1)", codes[0])
+        self.assertIn("make_tensor_descriptor(out_ptr0", codes[0])
 
     @parametrize("dynamic", (False, True))
     @parametrize("search_space", ("DEFAULT", "EXHAUSTIVE"))

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -3430,10 +3430,9 @@ class CUDABlackwellBMMTemplateConfigHeuristic(TemplateConfigHeuristics):
 
         output_layout = kernel_inputs.output_layout()
         flatten_output = len(output_layout.size) == 2
-        tma_store = (
-            flatten_output
-            and config.triton.enable_template_tma_store
-            and can_use_tma(output_layout=output_layout)
+        rank3_output = len(output_layout.size) == 3
+        can_tma_store = config.triton.enable_template_tma_store and can_use_tma(
+            output_layout=output_layout
         )
         descriptor_options = {
             "NUM_SMS": get_num_sms(),
@@ -3442,11 +3441,13 @@ class CUDABlackwellBMMTemplateConfigHeuristic(TemplateConfigHeuristics):
             "A_BROADCAST_BATCH": int(mat1.get_stride()[0]) == 0,
             "B_BROADCAST_BATCH": int(mat2.get_stride()[0]) == 0,
             "FLATTEN_OUTPUT": flatten_output,
-            "tma_store": tma_store,
         }
         use_meta_ws = meta_ws_enabled()
         for candidate in self.bmm_configs:
             two_ctas = use_meta_ws and candidate.two_ctas
+            tma_store = can_tma_store and (
+                flatten_output or (two_ctas and rank3_output)
+            )
             if two_ctas and not is_blackwell_bmm_2cta_compatible(
                 output_batch_rows=m,
                 block_m=candidate.block_m,
@@ -3468,6 +3469,8 @@ class CUDABlackwellBMMTemplateConfigHeuristic(TemplateConfigHeuristics):
                 "DATA_PARTITION_FACTOR": candidate.data_partition_factor,
                 "SEPARATE_EPILOGUE_STORE": candidate.separate_epilogue_store,
                 "TWO_CTAS": two_ctas,
+                "RANK3_TMA_OUTPUT": two_ctas and rank3_output,
+                "tma_store": tma_store,
                 **descriptor_options,
             }
             if two_ctas:

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -179,13 +179,14 @@ def is_blackwell_bmm_2cta_compatible(
 ) -> bool:
     """Whether the current paired-CTA output contract is safe.
 
-    The 2CTA template pairs adjacent M tiles.  Its flattened rank-2 output
-    representation is safe only when every physical batch contains complete
-    CTA pairs; otherwise the padded tile aliases the following batch.  The
-    current implementation also relies on TMA output stores for cross-CTA
-    publication and does not support the rank-3 pointer-store fallback.
+    The 2CTA template pairs adjacent M tiles. A flattened rank-2 output is safe
+    only when every physical batch contains complete CTA pairs; otherwise the
+    padded tile aliases the following batch. A rank-3 TMA output keeps the batch
+    boundary explicit and safely suppresses the padded partner tile.
     """
-    return flatten_output and tma_store and output_batch_rows % (2 * block_m) == 0
+    return tma_store and (
+        not flatten_output or output_batch_rows % (2 * block_m) == 0
+    )
 
 
 BLACKWELL_BMM_MAX_AUTOTUNE_CONFIGS = (

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_bmm.py.jinja
@@ -139,6 +139,17 @@
                 val_shape=("BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE"),
                 block_indexing=True
             )}}
+            {%- elif RANK3_TMA_OUTPUT %}
+            output_subtile = subtiles[i].reshape(
+                (1, BLOCK_M, BLOCK_N // EPILOGUE_SUBTILE)
+            )
+            {{store_output(
+                ("batch", "offs_cm", "offs_cn_i"),
+                "output_subtile",
+                indent_width=12,
+                val_shape=("1", "BLOCK_M", "BLOCK_N // EPILOGUE_SUBTILE"),
+                block_indexing=True
+            )}}
             {%- else %}
             rm = offs_cm + tl.arange(0, BLOCK_M)[:, None]
             rn = offs_cn_i + tl.arange(0, BLOCK_N // EPILOGUE_SUBTILE)[None, :]

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -568,20 +568,19 @@ class TritonTemplateKernel(TritonKernel):
         always_freeze_layout: bool = False,
         index_dtype_override: str | None = None,
     ) -> None:
-        tma_2d = tma_store or tma_load_for_template_epilogue
-        if tma_store:
-            pass
+        tma_tiled = tma_store or tma_load_for_template_epilogue
         numel = sympy_product(output_node.get_size())
-        if tma_2d:
-            if len(output_node.get_size()) != 2:
+        if tma_tiled:
+            output_rank = len(output_node.get_size())
+            supported_ranks = (2, 3) if tma_store else (2,)
+            if output_rank not in supported_ranks:
                 raise AssertionError(
-                    "TMA load/store only supported for 2D with templates"
+                    f"TMA template output rank must be in {supported_ranks}, "
+                    f"got {output_rank}"
                 )
-            tiling = {
-                "x": output_node.get_size()[0],
-                "y": output_node.get_size()[1],
-                "r0_": sympy.S.One,
-            }
+            prefixes = ("x", "y", "z")
+            tiling = dict(zip(prefixes, output_node.get_size()))
+            tiling["r0_"] = sympy.S.One
         else:
             tiling = {
                 "x": numel,
@@ -592,7 +591,7 @@ class TritonTemplateKernel(TritonKernel):
             features=SIMDKernelFeatures([], numel),
             hint_override=hint_override,
         )
-        if tma_2d:
+        if tma_tiled:
             # By default `construct_range_trees` will return the range_trees in the order
             # ["z", "y", "x", "r0_", "r1_"] (see simd.py:all_prefixes)
             # and this order defines what the kernel block shape will be. So if the template
@@ -1641,9 +1640,10 @@ class TritonTemplateKernel(TritonKernel):
                     raise AssertionError(
                         "Blocking indexing requires passing in val_shape"
                     )
-                if len(val_shape) != 2:
+                if len(val_shape) != len(lengths):
                     raise AssertionError(
-                        "Blocking indexing only supports 2D data at this time"
+                        "Blocking indexing requires one value dimension per output "
+                        f"dimension, got {len(val_shape)} and {len(lengths)}"
                     )
                 if mask:
                     raise AssertionError("Mask is not supported with blocking indexing")
@@ -1673,7 +1673,7 @@ class TritonTemplateKernel(TritonKernel):
                         intermediate_lines.extend(
                             self._generate_index_from_tma_index(
                                 name,
-                                "xoffset" if name == "xindex" else "yoffset",
+                                name.replace("index", "offset"),
                                 index_symbols[i],
                                 val_shape[i],
                                 i,
@@ -1686,7 +1686,7 @@ class TritonTemplateKernel(TritonKernel):
                             self._generated_mask_for_tma(
                                 name,
                                 self.size(None, i),
-                                "xmask" if name == "xindex" else "ymask",
+                                name.replace("index", "mask"),
                             )
                         )
                         # Update the val_shape information to use consistent naming


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196517
* #196516
* #195955
* #195940
* #195939
* #195776
* #196363
* __->__ #196849
* #195775
* #195774
* #195773

Use a rank-3 output descriptor for paired 2CTA BMM so padded M tiles cannot alias the next batch. This removes the complete-M-pair restriction without materializing padded output.