### PR TITLE
[CUDA][cuBLAS][Inductor] Don't get `bfx9` from the legacy precision getter

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -122,6 +122,34 @@ STATIC_LAUNCHER_DEVICES = ("cuda", "xpu")
 
 @instantiate_parametrized_tests
 class TestCacheKeyStrategy(TestCase):
+    @parametrize(
+        "backend_precision,expected,legacy_calls",
+        (("bfx9", "bfx9", 0), ("tf32", "high", 1)),
+    )
+    def test_precompile_cache_key_handles_bfx9(
+        self, backend_precision, expected, legacy_calls
+    ):
+        from torch._inductor.select_algorithm import create_precompile_key
+
+        choice = types.SimpleNamespace(kernel_hash_key=lambda: "choice")
+        with (
+            mock.patch.object(
+                torch._C,
+                "_get_fp32_precision_getter",
+                return_value=backend_precision,
+            ),
+            mock.patch.object(
+                torch,
+                "get_float32_matmul_precision",
+                return_value="high",
+            ) as legacy_getter,
+        ):
+            self.assertEqual(
+                create_precompile_key("op", "inputs", [choice]),
+                f"op:inputs:{expected}:choice",
+            )
+            self.assertEqual(legacy_getter.call_count, legacy_calls)
+
     def _compact_sha256(self, data: bytes) -> str:
         return (
             base64.b32encode(hashlib.sha256(data).digest())[:51].decode("utf-8").lower()

--- a/test/inductor/test_warnings.py
+++ b/test/inductor/test_warnings.py
@@ -47,6 +47,9 @@ class InductorWarningTests(TestCase):
                 },
             )
 
+        orig_matmul_precision = torch.get_float32_matmul_precision()
+        self.addCleanup(torch.set_float32_matmul_precision, orig_matmul_precision)
+        torch.set_float32_matmul_precision("high")
         torch.backends.cuda.matmul.fp32_precision = "bfx9"
         warning_once.cache_clear()
         self.addCleanup(warning_once.cache_clear)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -466,7 +466,10 @@ class PersistentCache(CacheBase):
                     local_cache[op][inputs][choice], and return the benchmark.
                 b. `max_autotune_gemm=False`: don't benchmark the choice, return nothing.
         """
-        precision = torch.get_float32_matmul_precision()
+        precision = torch.backends.cuda.matmul.fp32_precision
+        # bfx9 has no legacy equivalent, and the legacy getter may reject it.
+        if precision != "bfx9":
+            precision = torch.get_float32_matmul_precision()
         cache_key = f"{inputs}_{hint_override}" if hint_override is not None else inputs
 
         timings = {}

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -3913,11 +3913,15 @@ def create_inputs_key(input_nodes) -> str:
 def create_precompile_key(
     name: str, inputs_key: str, choices: list[ChoiceCaller]
 ) -> str:
+    precision = torch.backends.cuda.matmul.fp32_precision
+    # bfx9 has no legacy equivalent, and the legacy getter may reject it.
+    if precision != "bfx9":
+        precision = torch.get_float32_matmul_precision()
     return ":".join(
         [
             name,
             inputs_key,
-            torch.get_float32_matmul_precision(),
+            precision,
         ]
         + [choice.kernel_hash_key() for choice in choices]
     )


### PR DESCRIPTION
If the mode is `bfx9` we should avoid try trying to get it from the legacy getter which doesn't know about it

authored with codex

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo