### PR TITLE
[inductor] Skip scaled softmax rewrite for bool inputs

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -18,7 +18,7 @@ import torch
 from torch import nn
 from torch._C import FileCheck
 from torch._dynamo.testing import CompileCounterWithBackend, rand_strided
-from torch._dynamo.utils import same
+from torch._dynamo.utils import counters, same
 from torch._inductor import config, cpu_vec_isa, metrics, test_operators
 from torch._inductor.codegen.cpp import (
     CppKernelProxy,
@@ -4142,6 +4142,32 @@ class CPUReproTests(TestCase):
         x = torch.randn(8, 8, 2)
         metrics.reset()
         self.common(fn, (x,))
+
+    @config.patch(fx_graph_cache=False)
+    @parametrize("input_dtype", (torch.bool, torch.float32))
+    @parametrize("scale_dtype", (torch.float32, torch.float64))
+    @parametrize("scale", (2.0, -2.0))
+    @parametrize("broadcast", (False, True))
+    @parametrize("reverse", (False, True))
+    def test_scaled_softmax_bool_input(
+        self, input_dtype, scale_dtype, scale, broadcast, reverse
+    ):
+        def fn(x, scale):
+            return torch.softmax(scale * x if reverse else x * scale, dim=-1)
+
+        x = torch.tensor([[False, True, False], [True, False, True]], dtype=input_dtype)
+        scale = torch.tensor(
+            [[scale], [-scale]] if broadcast else scale, dtype=scale_dtype
+        )
+        expected = fn(x, scale)
+        counters.clear()
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(x, scale)
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual.dtype, expected.dtype)
+        self.assertEqual(
+            counters["inductor"]["pattern_matcher_count"],
+            0 if input_dtype == torch.bool else 1,
+        )
 
     def test_softmax_with_zero_dim(self):
         def fn(x):

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1177,6 +1177,13 @@ def _other_is_broadcasted_in_dim(match):
     return all(statically_known_true(other_shape[d] == 1) for d in dim)
 
 
+def _mul_softmax_is_eligible(match):
+    if not _other_is_broadcasted_in_dim(match):
+        return False
+    dtype = match.kwargs.get("dtype") or match.kwargs["inp"].meta["val"].dtype
+    return dtype != torch.bool
+
+
 def mul_softmax_pattern(match: Match, *, inp, other, dim, keepdim, dtype=None):
     def repl(inp, other):
         scaled = inp * other
@@ -1208,7 +1215,7 @@ for reverse, to_dtype in itertools.product((False, True), repeat=2):
         _partial_softmax_pattern(aten.mul.Tensor, reverse=reverse, to_dtype=to_dtype),
         # pyrefly: ignore [bad-argument-type]
         pass_dict=pass_patterns[1],
-        extra_check=_other_is_broadcasted_in_dim,
+        extra_check=_mul_softmax_is_eligible,
     )(mul_softmax_pattern)
 
 


### PR DESCRIPTION
## Summary

Fixes an Inductor compile-time failure when the scaled-softmax pattern matches a bool input multiplied by a floating tensor scale.

For example:

```python
import torch

def f(m):
    return torch.softmax(m * torch.tensor(2.0), dim=0)

m = torch.tensor([False, True])

f(m)  # eager works
torch.compile(f, backend="inductor", fullgraph=True)(m)
```

The scaled-softmax rewrite negates a constant derived from the input dtype. When the matched input is bool, this creates a bool negation and fails during compilation. This change keeps the optimization for supported numeric inputs while skipping the rewrite for bool inputs.

## Tests

Added focused regression coverage across:

- bool and float inputs
- float32 and float64 scales
- positive and negative scales
- scalar and broadcast scales
- both multiply operand orders

All 32 cases pass. Bool inputs skip the scaled-softmax rewrite, while float inputs continue to match it.

Fixes #196743

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo