### PR TITLE
[nn] Add BufferDict

### DIFF
--- a/docs/source/nn.md
+++ b/docs/source/nn.md
@@ -55,6 +55,7 @@ These are the basic building blocks for graphs:
     ModuleDict
     ParameterList
     ParameterDict
+    BufferDict
 ```
 
 Global Hooks For Module

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1481,6 +1481,58 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         finally:
             TensorWithTFOverrideVariable.global_mangled_class_name = original
 
+    def test_bufferdict(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.offsets = torch.nn.BufferDict(
+                    {
+                        "left": torch.ones(3),
+                        "right": torch.nn.Buffer(torch.zeros(3), persistent=False),
+                    }
+                )
+
+            def forward(self, x, choice):
+                return (x.sin() + self.offsets[choice]).square()
+
+        for backend in ("eager", "aot_eager"):
+            with self.subTest(backend=backend):
+                model = Model()
+                compiled = torch.compile(model, backend=backend, fullgraph=True)
+                for choice in ("left", "right"):
+                    x = torch.randn(2, 3, requires_grad=True)
+                    actual = compiled(x, choice)
+                    expected = model(x, choice)
+                    self.assertEqual(actual, expected)
+                    self.assertEqual(
+                        torch.autograd.grad(actual.sum(), x),
+                        torch.autograd.grad(expected.sum(), x),
+                    )
+                model.offsets["left"] = torch.full((3,), 2.0)
+                self.assertEqual(compiled(x, "left"), model(x, "left"))
+
+    def test_bufferdict_iteration_and_mutation(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.offsets = torch.nn.BufferDict({"a": torch.ones(3)})
+
+            def forward(self, x):
+                for value in self.offsets.values():
+                    x = x + value
+                return x
+
+        model = Model()
+        compiled = torch.compile(model, backend="eager", fullgraph=True)
+        x = torch.randn(2, 3)
+        self.assertEqual(compiled(x), model(x))
+        model.offsets["a"].fill_(2)
+        self.assertEqual(compiled(x), model(x))
+        model.offsets["b"] = torch.ones(3)
+        self.assertEqual(compiled(x), model(x))
+        del model.offsets["a"]
+        self.assertEqual(compiled(x), model(x))
+
     def test_nn_moduledict_contains(self):
         class M(torch.nn.Module):
             def __init__(self, module_dict):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15248,6 +15248,33 @@ def forward(self, x, b_t, y):
         epm = export(mod, (x,)).module()
         self.assertTrue(torch.allclose(mod(x), epm(x)))
 
+    def test_bufferdict(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.offsets = torch.nn.BufferDict(
+                    {
+                        "persistent": torch.ones(3),
+                        "temporary": torch.nn.Buffer(torch.zeros(3), persistent=False),
+                    }
+                )
+
+            def forward(self, x):
+                for value in self.offsets.values():
+                    x = x + value
+                return x
+
+        model = Model()
+        x = torch.randn(2, 3)
+        ep = export(model, (x,))
+        self.assertEqual(ep.module()(x), model(x))
+        self.assertEqual(set(ep.state_dict), {"offsets.persistent"})
+        self.assertEqual(set(ep.constants), {"offsets.temporary"})
+        self.assertEqual(
+            set(dict(ep.named_buffers())), {"offsets.persistent", "offsets.temporary"}
+        )
+        self.assertEqual(set(ep.module().state_dict()), {"offsets.persistent"})
+
     def test_non_persistent_buffer(self):
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1232,6 +1232,184 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertIsNotNone(p2.grad_fn)
             self.assertIs(p2._base, p)
 
+    def test_BufferDict(self):
+        persistent = Buffer(torch.randn(2, 3))
+        temporary = Buffer(torch.randn(2, 3), persistent=False)
+        tensor = torch.randn(2, 3)
+        buffers = nn.BufferDict(OrderedDict([
+            ("persistent", persistent), ("temporary", temporary), ("tensor", tensor), ("empty", None)
+        ]))
+        self.assertIs(buffers["persistent"], persistent)
+        self.assertIs(buffers["temporary"], temporary)
+        self.assertIsInstance(buffers["tensor"], Buffer)
+        self.assertEqual(buffers["tensor"], tensor)
+        self.assertIsNone(buffers["empty"])
+        self.assertEqual(list(buffers), ["persistent", "temporary", "tensor", "empty"])
+        self.assertEqual(list(reversed(buffers)), ["empty", "tensor", "temporary", "persistent"])
+        self.assertEqual(list(buffers.keys()), list(buffers))
+        self.assertEqual(list(buffers.items()), [(key, buffers[key]) for key in buffers])
+        self.assertEqual(list(buffers.values()), [buffers[key] for key in buffers])
+        self.assertEqual(list(buffers.parameters()), [])
+        self.assertEqual(list(buffers.named_buffers()), list(buffers.items())[:-1])
+        self.assertEqual(list(buffers.state_dict()), ["persistent", "tensor"])
+        module = nn.Module()
+        module.data = buffers
+        self.assertEqual(list(module.state_dict()), ["data.persistent", "data.tensor"])
+        self.assertEqual(list(module.parameters()), [])
+
+    def test_BufferDict_mutation(self):
+        buffers = nn.BufferDict()
+        self.assertEqual(len(buffers), 0)
+        value = Buffer(torch.ones(2), persistent=False)
+        buffers["value"] = value
+        self.assertIn("value", buffers)
+        self.assertIs(buffers.get("value"), value)
+        self.assertIs(buffers.setdefault("value", torch.zeros(2)), value)
+        self.assertIsNone(buffers.get("missing"))
+        self.assertEqual(buffers.get("missing", 123), 123)
+        self.assertIsNone(buffers.setdefault("empty"))
+        self.assertIsInstance(buffers.setdefault("other", torch.zeros(2)), Buffer)
+        buffers["value"] = Buffer(torch.zeros(2))
+        self.assertIn("value", buffers.state_dict())
+        buffers["value"] = value
+        self.assertNotIn("value", buffers.state_dict())
+        self.assertIs(buffers.pop("value"), value)
+        self.assertNotIn("value", buffers._non_persistent_buffers_set)
+        key, result = buffers.popitem()
+        self.assertEqual(key, "other")
+        self.assertEqual(result, torch.zeros(2))
+        del buffers["empty"]
+        self.assertEqual(len(buffers), 0)
+        with self.assertRaises(KeyError):
+            buffers.popitem()
+        buffers.update({"a": value, "b": None})
+        buffers.clear()
+        self.assertEqual(len(buffers), 0)
+        self.assertEqual(buffers._non_persistent_buffers_set, set())
+
+    @parametrize_test("operation", ["construct", "update", "copy", "union", "inplace_union"])
+    @parametrize_test("converted", [False, True])
+    def test_BufferDict_preserves_persistence(self, operation, converted):
+        source = nn.BufferDict(OrderedDict([
+            ("z", Buffer(torch.ones(2), persistent=False)),
+            ("a", Buffer(torch.zeros(2))),
+            ("empty", None),
+        ]))
+        if converted:
+            source.double()
+        if operation == "construct":
+            result = nn.BufferDict(source)
+        elif operation == "update":
+            result = nn.BufferDict({"z": torch.zeros(2)})
+            result.update(source)
+        elif operation == "copy":
+            result = source.copy()
+        elif operation == "union":
+            result = nn.BufferDict() | source
+        else:
+            result = nn.BufferDict()
+            result |= source
+        self.assertEqual(list(result), ["z", "a", "empty"])
+        self.assertEqual(list(result.state_dict()), ["a"])
+        for key in source:
+            self.assertIs(result[key], source[key])
+        result["new"] = torch.ones(2)
+        self.assertNotIn("new", source)
+
+    def test_BufferDict_update_order(self):
+        a, b, c = (Buffer(torch.tensor(i)) for i in range(3))
+        buffers = nn.BufferDict({"b": b, "a": a})
+        self.assertEqual(list(buffers), ["a", "b"])
+        buffers.update(OrderedDict([("d", c), ("c", a), ("a", b)]))
+        self.assertEqual(list(buffers), ["a", "b", "d", "c"])
+        self.assertIs(buffers["a"], b)
+        buffers.update(item for item in [("f", a), ("e", b)])
+        self.assertEqual(list(buffers), ["a", "b", "d", "c", "f", "e"])
+        buffers.update(buffers)
+        self.assertEqual(list(buffers), ["a", "b", "d", "c", "f", "e"])
+        result = buffers.fromkeys(["z", "a"], a)
+        self.assertEqual(list(result), ["z", "a"])
+        self.assertIs(result["z"], result["a"])
+
+    def test_BufferDict_invalid_entries(self):
+        buffers = nn.BufferDict({"valid": torch.ones(2)})
+        for key, value, error in [
+            (1, torch.ones(2), TypeError),
+            ("", torch.ones(2), KeyError),
+            ("a.b", torch.ones(2), KeyError),
+            ("training", torch.ones(2), KeyError),
+            ("items", torch.ones(2), KeyError),
+            ("_buffers", torch.ones(2), KeyError),
+            ("invalid", 1, TypeError),
+            ("invalid", nn.Linear(2, 2), TypeError),
+            ("valid", 1, TypeError),
+        ]:
+            with self.subTest(key=key, value_type=type(value)):
+                with self.assertRaises(error):
+                    buffers[key] = value
+                self.assertEqual(list(buffers), ["valid"])
+                self.assertEqual(buffers["valid"], torch.ones(2))
+        for key in ("missing", "training", "items"):
+            with self.assertRaises(KeyError):
+                buffers[key]
+            with self.assertRaises(KeyError):
+                del buffers[key]
+        for invalid, error in [(1, TypeError), ([1], TypeError), ([("x",)], ValueError)]:
+            with self.assertRaises(error):
+                buffers.update(invalid)
+        with self.assertRaisesRegex(RuntimeError, "BufferDict should not be called"):
+            buffers(torch.ones(2))
+
+    @parametrize_test("assign", [False, True])
+    def test_BufferDict_state_dict(self, assign):
+        buffers = nn.BufferDict({
+            "persistent": Buffer(torch.ones(2)),
+            "temporary": Buffer(torch.zeros(2), persistent=False),
+            "empty": None,
+        })
+        checkpoint = {"persistent": torch.full((2,), 3.0)}
+        buffers.load_state_dict(checkpoint, assign=assign)
+        self.assertEqual(buffers["persistent"], checkpoint["persistent"])
+        self.assertEqual(buffers["temporary"], torch.zeros(2))
+        self.assertEqual(list(buffers.state_dict()), ["persistent"])
+        self.assertEqual(list(buffers.copy().state_dict()), ["persistent"])
+        f = io.BytesIO()
+        torch.save(buffers.state_dict(), f)
+        f.seek(0)
+        self.assertEqual(torch.load(f, weights_only=True), checkpoint)
+
+    @parametrize_test("copier", [deepcopy, lambda x: pickle.loads(pickle.dumps(x))])
+    def test_BufferDict_serialization(self, copier):
+        buffers = nn.BufferDict({
+            "persistent": torch.ones(2),
+            "temporary": Buffer(torch.zeros(2), persistent=False),
+        }).double()
+        clone = copier(buffers)
+        self.assertIsInstance(clone, nn.BufferDict)
+        self.assertEqual(list(clone.state_dict()), ["persistent"])
+        for key in buffers:
+            self.assertEqual(clone[key], buffers[key])
+            self.assertIsNot(clone[key], buffers[key])
+
+    def test_BufferDict_parameter_and_alias(self):
+        parameter = Parameter(torch.ones(2))
+        buffer = Buffer(torch.ones(2), persistent=False)
+        buffers = nn.BufferDict({"parameter": parameter, "a": buffer, "b": buffer})
+        self.assertIsInstance(buffers["parameter"], Buffer)
+        self.assertNotIsInstance(buffers["parameter"], Parameter)
+        self.assertTrue(buffers["parameter"].requires_grad)
+        self.assertEqual(list(buffers.parameters()), [])
+        self.assertIs(buffers["a"], buffers["b"])
+        self.assertEqual(len(list(buffers.buffers())), 2)
+        self.assertEqual(len(list(buffers.named_buffers(remove_duplicate=False))), 3)
+
+    def test_BufferDict_repr(self):
+        buffers = nn.BufferDict(OrderedDict([("x", torch.zeros(2, 3)), ("empty", None)]))
+        self.assertIn("BufferDict(", repr(buffers))
+        self.assertIn("(x): Buffer containing:", repr(buffers))
+        self.assertIn("2x3", repr(buffers))
+        self.assertIn("(empty): None", repr(buffers))
+
     def test_ParameterDict(self):
         parameters = OrderedDict([
             ('p1', Parameter(torch.randn(10, 10))),
@@ -7090,6 +7268,24 @@ def _buildEquivalentAffineTransforms3d(device, input_size, output_size, angle_ra
 
 
 class TestNNDeviceType(NNTestCase):
+
+    @dtypes(torch.float32, torch.float64, torch.int64, torch.bool)
+    def test_BufferDict_device(self, device, dtype):
+        tensor = torch.arange(6).reshape(2, 3).to(dtype=dtype)
+        module = nn.Module()
+        module.data = nn.BufferDict({
+            "persistent": tensor,
+            "temporary": Buffer(tensor.clone(), persistent=False),
+        })
+        module.to(device)
+        for value in module.data.values():
+            self.assertEqual(value, tensor.to(device))
+            self.assertEqual(value.device, torch.device(device))
+        self.assertEqual(list(module.state_dict()), ["data.persistent"])
+        self.assertEqual(list(module.data.copy().state_dict()), ["persistent"])
+        module.cpu()
+        for value in module.data.values():
+            self.assertEqual(value, tensor)
 
     def test_grid_sample_backward_error_checking(self, device):
         input = torch.empty(1, 1, 2, 2, device=device)

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -43,6 +43,7 @@ from .batchnorm import (
 )
 from .channelshuffle import ChannelShuffle
 from .container import (
+    BufferDict,
     Container,
     ModuleDict,
     ModuleList,
@@ -186,6 +187,7 @@ __all__ = [
     "BatchNorm2d",
     "BatchNorm3d",
     "Bilinear",
+    "BufferDict",
     "CELU",
     "CTCLoss",
     "ChannelShuffle",

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import operator
 from collections import abc as container_abcs, OrderedDict
 from itertools import chain, islice
-from typing import Any, overload, TYPE_CHECKING, TypeVar
+from typing import Any, cast, overload, TYPE_CHECKING, TypeVar
 from typing_extensions import deprecated, Self
 
 import torch
 from torch._jit_internal import _copy_to_script_wrapper
-from torch.nn.parameter import Parameter
+from torch.nn.parameter import Buffer, Parameter
 
 from .module import Module
 
@@ -25,6 +25,7 @@ __all__ = [
     "ModuleDict",
     "ParameterList",
     "ParameterDict",
+    "BufferDict",
 ]
 
 T = TypeVar("T", bound=Module)
@@ -1041,5 +1042,211 @@ class ParameterDict(Module):
         return copy
 
     def __ior__(self, other: ParameterDict) -> Self:
+        self.update(other)
+        return self
+
+
+class BufferDict(Module):
+    r"""Holds buffers in a dictionary.
+
+    :class:`~torch.nn.BufferDict` can be indexed like a regular Python dictionary,
+    but its buffers are registered with the module. They are moved and converted
+    by :meth:`~torch.nn.Module.to` and appear in :meth:`~torch.nn.Module.buffers`.
+    Persistent buffers are included in :meth:`~torch.nn.Module.state_dict`.
+
+    The constructor, item assignment, and :meth:`update` convert tensors into
+    :class:`~torch.nn.Buffer` objects. Copying or updating from another
+    ``BufferDict`` reuses its buffers and preserves their persistence. Pass a
+    ``Buffer(tensor, persistent=False)`` to exclude an entry from the state dict.
+    Entries can also be ``None``, which are ignored by operations on buffers and
+    are not included in the state dict.
+
+    Like :class:`~torch.nn.ParameterDict`, this is an **ordered** dictionary.
+    The order of an ``OrderedDict``, another ``BufferDict``, or an iterable of
+    key-value pairs is preserved. Other mappings are sorted by key.
+
+    Args:
+        buffers (iterable, optional): a mapping from strings to tensors or
+            ``None``, or an iterable of such key-value pairs.
+
+    Example::
+
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.offsets = nn.BufferDict(
+                    {
+                        "left": torch.zeros(10),
+                        "right": nn.Buffer(torch.ones(10), persistent=False),
+                    }
+                )
+
+            def forward(self, x, choice):
+                return x + self.offsets[choice]
+    """
+
+    def __init__(
+        self,
+        buffers: Mapping[str, torch.Tensor | None]
+        | Iterable[tuple[str, torch.Tensor | None]]
+        | BufferDict
+        | None = None,
+    ) -> None:
+        super().__init__()
+        if buffers is not None:
+            self.update(buffers)
+
+    def __getitem__(self, key: str) -> torch.Tensor | None:
+        return self._buffers[key]
+
+    def __setitem__(self, key: str, value: torch.Tensor | None) -> None:
+        if isinstance(value, torch.Tensor) and not isinstance(value, Buffer):
+            value = Buffer(value)
+        persistent = value.persistent if isinstance(value, Buffer) else True
+        self.register_buffer(key, value, persistent=persistent)
+
+    def __delitem__(self, key: str) -> None:
+        del self._buffers[key]
+        self._non_persistent_buffers_set.discard(key)
+
+    def __len__(self) -> int:
+        return len(self._buffers)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._buffers)
+
+    def __reversed__(self) -> Iterator[str]:
+        return reversed(self._buffers)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._buffers
+
+    def copy(self) -> BufferDict:
+        """Return a shallow copy, preserving each buffer's persistence."""
+        return BufferDict(self)
+
+    def setdefault(
+        self, key: str, default: torch.Tensor | None = None
+    ) -> torch.Tensor | None:
+        """Return the buffer at ``key``, inserting ``default`` if it is absent."""
+        if key not in self:
+            self[key] = default
+        return self[key]
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        for key in list(self):
+            del self[key]
+
+    def pop(self, key: str) -> torch.Tensor | None:
+        """Remove and return the buffer at ``key``."""
+        value = self[key]
+        del self[key]
+        return value
+
+    def popitem(self) -> tuple[str, torch.Tensor | None]:
+        """Remove and return the last inserted key-buffer pair."""
+        if not self:
+            raise KeyError("BufferDict is empty")
+        key = next(reversed(self))
+        return key, self.pop(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the buffer at ``key``, or ``default`` if it is absent."""
+        return self._buffers.get(key, default)
+
+    def fromkeys(
+        self, keys: Iterable[str], default: torch.Tensor | None = None
+    ) -> BufferDict:
+        """Return a new BufferDict with each key set to ``default``."""
+        return BufferDict((key, default) for key in keys)
+
+    def keys(self) -> container_abcs.KeysView[str]:
+        """Return a view of the keys."""
+        return self._buffers.keys()
+
+    def items(self) -> container_abcs.ItemsView[str, torch.Tensor | None]:
+        """Return a view of the key-buffer pairs."""
+        return self._buffers.items()
+
+    def values(self) -> container_abcs.ValuesView[torch.Tensor | None]:
+        """Return a view of the buffers."""
+        return self._buffers.values()
+
+    def update(
+        self,
+        buffers: Mapping[str, torch.Tensor | None]
+        | Iterable[tuple[str, torch.Tensor | None]]
+        | BufferDict,
+    ) -> None:
+        """Add key-buffer pairs, overwriting existing keys.
+
+        An ``OrderedDict``, ``BufferDict``, or iterable of key-value pairs
+        preserves the order of new entries. Other mappings are sorted by key.
+        Updating from another ``BufferDict`` also preserves persistence after
+        device or dtype conversions.
+        """
+        if isinstance(buffers, BufferDict):
+            for key, value in buffers.items():
+                # Module._apply may replace a Buffer with a plain Tensor.
+                self.register_buffer(
+                    key,
+                    value,
+                    persistent=key not in buffers._non_persistent_buffers_set,
+                )
+        elif isinstance(buffers, container_abcs.Mapping):
+            entries: Iterable[tuple[str, torch.Tensor | None]] = cast(
+                "Mapping[str, torch.Tensor | None]", buffers
+            ).items()
+            if not isinstance(buffers, OrderedDict):
+                entries = sorted(entries)
+            for key, value in entries:
+                self[key] = value
+        else:
+            if not isinstance(buffers, container_abcs.Iterable):
+                raise TypeError(
+                    "BufferDict.update should be called with an iterable of "
+                    f"key/value pairs, but got {type(buffers).__name__}"
+                )
+            for i, entry in enumerate(buffers):
+                if not isinstance(entry, container_abcs.Iterable):
+                    raise TypeError(
+                        f"BufferDict update sequence element #{i} should be iterable, "
+                        f"but got {type(entry).__name__}"
+                    )
+                if len(entry) != 2:
+                    raise ValueError(
+                        f"BufferDict update sequence element #{i} has length "
+                        f"{len(entry)}; 2 is required"
+                    )
+                self[entry[0]] = entry[1]
+
+    def extra_repr(self) -> str:
+        lines = []
+        for key, value in self.items():
+            if value is None:
+                lines.append(f"  ({key}): None")
+            else:
+                size = "x".join(str(dim) for dim in value.size())
+                lines.append(
+                    f"  ({key}): Buffer containing: [{value.dtype} of size {size} "
+                    f"on {value.device}]"
+                )
+        return "\n".join(lines)
+
+    def __call__(self, *args, **kwargs):
+        raise RuntimeError("BufferDict should not be called.")
+
+    def __or__(self, other: BufferDict) -> BufferDict:
+        result = self.copy()
+        result.update(other)
+        return result
+
+    def __ror__(self, other: BufferDict) -> BufferDict:
+        result = BufferDict(other)
+        result.update(self)
+        return result
+
+    def __ior__(self, other: BufferDict) -> Self:
         self.update(other)
         return self


### PR DESCRIPTION
## Issue

Fixes #37386.

## Summary

Add `torch.nn.BufferDict`, the buffer counterpart to `ParameterDict`, using existing `Module.register_buffer` behavior. It supports dictionary operations, module device/dtype conversion, and serialization, with per-entry persistence from `nn.Buffer`. Plain tensors become buffers; `None` entries are supported. Ordering follows `ParameterDict`. Copying or updating another `BufferDict` preserves shallow identity and persistence, including after `.to()` replaces a `Buffer` with a plain tensor.

## Test Plan

- Fresh CPU native build at `d1ae7eed74b9ed5e31ac786b6434d2510169135b`: 32 focused tests passed across containers, `torch.compile` (eager/aot_eager), default/strict export, and public bindings. Restoring the unmodified implementation made all 24 new container tests fail because `nn.BufferDict` was absent.
- Supplementary RTX 3090 validation: 28 tests passed (20 generic, 4 CPU, 4 CUDA), reusing an existing CUDA 13.0 / SM86 native build with the two changed Python modules overlaid. This was not a fresh CUDA build at this base.
- Full upstream tests and the Sphinx docs build were not run. Reproduction commands are in the commit message.

## Checklist

- [x] Passes lint (`spin lint -a`, equivalent to `spin fixlint`)
- [x] Added tests
- [x] Updated documentation

Benchmarks: not applicable; additive container API with no performance claim.

## BC-breaking?

No. This adds a new public container API.

AI-assisted.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98