### PR TITLE
[BE] Evaluate the MetalPerformancePrimitives guard once in .metal files

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Convolution.metal
+++ b/aten/src/ATen/native/mps/kernels/Convolution.metal
@@ -310,9 +310,7 @@ INSTANTIATE_CONV_WEIGHT_TO_DHWIO(float)
 INSTANTIATE_CONV_WEIGHT_TO_DHWIO(half)
 INSTANTIATE_CONV_WEIGHT_TO_DHWIO(bfloat)
 
-#if __METAL_VERSION__ >= 400 && \
-    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
-#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#if C10_METAL_HAS_MPP
 #include <metal_cooperative_tensor>
 #include <metal_simdgroup>
 
@@ -822,7 +820,7 @@ INSTANTIATE_CONV3D_MPP_STANDARD(3, 3, 3, 1, 1, 1, 64, 64)
 INSTANTIATE_CONV3D_MPP_STANDARD(3, 3, 3, 1, 2, 2, dyn, -1)
 INSTANTIATE_CONV3D_MPP_STANDARD(3, 3, 3, 2, 2, 2, dyn, -1)
 
-#endif // __METAL_VERSION__ >= 400 && MetalPerformancePrimitives
+#endif // C10_METAL_HAS_MPP
 
 // Direct NCHW conv fallback for filter dims >= 256 (MPSGraph miscomputes); each
 // thread does R consecutive ow outputs. I is int when all numels fit in int32.

--- a/aten/src/ATen/native/mps/kernels/GroupedMM.metal
+++ b/aten/src/ATen/native/mps/kernels/GroupedMM.metal
@@ -323,9 +323,7 @@ kernel void grouped_mm(
       tile, params, a_tile, b_tile, simd_group, simd_lane);
 }
 
-#if __METAL_VERSION__ >= 400 && \
-    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
-#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#if C10_METAL_HAS_MPP
 
 // matmul2d tile op. TA/TB name the operand layouts ('t' = column-major); every
 // tensor is presented to matmul2d with a unit innermost stride and the matching

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -6,6 +6,14 @@
 #include <metal_simdgroup>
 #include <metal_stdlib>
 
+#if __METAL_VERSION__ >= 400 && \
+    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#define HAS_MPP 1
+#else
+#define HAS_MPP 0
+#endif
+
 using namespace metal;
 #include <ATen/native/mps/kernels/Gemv.h>
 
@@ -1264,9 +1272,7 @@ kernel void applyPanelTRSM(
 INSTANTIATE_APPLY_PANEL_TRSM(U, true)
 INSTANTIATE_APPLY_PANEL_TRSM(L, false)
 
-#if __METAL_VERSION__ >= 400 && \
-    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
-#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#if HAS_MPP
 
 template <bool upper, int BM, int BN, int NSG>
 kernel void applySYRKTrailing(
@@ -1417,7 +1423,7 @@ INSTANTIATE_SYRK_TRAILING(L, false, 32, 64, 2)
 INSTANTIATE_SYRK_TRAILING(U, true, 32, 128, 4)
 INSTANTIATE_SYRK_TRAILING(L, false, 32, 128, 4)
 
-#endif // __METAL_VERSION__ >= 400 && MetalPerformancePrimitives
+#endif // HAS_MPP
 
 // LU factorization with partial pivoting (mirrors LAPACK sgetrf), in place on a
 // row-major fp32 (B, M, N) buffer. The host (lu_factor_panel_encode in
@@ -2357,9 +2363,7 @@ kernel void gemmSimdLU(
   }
 }
 
-#if __METAL_VERSION__ >= 400 && \
-    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
-#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#if HAS_MPP
 
 template <int BM, int BN, int NSG>
 kernel void int_mm_mpp(
@@ -2514,7 +2518,7 @@ kernel void gemmLU(
 INSTANTIATE_GEMM_LU(64, 64, 4)
 INSTANTIATE_GEMM_LU(32, 64, 2)
 
-#endif // __METAL_VERSION__ >= 400 && MetalPerformancePrimitives
+#endif // HAS_MPP
 
 template <typename T, bool upper, bool unit, short TS>
 kernel void trsmDiagSolveLU(

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -6,14 +6,6 @@
 #include <metal_simdgroup>
 #include <metal_stdlib>
 
-#if __METAL_VERSION__ >= 400 && \
-    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
-#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
-#define HAS_MPP 1
-#else
-#define HAS_MPP 0
-#endif
-
 using namespace metal;
 #include <ATen/native/mps/kernels/Gemv.h>
 
@@ -1272,7 +1264,7 @@ kernel void applyPanelTRSM(
 INSTANTIATE_APPLY_PANEL_TRSM(U, true)
 INSTANTIATE_APPLY_PANEL_TRSM(L, false)
 
-#if HAS_MPP
+#if C10_METAL_HAS_MPP
 
 template <bool upper, int BM, int BN, int NSG>
 kernel void applySYRKTrailing(
@@ -1423,7 +1415,7 @@ INSTANTIATE_SYRK_TRAILING(L, false, 32, 64, 2)
 INSTANTIATE_SYRK_TRAILING(U, true, 32, 128, 4)
 INSTANTIATE_SYRK_TRAILING(L, false, 32, 128, 4)
 
-#endif // HAS_MPP
+#endif // C10_METAL_HAS_MPP
 
 // LU factorization with partial pivoting (mirrors LAPACK sgetrf), in place on a
 // row-major fp32 (B, M, N) buffer. The host (lu_factor_panel_encode in
@@ -2363,7 +2355,7 @@ kernel void gemmSimdLU(
   }
 }
 
-#if HAS_MPP
+#if C10_METAL_HAS_MPP
 
 template <int BM, int BN, int NSG>
 kernel void int_mm_mpp(
@@ -2518,7 +2510,7 @@ kernel void gemmLU(
 INSTANTIATE_GEMM_LU(64, 64, 4)
 INSTANTIATE_GEMM_LU(32, 64, 2)
 
-#endif // HAS_MPP
+#endif // C10_METAL_HAS_MPP
 
 template <typename T, bool upper, bool unit, short TS>
 kernel void trsmDiagSolveLU(

--- a/c10/metal/common.h
+++ b/c10/metal/common.h
@@ -4,6 +4,13 @@
 #ifdef __METAL__
 #include <metal_array>
 #define C10_METAL_CONSTEXPR constant constexpr
+#if __METAL_VERSION__ >= 400 && \
+    __has_include(<MetalPerformancePrimitives/MetalPerformancePrimitives.h>)
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#define C10_METAL_HAS_MPP 1
+#else
+#define C10_METAL_HAS_MPP 0
+#endif
 #else
 #include <c10/util/complex.h>
 #include <array>


### PR DESCRIPTION
Define `HAS_MPP` once at the top of LinearAlgebra.metal and use it later on instead of repeating the guard and re including the header.