### PR TITLE
Deterministic CUDA grid_sample backward

### DIFF
--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -301,26 +301,17 @@ namespace {
     }
   }
 
-// Note [Passing pointer and offset to fastAtomicAdd]
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// For its internal bounds checking, fastAtomicAdd needs to know where the destination address
-// lies relative to the entire tensor, so we pass the base grad_input.data and full offset information,
-// including batch * channel offset (NC_offset).
-
   template <typename scalar_t, typename index_t>
   C10_LAUNCH_BOUNDS_1(256)
-  __global__ void grid_sampler_2d_backward_kernel(
+  __global__ void grid_sampler_2d_grid_backward_kernel(
       const index_t nthreads,
       TensorInfo<const scalar_t, index_t> grad_output,
       TensorInfo<const scalar_t, index_t> input,
       TensorInfo<const scalar_t, index_t> grid,
-      TensorInfo<scalar_t, index_t> grad_input,  // initialized to zeros (or unused if input_requires_grad is false)
       TensorInfo<scalar_t, index_t> grad_grid,   // initialized to empty
       const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode,
-      bool align_corners,
-      const index_t grad_input_memory_span,
-      const bool input_requires_grad) {
+      bool align_corners) {
 
     index_t C = input.sizes[1];
     index_t inp_H = input.sizes[2];
@@ -339,17 +330,6 @@ namespace {
     index_t gOut_sC = grad_output.strides[1];
     index_t gOut_sH = grad_output.strides[2];
     index_t gOut_sW = grad_output.strides[3];
-    // gInp_* (and NC_offset below) are not really needed if input_requires_grad is false.
-    index_t gInp_sN;
-    index_t gInp_sC;
-    index_t gInp_sH;
-    index_t gInp_sW;
-    if (input_requires_grad) {
-      gInp_sN = grad_input.strides[0];
-      gInp_sC = grad_input.strides[1];
-      gInp_sH = grad_input.strides[2];
-      gInp_sW = grad_input.strides[3];
-    }
     index_t gGrid_sW = grad_grid.strides[2];
 
     CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
@@ -378,26 +358,12 @@ namespace {
         index_t ix_se = ix_nw + 1;
         index_t iy_se = iy_nw + 1;
 
-        // get surfaces to each neighbor:
-        scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-        scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-        scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-        scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
-
         scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
         const scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-        index_t NC_offset = n * gInp_sN;
         const scalar_t *inp_ptr_NC = input.data + n * inp_sN;
-        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, NC_offset += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
+        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, gOut_ptr_NCHW += gOut_sC) {
           const scalar_t gOut = *gOut_ptr_NCHW;
 
-          if (input_requires_grad) {
-            // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
-            safe_add_2d(grad_input.data, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut, NC_offset, grad_input_memory_span);
-            safe_add_2d(grad_input.data, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut, NC_offset, grad_input_memory_span);
-            safe_add_2d(grad_input.data, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut, NC_offset, grad_input_memory_span);
-            safe_add_2d(grad_input.data, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut, NC_offset, grad_input_memory_span);
-          }
 
           // calculate grad_grid
           if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
@@ -430,18 +396,6 @@ namespace {
         gGrid_ptr_NHW[0] = gix_mult * gix;
         gGrid_ptr_NHW[1] = giy_mult * giy;
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        if (input_requires_grad) {
-          index_t ix_nearest = static_cast<index_t>(std::nearbyint(ix));
-          index_t iy_nearest = static_cast<index_t>(std::nearbyint(iy));
-
-          // assign nearest neighbour pixel value to output pixel
-          const scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-          index_t NC_offset = n * gInp_sN;
-          for (index_t c = 0; c < C; ++c, NC_offset += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
-            // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
-            safe_add_2d(grad_input.data, iy_nearest, ix_nearest, gInp_sH, gInp_sW, inp_H, inp_W, *gOut_ptr_NCHW, NC_offset, grad_input_memory_span);
-          }
-        }
 
         // assuming grad_grid is contiguous
         // thus we can
@@ -475,10 +429,9 @@ namespace {
         scalar_t giy = static_cast<scalar_t>(0);
 
         const scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-        index_t NC_offset = n * gInp_sN;
         const scalar_t *inp_ptr_NC = input.data + n * inp_sN;
 
-        for (index_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, NC_offset += gInp_sC, inp_ptr_NC+= inp_sC) {
+        for (index_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, inp_ptr_NC+= inp_sC) {
           const scalar_t gOut = *gOut_ptr_NCHW;
 
           #pragma unroll 4
@@ -486,15 +439,6 @@ namespace {
             #pragma unroll 4
             for (index_t j = 0; j < 4; ++j) {
 
-              if (input_requires_grad) {
-                // set input gradient. See Note [Passing pointer and offset to fastAtomicAdd].
-                add_value_bounded<scalar_t>(grad_input.data, ix_nw - 1 + i, iy_nw - 1 + j, inp_W, inp_H, gInp_sW, gInp_sH,
-                  gOut * x_coeffs[i] * y_coeffs[j],
-                  padding_mode,
-                  align_corners,
-                  NC_offset,
-                  grad_input_memory_span);
-              }
 
               // set grid gradient
               scalar_t val = get_value_bounded<scalar_t>(inp_ptr_NC, ix_nw - 1 + i, iy_nw - 1 + j,
@@ -515,18 +459,15 @@ namespace {
 
   template <typename scalar_t, typename index_t>
   C10_LAUNCH_BOUNDS_1(256)
-  __global__ void grid_sampler_3d_backward_kernel(
+  __global__ void grid_sampler_3d_grid_backward_kernel(
       const index_t nthreads,
       TensorInfo<const scalar_t, index_t> grad_output,
       TensorInfo<const scalar_t, index_t> input,
       TensorInfo<const scalar_t, index_t> grid,
-      TensorInfo<scalar_t, index_t> grad_input,  // initialized to zeros (or unused if input_requires_grad is false)
       TensorInfo<scalar_t, index_t> grad_grid,   // initialized to empty
       const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode,
-      bool align_corners,
-      const index_t grad_input_memory_span,
-      const bool input_requires_grad) {
+      bool align_corners) {
 
     index_t C = input.sizes[1];
     index_t inp_D = input.sizes[2];
@@ -550,19 +491,6 @@ namespace {
     index_t gOut_sD = grad_output.strides[2];
     index_t gOut_sH = grad_output.strides[3];
     index_t gOut_sW = grad_output.strides[4];
-    // gInp_* (and NC_offset below) are not really needed if input_requires_grad is false.
-    int64_t gInp_sN = 0;
-    int64_t gInp_sC = 0;
-    int64_t gInp_sD = 0;
-    int64_t gInp_sH = 0;
-    int64_t gInp_sW = 0;
-    if (input_requires_grad) {
-      gInp_sN = grad_input.strides[0];
-      gInp_sC = grad_input.strides[1];
-      gInp_sD = grad_input.strides[2];
-      gInp_sH = grad_input.strides[3];
-      gInp_sW = grad_input.strides[4];
-    }
     index_t gGrid_sW = grad_grid.strides[3];
 
     CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
@@ -619,46 +547,13 @@ namespace {
         index_t iy_bse = iy_tnw + 1;
         index_t iz_bse = iz_tnw + 1;
 
-        // get surfaces to each neighbor:
-        scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
-        scalar_t tne = (ix    - ix_bsw) * (iy_bsw - iy)    * (iz_bsw - iz);
-        scalar_t tsw = (ix_bne - ix)    * (iy    - iy_bne) * (iz_bne - iz);
-        scalar_t tse = (ix    - ix_bnw) * (iy    - iy_bnw) * (iz_bnw - iz);
-        scalar_t bnw = (ix_tse - ix)    * (iy_tse - iy)    * (iz - iz_tse);
-        scalar_t bne = (ix    - ix_tsw) * (iy_tsw - iy)    * (iz - iz_tsw);
-        scalar_t bsw = (ix_tne - ix)    * (iy    - iy_tne) * (iz - iz_tne);
-        scalar_t bse = (ix    - ix_tnw) * (iy    - iy_tnw) * (iz - iz_tnw);
-
         scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0), giz = static_cast<scalar_t>(0);
         const scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
-        index_t NC_offset;
-        if (input_requires_grad) {
-          NC_offset = n * gInp_sN;
-        }
         const scalar_t *inp_ptr_NC = input.data + n * inp_sN;
-        // calculate bilinear weighted pixel value and set output pixel
-        for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, NC_offset += gInp_sC, inp_ptr_NC += inp_sC) {
+        // Accumulate coordinate gradients over channels in a fixed order.
+        for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, inp_ptr_NC += inp_sC) {
           scalar_t gOut = *gOut_ptr_NCDHW;
 
-          // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
-          if (input_requires_grad) {
-            safe_add_3d(grad_input.data, iz_tnw, iy_tnw, ix_tnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tnw * gOut,
-                        NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_tne, iy_tne, ix_tne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tne * gOut,
-                        NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_tsw, iy_tsw, ix_tsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tsw * gOut,
-                        NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_tse, iy_tse, ix_tse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, tse * gOut,
-                        NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bnw, iy_bnw, ix_bnw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bnw * gOut,
-                        NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bne, iy_bne, ix_bne, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bne * gOut,
-                        NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bsw, iy_bsw, ix_bsw, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bsw * gOut,
-                        NC_offset, grad_input_memory_span);
-            safe_add_3d(grad_input.data, iz_bse, iy_bse, ix_bse, gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, bse * gOut,
-                        NC_offset, grad_input_memory_span);
-          }
           // calculate grad_grid
           if (within_bounds_3d(iz_tnw, iy_tnw, ix_tnw, inp_D, inp_H, inp_W)) {
             scalar_t tnw_val = inp_ptr_NC[iz_tnw * inp_sD + iy_tnw * inp_sH + ix_tnw * inp_sW];
@@ -719,21 +614,6 @@ namespace {
         gGrid_ptr_NDHW[1] = giy_mult * giy;
         gGrid_ptr_NDHW[2] = giz_mult * giz;
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        if (input_requires_grad) {
-          auto ix_nearest = static_cast<index_t>(std::nearbyint(ix));
-          auto iy_nearest = static_cast<index_t>(std::nearbyint(iy));
-          auto iz_nearest = static_cast<index_t>(std::nearbyint(iz));
-
-          // assign nearest neighbour pixel value to output pixel
-          const scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
-          index_t NC_offset = n * gInp_sN;
-          for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, NC_offset += gInp_sC) {
-            // calculate and set grad_input. See Note [Passing pointer and offset to fastAtomicAdd].
-            safe_add_3d(grad_input.data, iz_nearest, iy_nearest, ix_nearest,
-                        gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, *gOut_ptr_NCDHW,
-                        NC_offset, grad_input_memory_span);
-          }
-        }
         // assuming grad_grid is contiguous
         // thus we can
         //   1. use index with gGrid_sW to directly compute gGrid_ptr_NDHW
@@ -845,17 +725,16 @@ void launch_grid_sampler_2d_backward_kernel(
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_2d_backward(input, grid, grad_output);
 
-  // See Note [Writing Nondeterministic Operations]
-  // Nondeterministic because of atomicAdd usage
-  globalContext().alertNotDeterministic("grid_sampler_2d_backward_cuda");
+  if (output_mask[0]) {
+    launch_grid_sampler_input_backward_kernel(
+        grad_input, grad_output, input, grid,
+        interpolation_mode, padding_mode, align_corners);
+  }
   auto N = input.size(0);
   auto H = grid.size(1);
   auto W = grid.size(2);
 
-  // If `input` gradient is not required, we skip computing it -- not needing to create
-  // the tensor to hold the gradient can markedly increase performance. (`grid` gradient
-  // is always computed.)
-  auto input_requires_grad = output_mask[0];
+  // Preserve the existing always-computed grid gradient.
 
   int64_t count = N * H * W;
   if (count > 0) {
@@ -864,34 +743,28 @@ void launch_grid_sampler_2d_backward_kernel(
       input.scalar_type(), "grid_sampler_2d_backward_cuda", [&] {
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(grad_output)) {
-        grid_sampler_2d_backward_kernel<scalar_t>
+        grid_sampler_2d_grid_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),
             getTensorInfo<const scalar_t, int>(grad_output),
             getTensorInfo<const scalar_t, int>(input),
             getTensorInfo<const scalar_t, int>(grid),
-            input_requires_grad ? getTensorInfo<scalar_t, int>(grad_input) : TensorInfo<scalar_t, int>(),
             getTensorInfo<scalar_t, int>(grad_grid),
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/input_requires_grad ? static_cast<int>(grad_input.numel()) : 0,
-            input_requires_grad);
+            align_corners);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
-        grid_sampler_2d_backward_kernel<scalar_t>
+        grid_sampler_2d_grid_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             count,
             getTensorInfo<const scalar_t, int64_t>(grad_output),
             getTensorInfo<const scalar_t, int64_t>(input),
             getTensorInfo<const scalar_t, int64_t>(grid),
-            input_requires_grad ? getTensorInfo<scalar_t, int64_t>(grad_input) : TensorInfo<scalar_t, int64_t>(),
             getTensorInfo<scalar_t, int64_t>(grad_grid),
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/input_requires_grad ? grad_input.numel() : 0,
-            input_requires_grad);
+            align_corners);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });
@@ -907,49 +780,44 @@ void launch_grid_sampler_3d_backward_kernel(
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_3d_backward(input, grid, grad_output, interpolation_mode);
 
-  // See Note [Writing Nondeterministic Operations]
-  // Nondeterministic because of atomicAdd usage
-  globalContext().alertNotDeterministic("grid_sampler_3d_backward_cuda");
+  if (output_mask[0]) {
+    launch_grid_sampler_input_backward_kernel(
+        grad_input, grad_output, input, grid,
+        interpolation_mode, padding_mode, align_corners);
+  }
   auto N = input.size(0);
   auto D = grid.size(1);
   auto H = grid.size(2);
   auto W = grid.size(3);
   int64_t count = N * D * H * W;
-  auto input_requires_grad = output_mask[0];
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half, ScalarType::BFloat16,
       input.scalar_type(), "grid_sampler_3d_backward_cuda", [&] {
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(grad_output)) {
-        grid_sampler_3d_backward_kernel<scalar_t>
+        grid_sampler_3d_grid_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),
             getTensorInfo<const scalar_t, int>(grad_output),
             getTensorInfo<const scalar_t, int>(input),
             getTensorInfo<const scalar_t, int>(grid),
-            input_requires_grad ? getTensorInfo<scalar_t, int>(grad_input) : TensorInfo<scalar_t, int>(),
             getTensorInfo<scalar_t, int>(grad_grid),
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/input_requires_grad ? static_cast<int>(grad_input.numel()) : 0,
-            input_requires_grad);
+            align_corners);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
-        grid_sampler_3d_backward_kernel<scalar_t>
+        grid_sampler_3d_grid_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
             count,
             getTensorInfo<const scalar_t, int64_t>(grad_output),
             getTensorInfo<const scalar_t, int64_t>(input),
             getTensorInfo<const scalar_t, int64_t>(grid),
-            input_requires_grad ? getTensorInfo<scalar_t, int64_t>(grad_input) : TensorInfo<scalar_t, int64_t>(),
             getTensorInfo<scalar_t, int64_t>(grad_grid),
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/input_requires_grad ? grad_input.numel() : 0,
-            input_requires_grad);
+            align_corners);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -1,6 +1,6 @@
 #pragma once
-#include <ATen/native/cuda/KernelUtils.cuh>
 #include <ATen/native/GridSamplerUtils.h>
+#include <climits>
 
 namespace at::native {
 
@@ -242,57 +242,6 @@ scalar_t get_value_bounded(
     return data[iy * sH + ix * sW];
   }
   return static_cast<scalar_t>(0);
-}
-
-template<typename scalar_t, typename index_t>
-__forceinline__ __device__
-void safe_add_2d(scalar_t *data, int h, int w,
-                 int sH, int sW, int H, int W,
-                 scalar_t delta,
-                 const index_t NC_offset,
-                 const index_t memory_span) {
-  if (within_bounds_2d(h, w, H, W)) {
-    fastAtomicAdd(data,
-                  NC_offset + h * sH + w * sW,
-                  memory_span,
-                  delta,
-                  true);
-  }
-}
-
-template<typename scalar_t, typename index_t>
-__forceinline__ __device__
-void safe_add_3d(scalar_t *data, int d, int h, int w,
-                 int sD, int sH, int sW, int D, int H, int W,
-                 scalar_t delta,
-                 const index_t NC_offset,
-                 const index_t memory_span) {
-  if (within_bounds_3d(d, h, w, D, H, W)) {
-    fastAtomicAdd(data,
-                  NC_offset + d * sD + h * sH + w * sW,
-                  memory_span,
-                  delta,
-                  true);
-  }
-}
-
-template<typename scalar_t, typename index_t>
-__forceinline__ __device__
-void add_value_bounded(
-    scalar_t* data, scalar_t x, scalar_t y, int W, int H, int sW, int sH,
-    scalar_t delta,
-    GridSamplerPadding padding_mode,
-    bool align_corners,
-    const index_t NC_offset,
-    const index_t memory_span) {
-
-  x = compute_coordinates(x, W, padding_mode, align_corners);
-  y = compute_coordinates(y, H, padding_mode, align_corners);
-
-  int ix = static_cast<int>(x);
-  int iy = static_cast<int>(y);
-
-  safe_add_2d(data, iy, ix, sH, sW, H, W, delta, NC_offset, memory_span);
 }
 
 // Calculate the differential of the cubic convolution, i.e. `d coeff / d x`

--- a/aten/src/ATen/native/cuda/GridSampler.h
+++ b/aten/src/ATen/native/cuda/GridSampler.h
@@ -16,6 +16,12 @@ void launch_grid_sampler_3d_forward_kernel(
     const TensorBase &output, const TensorBase &input, const TensorBase &grid,
     int64_t interpolation_mode, int64_t padding_mode, bool align_corners);
 
+// Accumulate into the caller's zero-initialized contiguous input gradient.
+void launch_grid_sampler_input_backward_kernel(
+    const TensorBase& grad_input, const TensorBase& grad_output,
+    const TensorBase& input, const TensorBase& grid,
+    int64_t interpolation_mode, int64_t padding_mode, bool align_corners);
+
 void launch_grid_sampler_2d_backward_kernel(
     const TensorBase &grad_input, const TensorBase &grad_grid,
     const TensorBase &grad_output, const TensorBase &input,

--- a/aten/src/ATen/native/cuda/GridSamplerBackward.cu
+++ b/aten/src/ATen/native/cuda/GridSamplerBackward.cu
@@ -1,0 +1,374 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
+#include <ATen/core/TensorBase.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/DeviceUtils.cuh>
+#include <ATen/cuda/cub.cuh>
+#include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/detail/KernelUtils.h>
+#include <ATen/cuda/detail/TensorInfo.cuh>
+#include <ATen/native/cuda/GridSampler.h>
+#include <ATen/native/cuda/GridSampler.cuh>
+#include <ATen/native/cuda/UpSample.cuh>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
+#endif
+
+namespace at::native {
+namespace {
+using at::cuda::detail::TensorInfo;
+using at::cuda::detail::getTensorInfo;
+constexpr int THREADS = 256;
+
+// NOTE [Deterministic Grid Sampler Input Gradient]
+// Each interpolation corner has a fixed record ID. Stable sorting groups these
+// records by input destination without changing their order within a segment.
+// One logical warp owns each segment/channel tile and uses a fixed reduction
+// tree, rather than floating-point atomics. Fixed-size chunks bound temporary
+// storage and commit on the caller stream in order; chunk sizes must not depend
+// on free memory or scheduling. The caller initializes grad_input to zero.
+
+// Convert a batch-local flattened spatial index using the tensor's own strides.
+template <typename scalar_t, int D>
+__device__ int64_t spatial_offset(int64_t index, const TensorInfo<scalar_t, int64_t>& tensor,
+                                  int first_dim) {
+  int64_t offset = 0;
+  for (int axis = D - 1; axis >= 0; --axis) {
+    offset += (index % tensor.sizes[first_dim + axis]) * tensor.strides[first_dim + axis];
+    index /= tensor.sizes[first_dim + axis];
+  }
+  return offset;
+}
+
+// A record is identified by (batch, output spatial index, interpolation corner).
+// Invalid neighbors sort after all valid destinations and never reach the output.
+template <typename scalar_t, int D>
+C10_LAUNCH_BOUNDS_1(THREADS)
+__global__ void make_records(
+    TensorInfo<const scalar_t, int64_t> input,
+    TensorInfo<const scalar_t, int64_t> grid,
+    TensorInfo<const scalar_t, int64_t> grad,
+    int64_t* keys, int64_t* ids, scalar_t* weights, int64_t* sample_offsets,
+    int64_t count, int64_t first_output, int64_t output_spatial, int64_t input_spatial,
+    int neighbors, GridSamplerInterpolation mode, GridSamplerPadding padding,
+    bool align_corners) {
+  const int64_t invalid = input.sizes[0] * input_spatial;
+  CUDA_KERNEL_LOOP_TYPE(local_t, count, int64_t) {
+    const int64_t t = first_output + local_t;
+    const int64_t n = t / output_spatial;
+    const int64_t grid_offset = n * grid.strides[0]
+        + spatial_offset<const scalar_t, D>(t % output_spatial, grid, 1);
+    sample_offsets[local_t] = n * grad.strides[0]
+        + spatial_offset<const scalar_t, D>(t % output_spatial, grad, 2);
+    scalar_t coord[D];
+    int64_t size[D];
+    for (int axis = 0; axis < D; ++axis) {
+      size[axis] = input.sizes[D + 1 - axis];
+      const scalar_t value = grid.data[grid_offset + axis * grid.strides[D + 1]];
+      scalar_t unused;
+      coord[axis] = mode == GridSamplerInterpolation::Bicubic
+          ? at::native::grid_sampler_unnormalize_set_grad(value, size[axis], align_corners, &unused)
+          : at::native::grid_sampler_compute_source_index_set_grad(
+                value, size[axis], padding, align_corners, &unused);
+    }
+    scalar_t cubic_x[4], cubic_y[4];
+    scalar_t cubic_base_x = 0, cubic_base_y = 0;
+    if (mode == GridSamplerInterpolation::Bicubic) {
+      cubic_base_x = std::floor(coord[0]);
+      cubic_base_y = std::floor(coord[1]);
+      at::native::get_cubic_upsampling_coefficients(cubic_x, scalar_t(coord[0] - cubic_base_x));
+      at::native::get_cubic_upsampling_coefficients(cubic_y, scalar_t(coord[1] - cubic_base_y));
+    }
+    for (int q = 0; q < neighbors; ++q) {
+      const int64_t r = local_t * neighbors + q;
+      int64_t dest[D];
+      scalar_t weight = 1;
+      scalar_t second_weight = 1;
+      if (mode == GridSamplerInterpolation::Bicubic) {
+        // Preserve native x-major corner order and (grad * wx) * wy grouping.
+        const int x = q / 4, y = q % 4;
+        dest[0] = static_cast<int64_t>(at::native::compute_coordinates(
+            scalar_t(cubic_base_x - 1 + x), size[0], padding, align_corners));
+        dest[1] = static_cast<int64_t>(at::native::compute_coordinates(
+            scalar_t(cubic_base_y - 1 + y), size[1], padding, align_corners));
+        weight = cubic_x[x];
+        second_weight = cubic_y[y];
+      } else {
+        for (int axis = 0; axis < D; ++axis) {
+          if (mode == GridSamplerInterpolation::Nearest) {
+            dest[axis] = static_cast<int64_t>(std::nearbyint(coord[axis]));
+          } else {
+            const int64_t base = static_cast<int64_t>(std::floor(coord[axis]));
+            const int upper = (q >> axis) & 1;
+            dest[axis] = base + upper;
+            const scalar_t factor = upper ? scalar_t(coord[axis] - base)
+                                          : scalar_t(base + 1 - coord[axis]);
+            weight = weight * factor;
+          }
+        }
+      }
+      bool valid = true;
+      int64_t key = n * input_spatial;
+      int64_t stride = 1;
+      for (int axis = 0; axis < D; ++axis) {
+        valid &= dest[axis] >= 0 && dest[axis] < size[axis];
+        key += dest[axis] * stride;
+        stride *= size[axis];
+      }
+      keys[r] = valid ? key : invalid;
+      ids[r] = r;
+      const int factors = mode == GridSamplerInterpolation::Bicubic ? 2 : 1;
+      weights[r * factors] = weight;
+      if (factors == 2) weights[r * 2 + 1] = second_weight;
+    }
+  }
+}
+
+// Evaluate one weighted contribution with the native scalar_t rounding order.
+template <typename scalar_t>
+__device__ at::opmath_type<scalar_t> record_value(
+    TensorInfo<const scalar_t, int64_t> grad, const scalar_t* weights,
+    const int64_t* sample_offsets, int64_t r, int64_t c, int neighbor_bits,
+    bool bicubic) {
+  const scalar_t g = grad.data[sample_offsets[r >> neighbor_bits] + c * grad.strides[1]];
+  return bicubic ? scalar_t(scalar_t(g * weights[r * 2]) * weights[r * 2 + 1])
+                 : scalar_t(weights[r] * g);
+}
+
+// Logical 32-lane groups also work on devices with wider hardware warps.
+template <typename acc_t>
+__device__ acc_t channel_sum(acc_t value, int channel_tile) {
+  for (int delta = 16; delta >= channel_tile; delta /= 2) {
+    value += WARP_SHFL_DOWN(value, delta, 32);
+  }
+  return value;
+}
+
+constexpr int PARTIAL_ROWS = 256;
+
+// Only long segments produce partials, so their total number is <= 2*ceil(R/256).
+C10_LAUNCH_BOUNDS_1(THREADS)
+__global__ void count_long_segments(
+    const int64_t* sorted_keys, const int64_t* offsets, const int64_t* num_segments,
+    int64_t* counts, int64_t max_segments, int64_t records, int64_t invalid_key) {
+  CUDA_KERNEL_LOOP_TYPE(s, max_segments, int64_t) {
+    int64_t count = 0;
+    if (s < *num_segments && sorted_keys[offsets[s]] != invalid_key) {
+      const int64_t end = s + 1 < *num_segments ? offsets[s + 1] : records;
+      const int64_t length = end - offsets[s];
+      if (length > PARTIAL_ROWS) count = (length + PARTIAL_ROWS - 1) / PARTIAL_ROWS;
+    }
+    counts[s] = count;
+  }
+}
+
+// Independent fixed-size ranges expose parallelism even if all samples collide.
+template <typename scalar_t>
+C10_LAUNCH_BOUNDS_1(THREADS)
+__global__ void partial_gradients(
+    TensorInfo<const scalar_t, int64_t> grad, const int64_t* offsets,
+    const int64_t* sorted_ids, const scalar_t* weights, const int64_t* sample_offsets,
+    const int64_t* num_segments, const int64_t* counts, const int64_t* prefix,
+    at::opmath_type<scalar_t>* partials, int64_t max_segments, int64_t max_partials,
+    int64_t records, int neighbor_bits, int channel_bits, bool bicubic) {
+  using acc_t = at::opmath_type<scalar_t>;
+  const int lane = threadIdx.x % 32;
+  const int channel_tile = 1 << channel_bits;
+  const int64_t channels = grad.sizes[1];
+  const int64_t channel_tiles = (channels + channel_tile - 1) >> channel_bits;
+  const int64_t total = prefix[max_segments - 1] + counts[max_segments - 1];
+  const int64_t first = int64_t(blockIdx.x) * (THREADS / 32) + threadIdx.x / 32;
+  const int64_t step = int64_t(gridDim.x) * (THREADS / 32);
+  for (int64_t item = first; item < max_partials * channel_tiles; item += step) {
+    const int64_t part = item / channel_tiles;
+    if (part >= total) continue;
+    int64_t low = 0, high = max_segments;
+    while (low < high) {
+      const int64_t mid = low + (high - low) / 2;
+      if (prefix[mid] <= part) low = mid + 1;
+      else high = mid;
+    }
+    const int64_t segment = low - 1;
+    const int64_t c = ((item % channel_tiles) << channel_bits) + (lane & (channel_tile - 1));
+    const int64_t begin = offsets[segment] + (part - prefix[segment]) * PARTIAL_ROWS;
+    const int64_t segment_end = segment + 1 < *num_segments ? offsets[segment + 1] : records;
+    const int64_t end = min(begin + PARTIAL_ROWS, segment_end);
+    acc_t acc = 0;
+    for (int64_t i = begin + (lane >> channel_bits); i < end; i += 32 >> channel_bits) {
+      if (c < channels) acc += record_value(grad, weights, sample_offsets, sorted_ids[i], c, neighbor_bits, bicubic);
+    }
+    acc = channel_sum(acc, channel_tile);
+    if (lane < channel_tile && c < channels) partials[part * channels + c] = acc;
+  }
+}
+
+// One warp owns the final write for a segment/channel tile. Short segments are
+// reduced directly; long ones use fixed-order partials, never floating atomics.
+template <typename scalar_t>
+C10_LAUNCH_BOUNDS_1(THREADS)
+__global__ void reduce_segments(
+    TensorInfo<const scalar_t, int64_t> grad,
+    scalar_t* output, const int64_t* sorted_keys, const int64_t* offsets,
+    const int64_t* sorted_ids, const scalar_t* weights, const int64_t* sample_offsets,
+    const int64_t* num_segments, int64_t max_segments, int64_t records,
+    int64_t input_spatial, int neighbor_bits, int channel_bits, bool bicubic,
+    const int64_t* partial_counts, const int64_t* partial_prefix,
+    const at::opmath_type<scalar_t>* partials) {
+  using acc_t = at::opmath_type<scalar_t>;
+  const int lane = threadIdx.x % 32;
+  const int channel_tile = 1 << channel_bits;
+  const int64_t channels = grad.sizes[1];
+  const int64_t channel_tiles = (channels + channel_tile - 1) >> channel_bits;
+  const int64_t initial = int64_t(blockIdx.x) * (THREADS / 32) + threadIdx.x / 32;
+  const int64_t step = int64_t(gridDim.x) * (THREADS / 32);
+  for (int64_t item = initial; item < max_segments * channel_tiles; item += step) {
+    const int64_t segment = item / channel_tiles;
+    if (segment >= *num_segments) continue;
+    const int64_t begin = offsets[segment];
+    const int64_t key = sorted_keys[begin];
+    if (key == grad.sizes[0] * input_spatial) continue;
+    const int64_t c = ((item % channel_tiles) << channel_bits) + (lane & (channel_tile - 1));
+    const int64_t end = segment + 1 < *num_segments ? offsets[segment + 1] : records;
+    acc_t acc = 0;
+    if (partial_counts != nullptr && partial_counts[segment] != 0) {
+      const int64_t first_part = partial_prefix[segment];
+      const int64_t last_part = first_part + partial_counts[segment];
+      for (int64_t p = first_part + (lane >> channel_bits); p < last_part; p += 32 >> channel_bits) {
+        if (c < channels) acc += partials[p * channels + c];
+      }
+    } else {
+      for (int64_t i = begin + (lane >> channel_bits); i < end; i += 32 >> channel_bits) {
+        if (c < channels) acc += record_value(grad, weights, sample_offsets, sorted_ids[i], c, neighbor_bits, bicubic);
+      }
+    }
+    acc = channel_sum(acc, channel_tile);
+    if (lane < channel_tile && c < channels) {
+      const int64_t n = key / input_spatial;
+      const int64_t index = n * channels * input_spatial + c * input_spatial + key % input_spatial;
+      // Chunks commit in stream order; each chunk has one writer per element.
+      output[index] = scalar_t(static_cast<acc_t>(output[index]) + acc);
+    }
+  }
+}
+
+template <typename scalar_t, int D>
+void launch_grouped(const TensorBase& input, const TensorBase& grid,
+                    const TensorBase& grad, const TensorBase& output,
+                    GridSamplerInterpolation mode, GridSamplerPadding padding, bool align) {
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  const int64_t count = grid.numel() / D;
+  if (!count || !input.numel()) return;
+  int64_t input_spatial = 1, output_spatial = 1;
+  for (int axis = 0; axis < D; ++axis) {
+    input_spatial *= input.size(axis + 2);
+    output_spatial *= grid.size(axis + 1);
+  }
+  const int64_t destinations = input.size(0) * input_spatial;
+  const bool bicubic = mode == GridSamplerInterpolation::Bicubic;
+  const int neighbor_bits = mode == GridSamplerInterpolation::Nearest ? 0 : bicubic ? 4 : D;
+  const int neighbors = 1 << neighbor_bits;
+  int channel_bits = 0;
+  while ((1 << channel_bits) < std::min<int64_t>(input.size(1), 32)) ++channel_bits;
+  const int channel_tile = 1 << channel_bits;
+  // Bound mapping storage and stay below CUB's INT_MAX record limit. Chunk
+  // boundaries depend only on the operator configuration, not free GPU memory.
+  constexpr int64_t MAX_RECORDS = 1 << 20;
+  const int64_t chunk_outputs = MAX_RECORDS / neighbors;
+  for (int64_t first = 0; first < count; first += chunk_outputs) {
+    const int64_t chunk = std::min(count - first, chunk_outputs);
+    const int64_t records = chunk * neighbors;
+    const int64_t max_segments = std::min(records, destinations + 1);
+    auto keys = at::empty({records}, input.options().dtype(at::kLong));
+    auto sorted_keys = at::empty_like(keys);
+    auto ids = at::empty_like(keys);
+    auto sorted_ids = at::empty_like(keys);
+    auto weights = at::empty({records, bicubic ? 2 : 1}, input.options());
+    auto sample_offsets = at::empty({chunk}, input.options().dtype(at::kLong));
+    auto num_segments = at::empty({}, input.options().dtype(at::kLong));
+    const int blocks = (chunk + THREADS - 1) / THREADS;
+    make_records<scalar_t, D><<<blocks, THREADS, 0, stream>>>(
+        getTensorInfo<const scalar_t, int64_t>(input), getTensorInfo<const scalar_t, int64_t>(grid),
+        getTensorInfo<const scalar_t, int64_t>(grad), keys.mutable_data_ptr<int64_t>(), ids.mutable_data_ptr<int64_t>(),
+        weights.mutable_data_ptr<scalar_t>(), sample_offsets.mutable_data_ptr<int64_t>(),
+        chunk, first, output_spatial, input_spatial,
+        neighbors, mode, padding, align);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    at::cuda::cub::radix_sort_pairs(
+        keys.const_data_ptr<int64_t>(), sorted_keys.mutable_data_ptr<int64_t>(),
+        ids.const_data_ptr<int64_t>(), sorted_ids.mutable_data_ptr<int64_t>(),
+        records, false, 0, at::cuda::cub::get_num_bits(destinations));
+    // Release consumed keys before unique_by_key allocates its temporary key output.
+    keys = Tensor();
+    at::cuda::cub::unique_by_key(
+        sorted_keys.const_data_ptr<int64_t>(), cccl_counting_iterator<int64_t>{0},
+        ids.mutable_data_ptr<int64_t>(), num_segments.mutable_data_ptr<int64_t>(), records);
+    using acc_t = at::opmath_type<scalar_t>;
+    Tensor partial_counts, partial_prefix;
+    c10::DataPtr partial_storage;
+    const int64_t max_partials = 2 * ((records + PARTIAL_ROWS - 1) / PARTIAL_ROWS);
+    // Bound payload workspace independently of channel count. Short workloads
+    // avoid the extra launches; the direct path remains deterministic.
+    constexpr int64_t MAX_PARTIAL_BYTES = 64 * 1024 * 1024;
+    if (records >= 1024 &&
+        max_partials <= MAX_PARTIAL_BYTES / static_cast<int64_t>(sizeof(acc_t)) / input.size(1)) {
+      partial_counts = at::empty({max_segments}, input.options().dtype(at::kLong));
+      partial_prefix = at::empty_like(partial_counts);
+      count_long_segments<<<(max_segments + THREADS - 1) / THREADS, THREADS, 0, stream>>>(
+          sorted_keys.const_data_ptr<int64_t>(), ids.const_data_ptr<int64_t>(),
+          num_segments.const_data_ptr<int64_t>(), partial_counts.mutable_data_ptr<int64_t>(),
+          max_segments, records, destinations);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      at::cuda::cub::exclusive_sum(partial_counts.const_data_ptr<int64_t>(),
+                                  partial_prefix.mutable_data_ptr<int64_t>(), max_segments);
+      partial_storage = c10::cuda::CUDACachingAllocator::get()->allocate(max_partials * input.size(1) * sizeof(acc_t));
+      const int64_t partial_warps = max_partials * ((input.size(1) + channel_tile - 1) >> channel_bits);
+      const int partial_blocks = std::min<int64_t>((partial_warps + THREADS / 32 - 1) / (THREADS / 32), 65535);
+      partial_gradients<scalar_t><<<partial_blocks, THREADS, 0, stream>>>(
+          getTensorInfo<const scalar_t, int64_t>(grad), ids.const_data_ptr<int64_t>(),
+          sorted_ids.const_data_ptr<int64_t>(), weights.const_data_ptr<scalar_t>(),
+          sample_offsets.const_data_ptr<int64_t>(), num_segments.const_data_ptr<int64_t>(),
+          partial_counts.const_data_ptr<int64_t>(), partial_prefix.const_data_ptr<int64_t>(),
+          static_cast<acc_t*>(partial_storage.get()), max_segments, max_partials, records,
+          neighbor_bits, channel_bits, bicubic);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
+    const int64_t warps = max_segments * ((input.size(1) + channel_tile - 1) >> channel_bits);
+    const int reduce_blocks = std::min<int64_t>((warps + THREADS / 32 - 1) / (THREADS / 32), 65535);
+    reduce_segments<scalar_t><<<reduce_blocks, THREADS, 0, stream>>>(
+        getTensorInfo<const scalar_t, int64_t>(grad), output.mutable_data_ptr<scalar_t>(),
+        sorted_keys.const_data_ptr<int64_t>(), ids.const_data_ptr<int64_t>(), sorted_ids.const_data_ptr<int64_t>(),
+        weights.const_data_ptr<scalar_t>(), sample_offsets.const_data_ptr<int64_t>(),
+        num_segments.const_data_ptr<int64_t>(), max_segments, records, input_spatial,
+        neighbor_bits, channel_bits, bicubic,
+        partial_counts.defined() ? partial_counts.const_data_ptr<int64_t>() : nullptr,
+        partial_prefix.defined() ? partial_prefix.const_data_ptr<int64_t>() : nullptr,
+        static_cast<const acc_t*>(partial_storage.get()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+}
+
+} // namespace
+
+void launch_grid_sampler_input_backward_kernel(
+    const TensorBase& grad_input, const TensorBase& grad_output,
+    const TensorBase& input, const TensorBase& grid,
+    int64_t interpolation_mode, int64_t padding_mode, bool align_corners) {
+  const auto mode = static_cast<GridSamplerInterpolation>(interpolation_mode);
+  const auto padding = static_cast<GridSamplerPadding>(padding_mode);
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      ScalarType::Half, ScalarType::BFloat16, input.scalar_type(),
+      "grid_sampler_input_backward_cuda", [&] {
+        if (input.dim() == 4) {
+          launch_grouped<scalar_t, 2>(input, grid, grad_output, grad_input, mode, padding, align_corners);
+        } else {
+          launch_grouped<scalar_t, 3>(input, grid, grad_output, grad_input, mode, padding, align_corners);
+        }
+      });
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/cudnn/GridSampler.cpp
+++ b/aten/src/ATen/native/cudnn/GridSampler.cpp
@@ -1,5 +1,4 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/Context.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/cuda/CUDAConfig.h>
 #include <ATen/native/GridSamplerUtils.h>
@@ -11,6 +10,7 @@
 #include <ATen/ops/cudnn_grid_sampler_backward_native.h>
 #include <ATen/ops/cudnn_grid_sampler_native.h>
 #include <ATen/ops/empty.h>
+#include <ATen/ops/grid_sampler_2d_backward.h>
 #endif
 
 #if !AT_CUDNN_ENABLED()
@@ -126,8 +126,7 @@ Tensor cudnn_grid_sampler_forward(const Tensor& input_t, const Tensor& grid_t) {
   return output_t;
 }
 
-// NB: CuDNN does not support output mask; you always get both
-// gradients.
+// This operator has no output mask and always returns both gradients.
 std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
     const Tensor& input_t,
     const Tensor& grid_t,
@@ -138,54 +137,17 @@ std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
   TORCH_CHECK(
       cond_cudnn_grid_sampler(input_t, grid_t),
       "Invalid arguments to cudnn_grid_sampler_backward");
-  globalContext().alertNotDeterministic("cudnn_grid_sampler_backward");
-
-  auto input_contig = contiguousIfZeroInStrides(input_t);
-  auto grid_contig = grid_t.contiguous();
-  auto grad_output_contig = contiguousIfZeroInStrides(grad_output_t);
-  TensorArg input{input_contig, "input", 1}, grid{grid_contig, "grid", 2},
-      grad_output{grad_output_contig, "grad_output", 3};
+  TensorArg input{input_t, "input", 1}, grid{grid_t, "grid", 2},
+      grad_output{grad_output_t, "grad_output", 3};
   CheckedFrom c = "cudnn_grid_sampler_backward";
   checkAllSameGPU(c, {input, grad_output, grid});
-  checkGridSize(c, grid, input);
   checkDim(c, input, 4);
   checkDim(c, grad_output, 4);
 
-  auto grad_input_t = at::empty({0}, input->options());
-  grad_input_t.resize_(input->sizes());
-  auto grad_grid_t = at::empty({0}, grid->options());
-  grad_grid_t.resize_(grid->sizes());
-
-  TensorDescriptor idesc{*input}; // input descriptor
-  TensorDescriptor odesc{*grad_output}; // grad_output descriptor
-  TensorDescriptor gdesc{grad_input_t}; // grad_input descriptor
-  SpatialTransformerDescriptor desc; // sampler descriptor
-
-  auto handle = getCudnnHandle();
-  auto dataType = getCudnnDataType(*input);
-  setSamplerDescriptor(desc, dataType, *grad_output);
-
-  Constant one(dataType, 1);
-  Constant zero(dataType, 0);
-  AT_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
-      handle,
-      desc.desc(),
-      &one,
-      idesc.desc(),
-      input->const_data_ptr(),
-      &zero,
-      gdesc.desc(),
-      grad_input_t.data_ptr(),
-      &one,
-      odesc.desc(),
-      grad_output->const_data_ptr(),
-      // intriguingly, the outputs don't need descriptors
-      grid->const_data_ptr(),
-      &zero,
-      grad_grid_t.data_ptr()));
-
-  return std::tuple<Tensor, Tensor>{
-      std::move(grad_input_t), std::move(grad_grid_t)};
+  // Keep cuDNN forward semantics, but use native deterministic accumulation in
+  // backward. The native implementation accepts the original tensor strides.
+  return at::grid_sampler_2d_backward(
+      grad_output_t, input_t, grid_t, 0, 0, true, {true, true});
 }
 
 } // namespace at::native

--- a/test/inductor/test_grid_sampler_codegen.py
+++ b/test/inductor/test_grid_sampler_codegen.py
@@ -4,6 +4,11 @@ import unittest
 import torch
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_utils import (
+    DeterministicGuard,
+    instantiate_parametrized_tests,
+    parametrize,
+)
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 
 
@@ -23,6 +28,36 @@ class GridSamplerCodegenTests(InductorTestCase):
         source_code = "\n".join(codes)
         self.assertIn(".to(tl.int32)", source_code)
         self.assertNotIn("tl.int64", source_code)
+
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @parametrize("dims_align", [(2, False), (2, True), (3, False)])
+    def test_grid_sampler_backward_deterministic(self, dims_align):
+        """Compiled autograd must preserve strict determinism for native and cuDNN routes."""
+        dims, align = dims_align
+
+        def fn(a, b):
+            return torch.nn.functional.grid_sample(a, b, align_corners=align)
+
+        a = torch.randn((1, 3) + (5,) * dims, device="cuda", requires_grad=True)
+        b = (
+            torch.rand((1,) + (3,) * dims + (dims,), device="cuda") * 1.5 - 0.75
+        ).requires_grad_()
+        grad = torch.randn((1, 3) + (3,) * dims, device="cuda")
+        with DeterministicGuard(True), torch.backends.cudnn.flags(enabled=align):
+            expected = torch.autograd.grad(fn(a, b), (a, b), grad)
+            compiled = torch.compile(fn, fullgraph=True)
+            first = torch.autograd.grad(compiled(a, b), (a, b), grad)
+            for actual, ref in zip(first, expected):
+                self.assertEqual(actual, ref, atol=2e-5, rtol=2e-5)
+            for _ in range(3):
+                actual = torch.autograd.grad(compiled(a, b), (a, b), grad)
+                for value, prior in zip(actual, first):
+                    self.assertTrue(
+                        torch.equal(value.view(torch.int32), prior.view(torch.int32))
+                    )
+
+
+instantiate_parametrized_tests(GridSamplerCodegenTests)
 
 
 if __name__ == "__main__":

--- a/test/test_grid_sampler.py
+++ b/test/test_grid_sampler.py
@@ -1,0 +1,280 @@
+# Owner(s): ["module: nn"]
+
+"""Public CUDA grid-sampler backward correctness and determinism coverage."""
+
+import unittest
+from functools import partial
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_cuda import TEST_CUDNN
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    instantiate_device_type_tests,
+    skipCUDAIfRocm,
+)
+from torch.testing._internal.common_utils import (
+    DeterministicGuard,
+    parametrize,
+    run_tests,
+    TestCase,
+)
+
+
+DIMENSION_MODES = [
+    (2, "bilinear"),
+    (2, "nearest"),
+    (2, "bicubic"),
+    (3, "bilinear"),
+    (3, "nearest"),
+]
+
+
+def gradients(input, grid, grad_output, options, required=(True, True)):
+    """Return fresh requested gradients through the public functional operator."""
+    input = input.detach().requires_grad_(required[0])
+    grid = grid.detach().requires_grad_(required[1])
+    output = F.grid_sample(input, grid, **options)
+    targets = tuple(t for t in (input, grid) if t.requires_grad)
+    return torch.autograd.grad(output, targets, grad_output)
+
+
+class TestGridSampler(TestCase):
+    """Exercise both public autograd and direct backward output-mask contracts."""
+
+    def assert_gradient_accuracy(
+        self, value: torch.Tensor, expected: torch.Tensor, baseline: torch.Tensor
+    ) -> None:
+        """Use CPU FP64 as the oracle, with CPU eager's low-precision rounding baseline."""
+        value = value.cpu()
+        if value.dtype in (torch.float16, torch.bfloat16):
+            error = (value.double() - expected).abs()
+            baseline_error = (baseline.double() - expected).abs()
+            eps = torch.finfo(value.dtype).eps
+            self.assertTrue(torch.isfinite(value).all())
+            self.assertLessEqual(
+                error.max().item(),
+                baseline_error.max().item() + 2 * eps * expected.abs().max().item(),
+            )
+            self.assertLessEqual(
+                error.mean().item(),
+                baseline_error.mean().item() + eps * expected.abs().mean().item(),
+            )
+        else:
+            tolerance = 1e-10 if value.dtype == torch.float64 else 2e-5
+            self.assertEqual(value.double(), expected, atol=tolerance, rtol=tolerance)
+
+    @dtypes(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    @parametrize("dimension_mode", DIMENSION_MODES)
+    @parametrize("padding", ["zeros", "border", "reflection"])
+    @parametrize("align", [False, True])
+    def test_backward(self, device, dtype, dimension_mode, padding, align):
+        """Check numerics, gradient masks, and identical bits with determinism on/off."""
+        dims, mode = dimension_mode
+        rng = torch.Generator().manual_seed(20260911)
+        spatial = (4, 8) if dims == 2 else (2, 4, 8)
+        output_shape = (3, 7) if dims == 2 else (2, 3, 5)
+        input = (
+            (torch.rand((2, 3) + spatial, generator=rng) * 2 - 1)
+            .to(dtype)
+            .transpose(-1, -2)
+        )
+        # Dyadic coordinates isolate accumulation error from low-precision
+        # coordinate rounding; arbitrary-coordinate coverage remains in test_nn.
+        grid = (
+            torch.randint(-6, 7, (2,) + output_shape + (dims,), generator=rng) / 4
+        ).to(dtype)
+        grid = grid.transpose(1, dims)
+        grad = (
+            (torch.rand((2,) + tuple(grid.shape[1:-1]) + (3,), generator=rng) * 2 - 1)
+            .to(dtype)
+            .movedim(-1, 1)
+        )
+        options = dict(mode=mode, padding_mode=padding, align_corners=align)
+        data = tuple(t.to(device) for t in (input, grid, grad))
+        with torch.backends.cudnn.flags(enabled=False):
+            for required in ((True, True), (True, False), (False, True)):
+                expected = gradients(
+                    input.double(), grid.double(), grad.double(), options, required
+                )
+                cpu = gradients(input, grid, grad, options, required)
+                with DeterministicGuard(False):
+                    first = gradients(*data, options, required)
+                with DeterministicGuard(True):
+                    actual = gradients(*data, options, required)
+                for value, prior, ref, baseline in zip(actual, first, expected, cpu):
+                    self.assertEqual(value.view(torch.uint8), prior.view(torch.uint8))
+                    self.assert_gradient_accuracy(value, ref, baseline)
+            backward = (
+                torch.ops.aten.grid_sampler_2d_backward
+                if dims == 2
+                else torch.ops.aten.grid_sampler_3d_backward
+            )
+            with DeterministicGuard(True):
+                no_input, grid_grad = backward(
+                    data[2],
+                    data[0],
+                    data[1],
+                    F.GRID_SAMPLE_INTERPOLATION_MODES[mode],
+                    F.GRID_SAMPLE_PADDING_MODES[padding],
+                    align,
+                    (False, False),
+                )
+            self.assertIsNone(no_input)
+            # Native backward historically returns a computed grid gradient even
+            # when the second output-mask entry is false.
+            self.assertEqual(grid_grad, first[0], atol=0, rtol=0)
+
+    @unittest.skipIf(not TEST_CUDNN, "cuDNN not available")
+    @skipCUDAIfRocm
+    def test_cudnn_backward(self, device):
+        """A cuDNN-selected forward must use deterministic backward as well."""
+        input = torch.randn(2, 3, 5, 7, device=device, requires_grad=True)
+        grid = torch.rand(2, 3, 4, 2, device=device, requires_grad=True)
+        grad = torch.randn(2, 3, 3, 4, device=device)
+        with torch.backends.cudnn.flags(enabled=True), DeterministicGuard(True):
+            output = F.grid_sample(input, grid, align_corners=True)
+            self.assertEqual(type(output.grad_fn).__name__, "CudnnGridSamplerBackward0")
+            first = torch.autograd.grad(output, (input, grid), grad)
+            second = gradients(input, grid, grad, dict(align_corners=True))
+        expected = gradients(
+            input.cpu().double(),
+            grid.cpu().double(),
+            grad.cpu().double(),
+            dict(align_corners=True),
+        )
+        for a, b, ref in zip(first, second, expected):
+            self.assertEqual(a.view(torch.int32), b.view(torch.int32))
+            self.assertEqual(a.cpu().double(), ref, atol=2e-5, rtol=2e-5)
+
+    @parametrize("dimension_mode", [(2, "bilinear"), (2, "bicubic"), (3, "bilinear")])
+    def test_gradcheck(self, device, dimension_mode):
+        """Preserve first- and second-order autograd formulas through the new kernel."""
+        dims, mode = dimension_mode
+        input = torch.randn(
+            (1, 2) + (3,) * dims, device=device, dtype=torch.double, requires_grad=True
+        )
+        grid = (
+            torch.rand((1,) + (2,) * dims + (dims,), device=device, dtype=torch.double)
+            * 0.6
+            - 0.3
+        ).requires_grad_()
+        with torch.backends.cudnn.flags(enabled=False), DeterministicGuard(True):
+            fn = partial(F.grid_sample, mode=mode, align_corners=False)
+            self.assertTrue(torch.autograd.gradcheck(fn, (input, grid)))
+            self.assertTrue(torch.autograd.gradgradcheck(fn, (input, grid)))
+
+    def test_expanded_streams_and_graph(self, device):
+        """Cover offsets/zero strides, singleton dimensions, channel tails, and stream isolation."""
+        rng = torch.Generator().manual_seed(91)
+        t = 513
+        bases = [
+            torch.rand(1, 1, 1, 18, generator=rng),
+            torch.rand(1, 1, 2 * t, 4, generator=rng) * 0.02 - 0.01,
+            torch.rand(2, 1, 1, 2 * t, generator=rng),
+        ]
+        bases = [t.to(device) for t in bases]
+        data = (
+            bases[0][..., 1::2].expand(2, 65, 1, 9),
+            bases[1][:, :, 1::2, ::2].expand(2, 1, t, 2),
+            bases[2][..., 1::2].expand(2, 65, 1, t),
+        )
+        options = dict(padding_mode="reflection", align_corners=False)
+        expected = gradients(*(t.cpu().double() for t in data), options)
+        current = torch.cuda.current_stream()
+        streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+        results = []
+        with DeterministicGuard(True), torch.backends.cudnn.flags(enabled=False):
+            for stream in streams:
+                stream.wait_stream(current)
+                with torch.cuda.stream(stream):
+                    results.append(gradients(*data, options))
+            for stream in streams:
+                current.wait_stream(stream)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured = torch.ops.aten.grid_sampler_2d_backward(
+                    data[2], data[0], data[1], 0, 2, False, (True, True)
+                )
+            for _ in range(3):
+                graph.replay()
+                for value, other, graph_value, ref in zip(*results, captured, expected):
+                    self.assertEqual(value.view(torch.int32), other.view(torch.int32))
+                    self.assertEqual(
+                        value.view(torch.int32), graph_value.view(torch.int32)
+                    )
+                    self.assertEqual(value.cpu().double(), ref, atol=2e-4, rtol=2e-5)
+            # Replaying fixed pointers must rebuild geometry from current values.
+            bases[1].add_(0.25)
+            graph.replay()
+            eager = gradients(*data, options)
+            expected = gradients(*(t.cpu().double() for t in data), options)
+            for value, other, ref in zip(captured, eager, expected):
+                self.assertEqual(value.view(torch.int32), other.view(torch.int32))
+                self.assertEqual(value.cpu().double(), ref, atol=2e-4, rtol=2e-5)
+
+    @dtypes(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    @parametrize("dimension_mode", DIMENSION_MODES)
+    def test_long_segments(self, device, dtype, dimension_mode):
+        """Exercise fixed partial reductions, including low-precision product rounding."""
+        dims, mode = dimension_mode
+        rng = torch.Generator().manual_seed(62)
+        output_shape = (1,) * (dims - 1) + (513,)
+        cpu = (
+            (torch.rand((2, 3) + (4,) * dims, generator=rng) * 2 - 1).to(dtype),
+            torch.zeros((2,) + output_shape + (dims,), dtype=dtype),
+            (torch.rand((2, 3) + output_shape, generator=rng) * 2 - 1).to(dtype),
+        )
+        options = dict(mode=mode, align_corners=False)
+        expected = gradients(*(t.double() for t in cpu), options)
+        baseline = gradients(*cpu, options)
+        data = tuple(t.to(device) for t in cpu)
+        with DeterministicGuard(True), torch.backends.cudnn.flags(enabled=False):
+            first = gradients(*data, options)
+            second = gradients(*data, options)
+        for value, other, ref, low in zip(first, second, expected, baseline):
+            value, other = value.cpu(), other.cpu()
+            self.assertEqual(value.view(torch.uint8), other.view(torch.uint8))
+            self.assert_gradient_accuracy(value, ref, low)
+
+    def test_chunk_boundary(self, device):
+        """Fixed workspace chunks must accumulate across a batch boundary without overwrite."""
+        rng = torch.Generator().manual_seed(18)
+        cpu = (
+            torch.rand(2, 1, 2, 2, generator=rng, dtype=torch.double),
+            torch.rand(2, 1, 131075, 2, generator=rng, dtype=torch.double) * 0.5 - 0.25,
+            torch.rand(2, 1, 1, 131075, generator=rng, dtype=torch.double) * 2 - 1,
+        )
+        expected = gradients(*cpu, dict(align_corners=False))
+        data = tuple(t.to(device) for t in cpu)
+        with DeterministicGuard(True), torch.backends.cudnn.flags(enabled=False):
+            first = gradients(*data, dict(align_corners=False))
+            second = gradients(*data, dict(align_corners=False))
+        for value, other, ref in zip(first, second, expected):
+            self.assertEqual(value.view(torch.int64), other.view(torch.int64))
+            self.assertEqual(value.cpu(), ref, atol=1e-9, rtol=1e-10)
+
+    @parametrize("dims", [2, 3])
+    @parametrize("empty", ["batch", "channel", "output"])
+    def test_empty(self, device, dims, empty):
+        """Empty cases retain defined zero gradients without launching invalid grids."""
+        n = 0 if empty == "batch" else 2
+        c = 0 if empty == "channel" else 3
+        output_shape = (0 if empty == "output" else 2,) + (2,) * (dims - 1)
+        input = torch.empty((n, c) + (3,) * dims, device=device, requires_grad=True)
+        grid = torch.zeros(
+            (n,) + output_shape + (dims,), device=device, requires_grad=True
+        )
+        with DeterministicGuard(True), torch.backends.cudnn.flags(enabled=False):
+            output = F.grid_sample(input, grid, align_corners=False)
+            gi, gg = torch.autograd.grad(
+                output, (input, grid), torch.empty_like(output)
+            )
+        self.assertEqual(gi, torch.zeros_like(input))
+        self.assertEqual(gg, torch.zeros_like(grid))
+
+
+instantiate_device_type_tests(TestGridSampler, globals(), only_for="cuda")
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1942,7 +1942,7 @@ class TestTorchDeviceType(TestCase):
         self.check_nondeterministic_alert(
             lambda: res.backward(grad, retain_graph=True),
             'grid_sampler_2d_backward_cuda',
-            torch.device(device).type == 'cuda')
+            False)
 
     @unittest.skipIf(not TEST_CUDNN, "CUDNN not available")
     @skipIfRocm
@@ -1958,7 +1958,8 @@ class TestTorchDeviceType(TestCase):
 
         self.check_nondeterministic_alert(
             fn,
-            'cudnn_grid_sampler_backward')
+            'cudnn_grid_sampler_backward',
+            False)
 
     @skipIfTorchInductor("https://github.com/pytorch/pytorch/issues/113707")
     def test_nondeterministic_alert_grid_sample_3d(self, device):
@@ -1970,7 +1971,7 @@ class TestTorchDeviceType(TestCase):
         self.check_nondeterministic_alert(
             lambda: res.backward(grad, retain_graph=True),
             'grid_sampler_3d_backward_cuda',
-            torch.device(device).type == 'cuda')
+            False)
 
     def test_invalid_shapes_grid_sampler(self, device):
         make_arg = partial(

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1845,7 +1845,6 @@ def use_deterministic_algorithms(
         * :func:`torch.bincount` when called on a CUDA tensor and ``weights``
           tensor is given
         * :func:`torch.median` with indices output when called on a CUDA tensor
-        * :func:`torch.nn.functional.grid_sample` when attempting to differentiate a CUDA tensor
         * :func:`torch.Tensor.scatter_reduce` when called on CUDA or MPS tensor
         * :func:`torch.Tensor.index_put` with ``accumulate=True`` when called on
           an MPS tensor with floating or complex dtype

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5557,11 +5557,6 @@ def grid_sample(
         to build `Spatial Transformer Networks`_ .
 
     Note:
-        When using the CUDA backend, this operation may induce nondeterministic
-        behaviour in its backward pass that is not easily switched off.
-        Please see the notes on :doc:`/notes/randomness` for background.
-
-    Note:
         NaN values in :attr:`grid` would be interpreted as ``-1``.
 
     Args:


### PR DESCRIPTION
## Human Note
Replaces the backwards witha determnisitic variant. It be much faster insome cases at the cost of extra memory; farming opinions but also I fully replaced we may just want this for determ option I was trying to keep tight so I can add back

## Agent Report
> ## Deterministic CUDA grid_sample backward
>
> Use stable destination grouping and fixed reductions for CUDA input gradients when deterministic algorithms are enabled. The original native atomic and cuDNN library backward paths remain the defaults. Under deterministic mode, cuDNN backward delegates to the native deterministic implementation; cuDNN forward is unchanged.
>
> ### Implementation
>
> - Support existing 2D nearest/bilinear/bicubic and 3D nearest/trilinear modes, padding/alignment settings, and FP16/BF16/FP32/FP64.
> - Reuse native coordinate helpers and preserve the existing single-writer grid-gradient math. Direct native backward still computes the grid gradient even when the second output-mask entry is false.
> - Stable-sort contribution IDs by destination, then reduce in a fixed order. Long segments use fixed 256-record partials; one writer owns each final destination/channel result.
> - Process at most 2**20 mapping records per chunk, committed in stream order. Partial payload has a separate 64 MiB cap; larger payload configurations use the direct deterministic reduction. Allocation sizes depend on shapes/dtype/mode, **not grid values or collision counts**.
> - All four new kernels have launch bounds matching their 256-thread blocks. Current-stream launches, caching-allocator workspace, CUB wrappers, and launch-error checks follow ATen conventions.
> - Preserve schemas and autocast registration; update obsolete determinism alerts/docs. Different floating-point summation order intentionally changes bits relative to old atomic results.
>
> ### Validation
>
> Latest launch-bound build: successful on GB300, CUDA 13.1, cuDNN 9.19.1, sm_103a. **152 public tests and four Inductor tests passed**, including CPU FP64/low-precision comparisons, strict/off bytewise replay, gradient masks, gradcheck/gradgradcheck, long segments, chunk crossings, streams, and graph replay with changed grid values. Scoped lint passed.
>
> Additional full-forward/autograd graph checks passed for native 2D, cuDNN-selected 2D, and native 3D with both native and cudaMallocAsync allocators: six cases. Earlier validation before the launch-bound annotations included 158 legacy-reference cases, five existing NN tests, three alert tests, one existing autocast test, and clean targeted memcheck/racecheck/synccheck runs. Those earlier suites were not all rerun after the annotation-only change. Large-address tests passed during development but were intentionally removed from the retained suite.
>
> ```sh
> python test/test_grid_sampler.py -v
> python test/inductor/test_grid_sampler_codegen.py -v
> ```
>
> ### Performance: dense shape heatmaps
>
> **The deterministic implementation is opt-in.** The original native atomic and cuDNN library backward paths remain the defaults; enabling deterministic algorithms selects the new native accumulation algorithm. The following figures measure native CUDA backward, not the cuDNN library backward or whole-model training.
>
> **All 440 paired comparisons completed and passed their numerical/replay gates:** 11 channel counts × 10 output sampling counts × 2 layouts × 2 candidate policies. Every heatmap cell is measured, with no interpolation or omitted failures. Each figure contains 220 cells: the CF and CL panels for one policy.
>
> The fixed workload is **N=1, input spatial shape 24×24, output spatial shape 1×T, FP32 bilinear sampling, zeros padding, `align_corners=False`, and both gradients**. C spans 1, 3, 4, 8, 16, 32, 64, 128, 256, 512, 1024; T spans powers of two from 64 through 32,768. Input/upstream values are random in [-1,1], and contiguous grid coordinates are random in [-1.2,1.2], using seed 20260911. CF and CL use identical logical values. This is a dense grid over C and T within one fixed operator family—not a sweep over all spatial geometries, dtypes or encoder workloads.
>
> #### Deterministic-mode latency
>
> **Ratio = original nondeterministic native latency / current deterministic latency; above 1 means faster.** Colors are logarithmic and centered at 1. Large-channel cases show the clearest gains, while small-channel cases are broadly slower. Across the measured grid, ratios range from **0.168× to 5.624× in CF** and **0.169× to 2.109× in CL**. Near-1 cells should not be read as statistically established wins or selector boundaries.
>
> The largest CF ratio is at C=1024, T=64: **629.02 → 111.84 us**. The same shape in CL is **455.39 → 215.90 us**. The worst CF cell is C=3, T=2048: **12.19 → 72.62 us**. These are specific synthetic operator results, not a universal or workload-weighted speedup.
>
> ![Dense deterministic backward speedup heatmaps across 11 channel counts and 10 sampling counts in CF and CL layouts](https://github.com/user-attachments/assets/c9137ee7-3058-4018-ba4f-732f725e147b)
>
> #### Default-mode latency
>
> **Change = 100 × (current / original − 1), percent; lower is better.** Across all 220 default-mode cells, the median latency change ranges from **−4.48% to +3.95%**. The reference and candidate are interleaved within each cell. Small differences in these microsecond-scale measurements do not establish statistical equivalence or a systematic speedup.
>
> ![Dense default-mode backward latency-change heatmaps; percent change with lower values better](https://github.com/user-attachments/assets/9f526f29-bbcb-40ff-8926-3f32b0d6a52e)
>
> #### Added eager peak allocation
>
> **Added peak = current peak − matched original-native peak, MiB; lower is better.** Default mode adds **zero bytes in every one of its 220 cells**. Deterministic-mode added peak ranges from **0.011 to 7.760 MiB** in this fixed input geometry. Memory includes returned gradients and temporary workspace but excludes resident input/grid/upstream tensors; output sizes match. It is not reserved VRAM, CUDA graph pool size, or whole-model memory. The 64 MiB partial-payload cap is not a total-workspace cap.
>
> ![Dense deterministic backward added-memory heatmaps in MiB across CF and CL layouts](https://github.com/user-attachments/assets/ae775bdd-4844-4e83-885b-ce34d5df8517)
>
> #### Measurement contract
>
> Measurements used **GB300, CUDA 13.1, sm_103a**, normal DVFS, and one exclusive GPU reservation. Each cell ran five alternating original/current rounds of 50 warm fixed-pointer CUDA graph samples per variant, with ten uncaptured/ten captured warmups; reported values are medians of the five round medians. `fill_uninitialized_memory=True` was retained for deterministic mode. Device zeroing, grouping, reduction, grid-gradient work and deterministic initialization fills are included; host allocation, transfers, compilation and graph capture are excluded. Eager peak allocation was measured separately.
>
> Before timing, both returned gradients were checked against an independent CPU FP64 reference with the existing dtype/shape-aware tolerances; input-gradient replay was checked bitwise when deterministic mode was enabled, and grid-gradient replay in both modes. All 44 shards have consistent source/device metadata, all 440 cells retain five rounds of 50 raw samples per variant, and all seven recorded source hashes match the current files. Code revision: `c723923d327`; the original native reference is frozen from seed `ad9365af5a15`. No kernels or selector rules were changed during this sweep.
>
> Raw records, numerical errors, kernel names and telemetry are preserved under job-local `general/dense-shapes-v1/`, including `heatmap-values.csv` with absolute latencies and `summary.json`. The frozen contract is `general/dense-shapes-contract.md`, the driver is `general/run_dense_shape_sweep.py`, and the renderer is `visuals/render_dense_heatmaps.py`; these investigation artifacts are not source files included in the PR. The separately measured 16-workload matrix below covers additional dtypes/modes and structured/collision grids; do not combine its ratios with this fixed random-grid sweep as an aggregate training speedup.

> <details>
> <summary>Earlier 16-workload matrix: other dtypes, modes, structured grids and collision stress</summary>
>
> #### Earlier 16-workload matrix: default versus deterministic mode
>
> **The current implementation is opt-in, not unconditional.** With deterministic algorithms disabled, the 16 measured configurations retain the original native backward's allocation footprint and have closely matching latency. With `torch.use_deterministic_algorithms(True)`, performance is shape/layout-dependent: some large-channel or high-contention cases improve, while ordinary small-channel images become slower. These are synthetic native-CUDA backward microbenchmarks, not encoder-training results.
>
> - **Default mode:** current/reference median latency changes range from -1.3% to +1.0% across all 16 cases; extra eager peak allocation is **zero bytes in every case**. Small timing differences are not evidence of a systematic speedup or a statistical equivalence guarantee.
> - **Deterministic mode:** the C1024 positional-table case is **2.00x faster in CF layout**, but only **1.07x in CL layout**; the variable-grid holdout is **1.09x**. The sampled FP16 bicubic case is **2.10x faster**. These ratios compare the old nondeterministic native implementation with the new deterministic implementation.
> - **Costs are retained in the table:** RGB backward is about **5.9x slower**, C32 images **2.2–2.6x slower**, and the sampled 3D trilinear case **4.7x slower** in deterministic mode. A small hot-grid case is **3.6x slower**, whereas the large collision/chunk stress case is **31.30x faster**. The latter is a stress result, not a general speedup claim or a measured crossover boundary.
> - **Workspace:** deterministic-mode added eager peak allocation ranges from **0 MiB** for grid-gradient-only work to **38.226 MiB** for the large-output stress case; positional-table cases add **0.949–1.948 MiB**. This is peak allocated memory above the matched reference, not reserved VRAM or CUDA graph pool size. The 64 MiB partial-payload cap is not a cap on total workspace.
>
> #### Coverage and how to read the table
>
> All **15 frozen configurations plus one variable-grid holdout** are shown, each measured in both candidate modes. The set covers N=1/2, C=1/3/4/8/16/32/1024, 2D/3D sampling, CF/CL layouts, FP16/BF16/FP32/FP64, bilinear/trilinear/bicubic/nearest, all three padding modes, both align settings, and gradient-mask variants. This is a representative matrix, **not a dense Cartesian sweep** of every combination.
>
> Shapes below are spatial input → spatial output; N and C are separate. CF means ordinary NCHW/NCDHW contiguous; CL means channel stride one for input/upstream. Unless noted, rows use FP32 bilinear, zeros padding, `align_corners=False`, and both gradients. The trilinear row uses reflection/False; the FP16 and BF16 rows state their exceptions explicitly. Grids are contiguous. `mask=(T,F)` still includes the native operator's always-computed grid gradient; it is not a grid-gradient-elision optimization.
>
> **Backward latency is in microseconds, lower is better. Each timing cell is its own paired old-native → current measurement. Old/deterministic is a speedup ratio; above 1 means the deterministic implementation is faster. Added peak memory is in MiB, lower is better, and applies only to deterministic mode; default added peak is zero for every row. Do not divide across the two independently paired timing columns.**
>
> | Workload | N, C | Input → output spatial shape | Layout | Default: old → current (us) | Deterministic: old → current (us) | Old/deterministic | Added peak (MiB) |
> | --- | ---: | --- | --- | ---: | ---: | ---: | ---: |
> | Tiny | 1, 1 | 8x8 → 8x8 | CF | 12.91 → 13.04 | 13.47 → 35.01 | 0.38x | 0.011 |
> | RGB | 2, 3 | 64x64 → 64x64 | CF | 12.16 → 12.21 | 12.24 → 72.22 | 0.17x | 1.700 |
> | RGB | 2, 3 | 64x64 → 64x64 | CL | 12.10 → 12.00 | 12.11 → 71.86 | 0.17x | 1.700 |
> | 32-channel image | 2, 32 | 64x64 → 64x64 | CF | 34.37 → 34.27 | 34.37 → 88.74 | 0.39x | 1.700 |
> | 32-channel image | 2, 32 | 64x64 → 64x64 | CL | 44.54 → 44.64 | 44.54 → 98.42 | 0.45x | 1.700 |
> | Positional table | 1, 1024 | 24x24 → 1x8192 | CF | 581.78 → 583.65 | 585.97 → 293.25 | 2.00x | 1.948 |
> | Positional table | 1, 1024 | 24x24 → 1x8192 | CL | 696.67 → 696.72 | 701.14 → 657.22 | 1.07x | 1.948 |
> | Positional table, mask=(T,F) | 1, 1024 | 24x24 → 1x8192 | CL | 697.10 → 696.93 | 697.78 → 652.48 | 1.07x | 1.948 |
> | Small hot grid | 1, 4 | 8x8 → 1x1024 | CL | 23.30 → 22.99 | 23.04 → 82.67 | 0.28x | 0.152 |
> | Large hot grid / chunk stress | 2, 4 | 2x2 → 1x131075 | CF | 5158.22 → 5163.10 | 5179.57 → 165.47 | 31.30x | 38.226 |
> | 3D trilinear, reflection | 2, 4 | 8x16x16 → 8x12x12 | CF | 17.74 → 17.71 | 17.62 → 83.38 | 0.21x | 0.940 |
> | FP16 bicubic, reflection, align=True | 1, 16 | 32x32 → 31x29 | CL | 792.77 → 796.38 | 791.36 → 376.85 | 2.10x | 0.730 |
> | BF16 3D nearest, border, align=True | 2, 1 | 8x16x16 → 8x12x12 | CF | 12.10 → 12.03 | 12.03 → 45.66 | 0.26x | 0.112 |
> | FP64 bilinear | 1, 8 | 8x8 → 9x11 | CF | 21.02 → 21.18 | 20.83 → 43.36 | 0.48x | 0.020 |
> | Grid gradient only, mask=(F,T) | 2, 32 | 16x16 → 16x16 | CL | 24.34 → 24.26 | 24.14 → 24.35 | 0.99x | 0.000 |
> | Variable-grid table holdout | 1, 1024 | 24x24 → 1x3963 | CL | 695.60 → 695.38 | 696.27 → 641.09 | 1.09x | 0.949 |
>
> The positional-table grids repeat eight 32x32 pixel-center grids. The holdout concatenates 24x32, 32x40, 16x48 and 31x37 grids (3963 sites), with a fixed 2**-13 normalized-coordinate offset to avoid one-sided derivatives at integer-pixel knots. It was added after the frozen 15-case matrix as confirmation, without dropping/reweighting cases or using it for tuning. These are synthetic table workloads, not an identified production NaViT callsite.
>
> #### Measurement contract and provenance
>
> NVIDIA **GB300**, CUDA **13.1**, target **sm_103a**; normal DVFS, no clock/power changes. CPU fixture seed 20260911, nontrivial random input/upstream values, random/central-hot/structured grids as labeled. Each policy used five alternating old/current rounds with 50 warm fixed-pointer CUDA graph samples per variant per round and ten uncaptured/ten captured warmups. Numbers are medians of the five round medians, not a single best run. The two policy matrices ran in one GPU reservation. Observed before/after telemetry ranges: SM clock 2070–2070 MHz, power 191.3–276.5 W, temperature 44–46 C; these sparse snapshots are not continuous clock-stability measurements.
>
> Device zeroing, grouping, reduction, grid-gradient work, and deterministic-mode initialization fills are included. `fill_uninitialized_memory=True` was retained for deterministic runs. Host allocation, transfers, compilation and graph capture are excluded from replay latency. Eager peak memory was measured separately, including returned gradients and workspace but excluding resident input/grid/upstream tensors. Forward code is unchanged; no forward speedup is claimed. These timings exercise native CUDA backward, not the cuDNN library backward or end-to-end autograd/training overhead.
>
> The old-native reference is from seed `ad9365af5a15`, rebuilt for the same sm_103a target. Raw result metadata records `36b911315de` plus the then-uncommitted mode-gating changes; SHA256 checks of the input-gradient kernel and native/cuDNN dispatch sources match the current `c723923d327` checkout. These 16-case measurements predate the separate dense shape sweep above. Correctness was gated independently against CPU FP64 before timing, including both returned gradients and dtype-appropriate error checks; kernel names and repeated-gradient checks are retained in the raw records.
>
> <details>
> <summary>Deterministic timing dispersion: min–max of the five round medians (us; lower is better)</summary>
>
> These ranges describe round-to-round variation, not confidence intervals.
>
> | Recorded case | Current deterministic round-median range (us) |
> | --- | ---: |
> | tiny | 33.97–35.49 |
> | rgb_cf | 72.11–72.98 |
> | rgb_cl | 71.09–72.24 |
> | image32_cf | 88.58–89.06 |
> | image32_cl | 98.26–98.70 |
> | navit_cf | 291.81–294.10 |
> | navit_cl | 652.83–660.64 |
> | navit_input_only | 652.42–660.43 |
> | collision4 | 81.70–83.39 |
> | long_collision | 164.10–167.06 |
> | volume | 82.78–84.42 |
> | bicubic_half | 376.37–379.63 |
> | nearest_bf16 | 44.61–45.82 |
> | double | 43.01–43.89 |
> | grid_only | 23.84–24.59 |
> | navit_varlen_holdout | 640.56–642.21 |
>
> </details>
>
> Raw samples, matching source hashes, per-round telemetry, numerical errors and memory measurements are preserved in job-local `general/results-mode-gate-final-default.json` and `general/results-mode-gate-final-deterministic.json`, with the fixture/contract in `general/benchmark-contract.md`. They are not files included in the source PR. Hardware coverage is GB300 only; no claim is made about older GPUs/toolkits, a dense crossover sweep, or real encoder throughput. No aggregate speedup is reported because these cases do not have a production workload weighting.
>
> </details>
>
> ### Kernel flow
>
> ![Deterministic grid-sampler backward in caller-stream order](https://github.com/user-attachments/assets/2614fdd7-29a2-4744-954e-cdae203b21f0)
>
> Each chunk generates fixed record IDs, stable-groups them by input destination, optionally forms fixed-size partials for long segments, and performs a fixed reduction with one final writer per destination/channel tile. Chunks commit in stream order. The existing coordinate-gradient kernel runs afterward. The input-gradient loop is skipped when its output mask is false; the native always-computed grid-gradient contract is preserved.

> ### Review boundaries
>
> Runtime coverage is GB300 only. No new Hopper/Blackwell-specific instruction dependency was found, but other GPU generations, older toolkit variants, ROCm, CPU-only builds, and full repository CI remain unverified. No cross-architecture/version bitwise identity guarantee is claimed. Larger workspace can affect memory-constrained workloads. Removing private helpers from the installed GridSampler.cuh header may affect external extensions using those helpers; retaining them is a possible compatibility cleanup.
>
> Full measurements, the workspace equation/examples, and development history are preserved in the job workspace rather than embedded in this PR. The source patch contains 10 files, 735 additions and 266 deletions.


<details>
<summary>Agent Worklog</summary>

> ## Current state
>
> Branch `ptq/20260911-pytorch-adhoc-4d8560`, commit `36b911315de`, based on `ad9365af5a15`. The user's PTQ submission committed and pushed the code, then PR creation failed because the generated body exceeded GitHub's 65,536-character limit. This follow-up compacted local body inputs only; no code edits, additional commits/pushes, or GitHub operations were performed.
>
> ## Evidence index
>
> Paths below are job-local artifacts, not files included in the source PR:
>
> - `report-detailed.md`: full implementation, performance, memory, and compatibility report before body compaction.
> - `worklog-history.md`: complete chronological investigation/build/test history.
> - `memory-workspace.md`: allocation equation, realistic worked examples, all measured memory deltas, and configuration-versus-value distinction.
> - `general/results-public-launch-bounds.json`: all 16 final source-matched benchmark cases and raw samples; contract in `general/benchmark-contract.md`.
> - `public-tests-launch-bounds.log`, `public-inductor-launch-bounds.log`: latest 152 public and four compiled tests.
> - `public-autograd-capture-corrected.log`, `public-autograd-capture-async-allocator.log`: six full-autograd capture cases.
> - `public-legacy-release.log`, `public-release-{memcheck,racecheck,synccheck}.log`: earlier legacy/sanitizer evidence, predating launch-bound annotations.
> - `build-public.log`, `build-public.exit`, `lint-launch-bounds.log`: latest successful build and scoped lint.
> - `workspace-value-independence.log`: unchanged peak allocation across three grid-value distributions at each fixed configuration.
>
> ## Body compaction
>
> PTQ concatenates report.md, worklog.md, and repro.py without a size budget. The previous body was about 81,700 characters before the human note. Detailed documents were archived rather than discarded. The original 10 KiB repro asserted pre-fix nondeterminism guards; it was preserved as `repro-investigation.py` so it is no longer automatically embedded as a current repro. Retained tests in the patch are the current runnable correctness/determinism checks.
>
> The saved human note was empty after the failed submission, so the retry may ask for it again. It was not replaced or invented. Full notes, memory equations, and raw evidence remain available locally. No agent-notes or shared configuration changes.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo