### PR TITLE
[inductor] Mask the 2D-tiled reduction tail store on the output axis

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1482,9 +1482,7 @@ class CPUReproTests(TestCase):
             q = F.pad(v, (0, 0, 0, 0, 0, 58), value=0.5)
             return torch.matmul(q, p)
 
-        x = torch.randn(1, 8, 66, 66).contiguous(
-            memory_format=torch.channels_last
-        )
+        x = torch.randn(1, 8, 66, 66).contiguous(memory_format=torch.channels_last)
         self.common(fn, (x,))
 
     @requires_vectorization

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1467,6 +1467,27 @@ class CPUReproTests(TestCase):
             self.common(mod, (x, weight), atol=5e-1, rtol=5e-1)
 
     @requires_vectorization
+    def test_tile2d_reduction_masked_tail_store(self):
+        # Fix issue: https://github.com/pytorch/pytorch/issues/196681
+        # A 2D-tiled reduction whose output axis is not a multiple of the
+        # vector width stored the tail block's accumulator at full width,
+        # spilling into the next row (or past the buffer on the last row).
+        # The main/tail suffix split misread the reduction layout whenever a
+        # pointwise level sat between the two tiled axes. 66 leaves a tail at
+        # every power-of-two vector width >= 2.
+        def fn(x):
+            v = (x * 0.5) * (torch.erf(x * 0.7071067811865476) + 1)
+            a = v.permute(3, 2, 1, 0)
+            p = F.pad(a, (0, 0, 0, 58), value=0.5)
+            q = F.pad(v, (0, 0, 0, 0, 0, 58), value=0.5)
+            return torch.matmul(q, p)
+
+        x = torch.randn(1, 8, 66, 66).contiguous(
+            memory_format=torch.channels_last
+        )
+        self.common(fn, (x,))
+
+    @requires_vectorization
     def test_max_parallel_depth_sub_vector_width_loop(self):
         # Fix issue: https://github.com/pytorch/pytorch/issues/190757
         # A vectorized loop smaller than the vector width runs 1 iteration, not

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4782,7 +4782,15 @@ class CppKernelProxy(CppKernel):
             if tiling_indices:
                 inner_loop_reduction = False
                 outer_loop_level = tiling_indices[0]
-                inner_loop_level = outer_loop_level + 1
+                # 2D tiling: the inner tiled axis is tiling_indices[1], not
+                # necessarily the level right after the outer one; a pointwise
+                # level can sit between them, and looking there instead of at
+                # the real inner tiled axis misreads the reduction layout.
+                inner_loop_level = (
+                    tiling_indices[1]
+                    if len(tiling_indices) == 2
+                    else outer_loop_level + 1
+                )
                 if len(self.loop_nest.loops) > inner_loop_level:
                     inner_loop_reduction = self.loop_nest.loops[
                         inner_loop_level


### PR DESCRIPTION
Fixes #196681

## Summary

A CPU 2D-tiled reduction whose two tiled axes are not adjacent loop levels (a pointwise level sits between them) stored the tail block's accumulator at full vector width. For a 66-wide output axis, the tail block at `x0=64` has 2 valid lanes but the epilogue emitted a full-width store, spilling into the next row on every row and past the buffer end on the last one — heap corruption or silent wrong results.

The store code is fine; the miss is one level up in the epilogue aggregation. `CppKernelProxy.aggregate_reduction_buffers` splits the reduction suffix into main/tail variants only when `_inner_loop_reduction_outer_not` holds, and that check probed `tiling_indices[0] + 1` for the inner reduction — assuming the second tiled axis is always the level right after the outer one. Here the tiled axes are levels 0 (output) and 2 (reduction) with a pointwise level in between, so the check read the wrong level, concluded "no inner reduction", and spliced only the main kernel's suffix. The tail kernels had already emitted the correctly masked store (`tmp_acc0_vec.store(ptr, 2)`); it never reached the output.

The fix probes the actual second tiled axis (`tiling_indices[1]` when two axes are tiled, the adjacent level otherwise as before). The epilogue then splits as designed:

```cpp
if(C10_LIKELY(x0 >= 0 && x0 < 64))   tmp_acc0_vec.store(out_ptr0 + x0 + 66*x1);
if(C10_UNLIKELY(x0 >= 64 && x0 < 66)) tmp_acc0_vec.store(out_ptr0 + x0 + 66*x1, 2);
```

## Test plan

New regression test in `test_cpu_repro.py` over the issue's channels_last GELU + pads + matmul shape (66 leaves a tail at every power-of-two vector width ≥ 2, so it exercises the tail on NEON and AVX alike):

```
python test/inductor/test_cpu_repro.py -k test_tile2d_reduction_masked_tail_store
```

Verified locally on CPU (Apple Silicon, torch 2.15.0.dev20260912 nightly): the test fails on main as shipped (3.0% of elements mismatched, max abs diff 19.5) and passes with this change; the same fix on the 2.14.0 release wheel takes the issue's repro from max abs diff 19.97 to 7.6e-06. A regression sweep over neighboring codegen shapes (2D-tiled pointwise, var_mean welford, argmax, mid-dim sum, and the 27-test reduction/tail/tile subset of test_cpu_repro) shows no outcome changes from the patch. The reduction/tail subset has 13 pre-existing failures on macOS (file-level `not IS_MACOS` gating means these run on Linux CI); the failure set is byte-identical with and without the patch. Ruff check/format on the changed lines is clean; full lintrunner was not run locally.

This PR was authored with AI assistance (Kimi); the mechanism analysis, the local verification described above, and the diff were reviewed by the committer before submission.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @laolvfan
