### PR TITLE
Make activation checkpointing knapsack evaluation deterministic

### DIFF
--- a/test/functorch/test_ac_knapsack.py
+++ b/test/functorch/test_ac_knapsack.py
@@ -1,4 +1,6 @@
 # Owner(s): ["module: functorch"]
+import networkx as nx
+
 from torch._functorch._activation_checkpointing.graph_info_provider import (
     GraphInfoProvider,
 )
@@ -134,8 +136,8 @@ class TestGraphInfoProvider(TestCase):
         # node2 has an indirect path to node5
         expected_edges = [("node1", "node2"), ("node2", "node5")]
         self.assertEqual(
-            sorted(recomputable_node_only_graph_with_larger_graph_context.nodes),
-            sorted(expected_nodes),
+            list(recomputable_node_only_graph_with_larger_graph_context.nodes),
+            expected_nodes,
         )
         self.assertEqual(
             sorted(recomputable_node_only_graph_with_larger_graph_context.edges),
@@ -328,6 +330,80 @@ class TestKnapsackEvaluator(TestCase):
         for result_item, expected_result_item in zip(result, expected_result):
             self.assertAlmostEqual(result_item[0], expected_result_item[0])
             self.assertEqual(result_item[1], expected_result_item[1])
+
+    def test_backward_memory_is_deterministic_across_graph_orderings(self):
+        provider = GraphInfoProvider(
+            graph_nodes_in_order=["src", "a1", "a2", "b1", "b2"],
+            graph_edges=[
+                ("src", "a1"),
+                ("src", "b1"),
+                ("a1", "a2"),
+                ("b1", "b2"),
+            ],
+            all_recomputable_banned_nodes=["src", "a1", "a2", "b1", "b2"],
+            recorded_knapsack_input_memories=[
+                1.0,
+                10.0,
+                10.0,
+                1.0,
+                1.0,
+            ],
+            recorded_knapsack_input_runtimes=[
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+            ],
+        )
+
+        evaluator = KnapsackEvaluator(provider)
+
+        def get_peak_memory(edges, node_order=None):
+            graph = nx.DiGraph()
+            if node_order is not None:
+                graph.add_nodes_from(node_order)
+            graph.add_edges_from(edges)
+
+            result = evaluator._get_backward_memory_from_topologically_sorted_graph(
+                node_graph=graph,
+                node_memories=provider.all_node_memories,
+                saved_nodes_set={"src"},
+                peak_memory_after_forward_pass=1.0,
+            )
+
+            return max(memory for memory, _ in result)
+
+        # The backward-memory simulation should not depend on the insertion
+        # order of an equivalent NetworkX graph; FX node order is used as the
+        # tie-breaker.
+        edges_a = [
+            ("src", "a1"),
+            ("src", "b1"),
+            ("a1", "a2"),
+            ("b1", "b2"),
+        ]
+
+        edges_b = [
+            ("src", "b1"),
+            ("src", "a1"),
+            ("a1", "a2"),
+            ("b1", "b2"),
+        ]
+
+        peak_a = get_peak_memory(edges_a)
+        peak_b = get_peak_memory(edges_b)
+
+        self.assertEqual(peak_a, peak_b)
+        self.assertEqual(peak_a, 21.0)
+
+        # Keep node insertion order fixed while changing edge insertion order.
+        # The tie-breaker must be independent of adjacency insertion order too.
+        fixed_node_order = ["src", "a1", "a2", "b1", "b2"]
+        self.assertEqual(
+            get_peak_memory(edges_a, fixed_node_order),
+            get_peak_memory(edges_b, fixed_node_order),
+        )
 
 
 class TestActivationCheckpointingKnapsack(TestCase):

--- a/torch/_functorch/_activation_checkpointing/graph_info_provider.py
+++ b/torch/_functorch/_activation_checkpointing/graph_info_provider.py
@@ -180,21 +180,21 @@ class GraphInfoProvider:
     def _create_recomputable_node_only_graph_with_larger_graph_context(
         self,
     ) -> nx.DiGraph:
-        # Create a dictionary to store the reachable nodes for each node
-        all_recomputable_banned_nodes_set = set(self.all_recomputable_banned_nodes)
-
+        # Iterate the ordered list, using the precomputed set only for membership:
+        # node insertion order into the candidate graph must follow original FX
+        # order, not string-hash order, which varies per process.
         reachable_nodes = {}
-        for node in all_recomputable_banned_nodes_set:
+        for node in self.all_recomputable_banned_nodes:
             # Use BFS to find all reachable nodes
             predecessors = dict(nx.bfs_predecessors(self.full_joint_nx_graph, node))
             reachable_recomputable_nodes = set(predecessors.keys()).intersection(
-                all_recomputable_banned_nodes_set
+                self.all_recomputable_banned_nodes_set
             )
             reachable_nodes[node] = reachable_recomputable_nodes
         # Create the candidate graph
         candidate_graph = nx.DiGraph()
-        candidate_graph.add_nodes_from(all_recomputable_banned_nodes_set)
-        for node1 in all_recomputable_banned_nodes_set:
+        candidate_graph.add_nodes_from(self.all_recomputable_banned_nodes)
+        for node1 in self.all_recomputable_banned_nodes:
             for node2 in reachable_nodes[node1]:
                 # Check if there is an overlapping path
                 overlapping_path = False

--- a/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
+++ b/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
@@ -54,7 +54,25 @@ class KnapsackEvaluator:
             (peak_memory_after_forward_pass, "Initial Peak/Current Memory")
         ]
         already_computed = set()
-        sorted_nodes = list(reversed(list(nx.topological_sort(node_graph))))
+
+        # Tie-break topological ordering using the original FX node order so the
+        # backward-memory simulation does not depend on NetworkX insertion order.
+        # FX order is topological for this graph, so reversing it gives the
+        # reverse-FX order used by the backward simulation.
+        original_order = {
+            name: i
+            for i, name in enumerate(self._graph_info_provider.graph_nodes_in_order)
+        }
+        sorted_nodes = list(
+            reversed(
+                list(
+                    nx.lexicographical_topological_sort(
+                        node_graph,
+                        key=lambda n: original_order[n],
+                    )
+                )
+            )
+        )
         dependencies_computed = set()
 
         for node in sorted_nodes:


### PR DESCRIPTION
Fixes #196512

## Description

`KnapsackEvaluator._get_backward_memory_from_topologically_sorted_graph` can
return different simulated peak-memory values for the same logical graph across
Python processes.

Two independent ordering sources, both rooted in string-hash iteration order:

1. `GraphInfoProvider._create_recomputable_node_only_graph_with_larger_graph_context`
   iterated `set(self.all_recomputable_banned_nodes)` to build the candidate
   graph, so NetworkX node insertion order varied per process.
2. `nx.topological_sort` delegates to `topological_generations`, which seeds its
   frontier from node insertion order and extends it via `G.neighbors()`, i.e.
   adjacency (edge) insertion order. Edge insertion order in the provider comes
   from iterating `reachable_nodes[node]`, which is a set.

Both ordering sources can affect the reverse schedule and therefore the
reported peak.

This change:

1. Iterates the ordered `all_recomputable_banned_nodes` list when building the
   candidate graph, using the existing `all_recomputable_banned_nodes_set`
   attribute for membership tests. The nodes and edges are unchanged; only
   insertion order changes.
2. Uses `nx.lexicographical_topological_sort` keyed on original FX node
   position as the tie-breaker. Because FX positions are unique, the result is
   independent of node and adjacency insertion order. This is why the
   evaluator change is needed in addition to (1): `reachable_nodes` is
   deliberately left as a set, and adjacency order no longer affects the
   resulting schedule.

The original FX node order is topological for the candidate graph, so reversing
the resulting order gives the reverse-FX order used by the backward simulation,
matching the stable FX ordering convention for this problem.

## Behavior change

The previous ordering was generation-based, which interleaves independent
branches. The new ordering traverses branches one at a time. On branching
graphs, the simulated peak value therefore changes; on chains, it is unchanged.

The affected backward-memory simulation path is gated by
`account_for_backward_pass`, which defaults to `False`.

## Testing

New test `test_backward_memory_is_deterministic_across_graph_orderings` covers
both ordering sources separately on a fork-shaped graph with asymmetric node
memories:

- differing node and edge insertion order, with the peak value pinned;
- fixed node insertion order with differing adjacency insertion order.

The regression fails with the old evaluator and passes with the fix.

`test_recomputable_node_only_graph_with_larger_graph_context` now asserts
candidate-graph node order rather than comparing sorted node lists, covering
the provider change.

Cross-process check: the same logical graph produced multiple peak-memory
values before the fix, while 8 subprocesses produced the same peak-memory value
after the fix with an identical graph fingerprint.

- `python test/functorch/test_ac_knapsack.py` — 18 passed
- `lintrunner` clean on all three changed files