### PR TITLE
[inductor] Handle full randperm in index_add pattern

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1792,6 +1792,22 @@ class CPUReproTests(TestCase):
             torch.unique(sliced_actual[:, 0]).numel(), sliced_actual.size(0)
         )
 
+    def test_randperm_full_index_add_issue_196631(self):
+        from torch._dynamo.utils import counters
+
+        def fn(x, y):
+            index = torch.randperm(x.size(0))
+            return torch.index_add(x, 0, index, y), index
+
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        y = torch.arange(12, dtype=torch.float32).reshape(3, 4) * 10
+
+        counters.clear()
+        actual, index = torch.compile(fn, backend="inductor", fullgraph=True)(x, y)
+        self.assertEqual(counters["inductor"]["pattern_matcher_count"], 1)
+        expected = torch.index_add(x, 0, index, y)
+        self.assertEqual(actual, expected)
+
     def test_ModularIndexing_range_issue_103133(self):
         def fn(q, k):
             einsum = torch.einsum("bcxd,bcyd->bcxy", (q, k))

--- a/torch/_inductor/fx_passes/misc_patterns.py
+++ b/torch/_inductor/fx_passes/misc_patterns.py
@@ -60,6 +60,32 @@ def _misc_patterns_init(input_device: torch.device | None = None):
         skip_duplicates=True,
     )
 
+    def randperm_index_add_full_pattern(x, y):
+        index = torch.randperm(x.shape[0], device=x.device)
+        return torch.index_add(x, dim=0, source=y, index=index), index
+
+    def randperm_index_add_full_replacement(x, y):
+        index = torch.randperm(x.shape[0], device=x.device)
+        return (
+            torch.ops.aten._unsafe_index_put(
+                x, (index,), aten._unsafe_index(x, (index,)) + y, accumulate=False
+            ),
+            index,
+        )
+
+    register_replacement(
+        # pyrefly: ignore [bad-argument-type]
+        randperm_index_add_full_pattern,
+        # pyrefly: ignore [bad-argument-type]
+        randperm_index_add_full_replacement,
+        [torch.empty(4, 8, device=device), torch.empty(4, 8, device=device)],
+        # pyrefly: ignore [bad-argument-type]
+        fwd_only,
+        # pyrefly: ignore [bad-argument-type]
+        [post_grad_patterns, joint_graph_patterns],
+        skip_duplicates=True,
+    )
+
     def randperm_index_full_pattern(x):
         index = torch.randperm(x.shape[0], device=x.device)
         return torch.ops.aten.index(x, (index,)), index


### PR DESCRIPTION
Fixes #196631

### Summary

TorchInductor already optimizes `index_add` when the index is a sliced permutation:

```python
index = torch.randperm(x.shape[0], device=x.device)[: y.shape[0]]
result = torch.index_add(x, dim=0, source=y, index=index)
```

Because the indices are unique and in bounds, the accumulating update can be rewritten using unsafe indexing and a non-accumulating `index_put`.

The full-permutation case:

```python
index = torch.randperm(x.shape[0], device=x.device)
result = torch.index_add(x, dim=0, source=y, index=index)
```

has the same uniqueness and bounds guarantees when `y.shape[0] == x.shape[0]`, but it does not contain the slice node expected by the existing `randperm_index_add_pattern`. As a result, the optimization does not currently match.

This change adds a dedicated full-permutation pattern and replacement, following the existing split between full and sliced `randperm` indexing patterns in `misc_patterns.py`.

### Test Plan

Added `test_randperm_full_index_add_issue_196631` in `test/inductor/test_cpu_repro.py`.

At the FX/pattern-matcher level I verified:

* before the change, the full-permutation case has `pattern_matcher_count == 0` and retains `index_put(..., accumulate=True)`;
* after the change, `pattern_matcher_count == 1`, `_unsafe_index` is introduced, and the update becomes non-accumulating;
* the existing sliced `randperm(N)[:M]` case continues to match;
* concrete mismatched source/index sizes are rejected before the Inductor optimization;
* dynamic shape tracing derives the required equality constraint between the relevant dimensions.

`git diff --check` and Ruff checks on the changed Python code pass.

I was unable to run the final CPU Inductor code-generation portion locally because this Windows environment does not have MSVC `cl.exe`; the corresponding existing Inductor CPU tests fail for the same environment reason. CI should provide the end-to-end compiler validation.

### AI assistance

AI tooling was used during investigation and implementation assistance. I reviewed the resulting code and validation manually, verified the compiler transformation and shape-safety assumptions, and take responsibility for the submitted change.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo