### PR TITLE
[dynamo] Support Class.mro() on user-defined classes

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7195,6 +7195,51 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         self.assertEqual(len(sub_of_foo_subclass_var_optim), 1)
         self.assertEqual(sub_of_foo_subclass_var_optim, sub_of_foo_subclass_var_reg)
 
+    def test_type_mro_method(self):
+        class Foo:
+            pass
+
+        class Bar(Foo):
+            pass
+
+        counter = CompileCounter()
+
+        @torch._dynamo.optimize_assert(counter)
+        def fn():
+            return Bar.mro()
+
+        self.assertEqual(fn(), Bar.mro())
+
+    def test_type_mro_shadowed(self):
+        class Shadow:
+            @staticmethod
+            def mro():
+                return "shadowed"
+
+        class MroMeta(type):
+            def mro(cls):
+                return [cls, object]
+
+        class WithMroMeta(metaclass=MroMeta):
+            pass
+
+        class GetattributeMeta(type):
+            def __getattribute__(cls, name):
+                if name == "mro":
+                    return lambda: "dynamic"
+                return super().__getattribute__(name)
+
+        class WithGetattributeMeta(metaclass=GetattributeMeta):
+            pass
+
+        @torch.compile(backend="eager")
+        def fn(cls):
+            return cls.mro()
+
+        self.assertEqual(fn(Shadow), "shadowed")
+        self.assertEqual(fn(WithMroMeta), [WithMroMeta, object])
+        self.assertEqual(fn(WithGetattributeMeta), "dynamic")
+
     def test_builtin_str_on_user_defined_function(self):
         def another_fn():
             pass

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1164,6 +1164,17 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 source = CallFunctionNoArgsSource(source)
             return VariableTracker.build(tx, self.value.__subclasses__(), source)
         elif (
+            name == "mro"
+            and len(args) == 0
+            and not kwargs
+            and inspect.getattr_static(self.value, "mro", None) is type.mro
+        ):
+            source = self.source
+            if self.source:
+                source = AttrSource(self.source, "mro")
+                source = CallFunctionNoArgsSource(source)
+            return VariableTracker.build(tx, type.mro(self.value), source)
+        elif (
             self.value in {collections.OrderedDict, collections.defaultdict}
             and name == "fromkeys"
         ):


### PR DESCRIPTION
Calling `SomeClass.mro()` currently graph breaks in Dynamo with gb0156, while accessing `SomeClass.__mro__` is already supported.

This adds a small fast path in `UserDefinedClassVariable.call_method` for the default `type.mro` implementation, following the existing `__subclasses__` handling.

Overrides are left unchanged. The added tests cover:

* a normal user-defined class;
* a class that shadows `mro`;
* a metaclass that overrides `mro`;
* a metaclass with custom `__getattribute__`.

This change only covers `SomeClass.mro()` for user-defined classes. Builtin class objects and the unbound `type.mro(cls)` form are outside the scope of this PR.

The existing `test_altmro` expected failure is intentionally kept because that CPython test also exercises a custom metaclass MRO implementation that remains unsupported.

Towards #195901.

### Test plan

Verified the new tests against the installed PyTorch nightly with the patch applied. Without the patch, `test_type_mro_method` reproduces gb0156.

`lintrunner` passes for the modified files.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98