### PR TITLE
fix(elastic/rendezvous): honor use_libuv on Windows OS

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -25,8 +25,8 @@ from .api import (
 from .dynamic_rendezvous import RendezvousBackend, Token
 from .utils import (
     _matches_machine_hostname,
+    _should_use_libuv,
     parse_rendezvous_endpoint,
-    should_use_libuv,
 )
 
 
@@ -153,7 +153,7 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
     if read_timeout <= 0:
         raise ValueError("The read timeout must be a positive integer.")
 
-    use_libuv = should_use_libuv()
+    use_libuv = _should_use_libuv()
 
     # In specific cases we attempt to instantiate the store twice. For details
     # see the explanation in the except clause below.

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -23,7 +23,11 @@ from .api import (
     RendezvousStateError,
 )
 from .dynamic_rendezvous import RendezvousBackend, Token
-from .utils import _matches_machine_hostname, parse_rendezvous_endpoint, should_use_libuv
+from .utils import (
+    _matches_machine_hostname,
+    parse_rendezvous_endpoint,
+    should_use_libuv,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -161,7 +165,7 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
                 is_master=is_server,
                 multi_tenant=True,
                 timeout=timedelta(seconds=read_timeout),
-                use_libuv=use_libuv
+                use_libuv=use_libuv,
             )
 
             if is_server:

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -23,7 +23,7 @@ from .api import (
     RendezvousStateError,
 )
 from .dynamic_rendezvous import RendezvousBackend, Token
-from .utils import _matches_machine_hostname, parse_rendezvous_endpoint
+from .utils import _matches_machine_hostname, parse_rendezvous_endpoint, should_use_libuv
 
 
 logger = logging.getLogger(__name__)
@@ -149,6 +149,8 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
     if read_timeout <= 0:
         raise ValueError("The read timeout must be a positive integer.")
 
+    use_libuv = should_use_libuv()
+
     # In specific cases we attempt to instantiate the store twice. For details
     # see the explanation in the except clause below.
     for is_server in [is_host, False]:
@@ -159,6 +161,7 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
                 is_master=is_server,
                 multi_tenant=True,
                 timeout=timedelta(seconds=read_timeout),
+                use_libuv=use_libuv
             )
 
             if is_server:

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -35,7 +35,7 @@ from .api import (
     RendezvousStoreInfo,
     RendezvousTimeoutError,
 )
-from .utils import _delay, _PeriodicTimer
+from .utils import _delay, _PeriodicTimer, should_use_libuv
 
 
 __all__ = [
@@ -1124,11 +1124,14 @@ class DynamicRendezvousHandler(RendezvousHandler):
         )
 
     def _create_tcp_store_server(self, master_addr, master_port) -> dist.TCPStore:
+        use_libuv = should_use_libuv()
+
         return dist.TCPStore(
             host_name=master_addr,
             port=master_port,
             is_master=True,
             multi_tenant=True,
+            use_libuv=use_libuv,
         )
 
     @property

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -35,7 +35,7 @@ from .api import (
     RendezvousStoreInfo,
     RendezvousTimeoutError,
 )
-from .utils import _delay, _PeriodicTimer, should_use_libuv
+from .utils import _delay, _PeriodicTimer, _should_use_libuv
 
 
 __all__ = [
@@ -1124,7 +1124,7 @@ class DynamicRendezvousHandler(RendezvousHandler):
         )
 
     def _create_tcp_store_server(self, master_addr, master_port) -> dist.TCPStore:
-        use_libuv = should_use_libuv()
+        use_libuv = _should_use_libuv()
 
         return dist.TCPStore(
             host_name=master_addr,

--- a/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
@@ -18,7 +18,7 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousParameters,
     RendezvousStoreInfo,
 )
-from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint
+from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint, should_use_libuv
 
 
 __all__ = ["StaticTCPRendezvous", "create_rdzv_handler"]
@@ -64,6 +64,8 @@ class StaticTCPRendezvous(RendezvousHandler):
         logger.info("Creating TCPStore as the c10d::Store implementation")
         is_master = self.rank == 0
         if not self._store:
+            use_libuv = should_use_libuv()
+
             self._store = TCPStore(  # type: ignore[call-arg]
                 self.master_addr,
                 self.master_port,
@@ -71,6 +73,7 @@ class StaticTCPRendezvous(RendezvousHandler):
                 is_master,
                 self.timeout,
                 multi_tenant=True,
+                use_libuv=use_libuv,
             )
         store = PrefixStore(self.run_id, self._store)
         # TCPStore server instance is used by trainer code

--- a/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
@@ -18,7 +18,10 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousParameters,
     RendezvousStoreInfo,
 )
-from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint, should_use_libuv
+from torch.distributed.elastic.rendezvous.utils import (
+    parse_rendezvous_endpoint,
+    should_use_libuv,
+)
 
 
 __all__ = ["StaticTCPRendezvous", "create_rdzv_handler"]

--- a/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
@@ -19,8 +19,8 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousStoreInfo,
 )
 from torch.distributed.elastic.rendezvous.utils import (
+    _should_use_libuv,
     parse_rendezvous_endpoint,
-    should_use_libuv,
 )
 
 
@@ -67,7 +67,7 @@ class StaticTCPRendezvous(RendezvousHandler):
         logger.info("Creating TCPStore as the c10d::Store implementation")
         is_master = self.rank == 0
         if not self._store:
-            use_libuv = should_use_libuv()
+            use_libuv = _should_use_libuv()
 
             self._store = TCPStore(  # type: ignore[call-arg]
                 self.master_addr,

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -6,9 +6,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import ipaddress
+import os
 import random
 import re
 import socket
+import sys
 import time
 import weakref
 from collections.abc import Callable
@@ -17,7 +19,7 @@ from threading import Event, Thread
 from typing import Any
 
 
-__all__ = ["parse_rendezvous_endpoint"]
+__all__ = ["parse_rendezvous_endpoint", "should_use_libuv"]
 
 
 def _parse_rendezvous_config(config_str: str) -> dict[str, str]:
@@ -283,3 +285,12 @@ class _PeriodicTimer:
         stop_event.set()
 
         thread.join()
+
+def should_use_libuv() -> bool:
+    """
+    Determine whether or not should use the libuv-based TCPStore backend.
+
+    Returns:
+        bool: True if libuv should be used, False otherwise.
+    """
+    return os.environ.get("USE_LIBUV", "0" if sys.platform == "win32" else "1") == "1"

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -286,6 +286,7 @@ class _PeriodicTimer:
 
         thread.join()
 
+
 def should_use_libuv() -> bool:
     """
     Determine whether or not should use the libuv-based TCPStore backend.

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -19,7 +19,7 @@ from threading import Event, Thread
 from typing import Any
 
 
-__all__ = ["parse_rendezvous_endpoint", "should_use_libuv"]
+__all__ = ["parse_rendezvous_endpoint"]
 
 
 def _parse_rendezvous_config(config_str: str) -> dict[str, str]:
@@ -287,7 +287,7 @@ class _PeriodicTimer:
         thread.join()
 
 
-def should_use_libuv() -> bool:
+def _should_use_libuv() -> bool:
     """
     Determine whether or not should use the libuv-based TCPStore backend.
 

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -209,6 +209,7 @@ def _create_c10d_store(
             world_size=world_size,
             is_master=False,
             timeout=timeout,
+            use_libuv=use_libuv,
         )
     else:
         start_daemon = rank == 0


### PR DESCRIPTION
Elastic rendezvous creates TCPStore with use_libuv defaulting to True, causing: RuntimeError: use_libuv was requested but PyTorch was built without libuv support.

This fix is to correctly honor `use_libuv`.

Summary of changes:

- Honor USE_LIBUV env when initializing three TCPStore instance for c10d, dynamic, and static_tcp rendezvous, respectively.
- Honor `use_libuv` obtained from `init_method` at ProcessGroup Initialization,  when initializing TCPStore instance in `rendezvous.py`. Reference to the documentation: https://docs.pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html#exit-route-2-add-use-libuv-0-to-init-method-at-processgroup-initialization

Fixes https://github.com/pytorch/pytorch/issues/178600

Note: this solution originated from https://github.com/pytorch/pytorch/pull/175316