### PR TITLE
[BE] Remove tests from test_mps for log, log10, log2, logsumexp and gelu (tanh)

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7875,42 +7875,6 @@ class TestMPS(TestCaseMPS):
         helper((2, 8, 4, 5), torch.float32)
         helper((2, 8, 4, 5), torch.complex64)
 
-    def test_log(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            x = cpu_x.detach().clone().to('mps')
-
-            log_result = torch.log(x)
-            log_result_cpu = torch.log(cpu_x)
-
-            self.assertEqual(log_result, log_result_cpu)
-
-        helper((2, 8, 4, 5))
-
-    def test_log_ten(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            x = cpu_x.detach().clone().to('mps')
-
-            log_ten_result = torch.log10(x)
-            log_ten_result_cpu = torch.log10(cpu_x)
-
-            self.assertEqual(log_ten_result, log_ten_result_cpu)
-
-        helper((2, 8, 4, 5))
-
-    def test_log_two(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            x = cpu_x.detach().clone().to('mps')
-
-            log_two_result = torch.log2(x)
-            log_two_result_cpu = torch.log2(cpu_x)
-
-            self.assertEqual(log_two_result, log_two_result_cpu)
-
-        helper((2, 8, 4, 5))
-
     @parametrize("dtype", {torch.float, torch.half, torch.bfloat16})
     def test_log1p(self, dtype):
         eps = torch.finfo(dtype).eps
@@ -7935,18 +7899,6 @@ class TestMPS(TestCaseMPS):
         # precise::metal::log promises to be accurate to within 4 ulps
         # https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf Table 8.2
         self.ulpAssertAllClose(log_result.cpu(), log_result_cpu, n_ulps=4)
-
-    def test_logsumexp(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
-            x = cpu_x.detach().clone().to('mps')
-
-            log_result = torch.logsumexp(x, -1)
-            log_result_cpu = torch.logsumexp(cpu_x, -1)
-
-            self.assertEqual(log_result, log_result_cpu)
-
-        helper((2, 8, 4, 5))
 
     # Test concat forward
     def test_cat2(self):
@@ -8427,17 +8379,6 @@ class TestMPS(TestCaseMPS):
             _test_gelu(32, 32, torch.float32, False)
         finally:
             torch.set_num_threads(num_threads)
-
-    def test_gelu_tanh(self):
-        def helper(shape):
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float)
-            x = cpu_x.detach().clone().to('mps')
-
-            gelu_tanh_result = torch.nn.functional.gelu(x, approximate='tanh')
-            gelu_tanh_result_cpu = torch.nn.functional.gelu(cpu_x, approximate='tanh')
-            self.assertEqual(gelu_tanh_result, gelu_tanh_result_cpu)
-
-        helper((2, 8, 4, 5))
 
     def test_gelu_tanh_large_values(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/186278


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* #196879
* #196878
* __->__ #196877


Remove `test_log`, `test_log_ten`, `test_log_two`, `test_logsumexp` and `test_gelu_tanh` from `test/test_mps.py`. These ops are already covered by the MPS OpInfo consistency tests, which also check backward (the removed tests were forward-only).

Shape coverage for the removed float32 cases:

| Deleted test | Removed input | Comparable MPS OpInfo input |
| --- | --- | --- |
| `test_log` | Contiguous `(2, 8, 4, 5)` | Contiguous `(20,)` |
| `test_log_ten` | Contiguous `(2, 8, 4, 5)` | Contiguous `(20,)` |
| `test_log_two` | Contiguous `(2, 8, 4, 5)` | Contiguous `(20,)` |
| `test_logsumexp` | Contiguous `(2, 8, 4, 5)`, `dim=-1` | Contiguous `(5, 5)`, `dim=[1]` (also `[-2]`, `[0, 1]` and keepdim variants) |
| `test_gelu_tanh` | Contiguous `(2, 8, 4, 5)`, `approximate='tanh'` | Contiguous `(10, 10)`, `approximate='tanh'` |

`log`, `log10`, `log2` and `gelu` are elementwise ops using TensorIterator and Metal kernels, so the smaller OpInfo shapes exercise the same dense kernel paths. `logsumexp` is CompositeExplicitAutograd and decomposes into `amax`/`exp`/`sum`/`log` on MPS, so the 4D shape had no MPS-specific path either.

Run the existing MPS OpInfo checks with:

```bash
python test/test_mps.py -v \
  TestConsistencyMPS.test_output_match_log_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_log_mps_float32 \
  TestConsistencyMPS.test_output_match_log10_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_log10_mps_float32 \
  TestConsistencyMPS.test_output_match_log2_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_log2_mps_float32 \
  TestConsistencyMPS.test_output_match_logsumexp_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_logsumexp_mps_float32 \
  TestConsistencyMPS.test_output_match_nn_functional_gelu_mps_float32 \
  TestConsistencyMPS.test_output_grad_match_nn_functional_gelu_mps_float32
```