### PR TITLE
Fix reduction backward failing for real inputs with dtype=<complex>

### DIFF
--- a/test/autograd/test_complex.py
+++ b/test/autograd/test_complex.py
@@ -103,6 +103,30 @@ class TestAutogradComplex(TestCase):
 
         self.assertEqual(z.grad, z1.grad)
 
+    def test_reduction_backward_real_to_complex_output_dtype(self):
+        # #192719: reducing a real input with dtype=<complex> must hand the
+        # input a real gradient (the real part of the complex grad_output)
+        # instead of failing the engine's grad dtype validation.
+        for op in (torch.sum, torch.mean, torch.prod):
+            x = torch.ones(2, 2, dtype=torch.float64, requires_grad=True)
+            y = op(x, dtype=torch.complex128)
+            y.backward(torch.ones_like(y))
+            self.assertEqual(x.grad.dtype, torch.float64)
+            self.assertEqual(
+                x.grad,
+                torch.full_like(x, 0.25 if op is torch.mean else 1.0),
+            )
+
+        for op in (torch.sum, torch.mean, torch.prod):
+            x = torch.ones(2, 2, dtype=torch.float64, requires_grad=True)
+            y = op(x, 0, dtype=torch.complex128)
+            y.backward(torch.ones_like(y))
+            self.assertEqual(x.grad.dtype, torch.float64)
+            self.assertEqual(
+                x.grad,
+                torch.full_like(x, 0.5 if op is torch.mean else 1.0),
+            )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1156,7 +1156,7 @@
 - name: mean(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: grad.expand_symint(self.sym_sizes()) / self.sym_numel()
+      self: grad.to(self.scalar_type()).expand_symint(self.sym_sizes()) / self.sym_numel()
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this with grad.expand_as(self) / self.sym_numel() when that is supported
@@ -1164,7 +1164,7 @@
       result: auto_linear
 
 - name: mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
-  self: mean_backward(grad, self.sym_sizes(), dim, self.sym_numel(), keepdim)
+  self: mean_backward(grad.to(self.scalar_type()), self.sym_sizes(), dim, self.sym_numel(), keepdim)
   result: auto_linear
 
 - name: median(Tensor self) -> Tensor
@@ -1423,11 +1423,11 @@
   result: auto_element_wise
 
 - name: prod(Tensor self, *, ScalarType? dtype=None) -> Tensor
-  self: prod_backward(grad, self.to(grad.scalar_type()), result)
+  self: prod_backward(grad, self.to(grad.scalar_type()), result).to(self.scalar_type())
   result: (prod_backward(at::ones({}, result.options()).expand_as(result), self_p.to(result.scalar_type()), result) * self_t.conj()).sum().conj()
 
 - name: prod.dim_int(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
-  self: prod_backward(grad, self.to(grad.scalar_type()), result, dim, keepdim)
+  self: prod_backward(grad, self.to(grad.scalar_type()), result, dim, keepdim).to(self.scalar_type())
   result: (prod_backward(at::ones({}, result.options()).expand_as(result), self_p.to(result.scalar_type()), result, dim, keepdim) * self_t.conj()).sum(dim, keepdim).conj()
 
 - name: put(Tensor self, Tensor index, Tensor source, bool accumulate=False) -> Tensor
@@ -1714,7 +1714,7 @@
 - name: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: grad.expand_symint(self.sym_sizes())
+      self: grad.to(self.scalar_type()).expand_symint(self.sym_sizes())
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this with grad.expand_as(self) when that is supported
@@ -1724,7 +1724,7 @@
 - name: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   dispatch:
     Default:
-      self: sum_backward(grad, self.sym_sizes(), dim, keepdim)
+      self: sum_backward(grad.to(self.scalar_type()), self.sym_sizes(), dim, keepdim)
       result: auto_linear
     AutogradNestedTensor:
       # TODO: replace this function once semantics for nested tensor expand have been settled on


### PR DESCRIPTION
Fixes #192719

## Summary

Reducing a real tensor with `dtype=<complex dtype>` (e.g. `torch.sum(x, dtype=torch.complex128)`) computed the forward but raised in `backward()`. The derivative formulas for `sum`, `mean`, and `prod` passed the incoming complex grad to the real input edge unchanged, and the autograd engine's grad-dtype validation (`isFloatingType(grad) || (input_is_complex == grad_is_complex)` in `torch/csrc/autograd/engine.cpp`) rejected it.

`nansum`, `cumsum`, and `cumprod` already convert the grad at the formula site with `grad.to(self.scalar_type())`, which for a complex grad on a real input keeps the real part — the correct pullback for a real-to-complex reduction. This PR applies the same conversion to the six `sum`/`mean`/`prod` formula sites (whole-tensor and `dim` variants of each) and adds a regression test in `test/autograd/test_complex.py`.

The alternative of relaxing the engine check was rejected: that check catches genuine dtype bugs for every other op, and the formula-site conversion matches the pattern the neighboring reductions already use. Casting a complex grad to a real dtype takes its real part and emits torch's standard "Casting complex values to real discards the imaginary part" warning, the same behavior `cumsum`'s formula already produces in this situation.

## Test plan

New regression test covers `sum`/`mean`/`prod` with and without `dim`, asserting the gradient dtype matches the input dtype and the values are the real part of the complex grad_output:

```
python test/autograd/test_complex.py -k real_to_complex
```

The change is limited to `tools/autograd/derivatives.yaml` formulas and needs the autograd codegen plus a full build to exercise end to end, which is not feasible in my local environment; I verified locally that the yaml parses, that the six edited formulas land as intended, and reproduced the original failure on a release build (sum/mean/prod all raise with the engine's dtype error, `nansum` follows the converted pattern). CI runs the new test.

This PR was authored with AI assistance (Kimi); the diff and the verification described above were reviewed by the committer before submission.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo