### PR TITLE
Add tzdata to dev requirements on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,7 @@ dev = [
     "psutil",
     "spin",
     "sympy>=1.13.3",
+    "tzdata ; platform_system == \"Windows\"",
     "wheel"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ optree>=0.13.0
 psutil
 spin
 sympy>=1.13.3
+tzdata ; platform_system == "Windows"
 wheel


### PR DESCRIPTION
Two tests in `test_serialization.py` fail on a clean Windows checkout that follows the documented dev setup:

```
FAILED test/test_serialization.py::TestSerialization::test_weights_only_blocked_func_error_msg
FAILED test/test_serialization.py::TestSerialization::test_weights_only_with_zoneinfo_unpickle_registration_success
```

Both hit the same thing:

```
ModuleNotFoundError: No module named 'tzdata'
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key UTC'
```

Both tests call `zoneinfo.ZoneInfo(key="UTC")`. On Linux and macOS that reads the system IANA database at `/usr/share/zoneinfo`. Windows doesn't ship one, so `zoneinfo` falls back to the `tzdata` PyPI package, which isn't declared anywhere in the repo.

CI doesn't catch this because `.ci/docker/requirements-ci.txt` pins `pandas`, and pandas depends on `tzdata`, so CI picks it up transitively. The root `requirements.txt` that contributors are told to install has neither.

So the tests are unrunnable on Windows for anyone following CONTRIBUTING, while CI stays green by accident of a transitive dependency.

This declares `tzdata` on Windows in both `requirements.txt` and the `dev` dependency group in `pyproject.toml` (kept in sync per the comment in that block), using the same platform-marker style as the existing `lintrunner` entry.

**Testing:** Windows 11, Python 3.13, `2.15.0.dev20260911+cpu`.

Before, on a checkout with `pip install -r requirements.txt` only:

```
2 failed, 190 passed, 33 skipped
```

After `pip install tzdata`, no other change:

```
python -m pytest test\test_serialization.py -k "zoneinfo or blocked_func_error_msg" -q
2 passed, 223 deselected in 2.28s
```

Note: Used an AI assistant to help track down the root cause.