### PR TITLE
[Inductor][FlyDSL] Add gfx950 MXFP8 grouped wgrad

### DIFF
--- a/test/inductor/test_flydsl_grouped_scheduler.py
+++ b/test/inductor/test_flydsl_grouped_scheduler.py
@@ -1,0 +1,186 @@
+# Owner(s): ["module: inductor"]
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+from torch._inductor.codegen.flydsl import flydsl_utils
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize
+
+
+try:
+    from . import test_flydsl_template as input_factory
+except ImportError:
+    import test_flydsl_template as input_factory
+
+
+class TestFlyDSLGroupedSchedulerPolicy(TestCase):
+    def setUp(self):
+        super().setUp()
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+    def test_grid_cap_and_cache_modes(self):
+        import dataclasses
+
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            mxfp8_grouped_gemm_gfx950 as kernel,
+        )
+
+        param = kernel.make_mxfp8_grouped_gemm_param(512, 2048, 8, 128, 128)
+        props = SimpleNamespace(multi_processor_count=256)
+        for rows in (0, 1, 128, 4096, 32768):
+            bound, _ = kernel.get_mxfp8_grouped_gemm_grid_size(param, rows)
+            grid = kernel.get_mxfp8_grouped_gemm_persistent_grid_size(
+                param, rows, props
+            )
+            self.assertEqual(grid, max(1, min(bound, 256)))
+        single = dataclasses.replace(param, persistent=False)
+        self.assertNotEqual(param.__cache_signature__(), single.__cache_signature__())
+        self.assertNotEqual(
+            kernel.make_mxfp8_grouped_gemm_kernel_name(param),
+            kernel.make_mxfp8_grouped_gemm_kernel_name(single),
+        )
+        self.assertIs(
+            kernel.cached_launch(*param.key()), kernel.cached_launch(*param.key())
+        )
+
+
+@unittest.skipIf(torch.version.hip is None, "requires ROCm")
+class TestFlyDSLGroupedScheduler(TestCase):
+    def setUp(self):
+        super().setUp()
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+        arch = torch.cuda.get_device_properties(torch.cuda.current_device()).gcnArchName
+        if arch.split(":")[0] != "gfx950":
+            self.skipTest("requires gfx950")
+
+    @parametrize(
+        "tile", ((64, 128), (64, 256), (128, 128), (128, 256), (256, 128), (256, 256))
+    )
+    @parametrize("k", (512, 640, 2048))
+    def test_persistent_tiles(self, device, tile, k):
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            mxfp8_grouped_gemm_gfx950 as kernel,
+        )
+        from torch._inductor.runtime.flydsl_cache import flydsl_tensor_arg
+
+        n = 384  # Partial column tile for BLOCK_C=256.
+        param = kernel.make_mxfp8_grouped_gemm_param(k, n, 6, *tile)
+        # Same compiled specialization, different routing and token counts.
+        for sizes in ([0, 1, 257, 0, 63, 513], [65, 0, 0, 129, 17, 0]):
+            a, b, sa, sb, offs, reference = (
+                input_factory.TestFlyDSLTemplate._make_mxfp8_grouped_inputs(
+                    sizes, k, n, device=device
+                )
+            )
+            output = torch.empty_like(reference)
+            # Non-power-of-two grid, repeated tiles, and empty groups.
+            with mock.patch.object(
+                kernel,
+                "get_mxfp8_grouped_gemm_persistent_grid_size",
+                return_value=3,
+            ):
+                for _ in range(8):
+                    output.fill_(float("nan"))
+                    kernel.launch_mxfp8_grouped_gemm_gfx950(
+                        output,
+                        a,
+                        b.permute(0, 2, 1),
+                        sa,
+                        sb,
+                        offs,
+                        param,
+                        torch.cuda.current_stream(),
+                        tensor_arg=flydsl_tensor_arg,
+                    )
+                    self.assertEqual(
+                        output.float(), reference.float(), atol=6e-2, rtol=6e-2
+                    )
+
+    @parametrize("grid", (1, 3, 256))
+    def test_empty_routing_leaves_output_untouched(self, device, grid):
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            mxfp8_grouped_gemm_gfx950 as kernel,
+        )
+        from torch._inductor.runtime.flydsl_cache import flydsl_tensor_arg
+
+        a, b, sa, sb, offs, reference = (
+            input_factory.TestFlyDSLTemplate._make_mxfp8_grouped_inputs(
+                [0, 17, 0, 0], 512, 384, device=device
+            )
+        )
+        param = kernel.make_mxfp8_grouped_gemm_param(512, 384, 4, 64, 256)
+        output = torch.full_like(reference, 42)
+        offs.zero_()
+        with mock.patch.object(
+            kernel, "get_mxfp8_grouped_gemm_persistent_grid_size", return_value=grid
+        ):
+            kernel.launch_mxfp8_grouped_gemm_gfx950(
+                output,
+                a,
+                b.permute(0, 2, 1),
+                sa,
+                sb,
+                offs,
+                param,
+                torch.cuda.current_stream(),
+                tensor_arg=flydsl_tensor_arg,
+            )
+        self.assertEqual(output, torch.full_like(output, 42))
+
+    def test_persistent_routing_changes_in_place(self, device):
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            mxfp8_grouped_gemm_gfx950 as kernel,
+        )
+        from torch._inductor.runtime.flydsl_cache import flydsl_tensor_arg
+
+        a, b, sa, sb, offs, _ = (
+            input_factory.TestFlyDSLTemplate._make_mxfp8_grouped_inputs(
+                [256] * 4, 2048, 384, device=device
+            )
+        )
+        a_scales = torch.pow(2.0, sa.view(torch.uint8).float() - 127)
+        b_scales = torch.pow(2.0, sb.view(torch.uint8).float() - 127).reshape(
+            4, 384, -1
+        )
+        param = kernel.make_mxfp8_grouped_gemm_param(2048, 384, 4, 128, 256)
+        output = torch.empty((1024, 384), device=device, dtype=torch.bfloat16)
+        with mock.patch.object(
+            kernel, "get_mxfp8_grouped_gemm_persistent_grid_size", return_value=3
+        ):
+            for boundaries in (
+                [0, 1, 513, 1024],
+                [257, 257, 1024, 1024],
+                [0, 0, 17, 17],
+            ):
+                offs.copy_(torch.tensor(boundaries, device=device, dtype=offs.dtype))
+                reference = input_factory.TestFlyDSLTemplate._mxfp8_grouped_reference(
+                    a, a_scales, b.transpose(-2, -1), b_scales, offs
+                )
+                output.fill_(42)
+                kernel.launch_mxfp8_grouped_gemm_gfx950(
+                    output,
+                    a,
+                    b.permute(0, 2, 1),
+                    sa,
+                    sb,
+                    offs,
+                    param,
+                    torch.cuda.current_stream(),
+                    tensor_arg=flydsl_tensor_arg,
+                )
+                end = boundaries[-1]
+                self.assertEqual(
+                    output[:end].float(), reference[:end].float(), atol=0.06, rtol=0.06
+                )
+                self.assertEqual(output[end:], torch.full_like(output[end:], 42))
+
+
+instantiate_device_type_tests(TestFlyDSLGroupedScheduler, globals(), only_for="cuda")
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -543,6 +543,193 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(compile_calls, 1)
         compiled.assert_called_once_with("second")
 
+    @parametrize("raises", (False, True))
+    def test_precompile_flydsl_restores_environment(self, raises):
+        from torch._inductor.runtime.flydsl_cache import precompile_flydsl
+        from torch._subclasses.fake_tensor import FakeTensor
+
+        seen = []
+
+        def kernel(*, mat1, output, stream, compile_only):
+            self.assertIsInstance(mat1, FakeTensor)
+            self.assertEqual(mat1.shape, (2, 3))
+            self.assertEqual(mat1.stride(), (4, 1))
+            self.assertEqual(output.dtype, torch.bfloat16)
+            self.assertTrue(compile_only)
+            self.assertEqual(stream, 0)
+            self.assertEqual(os.environ["COMPILE_ONLY"], "1")
+            self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx950")
+            seen.append(True)
+            if raises:
+                raise RuntimeError("compile failed")
+
+        with mock.patch.dict(
+            os.environ, {"COMPILE_ONLY": "0", "FLYDSL_GPU_ARCH": "gfx942"}
+        ):
+
+            def precompile():
+                precompile_flydsl(
+                    kernel,
+                    {"mat1": (2, 3), "output": (2, 5)},
+                    {"mat1": (4, 1), "output": (5, 1)},
+                    {"mat1": "float32", "output": "bfloat16"},
+                    "gfx950",
+                )
+
+            if raises:
+                with self.assertRaisesRegex(RuntimeError, "compile failed"):
+                    precompile()
+            else:
+                precompile()
+            self.assertEqual(os.environ["COMPILE_ONLY"], "0")
+            self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx942")
+        self.assertEqual(seen, [True])
+
+    @parametrize("kind", ("mm", "grouped_mm", "mxfp8_grouped_mm"))
+    def test_flydsl_precompile_fake_tensors(self, kind):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+        import flydsl.compiler as flyc
+        import flydsl.expr as fx
+        import jinja2
+
+        from torch._inductor.kernel.mm_common import load_kernel_template
+
+        namespace = dict(
+            torch=torch,
+            flyc=flyc,
+            fx=fx,
+            GEMM_M=256,
+            GEMM_N=256,
+            GEMM_K=512,
+            GEMM_G=2,
+            GEMM_DTYPE_ID=2,
+            TILE_M=128,
+            TILE_N=128,
+            TILE_K=64,
+            STAGES=2,
+            M_WAVES=1,
+            N_WAVES=4,
+            GROUP_M=0,
+            USE_HALF_TILE_INTERLEAVED=False,
+            A_IS_TRANSPOSED=False,
+            B_IS_TRANSPOSED=True,
+            BLOCK_R=64,
+            BLOCK_C=128,
+        )
+        source = jinja2.Template(load_kernel_template(f"flydsl_{kind}")).render(
+            gen_defines=lambda: "",
+            def_kernel=lambda *names: f"def kernel_main({','.join(names)}, output, stream):",
+            get_output=lambda: "output",
+            kernel_name="kernel",
+        )
+        exec(compile(source, "<flydsl precompile test>", "exec"), namespace)
+        shapes = {"mat1": (256, 512), "mat2": (512, 256), "output": (256, 256)}
+        strides = {"mat1": (512, 1), "mat2": (1, 512), "output": (256, 1)}
+        dtypes = dict.fromkeys(shapes, "bfloat16")
+        if kind != "mm":
+            shapes.update(mat2=(2, 512, 256), offs=(2,))
+            strides.update(mat2=(131072, 256, 1), offs=(1,))
+            dtypes["offs"] = "int32"
+        if kind == "mxfp8_grouped_mm":
+            strides["mat2"] = (131072, 1, 512)
+            dtypes.update(
+                mat1="float8_e4m3fn",
+                mat2="float8_e4m3fn",
+                scale_a="float8_e8m0fnu",
+                scale_b="float8_e8m0fnu",
+            )
+            shapes.update(scale_a=(256, 16), scale_b=(2, 4096))
+            strides.update(scale_a=(16, 1), scale_b=(4096, 1))
+        # Exercise the real compiler with metadata only, including on hosts
+        # without a GPU. A normal flyc.compile call attempts to execute.
+        with mock.patch.object(
+            torch.cuda,
+            "get_device_properties",
+            side_effect=AssertionError("device queried"),
+        ):
+            namespace["kernel_precompile"](
+                shapes, strides, dtypes, flydsl_gpu_arch="gfx950"
+            )
+
+    @parametrize("block_m", (2, 4, 8))
+    def test_grouped_row_tile_upper_bound(self, block_m):
+        from itertools import product
+
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels.grouped_config import (
+            grouped_row_tiles_upper_bound,
+        )
+
+        for total in range(9):
+            for groups in range(1, 5):
+                actual_max = max(
+                    sum((rows + block_m - 1) // block_m for rows in partition)
+                    for partition in product(range(total + 1), repeat=groups)
+                    if sum(partition) == total
+                )
+                self.assertEqual(
+                    grouped_row_tiles_upper_bound(total, groups, block_m),
+                    actual_max,
+                )
+
+    def test_precompile_flydsl_concurrent_dispatch(self):
+        from torch._inductor.runtime.flydsl_cache import precompile_flydsl
+
+        precompile_started = threading.Event()
+        release_precompile = threading.Event()
+        cold_started = threading.Event()
+        cold_compiler_started = threading.Event()
+        warm_dispatch = mock.Mock()
+        cold_jit = SimpleNamespace()
+
+        def precompile_kernel(**kwargs):
+            precompile_started.set()
+            self.assertTrue(release_precompile.wait(5))
+
+        def cold_compiler(*args):
+            cold_compiler_started.set()
+            self.assertNotEqual(os.environ.get("COMPILE_ONLY"), "1")
+            return mock.Mock()
+
+        def cold_launch():
+            cold_started.set()
+            return run_cached_flydsl(
+                cold_jit,
+                constexpr_param=_CacheParam(),
+                compiler=cold_compiler,
+                dispatch_args=(dispatch,),
+            )
+
+        # Supply a dispatch argument because the cache keys include its device.
+        dispatch = SimpleNamespace(device=SimpleNamespace(index=0))
+        warm_jit = SimpleNamespace()
+        run_cached_flydsl(
+            warm_jit,
+            constexpr_param=_CacheParam(),
+            compiler=lambda *args: warm_dispatch,
+            dispatch_args=(dispatch,),
+        )
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            precompile = pool.submit(precompile_flydsl, precompile_kernel, {}, {}, {})
+            try:
+                self.assertTrue(precompile_started.wait(5))
+                run_cached_flydsl(
+                    warm_jit,
+                    constexpr_param=_CacheParam(),
+                    compiler=mock.Mock(
+                        side_effect=AssertionError("unexpected compile")
+                    ),
+                    dispatch_args=(dispatch,),
+                )
+                warm_dispatch.assert_called_once_with(dispatch)
+                cold = pool.submit(cold_launch)
+                self.assertTrue(cold_started.wait(5))
+                self.assertFalse(cold_compiler_started.wait(0.05))
+            finally:
+                release_precompile.set()
+            precompile.result()
+            cold.result()
+
     def _assert_compiled_mm(
         self,
         a,
@@ -599,9 +786,9 @@ class TestFlyDSLTemplate(TestCase):
                 a = torch.randn(m, k, device="cuda", dtype=dtype)
                 b = torch.randn(n, k, device="cuda", dtype=dtype)
                 code = self._assert_compiled_mm(a, b)
-                self.assertIn(".mark_layout_dynamic()", code)
+                self.assertIn("flydsl_tensor_arg", code)
                 self.assertNotIn("mat2.transpose(0, 1)", code)
-                self.assertIn("_inductor_tensor_arg(mat2)", code)
+                self.assertIn("flydsl_tensor_arg(mat2)", code)
                 self.assertIn(".run(", code)
                 self.assertIn("TILE_M: fx.Constexpr", code)
 
@@ -899,7 +1086,7 @@ class TestFlyDSLTemplate(TestCase):
         ) as grid_size:
             code = self._assert_compiled_grouped_mm(a, b, offs)
         grid_size.assert_called_once()
-        self.assertIn("FLYDSL_COMPILE_ONLY", code)
+        self.assertIn("precompile_flydsl", code)
         self.assertIn("_precompile", code)
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
@@ -1109,72 +1296,6 @@ class TestFlyDSLTemplate(TestCase):
         self.assertNotIn("async_compile.flydsl", code)
         self.assertIn("extern_kernels._grouped_mm", code)
         self.assertEqual(result, fn(a_unaligned_base, b, offs), atol=3e-2, rtol=3e-2)
-
-
-
-    def test_compiled_cache_keys_on_device_and_param(self):
-        jit_func = SimpleNamespace()
-        compiled = mock.Mock()
-        compiler = mock.Mock(return_value=compiled)
-
-        def invoke(device_index):
-            dispatch = SimpleNamespace(device=SimpleNamespace(index=device_index))
-            return run_cached_flydsl(
-                jit_func,
-                object(),
-                constexpr_param=_CacheParam(),
-                compiler=compiler,
-                dispatch_args=(dispatch,),
-            )
-
-        first = invoke(0)
-        with mock.patch(
-            "torch._inductor.runtime.flydsl_cache._compiled_cache_lock"
-        ) as cache_lock:
-            second = invoke(0)
-        third = invoke(1)
-
-        self.assertIs(first, compiled)
-        self.assertIs(second, compiled)
-        self.assertIs(third, compiled)
-        cache_lock.__enter__.assert_not_called()
-        self.assertEqual(compiler.call_count, 2)
-        compiled.assert_called_once()
-
-    def test_compiled_cache_serializes_same_param(self):
-        jit_func = SimpleNamespace()
-        compile_started = threading.Event()
-        allow_compile = threading.Event()
-        compiled = mock.Mock()
-        compile_calls = 0
-
-        def compiler(*args):
-            nonlocal compile_calls
-            compile_calls += 1
-            compile_started.set()
-            self.assertTrue(allow_compile.wait(5))
-            return compiled
-
-        def invoke(value):
-            return run_cached_flydsl(
-                jit_func,
-                object(),
-                constexpr_param=_CacheParam(),
-                compiler=compiler,
-                dispatch_args=(value,),
-            )
-
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            first = pool.submit(invoke, "first")
-            self.assertTrue(compile_started.wait(5))
-            second = pool.submit(invoke, "second")
-            allow_compile.set()
-            self.assertIs(first.result(), compiled)
-            self.assertIs(second.result(), compiled)
-
-        self.assertEqual(compile_calls, 1)
-        compiled.assert_called_once_with("second")
-
 
     # ------------------------------------------------------------------
     # MXFP8 ragged grouped GEMM (aten._scaled_grouped_mm_v2)
@@ -1456,11 +1577,9 @@ class TestFlyDSLTemplate(TestCase):
             self.skipTest("FlyDSL runtime unavailable")
 
         code = self._assert_compiled_mxfp8_grouped_mm(group_sizes, k, n)
-        self.assertIn(".mark_layout_dynamic()", code)
+        self.assertIn("flydsl_tensor_arg", code)
         self.assertIn("_precompile", code)
-        # Compile-only is an argument, not a process-global env flag: warming
-        # and a real dispatch can share a process.
-        self.assertIn("compile_only=True", code)
+        self.assertIn("precompile_flydsl", code)
         self.assertNotIn("FLYDSL_COMPILE_ONLY", code)
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
@@ -1578,6 +1697,7 @@ class TestFlyDSLTemplate(TestCase):
             self.assertGreaterEqual(int(window_offs.min()), 0)
             covered += rows
         self.assertEqual(covered, total_m)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -585,7 +585,7 @@ class TestFlyDSLTemplate(TestCase):
             self.assertEqual(os.environ["FLYDSL_GPU_ARCH"], "gfx942")
         self.assertEqual(seen, [True])
 
-    @parametrize("kind", ("mm", "grouped_mm", "mxfp8_grouped_mm"))
+    @parametrize("kind", ("mm", "grouped_mm", "mxfp8_grouped_mm", "mxfp8_wgrad"))
     def test_flydsl_precompile_fake_tensors(self, kind):
         if not flydsl_utils.runtime_available():
             self.skipTest("FlyDSL runtime unavailable")
@@ -641,6 +641,32 @@ class TestFlyDSLTemplate(TestCase):
             )
             shapes.update(scale_a=(256, 16), scale_b=(2, 4096))
             strides.update(scale_a=(16, 1), scale_b=(4096, 1))
+        elif kind == "mxfp8_wgrad":
+            namespace["GEMM_K"] = 384
+            shapes.update(
+                mat1=(256, 512),
+                mat2=(512, 384),
+                scale_a=(256, 16),
+                scale_b=(384, 16),
+                offs=(2,),
+                output=(2, 256, 384),
+            )
+            strides.update(
+                mat1=(512, 1),
+                mat2=(1, 512),
+                scale_a=(16, 1),
+                scale_b=(16, 1),
+                offs=(1,),
+                output=(256 * 384, 384, 1),
+            )
+            dtypes.update(
+                mat1="float8_e4m3fn",
+                mat2="float8_e4m3fn",
+                scale_a="float8_e8m0fnu",
+                scale_b="float8_e8m0fnu",
+                offs="int32",
+                output="bfloat16",
+            )
         # Exercise the real compiler with metadata only, including on hosts
         # without a GPU. A normal flyc.compile call attempts to execute.
         with mock.patch.object(
@@ -1697,6 +1723,132 @@ class TestFlyDSLTemplate(TestCase):
             self.assertGreaterEqual(int(window_offs.min()), 0)
             covered += rows
         self.assertEqual(covered, total_m)
+
+    def test_flydsl_mxfp8_wgrad_gate(self):
+        from torch._inductor.kernel import mm_grouped
+
+        n, m, k, g = 256, 512, 384, 4
+        scale_m = m // 32
+
+        def node(size, stride, dtype, offset=0):
+            return SimpleNamespace(
+                get_size=lambda: size,
+                get_stride=lambda: stride,
+                get_dtype=lambda: dtype,
+                get_layout=lambda: SimpleNamespace(offset=offset),
+            )
+
+        fp8 = torch.float8_e4m3fn
+        e8m0 = torch.float8_e8m0fnu
+        mat_a = node([n, m], [m, 1], fp8)
+        mat_b = node([m, k], [1, m], fp8)
+        scale_a = node([n, scale_m], [scale_m, 1], e8m0)
+        scale_b = node([k, scale_m], [scale_m, 1], e8m0)
+        offs = node([g], [1], torch.int32)
+        layout = SimpleNamespace(
+            stride=[n * k, k, 1],
+            dtype=torch.bfloat16,
+            size=[g, n, k],
+            device=torch.device("cpu"),
+        )
+        sizevars = SimpleNamespace(
+            statically_known_multiple_of=lambda x, y: x % y == 0,
+        )
+        with (
+            V.set_graph_handler(SimpleNamespace(sizevars=sizevars)),
+            mock.patch.object(
+                mm_grouped, "use_flydsl_gemm_template", return_value=True
+            ),
+            mock.patch.object(mm_grouped, "is_unaligned", return_value=False),
+        ):
+            kwargs = mm_grouped.get_flydsl_mxfp8_wgrad_template_kwargs(
+                mat_a, mat_b, scale_a, scale_b, offs, layout, True
+            )
+            self.assertEqual(kwargs, [{"GEMM_N": n, "GEMM_K": k, "GEMM_G": g}])
+
+            bad_stride = node([m, k], [k, 1], fp8)
+            self.assertEqual(
+                mm_grouped.get_flydsl_mxfp8_wgrad_template_kwargs(
+                    mat_a, bad_stride, scale_a, scale_b, offs, layout, True
+                ),
+                [],
+            )
+
+            bad_m = node([n, m + 32], [m + 32, 1], fp8)
+            self.assertEqual(
+                mm_grouped.get_flydsl_mxfp8_wgrad_template_kwargs(
+                    bad_m, mat_b, scale_a, scale_b, offs, layout, True
+                ),
+                [],
+            )
+
+    def test_flydsl_mxfp8_wgrad_order(self):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            make_mxfp8_wgrad_param,
+        )
+
+        small = make_mxfp8_wgrad_param(1408, 2048, 8, sc_pair=True)
+        self.assertEqual(small.order, "lpt")
+        self.assertEqual((small.xcd_count, small.group_r, small.group_c), (8, 2, 2))
+
+        large = make_mxfp8_wgrad_param(4096, 7168, 32, sc_pair=True)
+        self.assertEqual(large.order, "idsel")
+        self.assertEqual((large.xcd_count, large.group_r, large.group_c), (8, 2, 2))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=False,
+    )
+    @parametrize(
+        "group_sizes,n,k",
+        (
+            ([128, 256, 0, 384], 256, 384),
+            ([32, 96, 224, 160], 1408, 2048),
+        ),
+    )
+    def test_flydsl_mxfp8_wgrad_e2e(self, group_sizes, n, k):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        from torch._inductor.utils import run_and_get_code
+
+        offs = torch.tensor(group_sizes, device="cuda", dtype=torch.int32).cumsum(0)
+        offs = offs.to(torch.int32)
+        m = sum(group_sizes)
+        a, a_scale, a_scale_f32 = self._mxfp8_quantize(
+            torch.randn(n, m, device="cuda") * 0.5
+        )
+        b_t, b_scale, b_scale_f32 = self._mxfp8_quantize(
+            torch.randn(k, m, device="cuda") * 0.5
+        )
+        b = b_t.t()
+
+        a_deq = (a.float().reshape(n, m // 32, 32) * a_scale_f32.unsqueeze(-1)).reshape(
+            n, m
+        )
+        b_deq = (
+            b_t.float().reshape(k, m // 32, 32) * b_scale_f32.unsqueeze(-1)
+        ).reshape(k, m)
+        reference = torch.empty(len(group_sizes), n, k, device="cuda")
+        start = 0
+        for group, end in enumerate(offs.tolist()):
+            reference[group] = a_deq[:, start:end] @ b_deq[:, start:end].t()
+            start = end
+
+        def fn(a, b, a_scale, b_scale, offs):
+            return self._scaled_grouped_mm_mxfp8(a, b, a_scale, b_scale, offs)
+
+        result, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor"), a, b, a_scale, b_scale, offs
+        )
+        self.assertIn("mxfp8_wgrad_gfx950", code)
+        self.assertEqual(result.float(), reference, atol=6e-2, rtol=6e-2)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -22,6 +22,7 @@ from torch._inductor.select_algorithm import PartialRender
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import OrderedSet
 from torch._inductor.virtualized import V
+from torch.nn.functional import ScalingType, SwizzleType
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -1109,6 +1110,474 @@ class TestFlyDSLTemplate(TestCase):
         self.assertIn("extern_kernels._grouped_mm", code)
         self.assertEqual(result, fn(a_unaligned_base, b, offs), atol=3e-2, rtol=3e-2)
 
+
+
+    def test_compiled_cache_keys_on_device_and_param(self):
+        jit_func = SimpleNamespace()
+        compiled = mock.Mock()
+        compiler = mock.Mock(return_value=compiled)
+
+        def invoke(device_index):
+            dispatch = SimpleNamespace(device=SimpleNamespace(index=device_index))
+            return run_cached_flydsl(
+                jit_func,
+                object(),
+                constexpr_param=_CacheParam(),
+                compiler=compiler,
+                dispatch_args=(dispatch,),
+            )
+
+        first = invoke(0)
+        with mock.patch(
+            "torch._inductor.runtime.flydsl_cache._compiled_cache_lock"
+        ) as cache_lock:
+            second = invoke(0)
+        third = invoke(1)
+
+        self.assertIs(first, compiled)
+        self.assertIs(second, compiled)
+        self.assertIs(third, compiled)
+        cache_lock.__enter__.assert_not_called()
+        self.assertEqual(compiler.call_count, 2)
+        compiled.assert_called_once()
+
+    def test_compiled_cache_serializes_same_param(self):
+        jit_func = SimpleNamespace()
+        compile_started = threading.Event()
+        allow_compile = threading.Event()
+        compiled = mock.Mock()
+        compile_calls = 0
+
+        def compiler(*args):
+            nonlocal compile_calls
+            compile_calls += 1
+            compile_started.set()
+            self.assertTrue(allow_compile.wait(5))
+            return compiled
+
+        def invoke(value):
+            return run_cached_flydsl(
+                jit_func,
+                object(),
+                constexpr_param=_CacheParam(),
+                compiler=compiler,
+                dispatch_args=(value,),
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(invoke, "first")
+            self.assertTrue(compile_started.wait(5))
+            second = pool.submit(invoke, "second")
+            allow_compile.set()
+            self.assertIs(first.result(), compiled)
+            self.assertIs(second.result(), compiled)
+
+        self.assertEqual(compile_calls, 1)
+        compiled.assert_called_once_with("second")
+
+
+    # ------------------------------------------------------------------
+    # MXFP8 ragged grouped GEMM (aten._scaled_grouped_mm_v2)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _mxfp8_quantize(x, block=32):
+        """Cast the last dim of `x` to MXFP8: e4m3 data + e8m0 block scales.
+
+        Returns (fp8 data, e8m0 scales, f32 scales) -- the f32 scales are the
+        exact values the e8m0 ones encode, so a reference can dequantize
+        without re-deriving the exponent.
+        """
+        k = x.shape[-1]
+        blocks = x.reshape(*x.shape[:-1], k // block, block)
+        amax = blocks.abs().amax(-1)
+        # e4m3 max is 448 = 2**8.8; take the exponent that maps amax below it.
+        exponent = torch.floor(torch.log2(amax.clamp(min=1e-30))).to(torch.int32) - 7
+        exponent = exponent.clamp(-127, 127)
+        scale_f32 = torch.exp2(exponent.float())
+        data = (
+            (blocks / scale_f32.unsqueeze(-1))
+            .clamp(-448, 448)
+            .to(torch.float8_e4m3fn)
+            .reshape(*x.shape[:-1], k)
+        )
+        scale_e8m0 = (exponent + 127).to(torch.uint8).view(torch.float8_e8m0fnu)
+        return data, scale_e8m0, scale_f32
+
+    @classmethod
+    def _mxfp8_grouped_reference(cls, a, a_scale, b, b_scale, offs, block=32):
+        """Dequantize and matmul per group, in f32."""
+        m, k = a.shape
+        g, n = b.shape[0], b.shape[1]
+        a_deq = a.float().reshape(m, k // block, block) * a_scale.unsqueeze(-1)
+        b_deq = b.float().reshape(g, n, k // block, block) * b_scale.unsqueeze(-1)
+        a_deq = a_deq.reshape(m, k)
+        b_deq = b_deq.reshape(g, n, k)
+        out = torch.zeros(m, n, device=a.device, dtype=torch.float32)
+        start = 0
+        for group in range(g):
+            end = int(offs[group])
+            if end > start:
+                out[start:end] = a_deq[start:end] @ b_deq[group].t()
+            start = end
+        return out.to(torch.bfloat16)
+
+    @classmethod
+    def _make_mxfp8_grouped_inputs(cls, group_sizes, k, n, device="cuda"):
+        offs = torch.tensor(group_sizes, device=device, dtype=torch.int32).cumsum(0)
+        offs = offs.to(torch.int32)
+        m = int(sum(group_sizes))
+        g = len(group_sizes)
+        a_hp = torch.randn(m, k, device=device) * 0.5
+        # The weight is generated as [G, N, K] row-major and handed to the op
+        # as the [G, K, N] view of it, which is the layout every scaled GEMM
+        # already requires of mat_b.
+        b_hp = torch.randn(g, n, k, device=device) * 0.5
+        a, a_scale, a_scale_f32 = cls._mxfp8_quantize(a_hp)
+        b, b_scale, b_scale_f32 = cls._mxfp8_quantize(b_hp)
+        reference = cls._mxfp8_grouped_reference(a, a_scale_f32, b, b_scale_f32, offs)
+        return (
+            a,
+            b.transpose(-2, -1),
+            a_scale,
+            b_scale.reshape(g, -1),
+            offs,
+            reference,
+        )
+
+    @staticmethod
+    def _scaled_grouped_mm_mxfp8(a, b, a_scale, b_scale, offs, **kwargs):
+        return F.scaled_grouped_mm(
+            a,
+            b,
+            a_scale,
+            ScalingType.BlockWise1x32,
+            b_scale,
+            ScalingType.BlockWise1x32,
+            swizzle_a=SwizzleType.NO_SWIZZLE,
+            swizzle_b=SwizzleType.NO_SWIZZLE,
+            offs=offs,
+            output_dtype=torch.bfloat16,
+            **kwargs,
+        )
+
+    def test_flydsl_mxfp8_grouped_gemm_config_schema(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        # Non-autotuned selection is the tile the kernel's own heuristic picks,
+        # not a fixed one -- so it has to be shape-dependent.
+        with (
+            mock.patch.object(
+                flydsl_heuristics,
+                "get_default_mxfp8_grouped_gemm_config",
+                return_value=flydsl_heuristics.FlyDSLMXFP8GroupedGemmConfig(64, 128),
+            ),
+            mock.patch.object(flydsl_heuristics, "_make_mxfp8_grouped_gemm_param"),
+            torch._inductor.config.patch(flydsl_enable_autotuning=False),
+        ):
+            selected = flydsl_heuristics.get_mxfp8_grouped_gemm_configs(
+                512, 2048, 2048, 8
+            )
+        self.assertEqual(selected, [{"BLOCK_R": 64, "BLOCK_C": 128}])
+
+        with (
+            mock.patch.object(flydsl_heuristics, "_make_mxfp8_grouped_gemm_param"),
+            torch._inductor.config.patch(flydsl_enable_autotuning=True),
+        ):
+            exhaustive = flydsl_heuristics.get_mxfp8_grouped_gemm_configs(
+                512, 2048, 2048, 8
+            )
+        self.assertEqual(len(exhaustive), 6)
+        self.assertIn({"BLOCK_R": 256, "BLOCK_C": 256}, exhaustive)
+        self.assertIn({"BLOCK_R": 64, "BLOCK_C": 128}, exhaustive)
+
+    @parametrize(
+        "k,n,g,block_r,block_c,expected",
+        (
+            (2048, 2048, 8, 256, 256, True),
+            (2048, 2048, 8, 64, 128, True),
+            # K must be a whole number of 128-element pipeline steps...
+            (2080, 2048, 8, 256, 256, False),
+            # ...and there must be at least four of them (2 prologue, 2 tails).
+            (384, 2048, 8, 256, 256, False),
+            # A 128-wide tile only pays when it divides N.
+            (2048, 1408, 8, 256, 128, True),
+            (2048, 1344, 8, 256, 128, False),
+            # Tiles the kernel does not implement.
+            (2048, 2048, 8, 32, 256, False),
+            (2048, 2048, 8, 256, 64, False),
+        ),
+    )
+    def test_flydsl_mxfp8_grouped_gemm_shape_validation(
+        self, k, n, g, block_r, block_c, expected
+    ):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        valid = flydsl_heuristics.is_mxfp8_grouped_gemm_config_valid_for_shape(
+            n, k, g, {"BLOCK_R": block_r, "BLOCK_C": block_c}
+        )
+        self.assertEqual(valid, expected)
+
+    @parametrize(
+        "case",
+        (
+            "a_dtype",
+            "out_dtype",
+            "scale_dtype",
+            "b_not_k_major",
+            "a_padded_stride",
+            "scale_a_padded_stride",
+            "scale_b_wrong_shape",
+            "offs_dtype",
+            "k_not_scale_aligned",
+        ),
+    )
+    def test_flydsl_mxfp8_grouped_gate_rejects_invalid_inputs(self, case):
+        """The gate rejects everything the kernel's layout contract excludes.
+
+        Driven through fake IR nodes rather than a compile so it runs without a
+        GPU, and -- more to the point -- without ATen, which has no MXFP8
+        grouped kernel on ROCm to fall back to.
+        """
+        from torch._inductor.kernel import mm_grouped
+
+        m, k, n, g = 512, 2048, 256, 4
+        scale_k = k // 32
+
+        def node(size, stride, dtype, offset=0):
+            return SimpleNamespace(
+                get_size=lambda: size,
+                get_stride=lambda: stride,
+                get_dtype=lambda: dtype,
+                get_layout=lambda: SimpleNamespace(offset=offset),
+            )
+
+        fp8 = torch.float8_e4m3fn
+        e8m0 = torch.float8_e8m0fnu
+        mat_a = node([m, k], [k, 1], fp8)
+        mat_b = node([g, k, n], [k * n, 1, k], fp8)
+        scale_a = node([m, scale_k], [scale_k, 1], e8m0)
+        scale_b = node([g, n * scale_k], [n * scale_k, 1], e8m0)
+        offs = node([g], [1], torch.int32)
+        out_dtype = torch.bfloat16
+
+        if case == "a_dtype":
+            mat_a = node([m, k], [k, 1], torch.float8_e5m2)
+        elif case == "out_dtype":
+            out_dtype = torch.float16
+        elif case == "scale_dtype":
+            scale_a = node([m, scale_k], [scale_k, 1], torch.float32)
+        elif case == "b_not_k_major":
+            mat_b = node([g, k, n], [k * n, n, 1], fp8)
+        elif case == "a_padded_stride":
+            mat_a = node([m, k], [k + 32, 1], fp8)
+        elif case == "scale_a_padded_stride":
+            scale_a = node([m, scale_k], [scale_k + 4, 1], e8m0)
+        elif case == "scale_b_wrong_shape":
+            scale_b = node([g, n, scale_k], [n * scale_k, scale_k, 1], e8m0)
+        elif case == "offs_dtype":
+            offs = node([g], [1], torch.int64)
+        elif case == "k_not_scale_aligned":
+            mat_a = node([m, k + 16], [k + 16, 1], fp8)
+
+        layout = SimpleNamespace(
+            stride=[n, 1],
+            dtype=out_dtype,
+            size=[m, n],
+            device=torch.device("cpu"),
+        )
+        sizevars = SimpleNamespace(
+            statically_known_equals=lambda x, y: x == y,
+            statically_known_multiple_of=lambda x, y: x % y == 0,
+        )
+        with (
+            V.set_graph_handler(SimpleNamespace(sizevars=sizevars)),
+            mock.patch.object(
+                mm_grouped, "use_flydsl_gemm_template", return_value=True
+            ),
+            mock.patch.object(mm_grouped, "is_unaligned", return_value=False),
+        ):
+            result = mm_grouped.get_flydsl_mxfp8_grouped_mm_template_kwargs(
+                mat_a, mat_b, scale_a, scale_b, offs, layout, True
+            )
+        self.assertEqual(result, [])
+
+    def _assert_compiled_mxfp8_grouped_mm(
+        self, group_sizes, k, n, *, expect_flydsl: bool = True
+    ):
+        from torch._inductor.utils import run_and_get_code
+
+        a, b, a_scale, b_scale, offs, reference = self._make_mxfp8_grouped_inputs(
+            group_sizes, k, n
+        )
+
+        def fn(a, b, a_scale, b_scale, offs):
+            return self._scaled_grouped_mm_mxfp8(a, b, a_scale, b_scale, offs)
+
+        torch._dynamo.reset()
+        result, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor"), a, b, a_scale, b_scale, offs
+        )
+        assertion = self.assertIn if expect_flydsl else self.assertNotIn
+        assertion("async_compile.flydsl", code)
+        # Rows past the last group are written by no block and are not part of
+        # the result, so only the grouped region is compared.
+        rows = int(offs[-1])
+        self.assertEqual(
+            result[:rows].float(), reference[:rows].float(), atol=6e-2, rtol=6e-2
+        )
+        return code
+
+    @parametrize(
+        "group_sizes,k,n",
+        (
+            ([512, 300, 700, 1000], 2048, 2048),
+            ([512] * 8, 4096, 4096),
+            # Empty groups, and a group boundary inside a row tile.
+            ([0, 1024, 0, 512, 2048, 128, 0, 896], 2048, 2048),
+            # The minimum K the pipeline supports: 4 steps of 128.
+            ([256] * 4, 512, 2048),
+            # N that only the 128-wide tile divides.
+            ([1, 3, 7, 15, 31, 63, 127, 255], 2048, 1408),
+        ),
+    )
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=False,
+    )
+    def test_flydsl_mxfp8_grouped_mm_e2e(self, group_sizes, k, n):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        code = self._assert_compiled_mxfp8_grouped_mm(group_sizes, k, n)
+        self.assertIn(".mark_layout_dynamic()", code)
+        self.assertIn("_precompile", code)
+        # Compile-only is an argument, not a process-global env flag: warming
+        # and a real dispatch can share a process.
+        self.assertIn("compile_only=True", code)
+        self.assertNotIn("FLYDSL_COMPILE_ONLY", code)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=False,
+    )
+    def test_flydsl_mxfp8_grouped_mm_autotune_e2e(self):
+        """Autotuning walks every tile the kernel implements, and each is correct."""
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        self._assert_compiled_mxfp8_grouped_mm([512, 300, 700, 1000], 2048, 2048)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    def test_flydsl_mxfp8_grouped_mm_tile_parity_e2e(self):
+        """Every tile must agree bitwise, on the shapes that once did not.
+
+        The N_ACCUMS=4 tiles (BLOCK_R=64, and 128x128) computed a small
+        fraction of elements wrong until `wait_barrier` was made to wait on
+        lgkmcnt as well as vmcnt: an s2r fragment issued in one cluster and
+        consumed in the next could cross the barrier still outstanding. Only
+        the MFMAs in between covered that gap, so exactly the tiles with four
+        accumulators broke. `pick_block_r` can return those tiles, so this
+        pins the property rather than trusting it.
+        """
+        import importlib
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+        module = importlib.import_module(
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels."
+            "mxfp8_grouped_gemm_gfx950"
+        )
+        import flydsl.compiler as flyc
+
+        group_sizes = [1, 3, 7, 15, 31, 63, 127, 255]
+        k, n, g = 2048, 1408, len(group_sizes)
+        a, b, a_scale, b_scale, offs, reference = self._make_mxfp8_grouped_inputs(
+            group_sizes, k, n
+        )
+        # The kernel wants B as a stack of [N, K] planes, the layout the
+        # lowering hands it after the template's permute.
+        weight = b.permute(0, 2, 1)
+        rows = int(offs[-1])
+        outputs = {}
+        for block_r in (64, 128, 256):
+            for block_c in (128, 256):
+                param = module.make_mxfp8_grouped_gemm_param_and_validate(
+                    k, n, g, block_r, block_c
+                )
+                if param is None:
+                    continue
+                out = torch.zeros(a.shape[0], n, dtype=torch.bfloat16, device=a.device)
+                module.launch_mxfp8_grouped_gemm_gfx950(
+                    out,
+                    a,
+                    weight,
+                    a_scale,
+                    b_scale.reshape(g, n, -1),
+                    offs,
+                    param,
+                    torch.cuda.current_stream(),
+                    tensor_arg=lambda t: flyc.from_torch_tensor(
+                        t
+                    ).mark_layout_dynamic(),
+                )
+                outputs[(block_r, block_c)] = out
+        self.assertGreaterEqual(len(outputs), 4)
+
+        tiles = list(outputs)
+        base = outputs[tiles[0]]
+        for tile in tiles[1:]:
+            differing = int((outputs[tile][:rows] != base[:rows]).sum())
+            self.assertEqual(
+                differing,
+                0,
+                f"tile {tile} disagrees with {tiles[0]} on {differing} elements",
+            )
+        self.assertEqual(
+            base[:rows].float(), reference[:rows].float(), atol=6e-2, rtol=6e-2
+        )
+
+    def test_flydsl_mxfp8_grouped_mm_row_windows(self):
+        """A token dim past the int32 operand limit is split, not truncated."""
+        import importlib
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        module = importlib.import_module(
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels."
+            "mxfp8_grouped_gemm_gfx950"
+        )
+        param = module.make_mxfp8_grouped_gemm_param(2048, 2048, 2, 256, 256)
+        total_m = 1 << 22
+        offs = torch.tensor([total_m // 2, total_m], dtype=torch.int32)
+        windows = list(
+            module._row_windows(total_m, param.k, param.n, offs, param.block_r)
+        )
+        # M * K here is 2**33, so this must split.
+        self.assertGreater(len(windows), 1)
+        covered = 0
+        for row_start, rows, window_offs in windows:
+            # Disjoint, contiguous, and never splitting a row tile.
+            self.assertEqual(row_start, covered)
+            self.assertEqual(rows % param.block_r, 0)
+            # Offsets are rebased into the window and clamped to it, so a group
+            # straddling the boundary ends at `rows` here and starts at 0 next.
+            self.assertEqual(int(window_offs.max()), rows)
+            self.assertGreaterEqual(int(window_offs.min()), 0)
+            covered += rows
+        self.assertEqual(covered, total_m)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -773,6 +773,8 @@ cutedsl_enable_autotuning: bool = (
     os.environ.get("CUTEDSL_ENABLE_AUTOTUNING", "0") == "1"
 )
 
+# Search every tile the vendored FlyDSL kernels implement instead of taking
+# the kernel's own analytic pick.
 flydsl_enable_autotuning: bool = os.environ.get("FLYDSL_ENABLE_AUTOTUNING", "0") == "1"
 
 # DEPRECATED. This setting is ignored.

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -380,3 +380,152 @@ def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
         log.warning("No valid FlyDSL grouped GEMM configuration is available")
         return []
     return [asdict(gemm_config) for gemm_config in candidates]
+
+
+# ---------------------------------------------------------------------------
+# MXFP8 grouped GEMM (gfx950)
+#
+# Shares this module with the BF16 GEMM heuristics above but no knobs: the
+# MXFP8 kernel is not a scaled variant of that kernel. See
+# FlyDSLMXFP8GroupedGemmConfig for which dimensions are fixed and why.
+# ---------------------------------------------------------------------------
+
+# OCP MX: 32 elements share one E8M0 scale. Fixed by the spec, so it is declared
+# here rather than imported from the vendored kernel (which pulls in the FlyDSL
+# runtime) and the lowering's shape gate stays importable without it.
+MXFP8_SCALE_BLOCK = 32
+
+
+@dataclass(frozen=True)
+class FlyDSLMXFP8GroupedGemmConfig:
+    """Tile shape of the MXFP8 grouped GEMM kernel.
+
+    The MXFP8 kernel is not a scaled variant of the BF16 grouped kernel and
+    does not share its knobs: its contraction step is fixed at 128 elements
+    (one scaled-MFMA K), its wave split is fixed at 4x4 over one 256-thread
+    block, and its LDS ping-pong depth is fixed at 2. What remains tunable is
+    the output tile, so that is the whole config.
+    """
+
+    BLOCK_R: int = 256
+    BLOCK_C: int = 256
+
+
+class FlyDSLMXFP8GroupedGemmConfigDict(TypedDict):
+    BLOCK_R: int
+    BLOCK_C: int
+
+
+# Every tile the kernel implements. BLOCK_R below 64 puts a wave-dim half under
+# one MFMA tile (16 rows x 2 wave-rows) and the row structure stops holding;
+# BLOCK_C below 128 does the same on the column side.
+_MXFP8_GROUPED_BLOCK_R = (64, 128, 256)
+_MXFP8_GROUPED_BLOCK_C = (128, 256)
+
+
+def _make_mxfp8_grouped_gemm_param(
+    k: int, n: int, group_count: int, gemm_config: dict[str, int]
+):
+    # Keep FlyDSL optional when this heuristics module is imported.
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        make_mxfp8_grouped_gemm_param,
+    )
+
+    return make_mxfp8_grouped_gemm_param(
+        k,
+        n,
+        group_count,
+        block_r=int(gemm_config["BLOCK_R"]),
+        block_c=int(gemm_config["BLOCK_C"]),
+    )
+
+
+def is_mxfp8_grouped_gemm_config_valid_for_shape(
+    n: int,
+    k: int,
+    group_count: int,
+    gemm_config: dict[str, int],
+) -> bool:
+    """Return whether a config supports this MXFP8 grouped GEMM shape.
+
+    M is deliberately not an argument: the per-group row counts live on the
+    device and the kernel is built not to sync on them, so nothing here may
+    depend on them.
+    """
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        make_mxfp8_grouped_gemm_param_and_validate,
+    )
+
+    return (
+        make_mxfp8_grouped_gemm_param_and_validate(
+            k,
+            n,
+            group_count,
+            int(gemm_config["BLOCK_R"]),
+            int(gemm_config["BLOCK_C"]),
+        )
+        is not None
+    )
+
+
+def get_exhaustive_mxfp8_grouped_gemm_configs() -> list[FlyDSLMXFP8GroupedGemmConfig]:
+    """Return every tile the MXFP8 grouped GEMM kernel implements."""
+    return [
+        FlyDSLMXFP8GroupedGemmConfig(BLOCK_R=block_r, BLOCK_C=block_c)
+        for block_r, block_c in product(_MXFP8_GROUPED_BLOCK_R, _MXFP8_GROUPED_BLOCK_C)
+    ]
+
+
+def get_default_mxfp8_grouped_gemm_config(
+    m: int, n: int, group_count: int
+) -> FlyDSLMXFP8GroupedGemmConfig:
+    """The tile the kernel's own measured heuristic picks for this shape.
+
+    Unlike the dense and BF16-grouped defaults, this one is shape-dependent.
+    It has to be: the tile trades per-block MFMA density against how much of
+    a row tile a group actually fills and against how many blocks the grid
+    ends up with, and both terms move with (M/G, N). ``pick_tile`` is the
+    upstream kernel's own measured answer, so the single non-autotuned choice
+    is the one it makes rather than a fixed tile that is wrong at both ends.
+    """
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        pick_mxfp8_grouped_gemm_tile,
+    )
+
+    block_r, block_c = pick_mxfp8_grouped_gemm_tile(m, group_count, n)
+    return FlyDSLMXFP8GroupedGemmConfig(BLOCK_R=block_r, BLOCK_C=block_c)
+
+
+def get_mxfp8_grouped_gemm_configs(
+    m: int, n: int, k: int, group_count: int
+) -> list[dict[str, int]]:
+    """Return configs for the MXFP8 ragged grouped GEMM kernel.
+
+    Shape compatibility beyond the tile itself is checked in the lowering
+    before this function is called. By default, autotuning is disabled and we
+    return only the tile ``pick_tile`` chooses.
+    """
+    if config.flydsl_enable_autotuning:
+        candidates = get_exhaustive_mxfp8_grouped_gemm_configs()
+    else:
+        candidates = [get_default_mxfp8_grouped_gemm_config(m, n, group_count)]
+
+    valid_configs: list[FlyDSLMXFP8GroupedGemmConfig] = []
+    for gemm_config in candidates:
+        try:
+            _make_mxfp8_grouped_gemm_param(
+                k,
+                n,
+                group_count,
+                cast(dict[str, int], asdict(gemm_config)),
+            )
+            valid_configs.append(gemm_config)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid FlyDSL MXFP8 grouped config %s: %s", gemm_config, e
+            )
+
+    if not valid_configs:
+        log.warning("No valid FlyDSL MXFP8 grouped GEMM configuration is available")
+        return []
+    return [asdict(gemm_config) for gemm_config in valid_configs]

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -23,7 +23,6 @@ from ..select_algorithm import (
     TritonTemplate,
 )
 from ..utils import (
-    GPU_ALIGN_BYTES,
     _descriptor_shape_fits_in_int32,
     _tma_descriptor_max_offset_fits_in_int32,
     get_gpu_shared_memory,
@@ -182,7 +181,6 @@ def use_flydsl_grouped_mm_template(
 
     n = mat_b.get_size()[-1]
     k = mat_a.get_size()[-1]
-    g = mat_b.get_size()[0]
     if not sizevars.statically_known_equals(mat1_stride[-2], k):
         return False
     if not sizevars.statically_known_equals(mat2_stride[-2], n):
@@ -207,12 +205,10 @@ def use_flydsl_grouped_mm_template(
     ):
         return False
 
-    m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
-    n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
-    k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
-    g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
-    if m_static is None or n_static is None or k_static is None or g_static is None:
+    static_shape = _flydsl_grouped_static_shape(mat_a, mat_b, offs)
+    if static_shape is None:
         return False
+    m_static, n_static, k_static, g_static = static_shape
     if n_static % 32 != 0 or k_static % 32 != 0:
         return False
     tensor_spans = (

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -762,6 +762,11 @@ flydsl_mxfp8_grouped_mm_template = FlyDSLTemplate(
     source=load_kernel_template("flydsl_mxfp8_grouped_mm"),
 )
 
+flydsl_mxfp8_wgrad_template = FlyDSLTemplate(
+    name="mxfp8_wgrad_flydsl",
+    source=load_kernel_template("flydsl_mxfp8_wgrad"),
+)
+
 
 def get_flydsl_mxfp8_grouped_mm_template_kwargs(
     mat_a: TensorBox,
@@ -912,6 +917,79 @@ def get_flydsl_mxfp8_grouped_mm_template_kwargs(
     ]
 
 
+def get_flydsl_mxfp8_wgrad_template_kwargs(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+    scale_a: TensorBox,
+    scale_b: TensorBox,
+    offs: TensorBox | None,
+    layout: Layout,
+    is_nonzero: bool,
+) -> list[dict[str, object]]:
+    """Return the FlyDSL config for a 2D x 2D grouped MXFP8 GEMM.
+
+    Offsets partition the shared contraction dimension, so each group computes
+    ``mat_a[:, start:end] @ mat_b[start:end, :]``. This is the weight-gradient
+    form used by MXFP8 MoE training.
+    """
+    if not is_nonzero or not use_flydsl_gemm_template(layout) or offs is None:
+        return []
+    if len(mat_a.get_size()) != 2 or len(mat_b.get_size()) != 2:
+        return []
+    if mat_a.get_dtype() != torch.float8_e4m3fn:
+        return []
+    if mat_b.get_dtype() != torch.float8_e4m3fn:
+        return []
+    if layout.dtype != torch.bfloat16:
+        return []
+    if scale_a.get_dtype() != torch.float8_e8m0fnu:
+        return []
+    if scale_b.get_dtype() != torch.float8_e8m0fnu:
+        return []
+    if offs.get_dtype() != torch.int32 or len(offs.get_size()) != 1:
+        return []
+
+    statically_known = PythonWrapperCodegen.statically_known_int_or_none
+    n = statically_known(mat_a.get_size()[0])
+    m = statically_known(mat_a.get_size()[1])
+    k = statically_known(mat_b.get_size()[1])
+    g = statically_known(offs.get_size()[0])
+    if n is None or m is None or k is None or g is None:
+        return []
+    if m != statically_known(mat_b.get_size()[0]):
+        return []
+    if m <= 0 or m % 128 != 0 or n % 16 != 0 or k % 16 != 0:
+        return []
+
+    sizevars = V.graph.sizevars
+    scale_m = m // 32
+    if mat_a.get_stride() != [m, 1]:
+        return []
+    if mat_b.get_stride() != [1, m]:
+        return []
+    if scale_a.get_size() != [n, scale_m] or scale_a.get_stride() != [scale_m, 1]:
+        return []
+    if scale_b.get_size() != [k, scale_m] or scale_b.get_stride() != [scale_m, 1]:
+        return []
+    if layout.stride != [n * k, k, 1]:
+        return []
+
+    operands = (mat_a, mat_b, scale_a, scale_b)
+    if any(is_unaligned(node) for node in operands):
+        return []
+    if any(
+        not sizevars.statically_known_multiple_of(
+            node.get_layout().offset, GPU_ALIGN_BYTES
+        )
+        for node in operands
+    ):
+        return []
+    if max(n * m, k * m, g * n * k) >= 2**31:
+        return []
+
+    return [{"GEMM_N": n, "GEMM_K": k, "GEMM_G": g}]
+
+
 # The op takes recipes and swizzles as plain ints, and the pybind enums compare
 # equal to neither ints nor freshly constructed instances of themselves, so the
 # two the lowering can serve are pinned to their integer values here.
@@ -947,14 +1025,12 @@ def tuned_scaled_grouped_mm_v2(
 ) -> TensorBox:
     """Auto-tuning for the _scaled_grouped_mm_v2() operator.
 
-    Only one combination has a lowering here: MXFP8 x MXFP8 (BlockWise1x32
-    e8m0 scales, NO_SWIZZLE) on gfx950, served by the vendored FlyDSL ragged
-    grouped GEMM. That combination has no ATen kernel on ROCm at all -- the
-    MSLK grouped path is CUDA-only and `_mx8_mx8_bf16_grouped_mm_mslk` raises
-    NOT_IMPLEMENTED there -- so the FlyDSL template is not competing with an
-    extern choice, it is the only one, and no ATen choice is offered for it.
-    Everything else falls back to the eager op, which is what happened before
-    this lowering existed.
+    MXFP8 x MXFP8 (BlockWise1x32 e8m0 scales, NO_SWIZZLE) on gfx950 is served
+    by FlyDSL for both the 2D x 3D forward form and the 2D x 2D weight-gradient
+    form. These combinations have no ATen kernel on ROCm -- the MSLK grouped
+    path is CUDA-only and `_mx8_mx8_bf16_grouped_mm_mslk` raises NOT_IMPLEMENTED
+    there -- so no ATen choice is offered. Everything else falls back to the
+    eager op, which is what happened before this lowering existed.
     """
 
     def _is_mxfp8_recipe(recipe: list[int]) -> bool:
@@ -1004,6 +1080,21 @@ def tuned_scaled_grouped_mm_v2(
                 layout=mm_layout,
                 **flydsl_kwargs,
             )
+        for flydsl_kwargs in get_flydsl_mxfp8_wgrad_template_kwargs(
+            mat_a,
+            mat_b,
+            scale_a_real,
+            scale_b_real,
+            offs,
+            mm_layout,
+            is_nonzero,
+        ):
+            flydsl_mxfp8_wgrad_template.maybe_append_choice(
+                choices,
+                input_nodes=input_nodes,
+                layout=mm_layout,
+                **flydsl_kwargs,
+            )
 
         if choices:
             counters["aten_mm_info"]["aten._scaled_grouped_mm_v2.default"] += 1
@@ -1018,9 +1109,10 @@ def tuned_scaled_grouped_mm_v2(
             )
             m, k = m1_size
             n = m2_size[-1]
+            alignment = 32 if len(m2_size) == 2 else 16 // mat_a.dtype.itemsize
             input_gen_fns = {
                 4: lambda x: create_offsets(
-                    x, True, False, m, n, k, 16 // mat_a.dtype.itemsize
+                    x, True, len(m2_size) == 2, m, n, k, alignment
                 )
             }
             node, _ = autotune_select_algorithm(

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -10,11 +10,12 @@ from torch._inductor.codegen.flydsl.flydsl_template import FlyDSLTemplate
 from torch._inductor.heuristics.template.cutedsl import get_groupgemm_configs
 from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
+from torch.nn.functional import ScalingType, SwizzleType
 from torch.utils._triton import has_triton
 
 from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import ChoiceCaller, is_unaligned, Layout, TensorBox
-from ..lowering import register_lowering
+from ..lowering import fallback_handler, register_lowering
 from ..select_algorithm import (
     autotune_select_algorithm,
     ExternKernelChoice,
@@ -22,6 +23,7 @@ from ..select_algorithm import (
     TritonTemplate,
 )
 from ..utils import (
+    GPU_ALIGN_BYTES,
     _descriptor_shape_fits_in_int32,
     _tma_descriptor_max_offset_fits_in_int32,
     get_gpu_shared_memory,
@@ -730,4 +732,324 @@ def tuned_scaled_grouped_mm(
         out_dtype,
         use_fast_accum,
         layout,
+    )
+
+
+def _flydsl_grouped_static_shape(
+    mat_a: TensorBox, mat_b: TensorBox, offs: TensorBox
+) -> tuple[int, int, int, int] | None:
+    """(M, N, K, G) as ints for a 2D-ragged x 3D grouped GEMM, or None.
+
+    None means one of them is dynamic, or `offs` does not name exactly the
+    groups B stacks. Total M only prunes configs -- the exact per-group sizes
+    stay runtime values that the kernel reads from `offs` on device -- but the
+    other three are compile keys, so a dynamic one has to decline the template.
+    Shared by the BF16 and MXFP8 grouped gates so the two cannot drift.
+    """
+    g = mat_b.get_size()[0]
+    k = mat_a.get_size()[-1]
+    n = mat_b.get_size()[-1]
+    statically_known = PythonWrapperCodegen.statically_known_int_or_none
+    m_static = statically_known(mat_a.get_size()[0])
+    n_static = statically_known(n)
+    k_static = statically_known(k)
+    g_static = statically_known(g)
+    if m_static is None or n_static is None or k_static is None or g_static is None:
+        return None
+    if not V.graph.sizevars.statically_known_equals(offs.get_size()[0], g):
+        return None
+    return m_static, n_static, k_static, g_static
+
+
+flydsl_mxfp8_grouped_mm_template = FlyDSLTemplate(
+    name="mxfp8_grouped_gemm_flydsl",
+    source=load_kernel_template("flydsl_mxfp8_grouped_mm"),
+)
+
+
+def get_flydsl_mxfp8_grouped_mm_template_kwargs(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+    scale_a: TensorBox,
+    scale_b: TensorBox,
+    offs: TensorBox | None,
+    layout: Layout,
+    is_nonzero: bool,
+) -> list[dict[str, object]]:
+    """Return supported FlyDSL template configs for an MXFP8 grouped GEMM.
+
+    The recipe/swizzle/bias/multi-level gates are checked by the caller; what
+    is left here is the dtype, shape, stride and alignment contract of the
+    kernel itself.
+    """
+    from ..heuristics.template.flydsl import (
+        get_mxfp8_grouped_gemm_configs,
+        is_mxfp8_grouped_gemm_config_valid_for_shape,
+        MXFP8_SCALE_BLOCK,
+    )
+
+    if not is_nonzero or not use_flydsl_gemm_template(layout):
+        return []
+    if offs is None:
+        return []
+    # 2D ragged A gathered by group offsets against a 3D [G, K, N] B. The
+    # kernel groups the output rows, which is exactly this case and no other.
+    if len(mat_a.get_size()) != 2 or len(mat_b.get_size()) != 3:
+        return []
+    if mat_a.get_dtype() != torch.float8_e4m3fn:
+        return []
+    if mat_b.get_dtype() != torch.float8_e4m3fn:
+        return []
+    if layout.dtype != torch.bfloat16:
+        return []
+    if scale_a.get_dtype() != torch.float8_e8m0fnu:
+        return []
+    if scale_b.get_dtype() != torch.float8_e8m0fnu:
+        return []
+    if offs.get_dtype() != torch.int32:
+        return []
+    # The kernel unrolls one scalar offset load per group at trace time, so the
+    # offsets tensor has to name exactly the groups B stacks.
+    if len(offs.get_size()) != 1:
+        return []
+
+    sizevars = V.graph.sizevars
+    g = mat_b.get_size()[0]
+    k = mat_a.get_size()[-1]
+    n = mat_b.get_size()[-1]
+    static_shape = _flydsl_grouped_static_shape(mat_a, mat_b, offs)
+    if static_shape is None:
+        return []
+    m_static, n_static, k_static, g_static = static_shape
+
+    if k_static % MXFP8_SCALE_BLOCK != 0:
+        return []
+    scale_k = k_static // MXFP8_SCALE_BLOCK
+
+    mat_a_stride = mat_a.get_stride()
+    mat_b_stride = mat_b.get_stride()
+    scale_a_stride = scale_a.get_stride()
+    scale_b_stride = scale_b.get_stride()
+    out_stride = layout.stride
+
+    # A is (M, K) row-major and its scales are (M, K // 32) row-major.
+    if not sizevars.statically_known_equals(mat_a_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(mat_a_stride[-2], k):
+        return []
+    # B is presented as [G, K, N] but the kernel reads a stack of [N, K]
+    # row-major weight planes, i.e. exactly the "mat_b is transposed" layout
+    # every scaled GEMM already requires. Anything else would need a copy.
+    if not sizevars.statically_known_equals(mat_b_stride[-2], 1):
+        return []
+    if not sizevars.statically_known_equals(mat_b_stride[-1], k):
+        return []
+    if not sizevars.statically_known_equals(mat_b_stride[0], k * n):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-2], n):
+        return []
+
+    # Scales are the plain unswizzled MX layout the ROCm recipe asks for:
+    # (M, K // 32) for A, and the op's flat per-group stack (G, N * K // 32)
+    # for B, which is a [G, N, K // 32] plane per group.
+    if len(scale_a.get_size()) != 2 or len(scale_b.get_size()) != 2:
+        return []
+    if not sizevars.statically_known_equals(scale_a.get_size()[0], mat_a.get_size()[0]):
+        return []
+    if not sizevars.statically_known_equals(scale_a.get_size()[1], scale_k):
+        return []
+    if not sizevars.statically_known_equals(scale_a_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(scale_a_stride[-2], scale_k):
+        return []
+    if not sizevars.statically_known_equals(scale_b.get_size()[0], g):
+        return []
+    if not sizevars.statically_known_equals(scale_b.get_size()[1], n * scale_k):
+        return []
+    if not sizevars.statically_known_equals(scale_b_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(scale_b_stride[-2], n * scale_k):
+        return []
+
+    # Every operand is read through 16-byte buffer loads, so an operand that
+    # starts mid-vector cannot be served. fp8 and e8m0 are both one byte, so
+    # the element offset is the byte offset.
+    operands = (mat_a, mat_b, scale_a, scale_b)
+    if any(is_unaligned(node) for node in operands):
+        return []
+    if any(
+        not sizevars.statically_known_multiple_of(
+            node.get_layout().offset, GPU_ALIGN_BYTES
+        )
+        for node in operands
+    ):
+        return []
+
+    # The kernel addresses every operand through a 32-bit buffer descriptor.
+    # `_row_windows` splits the token dim so the M-dependent operands always
+    # fit, but the weight and its scales are not split and must fit outright.
+    weight_spans = (
+        (g_static, n_static * k_static, n_static * k_static),
+        (g_static, n_static * scale_k, n_static * scale_k),
+    )
+    if any(
+        not _fits_int32_buffer_span(rows, stride, cols, 1)
+        for rows, stride, cols in weight_spans
+    ):
+        return []
+
+    return [
+        {
+            **gemm_config,
+            "GEMM_G": g_static,
+            "GEMM_N": n_static,
+            "GEMM_K": k_static,
+        }
+        for gemm_config in get_mxfp8_grouped_gemm_configs(
+            m_static, n_static, k_static, g_static
+        )
+        if is_mxfp8_grouped_gemm_config_valid_for_shape(
+            n_static, k_static, g_static, gemm_config
+        )
+    ]
+
+
+# The op takes recipes and swizzles as plain ints, and the pybind enums compare
+# equal to neither ints nor freshly constructed instances of themselves, so the
+# two the lowering can serve are pinned to their integer values here.
+_MXFP8_SCALE_RECIPE = int(ScalingType.BlockWise1x32)
+_NO_SWIZZLE = int(SwizzleType.NO_SWIZZLE)
+
+
+# Inductor has no template or extern choice for most _scaled_grouped_mm_v2
+# recipes; defer those to the eager op exactly as the absence of a lowering
+# used to. add_to_fallback_set is False because this handler is invoked from
+# the lowering below rather than registered as the op's global fallback.
+scaled_grouped_mm_v2_fallback = fallback_handler(
+    aten._scaled_grouped_mm_v2.default, add_to_fallback_set=False
+)
+
+
+@register_lowering(aten._scaled_grouped_mm_v2.default, type_promotion_kind=None)
+def tuned_scaled_grouped_mm_v2(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+    scale_a: list[Any],
+    scale_recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[Any],
+    scale_recipe_b: list[int],
+    swizzle_b: list[int],
+    offs: TensorBox | None = None,
+    bias: TensorBox | None = None,
+    out_dtype: torch.dtype | None = None,
+    contraction_dim: list[int] | None = None,
+    use_fast_accum: bool = False,
+    layout: Layout | None = None,
+) -> TensorBox:
+    """Auto-tuning for the _scaled_grouped_mm_v2() operator.
+
+    Only one combination has a lowering here: MXFP8 x MXFP8 (BlockWise1x32
+    e8m0 scales, NO_SWIZZLE) on gfx950, served by the vendored FlyDSL ragged
+    grouped GEMM. That combination has no ATen kernel on ROCm at all -- the
+    MSLK grouped path is CUDA-only and `_mx8_mx8_bf16_grouped_mm_mslk` raises
+    NOT_IMPLEMENTED there -- so the FlyDSL template is not competing with an
+    extern choice, it is the only one, and no ATen choice is offered for it.
+    Everything else falls back to the eager op, which is what happened before
+    this lowering existed.
+    """
+
+    def _is_mxfp8_recipe(recipe: list[int]) -> bool:
+        return len(recipe) == 1 and int(recipe[0]) == _MXFP8_SCALE_RECIPE
+
+    is_single_level_scale = len(scale_a) == 1 and len(scale_b) == 1
+    is_mxfp8 = (
+        is_single_level_scale
+        and _is_mxfp8_recipe(scale_recipe_a)
+        and _is_mxfp8_recipe(scale_recipe_b)
+        # An empty swizzle list is how F.scaled_grouped_mm spells "none".
+        and not any(int(s) != _NO_SWIZZLE for s in swizzle_a)
+        and not any(int(s) != _NO_SWIZZLE for s in swizzle_b)
+        and bias is None
+        # contraction_dim overrides which dim is K; the kernel only implements
+        # the default (A dim 1, B dim 1 of a [G, K, N] operand).
+        and not contraction_dim
+    )
+
+    if is_mxfp8 and offs is not None:
+        m1_size, m2_size, mm_layout, mat_a, mat_b, offs = grouped_mm_args(
+            mat_a, mat_b, offs, layout=layout, out_dtype=out_dtype or torch.bfloat16
+        )
+        _, is_nonzero = _is_static_problem(mm_layout)
+        scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
+        input_nodes: list[Any] = [
+            mat_a,
+            mat_b,
+            scale_a_real,
+            scale_b_real,
+            realize_inputs(offs),
+        ]
+
+        choices: list[ChoiceCaller] = []
+        for flydsl_kwargs in get_flydsl_mxfp8_grouped_mm_template_kwargs(
+            mat_a,
+            mat_b,
+            scale_a_real,
+            scale_b_real,
+            offs,
+            mm_layout,
+            is_nonzero,
+        ):
+            flydsl_mxfp8_grouped_mm_template.maybe_append_choice(
+                choices,
+                input_nodes=input_nodes,
+                layout=mm_layout,
+                **flydsl_kwargs,
+            )
+
+        if choices:
+            counters["aten_mm_info"]["aten._scaled_grouped_mm_v2.default"] += 1
+            log.info(
+                "Tuned aten._scaled_grouped_mm_v2.default: mat1_shape=%s, "
+                "mat2_shape=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
+                m1_size,
+                m2_size,
+                mat_a.get_dtype(),
+                mat_b.get_dtype(),
+                mm_layout,
+            )
+            m, k = m1_size
+            n = m2_size[-1]
+            input_gen_fns = {
+                4: lambda x: create_offsets(
+                    x, True, False, m, n, k, 16 // mat_a.dtype.itemsize
+                )
+            }
+            node, _ = autotune_select_algorithm(
+                "scaled_grouped_mm_v2",
+                choices,
+                input_nodes,
+                mm_layout,
+                input_gen_fns=input_gen_fns,
+            )
+            return node
+
+    # contraction_dim is a non-optional int[] in the schema (default []); this
+    # lowering defaults it to None, so coerce before the eager call.
+    return scaled_grouped_mm_v2_fallback(
+        mat_a,
+        mat_b,
+        scale_a,
+        scale_recipe_a,
+        swizzle_a,
+        scale_b,
+        scale_recipe_b,
+        swizzle_b,
+        offs,
+        bias,
+        out_dtype,
+        [] if contraction_dim is None else contraction_dim,
+        use_fast_accum,
     )

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -1,4 +1,3 @@
-import os
 import threading
 
 from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
@@ -9,8 +8,9 @@ from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
 )
 from torch._inductor.runtime.flydsl_cache import (
     configure_flydsl_cache_dir,
+    flydsl_tensor_arg,
+    precompile_flydsl,
     run_cached_flydsl,
-    temporary_env,
 )
 
 {{gen_defines()}}
@@ -20,11 +20,7 @@ _grouped_param = None
 _grouped_param_lock = threading.Lock()
 
 
-def _inductor_tensor_arg(tensor):
-    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
-
-
-def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
+def _flydsl_grouped_mm(output, mat1, mat2, offs, stream, compile_only=False):
     global _grouped_param
     group_count, k, n = mat2.shape
     total_m = mat1.shape[0]
@@ -71,16 +67,7 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
     total_m = int(total_m)
     n_int = int(n)
     k_int = int(k)
-    flydsl_compile_only = os.environ.get("FLYDSL_COMPILE_ONLY") == "1"
-    compile_only = os.environ.get("COMPILE_ONLY", "").lower() in (
-        "1", "true", "yes", "on"
-    )
-    if compile_only != flydsl_compile_only:
-        raise RuntimeError(
-            "COMPILE_ONLY and FLYDSL_COMPILE_ONLY must only be enabled together "
-            "by the FlyDSL precompile path"
-        )
-    if flydsl_compile_only:
+    if compile_only:
         # Precompilation runs on fake tensors that have no device to query, and
         # the persistent kernel reads its grid from gridDim, so the size the disk
         # cache is warmed with does not have to match the one used at runtime.
@@ -98,25 +85,27 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
     group_count_arg = fx.Int32(group_count)
     n_arg = fx.Int32(n_int)
     k_arg = fx.Int32(k_int)
-    compile_args = (
-        _inductor_tensor_arg(output),
-        _inductor_tensor_arg(mat1),
-        _inductor_tensor_arg(mat2),
-        _inductor_tensor_arg(offs),
-        group_count_arg,
-        n_arg,
-        k_arg,
-        grid_size,
-        param,
-        stream,
-    )
+
+    def compile_args():
+        return (
+            flydsl_tensor_arg(output),
+            flydsl_tensor_arg(mat1),
+            flydsl_tensor_arg(mat2),
+            flydsl_tensor_arg(offs),
+            group_count_arg,
+            n_arg,
+            k_arg,
+            grid_size,
+            param,
+            stream,
+        )
     configure_flydsl_cache_dir()
-    if flydsl_compile_only:
-        flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
+    if compile_only:
+        flyc.compile(launch_gemm_gfx950_grouped, *compile_args())
     else:
         run_cached_flydsl(
             launch_gemm_gfx950_grouped,
-            *compile_args,
+            compile_args_factory=compile_args,
             constexpr_param=param,
             compiler=flyc.compile,
             dispatch_args=(
@@ -148,36 +137,7 @@ def {{kernel_name}}_precompile(
     device_capability=None,
     flydsl_gpu_arch=None,
 ):
-    """Warm FlyDSL's disk cache using metadata-only fake tensors."""
-    dtype_mat1 = getattr(torch, precompile_dtypes["mat1"])
-    dtype_mat2 = getattr(torch, precompile_dtypes["mat2"])
-    dtype_offs = getattr(torch, precompile_dtypes["offs"])
-    dtype_output = getattr(torch, precompile_dtypes["output"])
-
-    shape_mat1 = tuple(precompile_shapes["mat1"])
-    shape_mat2 = tuple(precompile_shapes["mat2"])
-    shape_offs = tuple(precompile_shapes["offs"])
-    shape_output = tuple(precompile_shapes["output"])
-
-    stride_mat1 = tuple(precompile_strides["mat1"])
-    stride_mat2 = tuple(precompile_strides["mat2"])
-    stride_offs = tuple(precompile_strides["offs"])
-    stride_output = tuple(precompile_strides["output"])
-
-    env_updates = {"COMPILE_ONLY": "1", "FLYDSL_COMPILE_ONLY": "1"}
-    if flydsl_gpu_arch is not None:
-        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
-
-    with temporary_env(env_updates):
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-
-            def _fake_proxy(shape, stride, dtype):
-                return torch.empty_strided(shape, stride, dtype=dtype, device="cpu")
-
-            mat1 = _fake_proxy(shape_mat1, stride_mat1, dtype_mat1)
-            mat2 = _fake_proxy(shape_mat2, stride_mat2, dtype_mat2)
-            offs = _fake_proxy(shape_offs, stride_offs, dtype_offs)
-            output = _fake_proxy(shape_output, stride_output, dtype_output)
-            {{kernel_name}}_main(mat1, mat2, offs, output, stream=0)
+    precompile_flydsl(
+        _flydsl_grouped_mm, precompile_shapes, precompile_strides,
+        precompile_dtypes, flydsl_gpu_arch,
+    )

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -1,4 +1,3 @@
-import os
 import threading
 
 from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
@@ -10,8 +9,9 @@ from torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_gfx950 import
 )
 from torch._inductor.runtime.flydsl_cache import (
     configure_flydsl_cache_dir,
+    flydsl_tensor_arg,
+    precompile_flydsl,
     run_cached_flydsl,
-    temporary_env,
 )
 
 {{gen_defines()}}
@@ -21,12 +21,7 @@ _gemm_param = None
 _gemm_param_lock = threading.Lock()
 
 
-def _inductor_tensor_arg(tensor):
-    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
-
-
-{{def_kernel("mat1", "mat2")}}
-    output = {{get_output()}}
+def _flydsl_mm(output, mat1, mat2, stream, compile_only=False):
     global _gemm_param
     param = _gemm_param
     if param is None:
@@ -63,33 +58,32 @@ def _inductor_tensor_arg(tensor):
                     )
                 _gemm_param = param
     configure_flydsl_cache_dir()
-    compile_args = (
-        _inductor_tensor_arg(output),
-        _inductor_tensor_arg(mat1),
-        _inductor_tensor_arg(mat2),
-        param,
-        stream,
-    )
-    flydsl_compile_only = os.environ.get("FLYDSL_COMPILE_ONLY") == "1"
-    compile_only = os.environ.get("COMPILE_ONLY", "").lower() in (
-        "1", "true", "yes", "on"
-    )
-    if compile_only != flydsl_compile_only:
-        raise RuntimeError(
-            "COMPILE_ONLY and FLYDSL_COMPILE_ONLY must only be enabled together "
-            "by the FlyDSL precompile path"
+
+    def compile_args():
+        return (
+            flydsl_tensor_arg(output),
+            flydsl_tensor_arg(mat1),
+            flydsl_tensor_arg(mat2),
+            param,
+            stream,
         )
-    if flydsl_compile_only:
-        flyc.compile(gemm_gfx950, *compile_args)
+
+    if compile_only:
+        flyc.compile(gemm_gfx950, *compile_args())
     else:
         run_cached_flydsl(
             gemm_gfx950,
-            *compile_args,
+            compile_args_factory=compile_args,
             constexpr_param=param,
             compiler=flyc.compile,
             dispatch_args=(output, mat1, mat2, param, stream),
         )
     return output
+
+
+{{def_kernel("mat1", "mat2")}}
+    output = {{get_output()}}
+    return _flydsl_mm(output, mat1, mat2, stream)
 
 
 def {{kernel_name}}_precompile(
@@ -100,32 +94,7 @@ def {{kernel_name}}_precompile(
     device_capability=None,
     flydsl_gpu_arch=None,
 ):
-    """Warm FlyDSL's disk cache using metadata-only fake tensors."""
-    dtype_mat1 = getattr(torch, precompile_dtypes["mat1"])
-    dtype_mat2 = getattr(torch, precompile_dtypes["mat2"])
-    dtype_output = getattr(torch, precompile_dtypes["output"])
-
-    shape_mat1 = tuple(precompile_shapes["mat1"])
-    shape_mat2 = tuple(precompile_shapes["mat2"])
-    shape_output = tuple(precompile_shapes["output"])
-
-    stride_mat1 = tuple(precompile_strides["mat1"])
-    stride_mat2 = tuple(precompile_strides["mat2"])
-    stride_output = tuple(precompile_strides["output"])
-
-    env_updates = {"COMPILE_ONLY": "1", "FLYDSL_COMPILE_ONLY": "1"}
-    if flydsl_gpu_arch is not None:
-        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
-
-    with temporary_env(env_updates):
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-
-            def _fake_proxy(shape, stride, dtype):
-                return torch.empty_strided(shape, stride, dtype=dtype, device="cpu")
-
-            mat1 = _fake_proxy(shape_mat1, stride_mat1, dtype_mat1)
-            mat2 = _fake_proxy(shape_mat2, stride_mat2, dtype_mat2)
-            output = _fake_proxy(shape_output, stride_output, dtype_output)
-            {{kernel_name}}_main(mat1, mat2, output, stream=0)
+    precompile_flydsl(
+        _flydsl_mm, precompile_shapes, precompile_strides,
+        precompile_dtypes, flydsl_gpu_arch,
+    )

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
@@ -1,0 +1,130 @@
+import contextlib
+import os
+import threading
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+    launch_mxfp8_grouped_gemm_gfx950,
+    make_mxfp8_grouped_gemm_param,
+)
+from torch._inductor.runtime.flydsl_cache import configure_flydsl_cache_dir
+
+{{gen_defines()}}
+
+
+_mxfp8_grouped_param = None
+_mxfp8_grouped_param_lock = threading.Lock()
+
+
+def _inductor_tensor_arg(tensor):
+    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
+
+
+@contextlib.contextmanager
+def _temporary_env(updates):
+    old_values = {key: os.environ.get(key) for key in updates}
+    os.environ.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    try:
+        yield
+    finally:
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+def _flydsl_mxfp8_grouped_mm(
+    output, mat1, mat2, scale_a, scale_b, offs, stream, compile_only=False
+):
+    global _mxfp8_grouped_param
+    if output.shape[0] == 0:
+        return output
+
+    param = _mxfp8_grouped_param
+    if param is None:
+        with _mxfp8_grouped_param_lock:
+            param = _mxfp8_grouped_param
+            if param is None:
+                param = make_mxfp8_grouped_gemm_param(
+                    GEMM_K,
+                    GEMM_N,
+                    GEMM_G,
+                    block_r=BLOCK_R,
+                    block_c=BLOCK_C,
+                )
+                _mxfp8_grouped_param = param
+
+    # The kernel reads B as a stack of [N, K] row-major weight planes. The
+    # lowering already required mat2's K dim to be the contiguous one, so this
+    # permute is a free relabelling of a contiguous buffer, not a copy.
+    weight = mat2.permute(0, 2, 1)
+    # scale_b arrives as the op's flat per-group scale stack, (G, N * K // 32).
+    configure_flydsl_cache_dir()
+    launch_mxfp8_grouped_gemm_gfx950(
+        output,
+        mat1,
+        weight,
+        scale_a,
+        scale_b,
+        offs,
+        param,
+        stream,
+        tensor_arg=_inductor_tensor_arg,
+        # Passed down rather than read from the environment: cache warming and
+        # a real dispatch can share a process (autotune_in_subproc=False), and
+        # a process-global flag would let a real call skip the GEMM and return
+        # the uninitialised output buffer.
+        compile_only=compile_only,
+    )
+    return output
+
+
+{{def_kernel("mat1", "mat2", "scale_a", "scale_b", "offs")}}
+    output = {{get_output()}}
+    return _flydsl_mxfp8_grouped_mm(
+        output, mat1, mat2, scale_a, scale_b, offs, stream
+    )
+
+
+def {{kernel_name}}_precompile(
+    precompile_shapes,
+    precompile_strides,
+    precompile_dtypes,
+    device_index=0,
+    device_capability=None,
+    flydsl_gpu_arch=None,
+):
+    """Warm FlyDSL's disk cache using metadata-only fake tensors."""
+    names = ("mat1", "mat2", "scale_a", "scale_b", "offs", "output")
+
+    # FLYDSL_GPU_ARCH is read by FlyDSL itself, so it has to go through the
+    # environment; compile-only is ours and is passed as an argument instead.
+    env_updates = {}
+    if flydsl_gpu_arch is not None:
+        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
+
+    with _temporary_env(env_updates):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            fakes = {
+                name: torch.empty_strided(
+                    tuple(precompile_shapes[name]),
+                    tuple(precompile_strides[name]),
+                    dtype=getattr(torch, precompile_dtypes[name]),
+                    device="cpu",
+                )
+                for name in names
+            }
+            _flydsl_mxfp8_grouped_mm(
+                fakes["output"],
+                fakes["mat1"],
+                fakes["mat2"],
+                fakes["scale_a"],
+                fakes["scale_b"],
+                fakes["offs"],
+                stream=0,
+                compile_only=True,
+            )

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
@@ -1,38 +1,20 @@
-import contextlib
-import os
 import threading
 
 from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
     launch_mxfp8_grouped_gemm_gfx950,
     make_mxfp8_grouped_gemm_param,
 )
-from torch._inductor.runtime.flydsl_cache import configure_flydsl_cache_dir
+from torch._inductor.runtime.flydsl_cache import (
+    configure_flydsl_cache_dir,
+    flydsl_tensor_arg,
+    precompile_flydsl,
+)
 
 {{gen_defines()}}
 
 
 _mxfp8_grouped_param = None
 _mxfp8_grouped_param_lock = threading.Lock()
-
-
-def _inductor_tensor_arg(tensor):
-    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
-
-
-@contextlib.contextmanager
-def _temporary_env(updates):
-    old_values = {key: os.environ.get(key) for key in updates}
-    os.environ.update(
-        {key: value for key, value in updates.items() if value is not None}
-    )
-    try:
-        yield
-    finally:
-        for key, old_value in old_values.items():
-            if old_value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = old_value
 
 
 def _flydsl_mxfp8_grouped_mm(
@@ -71,11 +53,7 @@ def _flydsl_mxfp8_grouped_mm(
         offs,
         param,
         stream,
-        tensor_arg=_inductor_tensor_arg,
-        # Passed down rather than read from the environment: cache warming and
-        # a real dispatch can share a process (autotune_in_subproc=False), and
-        # a process-global flag would let a real call skip the GEMM and return
-        # the uninitialised output buffer.
+        tensor_arg=flydsl_tensor_arg,
         compile_only=compile_only,
     )
     return output
@@ -96,35 +74,7 @@ def {{kernel_name}}_precompile(
     device_capability=None,
     flydsl_gpu_arch=None,
 ):
-    """Warm FlyDSL's disk cache using metadata-only fake tensors."""
-    names = ("mat1", "mat2", "scale_a", "scale_b", "offs", "output")
-
-    # FLYDSL_GPU_ARCH is read by FlyDSL itself, so it has to go through the
-    # environment; compile-only is ours and is passed as an argument instead.
-    env_updates = {}
-    if flydsl_gpu_arch is not None:
-        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
-
-    with _temporary_env(env_updates):
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
-        with FakeTensorMode():
-            fakes = {
-                name: torch.empty_strided(
-                    tuple(precompile_shapes[name]),
-                    tuple(precompile_strides[name]),
-                    dtype=getattr(torch, precompile_dtypes[name]),
-                    device="cpu",
-                )
-                for name in names
-            }
-            _flydsl_mxfp8_grouped_mm(
-                fakes["output"],
-                fakes["mat1"],
-                fakes["mat2"],
-                fakes["scale_a"],
-                fakes["scale_b"],
-                fakes["offs"],
-                stream=0,
-                compile_only=True,
-            )
+    precompile_flydsl(
+        _flydsl_mxfp8_grouped_mm, precompile_shapes, precompile_strides,
+        precompile_dtypes, flydsl_gpu_arch,
+    )

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_wgrad.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_wgrad.py.jinja
@@ -1,0 +1,74 @@
+import threading
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+    launch_mxfp8_wgrad_gfx950,
+    make_mxfp8_wgrad_param,
+)
+from torch._inductor.runtime.flydsl_cache import (
+    configure_flydsl_cache_dir,
+    flydsl_tensor_arg,
+    precompile_flydsl,
+)
+
+{{gen_defines()}}
+
+
+_mxfp8_wgrad_params = {}
+_mxfp8_wgrad_param_lock = threading.Lock()
+
+
+def _flydsl_mxfp8_wgrad(
+    output, mat1, mat2, scale_a, scale_b, offs, stream, compile_only=False
+):
+    if output.numel() == 0:
+        return output
+
+    m = mat1.shape[1]
+    sc_pair = m % 256 == 0
+    param = _mxfp8_wgrad_params.get(sc_pair)
+    if param is None:
+        with _mxfp8_wgrad_param_lock:
+            param = _mxfp8_wgrad_params.get(sc_pair)
+            if param is None:
+                param = make_mxfp8_wgrad_param(
+                    GEMM_N, GEMM_K, GEMM_G, sc_pair=sc_pair
+                )
+                _mxfp8_wgrad_params[sc_pair] = param
+
+    # mat2 is [M, K] with column-major storage. Its transpose is therefore the
+    # row-major [K, M] view consumed by the kernel, without a copy.
+    configure_flydsl_cache_dir()
+    launch_mxfp8_wgrad_gfx950(
+        output,
+        mat1,
+        mat2.permute(1, 0),
+        scale_a,
+        scale_b,
+        offs,
+        param,
+        stream,
+        tensor_arg=flydsl_tensor_arg,
+        compile_only=compile_only,
+    )
+    return output
+
+
+{{def_kernel("mat1", "mat2", "scale_a", "scale_b", "offs")}}
+    output = {{get_output()}}
+    return _flydsl_mxfp8_wgrad(
+        output, mat1, mat2, scale_a, scale_b, offs, stream
+    )
+
+
+def {{kernel_name}}_precompile(
+    precompile_shapes,
+    precompile_strides,
+    precompile_dtypes,
+    device_index=0,
+    device_capability=None,
+    flydsl_gpu_arch=None,
+):
+    precompile_flydsl(
+        _flydsl_mxfp8_wgrad, precompile_shapes, precompile_strides,
+        precompile_dtypes, flydsl_gpu_arch,
+    )

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -16,6 +16,8 @@ _EXPORT_MODULES = {
     "launch_mxfp8_grouped_gemm_gfx950": "mxfp8_grouped_gemm_gfx950",
     "make_mxfp8_grouped_gemm_param": "mxfp8_grouped_gemm_gfx950",
     "make_mxfp8_grouped_gemm_param_and_validate": "mxfp8_grouped_gemm_gfx950",
+    "launch_mxfp8_wgrad_gfx950": "mxfp8_wgrad_gfx950",
+    "make_mxfp8_wgrad_param": "mxfp8_wgrad_gfx950",
     "pick_mxfp8_grouped_gemm_tile": "mxfp8_grouped_gemm_gfx950",
 }
 __all__ = list(_EXPORT_MODULES)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -13,6 +13,10 @@ _EXPORT_MODULES = {
     "get_grouped_gemm_persistent_grid_size": "grouped_gemm_gfx950_config",
     "is_grouped_gemm_gfx950_layout_valid": "grouped_gemm_gfx950_config",
     "launch_gemm_gfx950_grouped": "grouped_gemm_gfx950",
+    "launch_mxfp8_grouped_gemm_gfx950": "mxfp8_grouped_gemm_gfx950",
+    "make_mxfp8_grouped_gemm_param": "mxfp8_grouped_gemm_gfx950",
+    "make_mxfp8_grouped_gemm_param_and_validate": "mxfp8_grouped_gemm_gfx950",
+    "pick_mxfp8_grouped_gemm_tile": "mxfp8_grouped_gemm_gfx950",
 }
 __all__ = list(_EXPORT_MODULES)
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_config.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_config.py
@@ -1,0 +1,8 @@
+"""Host-side tile counts for grouped GEMMs with device-resident row offsets."""
+
+
+def grouped_row_tiles_upper_bound(total_m: int, group_count: int, block_m: int) -> int:
+    if total_m <= 0 or group_count <= 0:
+        return 0
+    nonempty = min(group_count, total_m)
+    return nonempty + (total_m - nonempty) // block_m

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950_config.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950_config.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from .grouped_config import grouped_row_tiles_upper_bound
+
 
 GFX950_DMA_BYTES = 16
 GFX950_WAVE_SIZE = 64
@@ -74,6 +76,5 @@ def get_grouped_gemm_persistent_grid_size(
     n_tiles = (n - 1) // param.block_n + 1
     light_blocks = min(1 << (resource_blocks_per_cu.bit_length() - 1), 8)
     blocks_per_cu = light_blocks if light_tile else min(resource_blocks_per_cu, 2)
-    nonempty = min(group_count, total_m)
-    m_tiles_upper = nonempty + (total_m - nonempty) // param.block_m
+    m_tiles_upper = grouped_row_tiles_upper_bound(total_m, group_count, param.block_m)
     return max(1, min(num_cus * blocks_per_cu, m_tiles_upper * n_tiles))

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_scheduling.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_scheduling.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, const_expr, range_constexpr
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T
+
+from . import mxfp8_buffer_ops as buffer_ops
+
+
+@flyc.jit
+def for_each_grouped_tile_static(
+    offsets,
+    group_count: fx.Constexpr,
+    n: fx.Constexpr,
+    block_m: fx.Constexpr,
+    block_n: fx.Constexpr,
+    persistent: fx.Constexpr,
+    tile_body,
+):
+    """N-fast grid-stride traversal with constexpr groups and column count.
+
+    Load boundaries once per workgroup, and walk only actual tiles. The callback
+    must finish LDS accesses and drain vector memory operations before returning.
+    """
+    num_pid_n = (n + block_n - 1) // block_n
+    # This specialization is for power-of-two row tiles and monotone offsets.
+    # Use a shift, avoiding signed floor-division fixups in the SALU prologue.
+    if block_m <= 0 or (block_m & (block_m - 1)) != 0:
+        raise AssertionError(f"block_m must be a positive power of two, got {block_m}")
+    row_shift = block_m.bit_length() - 1
+    resource = buffer_ops.create_buffer_resource(
+        offsets, max_size=False, num_records_bytes=group_count * 4
+    )
+    ends = [
+        ArithValue(
+            buffer_ops.buffer_load(
+                resource, fx.Int32(i), vec_width=1, dtype=T.i32, is_scalar=True
+            )
+        )
+        for i in range(group_count)
+    ]
+    starts = [ArithValue(fx.Int32(0))] + ends[:-1]
+    cumulative = [ArithValue(fx.Int32(0))]
+    for i in range_constexpr(group_count):
+        rows = ends[i] - starts[i]
+        cumulative.append(cumulative[-1] + ((rows + block_m - 1) >> row_shift))
+
+    def visit(tile):
+        slot = tile // num_pid_n
+        bid_n = tile % num_pid_n
+        group = ArithValue(fx.Int32(0))
+        bid_m = ArithValue(fx.Int32(0))
+        row_base = ArithValue(fx.Int32(0))
+        row_end = ArithValue(fx.Int32(0))
+        for i in range_constexpr(group_count):
+            hit = (slot >= cumulative[i]) & (slot < cumulative[i + 1])
+            group = arith.select(hit, fx.Int32(i), group)
+            bid_m = arith.select(hit, slot - cumulative[i], bid_m)
+            row_base = arith.select(hit, starts[i], row_base)
+            row_end = arith.select(hit, ends[i], row_end)
+        tile_body(group, bid_m, bid_n, row_end - row_base, row_base)
+
+    if const_expr(persistent):
+        for tile in range(
+            fx.Int32(fx.block_idx.x),
+            cumulative[-1] * num_pid_n,
+            fx.Int32(fx.grid_dim.x),
+        ):
+            visit(tile)
+    else:
+        tile = fx.Int32(fx.block_idx.x)
+        if tile < cumulative[-1] * num_pid_n:
+            visit(tile)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_buffer_ops.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_buffer_ops.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+# Vendored from the MXFP8 grouped GEMM
+# package in ROCm/AMD-TorchTitan-Ops (`amd_titan/_ops/fwdgemm/_buffer_ops.py`),
+# whose own upstream is the `flydsl-groupped-gemm` development repo. Kept as a
+# separate file from `gemm_gfx950.py` so it can be re-synced wholesale. The one
+# change is `_aux_is_positional`, which handles the 0.3.1 buffer-op builders.
+"""Buffer-descriptor loads and stores, on ops that exist in flydsl 0.2.4 AND 0.3.0.
+
+WHY THIS FILE EXISTS. These kernels were written against flydsl 0.2.4 and called
+``flydsl.expr.buffer_ops`` and ``flydsl.expr.vector``. 0.3.0 DELETED both
+modules, so the kernels only ran there via a compat shim that grafted the two
+0.2.4 modules back under their old names -- which meant carrying 763 lines of
+someone else's deleted code, on a path outside this repo.
+
+The shim was never the only option: ``rocdl.MakeBufferRsrcOp``,
+``RawPtrBufferLoadOp`` and ``RawPtrBufferStoreOp`` are present in BOTH versions.
+0.2.4's ``buffer_ops`` was a convenience layer over exactly those, and this is
+that layer, re-implemented against the ops directly and kept to what these
+kernels actually use. No shim, no version branch, no ``flydsl.expr.buffer_ops``.
+
+What is deliberately NOT here, because no caller needs it: ``mask=``,
+``cache_modifier``, ``stride``, ``base_byte_offset``, ``offset_is_bytes``, the
+``from_addr`` descriptor constructor, and the memref-derived size fallback (every
+caller passes ``num_records_bytes`` explicitly). Adding one back means porting
+its logic from 0.2.4, not guessing.
+
+THE BOUNDS ARE LOAD-BEARING, not an optimisation. ``num_records`` is what makes
+an out-of-range read return 0 instead of faulting, and this kernel relies on that:
+it over-provisions row-tile slots and lets a surplus block's scale read go past
+the plane, where 0 as an e8m0 is 2**-127 and underflows exactly as the epilogue
+mask intends. Dropping the bound gives ``hipErrorIllegalAddress`` on real
+DSV3-16B shapes -- see the descriptor comments in `_fwd_kernel.py`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Optional, Union
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import (
+    arith as std_arith,
+    fly as _fly,
+    llvm,
+    rocdl,
+    vector as _vector,
+)
+from flydsl._mlir.extras import types as T
+from flydsl.expr import arith as _arith_ext
+
+
+# CDNA (gfx9xx) buffer resource flags word, bits 127:96 of the V#:
+#   bits [14:12] DATA_FORMAT = 7 (float), bits [18:15] NUM_FORMAT = 4 (32-bit).
+# Mirrors LLVM's AMDGPUToROCDL makeBufferRsrc(). gfx950 is CDNA, so the RDNA
+# variant (bit 24, OOB_SELECT) is not needed and is not offered -- a kernel that
+# ran on RDNA with this constant would silently lose bounds checking.
+_CDNA_BUFFER_FLAGS = (7 << 12) | (4 << 15)  # 0x20070
+_UNBOUNDED = 0xFFFFFFFF
+
+
+def _aux_is_positional(op) -> bool:
+    """Whether this FlyDSL build still takes ``aux`` as a positional operand.
+
+    flydsl 0.2.4/0.3.0 declare ``RawPtrBuffer{Load,Store}Op(..., soffset, aux)``
+    with ``aux`` a required positional ir.Value; 0.3.1 made it a keyword-only
+    *attribute* defaulting to None. Passing the 0.2.4 form to 0.3.1 raises
+    ``TypeError: __init__() takes 5 positional arguments but 6 were given`` at
+    trace time, so the arity is read off the builder rather than assumed.
+    """
+    parameter = inspect.signature(op.__init__).parameters.get("aux")
+    return (
+        parameter is not None
+        and parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    )
+
+
+_LOAD_AUX_IS_POSITIONAL = _aux_is_positional(rocdl.RawPtrBufferLoadOp)
+_STORE_AUX_IS_POSITIONAL = _aux_is_positional(rocdl.RawPtrBufferStoreOp)
+
+
+def _unwrap(v):
+    """DSL Numeric / OpView / ir.Value -> ir.Value."""
+    if hasattr(v, "ir_value"):
+        v = v.ir_value()
+    if hasattr(v, "result"):
+        v = v.result
+    return v
+
+
+def _const_i32(v: int):
+    return std_arith.ConstantOp(T.i32(), ir.IntegerAttr.get(T.i32(), int(v))).result
+
+
+def _const_i16(v: int):
+    return std_arith.ConstantOp(T.i16(), ir.IntegerAttr.get(T.i16(), int(v))).result
+
+
+def _const_i64(v: int):
+    return std_arith.ConstantOp(T.i64(), ir.IntegerAttr.get(T.i64(), int(v))).result
+
+
+def _as_i32(v):
+    """Coerce an unwrapped value to i32, index-casting or sign-extending as needed."""
+    v = _unwrap(v)
+    if isinstance(v.type, ir.IntegerType) and v.type.width == 32:
+        return v
+    if isinstance(v.type, ir.IndexType):
+        return std_arith.IndexCastOp(T.i32(), v).result
+    return std_arith.ExtSIOp(T.i32(), v).result
+
+
+def _as_i64(v):
+    v = _unwrap(v)
+    if isinstance(v.type, ir.IntegerType) and v.type.width == 64:
+        return v
+    if isinstance(v.type, ir.IndexType):
+        return std_arith.IndexCastOp(T.i64(), v).result
+    return std_arith.ExtSIOp(T.i64(), v).result
+
+
+def create_buffer_resource(
+    memref_val,
+    max_size: bool = True,
+    *,
+    num_records_bytes: Optional[Union[int, ir.Value]] = None,
+):
+    """A buffer resource descriptor (V#, `!llvm.ptr<8>`) over a fly.memref.
+
+    `num_records_bytes` sets the hardware bound and takes precedence over
+    `max_size`. Pass it: an unbounded descriptor turns an out-of-range read from
+    a returned 0 into a fault (see the module docstring).
+    """
+    base_ptr = _fly.extract_aligned_pointer_as_index(
+        ir.Type.parse("!llvm.ptr"), _unwrap(memref_val)
+    )
+    if num_records_bytes is None:
+        num_records = _const_i64(_UNBOUNDED if max_size else 0)
+    elif isinstance(num_records_bytes, int):
+        num_records = _const_i64(max(0, min(int(num_records_bytes), _UNBOUNDED)))
+    else:
+        num_records = _as_i64(num_records_bytes)
+    return rocdl.MakeBufferRsrcOp(
+        ir.Type.parse("!llvm.ptr<8>"),
+        base_ptr,
+        _const_i16(0),
+        num_records,
+        _const_i32(_CDNA_BUFFER_FLAGS),
+    ).result
+
+
+def buffer_load(
+    rsrc,
+    offset,
+    vec_width: int = 4,
+    dtype=None,
+    soffset_bytes: Optional[Union[int, ir.Value]] = None,
+    is_scalar: bool = False,
+):
+    """Load `vec_width` x `dtype` from `rsrc` at an ELEMENT offset.
+
+    `offset` is in elements and is scaled to bytes here -- the hardware wants
+    bytes. `soffset_bytes` rides the instruction's scalar offset field, so a
+    small wave-uniform delta costs no VGPR arithmetic.
+
+    `is_scalar` emits `s.buffer.load` instead: a uniform SMEM load landing in
+    SGPRs, for wave-uniform addresses only. It forces i32 (the intrinsic returns
+    raw dwords) and takes no soffset, matching 0.2.4.
+    """
+    if is_scalar:
+        if vec_width not in (1, 4):
+            raise ValueError(f"buffer_load(is_scalar=True): vec_width={vec_width}")
+        if soffset_bytes is not None:
+            raise ValueError("buffer_load(is_scalar=True) takes no soffset_bytes")
+        dtype = T.i32()
+    elif dtype is None:
+        dtype = T.f32()
+    elif hasattr(dtype, "ir_type"):
+        dtype = dtype.ir_type
+
+    offset = _const_i32(offset) if isinstance(offset, int) else _as_i32(offset)
+    # element offset -> byte offset
+    offset = std_arith.MulIOp(offset, _const_i32(dtype.width // 8)).result
+    result_type = dtype if vec_width == 1 else ir.VectorType.get([vec_width], dtype)
+
+    if is_scalar:
+        # The s.buffer.load intrinsic wants the descriptor as v4i32, not the
+        # opaque ptr<8> the vector path uses. It takes TWO steps: `llvm.bitcast`
+        # only casts pointer-to-pointer, so go through an i128 first. Casting
+        # ptr<8> straight to v4i32 fails to compile with
+        # "'llvm.bitcast' op can only cast pointers from and to pointers".
+        rsrc_v4 = llvm.bitcast(
+            ir.VectorType.get([4], T.i32()),
+            llvm.ptrtoint(ir.IntegerType.get_signless(128), _unwrap(rsrc)),
+        )
+        return llvm.call_intrinsic(
+            result_type,
+            "llvm.amdgcn.s.buffer.load." + ("i32" if vec_width == 1 else "v4i32"),
+            [rsrc_v4, offset, _const_i32(0)],
+            [],
+            [],
+        )
+
+    soffset = (
+        _const_i32(0)
+        if soffset_bytes is None
+        else _const_i32(soffset_bytes)
+        if isinstance(soffset_bytes, int)
+        else _as_i32(soffset_bytes)
+    )
+    load_args = [result_type, _unwrap(rsrc), offset, soffset]
+    if _LOAD_AUX_IS_POSITIONAL:
+        load_args.append(_const_i32(0))
+    return rocdl.RawPtrBufferLoadOp(*load_args).result
+
+
+def buffer_store(data, rsrc, offset):
+    """Store `data` to `rsrc` at an ELEMENT offset (scaled to bytes here)."""
+    data = _unwrap(data)
+    offset = _const_i32(offset) if isinstance(offset, int) else _as_i32(offset)
+    elem_t = data.type.element_type if hasattr(data.type, "element_type") else data.type
+    offset = std_arith.MulIOp(offset, _const_i32(elem_t.width // 8)).result
+    store_args = [data, _unwrap(rsrc), offset, _const_i32(0)]
+    if _STORE_AUX_IS_POSITIONAL:
+        store_args.append(_const_i32(0))
+    rocdl.RawPtrBufferStoreOp(*store_args)
+
+
+def vec_extract(vector, static_position=None, dynamic_position=None):
+    """`vector.extract`, replacing 0.3.0's deleted `flydsl.expr.vector.extract`.
+
+    A dynamic index needs a kDynamic sentinel in the static attribute for the
+    ODS builder to pair the two, so fill those in when only dynamic indices are
+    given.
+    """
+    static_position = list(static_position or [])
+    dynamic_position = [
+        _arith_ext.unwrap(i, index=True) for i in (dynamic_position or [])
+    ]
+    if dynamic_position and len(static_position) < len(dynamic_position):
+        static_position += [ir.ShapedType.get_dynamic_size()] * (
+            len(dynamic_position) - len(static_position)
+        )
+    return _vector.ExtractOp(
+        _arith_ext.unwrap(vector),
+        static_position=static_position,
+        dynamic_position=dynamic_position,
+    ).result

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_gemm_utils.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_gemm_utils.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# Vendored, unmodified apart from this header, from the MXFP8 grouped GEMM
+# package in ROCm/AMD-TorchTitan-Ops
+# (`amd_titan/_ops/fwdgemm/_fp8_gemm_utils.py`).
+# Copyright (c) 2025 FlyDSL Project Contributors
+#
+# FP8-GEMM data-path helpers for the flydsl_8wave candidate. Self-contained:
+# the only dependency is the `flydsl` pip wheel (flydsl.*).
+#
+# TRIMMED TO WHAT `mxfp8_grouped_gemm_gfx950` IMPORTS. Upstream also carries
+# `preshuffle_b`, `ceildiv`, `divmod`, `StoreC` and `Mfma16x16x128`; this
+# kernel imports none of them (it issues its own scaled MFMA through
+# `_mfma_scale_agpr` and stores via `buffer_ops.buffer_store`), so they are
+# dropped rather than vendored unused. `Mfma16x16x128` in particular built an
+# `MFMA_Scale` atom and left its scale operands at the atom default, which is
+# only correct while FlyDSL treats that default as an identity scale -- an
+# assumption no live code here depends on.
+
+import flydsl.expr as fx
+from flydsl._mlir.dialects import fly as fly_dialect, llvm as _llvm
+from flydsl._mlir.dialects.fly_rocdl import TargetAddressSpace
+from flydsl.expr import arith, const_expr, range_constexpr
+from flydsl.expr.typing import Vector as Vec
+
+
+def make_fp8_buffer_tensor(arg_i8, fp8_ir_t):
+    # max_size=False with no num_records_bytes: cosize(layout) becomes a
+    # runtime expression because TensorAdaptor defaults to layout-dynamic
+    # memref (post #554), so the descriptor adapts to the actual tensor
+    # extent and no longer bakes the first-call's shape into IR.
+    t_i8 = fx.rocdl.make_buffer_tensor(arg_i8, max_size=False)
+    iter_i8 = fx.get_iter(t_i8)
+    f8_buf_ptr_ty = fx.PointerType.get(
+        elem_ty=fp8_ir_t,
+        address_space=TargetAddressSpace.BufferDesc,
+        alignment=fx.PointerType(iter_i8.type).alignment,
+    )
+    iter_f8 = fx.recast_iter(f8_buf_ptr_ty, iter_i8)
+    return fx.Tensor(fx.make_view(iter_f8, fx.get_layout(t_i8)))
+
+
+def swizzle_128(row, col):
+    offset = row * 128 + col
+    swizzle = ((offset % (16 * 128)) >> 8) << 4
+    swizzled_offset = offset ^ swizzle
+    return swizzled_offset // 128, swizzled_offset % 128
+
+
+def compute_global_swizzle(lane_id, wave_id, K, n_rounds, preshuffled):
+    offsets = []
+    n_waves = fx.block_dim.x // 64
+    for round in range_constexpr(n_rounds):
+        if const_expr(preshuffled):
+            row = lane_id % 8 + wave_id * 8 + round * (n_waves * 8)
+            col = (lane_id // 8) * 16
+            offsets.append(
+                (row // 16) * (K * 16)
+                + (row % 16) * 16
+                + (col // 64) * 1024
+                + ((col % 64) // 16) * 256
+                + (col % 16)
+            )
+        else:
+            row = lane_id // 8 + wave_id * 8 + round * (n_waves * 8)
+            col = (lane_id % 8) * 16
+            r, c = swizzle_128(row, col)
+            offsets.append(r * K + c)
+    return offsets
+
+
+class G2SLoader:
+    def __init__(self, gl_src, gl_offsets, n_load_steps, lds_dtype, wave_id):
+        self.g2lds_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
+        self.LdsPtr_t = fx.PointerType.get(lds_dtype, 2, 512)
+        self.gl_src = gl_src
+        self.gl_offsets = gl_offsets
+        self.n_load_steps = n_load_steps
+        self.wave_id = wave_id
+        self.n_waves = fx.block_dim.x // 64
+
+    def _lds_dst_at(self, lds_dst, step):
+        step_off = self.wave_id * 1024 + step * (self.n_waves * 1024)
+        base_i32 = fx.Int32(fx.ptrtoint(lds_dst.ptr))
+        sum_i32 = base_i32 + fx.Int32(step_off)
+        lds_ptr = fx.inttoptr(self.LdsPtr_t, sum_i32)
+        return fx.make_view(lds_ptr, fx.make_layout(1, 1))
+
+    def load(self, lds_dst, k_offset):
+        for step in range_constexpr(self.n_load_steps):
+            src = fx.slice(self.gl_src, (None, fx.Int32(self.gl_offsets[step])))
+            dst = self._lds_dst_at(lds_dst, step)
+            fx.copy(self.g2lds_atom, src, dst, soffset=fx.Int32(k_offset))
+
+    def load_one(self, lds_dst, k_offset, step):
+        src = fx.slice(self.gl_src, (None, fx.Int32(self.gl_offsets[step])))
+        dst = self._lds_dst_at(lds_dst, step)
+        fx.copy(self.g2lds_atom, src, dst, soffset=fx.Int32(k_offset))
+
+
+def pack_i32x4_i32x8(lo, hi):
+    # Pack two i32x4 as one i32x8
+    return lo.shuffle(hi, list(range(8)))
+
+
+class S2RLoader:
+    def __init__(self, wave_idx, n_tiles):
+        self.lane_id = fx.thread_idx.x % 64
+        self.wave_idx = wave_idx
+        self.n_tiles = n_tiles
+
+    def _vec_load_16xf8(self, lds_src, offset):
+        off_tup = fx.make_int_tuple(offset)
+        ptr_off = fx.add_offset(lds_src.ptr, off_tup)
+        i8_iter = fx.recast_iter(fx.Uint8, ptr_off)
+        view = fx.make_view(i8_iter, fx.make_layout(16, 1))
+        return view.load()
+
+    def load(self, lds_src, preshuffled=False):
+        frag = []
+        for i in range_constexpr(self.n_tiles):
+            halves = []
+            row = self.wave_idx * (self.n_tiles * 16) + i * 16 + self.lane_id % 16
+            for step in range_constexpr(2):
+                col = (self.lane_id // 16) * 16 + step * 64
+                if const_expr(preshuffled):
+                    offset = (row // 8) * 1024 + (row % 8) * 16 + (col // 16) * 128
+                else:
+                    row_swz, col_swz = swizzle_128(row, col)
+                    offset = row_swz * 128 + col_swz
+                v = self._vec_load_16xf8(lds_src, offset)
+                halves.append(v.bitcast(fx.Int32))
+            frag.append(pack_i32x4_i32x8(halves[0], halves[1]))
+        return frag
+
+    def load_one(self, lds_src, lds_offset):
+        v = self._vec_load_16xf8(lds_src, lds_offset)
+        return v.bitcast(fx.Int32)
+
+
+def wait_barrier(count):
+    """`s_waitcnt vmcnt(count) lgkmcnt(0)` then `s_barrier`.
+
+    THE lgkmcnt(0) IS LOAD-BEARING. This barrier protects LDS buffers that other
+    waves are about to overwrite, and vmcnt alone does not cover the ds_reads
+    this wave still has in flight -- ds_read retires on lgkmcnt. The `s_barrier`
+    lives inside an inline-asm string, so the backend cannot see a barrier here
+    and will not insert the lgkmcnt(0) it normally places ahead of one.
+
+    Without it the kernel is correct only by accident, on instruction distance:
+    an s2r fragment is issued in one cluster and consumed in the NEXT, so it
+    crosses this barrier outstanding, and the buffer it reads (`ac1`) is
+    overwritten two clusters later by another wave that this same barrier just
+    released. What covers the gap is the MFMAs in between -- N_ACCUMS of them.
+    At N_ACCUMS 16 (256x256) and 8 (128x256, 256x128) the read always retires
+    first. At N_ACCUMS 4 it does not, which is exactly the set that failed:
+    (128,128) and BLOCK_R=64, 0.01-0.10% of elements wrong, varying run to run
+    and only after repeated calls. Nothing else distinguished those two tiles --
+    occupancy, the interleave plan and the swizzle round count were each ruled
+    out by experiment first.
+    """
+    _llvm.inline_asm(
+        res=None,
+        operands_=[],
+        asm_string=f"s_waitcnt vmcnt({count}) lgkmcnt(0)\ns_barrier",
+        constraints="",
+        has_side_effects=True,
+    )

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -1,0 +1,1198 @@
+# SPDX-License-Identifier: MIT
+#
+# RAGGED MXFP8 FORWARD grouped GEMM, 4-wave AGPR body.
+#
+#     out[group_g] = X[group_g] @ W[g]^T        X(M,K), W(E,N,K) -> (M,N)
+#
+# The ragged axis is NOT the contraction: K is uniform across experts, so the
+# K-walk never learns the groups are ragged. Raggedness is therefore confined
+# to the four points below -- the 8-buffer LDS ping-pong, the AGPR-pinned
+# scaled MFMA, the cooperative scale load, the interleave plan and the
+# hand-counted vmcnt barriers are all independent of it.
+#
+#   1. `OFFS` is a new kernel argument, and the block -> (group, row tile,
+#      col tile) mapping is resolved ON DEVICE from it, rather than from a
+#      constexpr M_G.
+#   2. `row0 = m_start + r_base` instead of `g * M_G + r_base`.
+#   3. The epilogue store masks on `active & (r_ < m_end)`: a row tile may
+#      overhang its group, and those rows hold this expert's weights applied to
+#      the next group's tokens.
+#   4. The compile key drops M_G and M_TOTAL, keeping only (K, N, E, BLOCK_C).
+#      Both are routing-dependent, so keying on them recompiles per token
+#      count -- invisible under balanced routing, a per-step JIT under real
+#      routing.
+#
+# Host side: the grid is over-provisioned to ceildiv(M, BLOCK_R) + E row tiles
+# and the output is zero-initialised, because a masked store no longer covers
+# every row.
+#
+# Two structural consequences of the short contraction (K/128 = 11-16 steps):
+#   * The K-loop is fully unrolled at compile time; the loop-carried a0/b0
+#     fragments and scale chunk disappear.
+#   * Pipeline fill and drain are a much larger fraction of the kernel (2 of 16
+#     steps are prologue, 2 are tails), so prologue cost matters here.
+#
+# The vmcnt accounting is derived, not transcribed: with the loop unrolled the
+# issue pattern is not perfectly periodic, so `_VmCounter` tracks issued
+# vector-memory ops and each barrier waits for exactly "everything up to the op
+# I depend on".
+
+# NOTE: no `from __future__ import annotations` -- fx.struct needs real types.
+
+import dataclasses
+import functools
+import logging
+import os
+
+import torch
+from torch._inductor.runtime.flydsl_cache import run_cached_flydsl
+
+
+# NOTE: no flydsl_compat. `_buffer_ops` implements the descriptor loads/stores
+# on rocdl ops that exist in BOTH flydsl 0.2.4 and 0.3.0, so this kernel runs on
+# either without the shim that grafted 0.3.0's deleted modules back.
+
+
+# OCP MX: 32 elements share one E8M0 scale.
+SCALE_BLOCK = 32
+
+BLOCK_R = 256  # DEFAULT output rows (tokens) per tile; see pick_block_r
+BLOCK_C_DEFAULT = 256  # output cols (N) per tile; 128 also supported, see pick_tile
+BLOCK_M = 128  # contraction elements per pipeline step (= BLOCK_K)
+
+
+def pick_block_r(m_total: int, e: int) -> int:
+    """Row tile height, from the AVERAGE group size.
+
+    A row tile is charged for every row it covers: a group of m_avg rows under a
+    BLOCK_R tile is charged ceildiv(m_avg, BLOCK_R) * BLOCK_R rows and discards
+    the rest at the masked store. A narrower tile removes that overhang but
+    costs per-block efficiency -- the MFMA-per-ds_read ratio is NA*NB/(NA+NB),
+    2.0 at 4x4 (BLOCK_R=256), 1.33 at 2x4 (128), 0.8 at 1x4 (64) -- so the two
+    are scored against each other below.
+
+    AVERAGE, not per-group, and that is forced: the group sizes live on the
+    device and this kernel's whole design is not to sync on them. m_total and E
+    are host-side shape metadata, so m_total // E costs nothing. Under real MoE
+    routing the groups are within ~2x of the mean; a skewed batch gets a tile
+    sized for its mean, which is no worse than the fixed 256.
+
+    BLOCK_R=64 computed wrong answers until the `wait_barrier` lgkmcnt fix in
+    `mxfp8_gemm_utils`; verified clean since.
+    """
+    if e <= 0:
+        return 256
+    m_avg = max(m_total // e, 1)
+
+    # Density against actual overhang, not a threshold on m_avg: at m_avg=256
+    # every legal tile has overhang 1.0, so narrowing there gives up the ratio
+    # for nothing. Shapes with m_avg >= 384 pick 256 either way.
+    best_block_r, best_score = 256, -1.0
+    for block_r in (64, 128, 256):
+        n_tiles_a = block_r // 64
+        # MFMA-per-ds_read ratio at this tile height, against a 4-wide tile.
+        density = n_tiles_a * 4 / (n_tiles_a + 4)
+        overhang = ceildiv(m_avg, block_r) * block_r / m_avg
+        score = density / overhang
+        if score > best_score:
+            best_block_r, best_score = block_r, score
+    return best_block_r
+
+
+def pick_tile(m_total: int, e: int, n: int) -> tuple:
+    """(BLOCK_R, BLOCK_C) for this shape, shrinking both when the grid starves.
+
+    `pick_block_r` answers a local question and does not look at how many
+    blocks the resulting tile produces. That is fine everywhere except
+    small N, where BLOCK_C=256 leaves ONE column tile and the row dim is the
+    only parallelism left: K4096 x N256 tiles to 16 blocks on a 256-CU part.
+
+    Halving a tile dimension doubles the block count, and at a starved grid that
+    trade is strongly positive even though the narrower tile is worse per block.
+    THE THRESHOLD IS ONE FULL WAVE, and the shrink stops at (128, 128): going
+    on to BLOCK_R=64 gains too little to pay for another branch here.
+    """
+    br = pick_block_r(m_total, e)
+    # BLOCK_C is always 256 to start: a tile that overhangs N is not free, but
+    # the narrow tile is still slower where it removes the whole overhang,
+    # because per K-step a wave issues 4*NA*NB MFMAs against 4*(NA+NB) LDS reads
+    # -- ratio 2.0 at 4x4 against 1.33 at 4x2. 128 is taken below only when the
+    # grid is starved, where occupancy outweighs that ratio.
+    bc = BLOCK_C_DEFAULT
+    if e <= 0 or n <= 0:
+        return br, bc
+    # Row tiles are per-group, so the average group is what the grid sees.
+    tiles = max(1, e * ceildiv(max(m_total // e, 1), br)) * ceildiv(n, bc)
+    if tiles >= _STARVED_TILES:
+        return br, bc
+    # Only a tile that is 256 in BOTH dims can be halved: halving one that is
+    # already 128 lands on (128, 128). SHRINK ONE STEP AT A TIME, re-checking;
+    # the partial-wave shapes gain from the first step. (128,128) and
+    # BLOCK_R=64 were banned until the `wait_barrier` lgkmcnt fix, which is what
+    # made the N_ACCUMS=4 tiles compute wrong answers.
+    tiles_at = lambda r, c: (
+        max(1, e * ceildiv(max(m_total // e, 1), r)) * ceildiv(n, c)
+    )
+    if bc == 256 and n % 128 == 0:
+        bc = 128
+        if tiles_at(br, bc) >= _STARVED_TILES:
+            return br, bc
+    if br == 256:
+        br = 128
+        if tiles_at(br, bc) >= _STARVED_TILES:
+            return br, bc
+    return br, bc
+
+
+log = logging.getLogger(__name__)
+
+_STARVED_TILES = 256  # one full wave on MI350X's 256 CUs; see pick_tile
+
+_guard_fallback_warned = set()
+
+# (K, N, E, BLOCK_C, BLOCK_R) whose guarded kernel failed to TRACE. FlyDSL
+# traces on first launch, not at compile, so this is discovered at the launch
+# site and remembered here -- see `launch_for` / `launch_guarded`.
+_guard_broken = set()
+
+
+def _warn_guard_fallback(K, N, E, BLOCK_C, BLOCK_R, err) -> None:
+    """Say once, per shape, that the surplus-slot guard did not compile.
+
+    Loud enough to notice (this shape is now paying for its surplus row-tile
+    slots, up to 1.74x) but not per call, and never fatal.
+    """
+    key = (K, N, E, BLOCK_C, BLOCK_R)
+    if key in _guard_fallback_warned:
+        return
+    _guard_fallback_warned.add(key)
+    log.warning(
+        "FlyDSL MXFP8 grouped GEMM: surplus-slot guard failed to compile at "
+        "K=%d N=%d E=%d BLOCK_C=%d BLOCK_R=%d (%s: %s); falling back to the "
+        "unguarded kernel, which is correct but pays for its surplus slots.",
+        K,
+        N,
+        E,
+        BLOCK_C,
+        BLOCK_R,
+        type(err).__name__,
+        str(err).splitlines()[0][:120],
+    )
+
+
+
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith, range_constexpr, rocdl
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T, Vector as Vec
+
+from . import mxfp8_buffer_ops as buffer_ops
+from .mxfp8_gemm_utils import (
+    compute_global_swizzle,
+    G2SLoader,
+    make_fp8_buffer_tensor,
+    pack_i32x4_i32x8,
+    S2RLoader,
+    swizzle_128,
+    wait_barrier,
+)
+
+
+# Each quadrant's 16 MFMAs are interleaved with the g2s/s2r loads of the NEXT
+# fragment so they co-issue in the MFMA execute shadow.
+
+
+def _mfma_scale_agpr(a, b, sa, sb, acc):
+    """fp8 16x16x128 scaled MFMA with the accumulator pinned in AGPR (=a,...,0)
+    so the f32x4 accumulates in place and the compiler does not shuffle it
+    between AGPR slots. a/b are i32x8 (K=128 fp8); sa/sb are broadcast-i32
+    E8M0 scales (one e8m0 replicated to 4 bytes). cbsz:0 blgp:0, no op_sel."""
+    asm = "v_mfma_scale_f32_16x16x128_f8f6f4 $0, $1, $2, $0, $3, $4 cbsz:0 blgp:0"
+    return _llvm.inline_asm(
+        Vec.make_type(4, fx.Float32),
+        [
+            arith._to_raw(a),
+            arith._to_raw(b),
+            arith._to_raw(sa),
+            arith._to_raw(sb),
+            arith._to_raw(acc),
+        ],
+        asm,
+        "=a,v,v,v,v,0",
+        has_side_effects=True,
+    )
+
+
+class _VmCounter:
+    """Issue-order bookkeeping for `s_waitcnt vmcnt(n)`.
+
+    vmcnt retires IN ORDER, so "wait until op X has landed" is spelled
+    "allow at most (ops issued after X) to be outstanding". Every vector
+    memory op the kernel issues is counted here; `mark()` records a
+    watermark right after the ops a later barrier will depend on, and
+    `wait(mark)` emits the barrier with the exact count.
+
+    Getting this wrong in the unsafe direction is silent: too LARGE a count
+    under-waits and reads LDS the copy has not filled yet. Deriving it from
+    the issue order removes the chance to mis-transcribe a constant.
+    """
+
+    def __init__(self):
+        self.n = 0
+
+    def issue(self, k):
+        self.n += k
+        return self.n
+
+    def mark(self):
+        return self.n
+
+    def wait(self, mark):
+        wait_barrier(self.n - mark)
+
+
+def _compile(
+    K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int = BLOCK_R, GUARD: bool = True
+):
+    """Compile a RAGGED forward grouped GEMM for one (K, N, E) shape.
+
+    Deliberately absent from the key: the token count and every group size.
+    Both are runtime. Under real MoE routing they change every step, and a
+    shape-keyed compile leaks a JIT compile plus a retained GPU module per
+    step per layer; only balanced routing would hide it.
+    """
+    if K % BLOCK_M != 0:
+        raise ValueError(f"K ({K}) must be a multiple of {BLOCK_M}")
+    if BLOCK_C not in (128, 256):
+        raise ValueError(f"BLOCK_C {BLOCK_C} not supported")
+    # 64/128/256 give N_TILES_A of 1/2/4. Below 64 a half is under one MFMA
+    # tile (16 rows x 2 wave-rows) and the row structure stops holding.
+    if BLOCK_R not in (64, 128, 256):
+        raise ValueError(f"BLOCK_R {BLOCK_R} not supported")
+
+    K_ITERS = K // BLOCK_M
+    if K_ITERS < 4:
+        raise ValueError(
+            f"K {K} gives {K_ITERS} steps; need >= 4 (2 prologue + 2 tails)"
+        )
+
+    SCALE_I32_ROW = K // 128  # i32 of e8m0 per operand row
+
+    N_TILES_A = BLOCK_R // 4 // 16
+    N_TILES_B = BLOCK_C // 4 // 16
+    N_ACCUMS = N_TILES_A * N_TILES_B
+    N_LDS_ROUNDS = max(N_TILES_A, N_TILES_B)
+
+    # A dwordx2 scale load needs an even element index. The index is
+    # lane*SCALE_I32_ROW + (row_base*SCALE_I32_ROW) + k with k always even
+    # (a chunk starts on an even K-step) and no per-group K offset here, so
+    # the row stride alone decides. K=2048 -> 16 (paired); K=1408 -> 11 (two
+    # dword loads instead; same cache lines, one extra instruction).
+    SC_PAIR = SCALE_I32_ROW % 2 == 0
+    N_SC_OPS = 4 if SC_PAIR else 8  # scale vm ops per chunk (2 K-steps)
+    N_CHUNKS = (K_ITERS + 1) // 2
+
+    LDS_BLOCK_R = BLOCK_R // 2  # each wave-dim half owns BLOCK_R/2 rows
+    LDS_BLOCK_C = BLOCK_C // 2
+
+    def _interleave_plan(n_mfma, n_g2s, n_tiles):
+        """Where to slot each load into the cluster's MFMA stream.
+
+        Returns three lists indexed by MFMA position: the g2s steps, the
+        first-half s2r tiles and the second-half s2r tiles to issue just
+        before that MFMA. Generated rather than written out because the
+        counts move with the tile -- BLOCK_C=256 is 16 MFMAs against 4 g2s
+        steps and 4x2 s2r reads, BLOCK_C=128 is 8 against 4 and 2x2.
+
+        Computed HERE, outside the kernel body, on purpose: FlyDSL's AST
+        rewriter turns an `if` inside a nested kernel-body function into a
+        separate `__then_N` function that cannot see the enclosing closure,
+        so schedule logic has to be plain Python that runs before tracing.
+        The kernel body then walks the plan with no branches at all.
+        """
+        acts = []
+        for r in range(max(n_g2s, n_tiles)):
+            if r < n_g2s:
+                acts.append(("g", r))
+            if r < n_tiles:
+                acts.append(("s0", r))
+                acts.append(("s1", r))
+        g_at = [[] for _ in range(n_mfma)]
+        s0_at = [[] for _ in range(n_mfma)]
+        s1_at = [[] for _ in range(n_mfma)]
+        for n_, act in enumerate(acts):
+            # Spread the loads evenly across the MFMA stream. The clamp is
+            # load-bearing at NA=1 (BLOCK_R=64), where 9 acts share only 4
+            # MFMA slots: the last act lands at round(9*4/10) = round(3.6) =
+            # 4, one past the end. `round` can exceed the floor whenever the
+            # ratio's fraction is >= .5, so the clamp -- not the ratio -- is
+            # what guarantees every load keeps a slot. It is a no-op at the
+            # 4x4/2x4/4x2 tiles, where the ratio never reaches n_mfma - 0.5.
+            pos = min(n_mfma - 1, int(round((n_ + 1) * n_mfma / (len(acts) + 1))))
+            {"g": g_at, "s0": s0_at, "s1": s1_at}[act[0]][pos].append(act[1])
+        return g_at, s0_at, s1_at
+
+    MFMA_SEQ = [(i, j) for i in range(N_TILES_A) for j in range(N_TILES_B)]
+    # Keyed by (g2s steps, s2r tiles): clusters 1 and 4 push A and pull B,
+    # clusters 2 and 3 the other way round. Keys collide harmlessly when the
+    # tile is square.
+    PLANS = {
+        (N_TILES_A, N_TILES_B): _interleave_plan(len(MFMA_SEQ), N_TILES_A, N_TILES_B),
+        (N_TILES_B, N_TILES_A): _interleave_plan(len(MFMA_SEQ), N_TILES_B, N_TILES_A),
+    }
+    a_lds_size = LDS_BLOCK_R * BLOCK_M
+    b_lds_size = LDS_BLOCK_C * BLOCK_M
+
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_fwd(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        OUT: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        OFFS: fx.Tensor,
+        n_c_tiles: fx.Int32,
+        out_m: fx.Int32,
+        out_n: fx.Int32,
+    ):
+        F8_IR_t = fx.Float8E4M3FN.ir_type
+
+        # ── Block -> (group, row tile, col tile), resolved ON DEVICE ──
+        # Groups partition the OUTPUT ROWS here, not the contraction, so
+        # unlike the wgrad kernel nothing about the K-walk changes: K is
+        # uniform across experts. Only this mapping and the epilogue mask
+        # care that the groups are ragged.
+        bid = fx.block_idx.x
+        slot = ArithValue(bid) // n_c_tiles  # which row tile overall
+        c_base = (ArithValue(bid) % n_c_tiles) * fx.Int32(BLOCK_C)
+
+        offs_rsrc = buffer_ops.create_buffer_resource(
+            OFFS, max_size=False, num_records_bytes=E * 4
+        )
+        # Uniform (SGPR) loads: every lane in the block wants the same
+        # boundaries, so this is E scalar loads, not E per-lane loads.
+        ends = [
+            ArithValue(
+                buffer_ops.buffer_load(
+                    offs_rsrc, fx.Int32(i), vec_width=1, dtype=T.i32, is_scalar=True
+                )
+            )
+            for i in range(E)
+        ]
+        starts = [ArithValue(fx.Int32(0))] + ends[:-1]
+
+        # Walk the groups accumulating row tiles until the slot lands in one.
+        # E is constexpr, so this unrolls to E selects on the SALU against a
+        # K-walk of many iterations -- the same O(E) prologue the wgrad
+        # kernel pays. `active` is false for slots past the last group's
+        # tiles, which predicates those blocks off in the epilogue.
+        g = ArithValue(fx.Int32(0))
+        r_base = ArithValue(fx.Int32(0))
+        m_start = ArithValue(fx.Int32(0))
+        m_end = ArithValue(fx.Int32(0))
+        active = fx.Int32(0) > fx.Int32(0)  # false
+        cum = ArithValue(fx.Int32(0))
+        # range_constexpr, not range: the AST rewriter turns a plain `range`
+        # into a device-side scf.for, whose induction variable is an
+        # ArithValue and cannot index the `ends`/`starts` Python lists. This
+        # loop must unroll at trace time.
+        for i in range_constexpr(E):
+            m_i = ends[i] - starts[i]
+            t_i = (m_i + fx.Int32(BLOCK_R - 1)) // fx.Int32(BLOCK_R)
+            hit = (slot >= cum) & (slot < cum + t_i)
+            g = arith.select(hit, fx.Int32(i), g)
+            r_base = arith.select(hit, (slot - cum) * fx.Int32(BLOCK_R), r_base)
+            m_start = arith.select(hit, starts[i], m_start)
+            m_end = arith.select(hit, ends[i], m_end)
+            active = active | hit
+            cum = cum + t_i
+
+        # A is offset by the group's first token row, B by the expert's
+        # weight plane. Both are plain row offsets at the same stride K --
+        # the "dynamic per-group stride" problem the MXFP8-MoE post
+        # describes does not arise on this axis.
+        row0 = m_start + r_base
+        wrow0 = ArithValue(g) * fx.Int32(N) + c_base
+
+        # ── SURPLUS SLOTS EXIT HERE, BEFORE ANY GLOBAL TRAFFIC ──
+        # The host cannot know how many row tiles the groups actually need
+        # -- that is sum_g ceildiv(m_g, BLOCK_R), and the m_g live on the
+        # device -- so it launches the upper bound, ceildiv(M, BLOCK_R) + E.
+        # The slack is real: at g8x512x4096x4096 it is 24 slots launched for
+        # 16 needed, and since n_blocks = n_slots * n_c that is 384 blocks
+        # where 256 would do. On 256 CUs that is the difference between one
+        # wave and two, which is why the surplus cost 1.74x there and
+        # 1.12-1.68x across the shapes -- far more than its 33% share of the
+        # blocks, because it is wave quantization and not just wasted bytes.
+        #
+        # `active` was already computed for the store mask; consulting it
+        # here instead skips the K-walk entirely. It is BLOCK-UNIFORM (it
+        # depends only on block_idx and on scalar loads of OFFS), so every
+        # thread takes the same branch and the barriers inside stay legal.
+        # `GUARD` is a plain Python bool from the compile key, so the tracer
+        # resolves this at TRACE time: True leaves `proceed` dynamic and the
+        # rewriter builds the scf.if; False makes it a Python True and the
+        # body is traced unconditionally, reproducing the pre-guard kernel
+        # byte for byte. One copy of the body, two kernels. The fallback
+        # exists because the guard does not compile everywhere -- see
+        # `cached_launch`.
+        proceed = active if GUARD else True
+        if proceed:
+            lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+            a_cur0, a_cur1 = lds.A_lds_cur_0, lds.A_lds_cur_1
+            a_next0, a_next1 = lds.A_lds_next_0, lds.A_lds_next_1
+            b_cur0, b_cur1 = lds.B_lds_cur_0, lds.B_lds_cur_1
+            b_next0, b_next1 = lds.B_lds_next_0, lds.B_lds_next_1
+
+            lane_id = fx.thread_idx.x % 64
+            wave_id = fx.thread_idx.x // 64
+            wave_i = wave_id // 2
+            wave_j = wave_id % 2
+
+            m_lane = lane_id % fx.Int32(16)
+            k_grp = lane_id // fx.Int32(16)
+            kshift = k_grp * fx.Int32(8)
+            mask_ff = fx.Int32(0xFF)
+            bcast = fx.Int32(0x01010101)
+
+            A0_gl = row0 * fx.Int32(K)
+            A1_gl = (row0 + fx.Int32(LDS_BLOCK_R)) * fx.Int32(K)
+            B0_gl = wrow0 * fx.Int32(K)
+            B1_gl = (wrow0 + fx.Int32(LDS_BLOCK_C)) * fx.Int32(K)
+
+            gA = make_fp8_buffer_tensor(A, F8_IR_t)
+            gB = make_fp8_buffer_tensor(B, F8_IR_t)
+            a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+            b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+
+            # BOUND THE SCALE DESCRIPTORS. `max_size=True` sets num_records to
+            # 0xFFFFFFFF, so an out-of-range e8m0 read is NOT clamped by the
+            # hardware -- it touches unmapped memory and faults. This kernel
+            # over-provisions row tiles (`n_slots = ceildiv(M, BLOCK_R) + E`) and
+            # relies on `active` to predicate the surplus blocks off in the
+            # epilogue, so a scale read issued before that predicate goes past
+            # the plane whenever the group boundaries leave a slot mapping past
+            # the last group.
+            #
+            # This is observed, not theoretical: group boundaries that leave a
+            # slot mapping past the last group fault with hipErrorIllegalAddress,
+            # reliably when every boundary sits on a row-tile boundary and
+            # intermittently otherwise.
+            #
+            # A bounded descriptor returns 0 for an out-of-range read, and 0 as
+            # an e8m0 is 2**-127, which underflows the product exactly as the
+            # epilogue mask intends.
+            #
+            # A is (M, K/32) with M a runtime value; B is (E, N, K/32), all
+            # constexpr, so its bound folds to a constant.
+            sa_bytes = arith.index_cast(
+                T.i64, arith.index_cast(T.index, out_m * fx.Int32(K // SCALE_BLOCK))
+            )
+            sa_rsrc = buffer_ops.create_buffer_resource(
+                A_scale, max_size=False, num_records_bytes=sa_bytes
+            )
+            sb_rsrc = buffer_ops.create_buffer_resource(
+                B_scale, max_size=False, num_records_bytes=E * N * (K // SCALE_BLOCK)
+            )
+
+            gl_off_a = compute_global_swizzle(
+                lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False
+            )
+            gl_off_b = compute_global_swizzle(
+                lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False
+            )
+
+            a_g2s = G2SLoader(a_div, gl_off_a, N_TILES_A, F8_IR_t, wave_id)
+            b_g2s = G2SLoader(b_div, gl_off_b, N_TILES_B, F8_IR_t, wave_id)
+            a_s2r = S2RLoader(wave_i, N_TILES_A)
+            b_s2r = S2RLoader(wave_j, N_TILES_B)
+
+            vm = _VmCounter()
+
+            # ── MXFP8 scales: cooperative wide load + ds_bpermute ──
+            # Each operand-half needs the e8m0 byte of 64 consecutive rows (4 MFMA
+            # tiles x 16 rows) at this K-step; one i32 per row covers 128 K, of
+            # which lane group k_grp takes byte k_grp and broadcasts it to 4 bytes.
+            #
+            # The naive form -- one buffer_load per (half, tile) -- issues 16 dword
+            # loads per K-step that touch the SAME 16 cache lines four times over,
+            # because lanes m_lane..m_lane+48 share an address. That is the same L1
+            # request count as all of the step's data traffic, and it, not the
+            # matrix core, sets the pace: stubbing the scale loads out nearly
+            # doubles measured throughput.
+            #
+            # Instead: ONE cooperative load per half, lane L taking row
+            # (half_base + L), so 64 lanes cover 64 rows with no duplicate address,
+            # widened to a dwordx2 spanning two K-steps. 8x fewer scale L1
+            # requests. Each lane then pulls the tile it actually needs with
+            # ds_bpermute (lane L from lane t*16 + L%16) -- LDS crossbar, not HBM.
+            #
+            # A half spans N_TILES*16 rows, so 64 lanes cover it exactly at
+            # N_TILES=4 and cover it twice over at N_TILES=2 (BLOCK_C=128). The
+            # duplicate half of that load is wasted address bandwidth but stays
+            # ONE instruction, and the rows it touches are the next 32 of the same
+            # weight plane -- already-warm cache lines, or an in-bounds read the
+            # bpermute never selects.
+
+            sa0_base = row0 + wave_i * fx.Int32(N_TILES_A * 16)
+            sa1_base = row0 + fx.Int32(LDS_BLOCK_R) + wave_i * fx.Int32(N_TILES_A * 16)
+            sb0_base = wrow0 + wave_j * fx.Int32(N_TILES_B * 16)
+            sb1_base = wrow0 + fx.Int32(LDS_BLOCK_C) + wave_j * fx.Int32(N_TILES_B * 16)
+
+            # Only the row term is per-lane; the half base and the K index are
+            # wave-uniform and ride the buffer instruction's SGPR soffset, so the
+            # address costs no per-step VALU and exactly one VGPR.
+            sc_voff = lane_id * fx.Int32(SCALE_I32_ROW)
+            sc_sbase = [
+                (_rs, _base * fx.Int32(SCALE_I32_ROW * 4))
+                for _rs, _base in (
+                    (sa_rsrc, sa0_base),
+                    (sa_rsrc, sa1_base),
+                    (sb_rsrc, sb0_base),
+                    (sb_rsrc, sb1_base),
+                )
+            ]
+            sc_perm = [
+                fx.Int32(t_ * 64) + m_lane * fx.Int32(4)
+                for t_ in range_constexpr(max(N_TILES_A, N_TILES_B))
+            ]
+            # Tiles per half, in the order the chunk stores them: A0, A1, B0, B1.
+            sc_tiles = (N_TILES_A, N_TILES_A, N_TILES_B, N_TILES_B)
+
+            def issue_chunk(k_i32):
+                """Cooperative scale loads for K-steps (k_i32, k_i32+1).
+
+                Returns 2 raw i32 per operand-half, flat: [a0_lo, a0_hi, a1_lo, ...].
+                A chunk for a K-step past the end reads the next row's scales (or
+                out of bounds, which the buffer resource returns as 0) and is never
+                consumed -- cheaper than predicating the last prefetch.
+                """
+                out = []
+                for _rs, _sb in sc_sbase:
+                    soff = _sb + fx.Int32(k_i32 * 4)
+                    if SC_PAIR:
+                        v = buffer_ops.buffer_load(
+                            _rs, sc_voff, vec_width=2, dtype=T.i32, soffset_bytes=soff
+                        )
+                        out.append(
+                            buffer_ops.vec_extract(
+                                v, static_position=[0], dynamic_position=[]
+                            )
+                        )
+                        out.append(
+                            buffer_ops.vec_extract(
+                                v, static_position=[1], dynamic_position=[]
+                            )
+                        )
+                    else:
+                        out.append(
+                            buffer_ops.buffer_load(
+                                _rs,
+                                sc_voff,
+                                vec_width=1,
+                                dtype=T.i32,
+                                soffset_bytes=soff,
+                            )
+                        )
+                        out.append(
+                            buffer_ops.buffer_load(
+                                _rs,
+                                sc_voff,
+                                vec_width=1,
+                                dtype=T.i32,
+                                soffset_bytes=soff + fx.Int32(4),
+                            )
+                        )
+                vm.issue(N_SC_OPS)
+                return out
+
+            def use_chunk(chunk, p):
+                """Redistribute + consume the chunk's K-step `p` -> (sa0, sa1, sb0, sb1)."""
+                groups = []
+                for h_ in range_constexpr(4):
+                    src = chunk[2 * h_ + p]
+                    grp = []
+                    for t_ in range_constexpr(sc_tiles[h_]):
+                        v = rocdl.ds_bpermute(res=T.i32, index=sc_perm[t_], src=src)
+                        grp.append(((ArithValue(v) >> kshift) & mask_ff) * bcast)
+                    groups.append(grp)
+                return groups
+
+            def mma(a, b, c, sa, sb):
+                for i in range_constexpr(N_TILES_A):
+                    for j in range_constexpr(N_TILES_B):
+                        idx = i * N_TILES_B + j
+                        c[idx] = _mfma_scale_agpr(a[i], b[j], sa[i], sb[j], c[idx])
+                return c
+
+            zero = Vec.filled(4, 0.0, fx.Float32)
+            c00 = [zero] * N_ACCUMS
+            c01 = [zero] * N_ACCUMS
+            c10 = [zero] * N_ACCUMS
+            c11 = [zero] * N_ACCUMS
+
+            def _lds_swizzle(s2r):
+                out = []
+                for row_off in range_constexpr(s2r.n_tiles):
+                    row = (
+                        s2r.wave_idx * fx.Int32(s2r.n_tiles * 16)
+                        + fx.Int32(row_off * 16)
+                        + (lane_id % fx.Int32(16))
+                    )
+                    swz = []
+                    for ii in range_constexpr(2):
+                        col = (lane_id // fx.Int32(16)) * fx.Int32(16) + fx.Int32(
+                            ii * 64
+                        )
+                        r_, c_ = swizzle_128(row, col)
+                        swz.append(r_ * fx.Int32(BLOCK_M) + c_)
+                    out.append(swz)
+                return out
+
+            def _cluster(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+                # Interleave this quadrant's MFMAs with the g2s and s2r loads of
+                # the NEXT fragment, so the loads co-issue in the MFMA execute
+                # shadow. Mirrors fp8_gemm_4wave's _interleaved_cluster; the MFMA
+                # is scaled + AGPR-pinned here. The schedule comes from
+                # `_interleave_plan` (computed before tracing), so this walks it
+                # with no branches -- see that function on why.
+                swz = _lds_swizzle(s2r)
+                rt = [None] * s2r.n_tiles
+                half = [None] * s2r.n_tiles
+                g_at, s0_at, s1_at = PLANS[(g2s.n_load_steps, s2r.n_tiles)]
+
+                for idx in range_constexpr(len(MFMA_SEQ)):
+                    for gi in range_constexpr(len(g_at[idx])):
+                        g2s.load_one(lds_dst, k_off, g_at[idx][gi])
+                    for si in range_constexpr(len(s0_at[idx])):
+                        t_ = s0_at[idx][si]
+                        half[t_] = s2r.load_one(lds_src, swz[t_][0])
+                    for si in range_constexpr(len(s1_at[idx])):
+                        t_ = s1_at[idx][si]
+                        rt[t_] = pack_i32x4_i32x8(
+                            half[t_], s2r.load_one(lds_src, swz[t_][1])
+                        )
+                    i_, j_ = MFMA_SEQ[idx]
+                    c[i_ * N_TILES_B + j_] = _mfma_scale_agpr(
+                        a[i_], b[j_], sa[i_], sb[j_], c[i_ * N_TILES_B + j_]
+                    )
+
+                vm.issue(g2s.n_load_steps)
+                return c, rt
+
+            # ── Prologue: pre-fill the 8-buffer LDS pipeline (2 K-steps) ──
+            # Chunk 0 goes first so it is the oldest thing in flight and the
+            # prologue barriers retire it for free.
+            chunks = [None] * N_CHUNKS
+            chunks[0] = issue_chunk(0)
+
+            a_g2s.load(a_cur0, A0_gl + 0 * BLOCK_M)
+            mk_ac0 = vm.issue(N_TILES_A)
+            b_g2s.load(b_cur0, B0_gl + 0 * BLOCK_M)
+            mk_bc0 = vm.issue(N_TILES_B)
+            b_g2s.load(b_cur1, B1_gl + 0 * BLOCK_M)
+            vm.issue(N_TILES_B)
+            a_g2s.load(a_cur1, A1_gl + 0 * BLOCK_M)
+            mk_a = vm.issue(N_TILES_A)
+
+            a_g2s.load(a_next0, A0_gl + 1 * BLOCK_M)
+            vm.issue(N_TILES_A)
+            b_g2s.load(b_next0, B0_gl + 1 * BLOCK_M)
+            mk_b = vm.issue(N_TILES_B)
+            b_g2s.load(b_next1, B1_gl + 1 * BLOCK_M)
+            vm.issue(N_TILES_B)
+            a_g2s.load(a_next1, A1_gl + 1 * BLOCK_M)
+            mk_c = vm.issue(N_TILES_A)
+
+            vm.wait(mk_ac0)
+            a0 = a_s2r.load(a_cur0)
+            vm.wait(mk_bc0)
+            b0 = b_s2r.load(b_cur0)
+
+            # ── Main K-steps 0 .. K_ITERS-3, fully unrolled ──
+            # Each step consumes the LDS buffers holding step k, loads step k+2
+            # into them, and reads step k+1's leading fragments. Which watermark
+            # each barrier waits on follows from the ping-pong depth:
+            #   * clusters 1-2 read the halves written by step k-2's SECOND half,
+            #   * clusters 3-4 read the halves written by step k-1's FIRST half.
+            # The two prologue groups stand in for steps -2 and -1: `mk_a` closes
+            # the k=0 group (step 0's second-half operands), `mk_b` sits right
+            # after b_next0 (step 1's leading fragments) and `mk_c` closes the
+            # k=1 group (step 1's second-half operands).
+            bufs = (a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1)
+            sec = {-2: mk_a, -1: mk_c}  # second-half watermark, by step index
+            fst = {-1: mk_b}  # first-half watermark, by step index
+
+            for kk in range_constexpr(K_ITERS - 2):
+                ac0, ac1, an0, an1, bc0, bc1, bn0, bn1 = bufs
+                k2 = (kk + 2) * BLOCK_M
+                p = kk % 2
+
+                # The scales for this step came off HBM a full step-pair ago; the
+                # only HBM touch is the prefetch for the pair two K-steps out --
+                # the same horizon the data ping-pong runs at.
+                vm.wait(sec[kk - 2])
+                if p == 0 and (kk // 2) + 1 < N_CHUNKS:
+                    chunks[(kk // 2) + 1] = issue_chunk(kk + 2)
+                sa0, sa1, sb0, sb1 = use_chunk(chunks[kk // 2], p)
+
+                c00, b1 = _cluster(
+                    ac0, a_g2s, A0_gl + k2, b_s2r, bc1, a0, b0, c00, sa0, sb0
+                )
+                c01, a1 = _cluster(
+                    bc0, b_g2s, B0_gl + k2, a_s2r, ac1, a0, b1, c01, sa0, sb1
+                )
+                fst[kk] = vm.mark()
+
+                vm.wait(fst[kk - 1])
+                c10, a0 = _cluster(
+                    bc1, b_g2s, B1_gl + k2, a_s2r, an0, a1, b0, c10, sa1, sb0
+                )
+                c11, b0 = _cluster(
+                    ac1, a_g2s, A1_gl + k2, b_s2r, bn0, a1, b1, c11, sa1, sb1
+                )
+                sec[kk] = vm.mark()
+
+                bufs = (an0, an1, ac0, ac1, bn0, bn1, bc0, bc1)
+
+            a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1 = bufs
+
+            # ── Tail step K_ITERS-2: drain, no more g2s ──
+            k_tail0 = K_ITERS - 2
+            vm.wait(sec[k_tail0 - 2])
+            sa0, sa1, sb0, sb1 = use_chunk(chunks[k_tail0 // 2], k_tail0 % 2)
+            b1 = b_s2r.load(b_cur1)
+            c00 = mma(a0, b0, c00, sa0, sb0)
+            a1 = a_s2r.load(a_cur1)
+            c01 = mma(a0, b1, c01, sa0, sb1)
+            vm.wait(fst[k_tail0 - 1])
+            a0 = a_s2r.load(a_next0)
+            c10 = mma(a1, b0, c10, sa1, sb0)
+            b0 = b_s2r.load(b_next0)
+            c11 = mma(a1, b1, c11, sa1, sb1)
+
+            a_cur0, a_next0 = a_next0, a_cur0
+            a_cur1, a_next1 = a_next1, a_cur1
+            b_cur0, b_next0 = b_next0, b_cur0
+            b_cur1, b_next1 = b_next1, b_cur1
+
+            # ── Tail step K_ITERS-1 ──
+            k_tail1 = K_ITERS - 1
+            vm.wait(sec[k_tail1 - 2])
+            sa0, sa1, sb0, sb1 = use_chunk(chunks[k_tail1 // 2], k_tail1 % 2)
+            b1 = b_s2r.load(b_cur1)
+            a1 = a_s2r.load(a_cur1)
+            c00 = mma(a0, b0, c00, sa0, sb0)
+            c01 = mma(a0, b1, c01, sa0, sb1)
+            c10 = mma(a1, b0, c10, sa1, sb0)
+            c11 = mma(a1, b1, c11, sa1, sb1)
+
+            # ── Epilogue: bf16 into out(M, N); the MFMA already applied the scales ──
+            # Storing f32 and converting outside would cost a full extra pass over
+            # M*N (553 MB at the e2e forward shape) -- more than half the kernel.
+            out_m_i = arith.index_cast(T.index, out_m)
+            out_n_i = arith.index_cast(T.index, out_n)
+            nbytes = arith.index_cast(T.i64, out_m_i * out_n_i * fx.Index(2))
+            o_rsrc = buffer_ops.create_buffer_resource(
+                OUT, max_size=False, num_records_bytes=nbytes
+            )
+            base_row = row0 + wave_i * fx.Int32(N_TILES_A * 16)
+            base_col = c_base + wave_j * fx.Int32(N_TILES_B * 16)
+            oob = out_m * out_n
+
+            def store_group(frag, br, bc):
+                for ti in range_constexpr(N_TILES_A):
+                    row = br + fx.Int32(ti * 16) + k_grp * fx.Int32(4)
+                    for tj in range_constexpr(N_TILES_B):
+                        col = bc + fx.Int32(tj * 16) + m_lane
+                        col_ok = col < out_n
+                        vec = Vec(frag[ti * N_TILES_B + tj])
+                        for e in range_constexpr(4):
+                            r_ = row + fx.Int32(e)
+                            # `r_ < m_end` is the ragged part. A row tile may
+                            # overhang its group, in which case the overhanging
+                            # rows hold this expert's weights applied to the
+                            # NEXT group's tokens -- correct arithmetic, wrong
+                            # expert -- so they must not be stored. `active`
+                            # kills whole slots past the last group's tiles.
+                            # Reading those A rows is harmless: each output
+                            # element is one A row dotted with one B column, so
+                            # nothing leaks across rows, and any fp8 NaN in the
+                            # pad region past m_total lands only in rows we drop.
+                            ok = active & (r_ < m_end) & (r_ < out_m) & col_ok
+                            off = arith.select(ok, r_ * out_n + col, oob)
+                            buffer_ops.buffer_store(vec[e].to(fx.BFloat16), o_rsrc, off)
+
+            store_group(c00, base_row, base_col)
+            store_group(c01, base_row, base_col + fx.Int32(LDS_BLOCK_C))
+            store_group(c10, base_row + fx.Int32(LDS_BLOCK_R), base_col)
+            store_group(
+                c11, base_row + fx.Int32(LDS_BLOCK_R), base_col + fx.Int32(LDS_BLOCK_C)
+            )
+
+    @flyc.jit
+    def launch_fwd(
+        A,
+        B,
+        OUT,
+        A_scale,
+        B_scale,
+        OFFS,
+        n_blocks: fx.Int32,
+        n_c_tiles: fx.Int32,
+        out_m: fx.Int32,
+        out_n: fx.Int32,
+        stream: fx.Stream,
+    ):
+        kernel_fwd(
+            A,
+            B,
+            OUT,
+            A_scale,
+            B_scale,
+            OFFS,
+            n_c_tiles,
+            out_m,
+            out_n,
+            value_attrs={
+                "rocdl.waves_per_eu": 1,
+                "rocdl.flat_work_group_size": "256,256",
+            },
+        ).launch(grid=(n_blocks, 1, 1), block=(256, 1, 1), stream=stream)
+
+    return launch_fwd
+
+
+@functools.lru_cache(maxsize=None)
+def cached_launch(
+    K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int = 256, GUARD: bool = True
+):
+    """Build the launcher. GUARD is part of the key -- see `launch_for`.
+
+    NOTE: this does NOT trace. FlyDSL traces lazily, on the first call
+    through `fast_launch`, so a tracer error surfaces at LAUNCH time and
+    cannot be caught here. That is what `launch_for` is for.
+    """
+    return _compile(K, N, E, BLOCK_C, BLOCK_R, GUARD=GUARD)
+
+
+def launch_for(K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int):
+    """The guarded launcher, unless this shape already failed to trace.
+
+    The surplus-slot guard is worth 1.2-1.74x but does not trace on every
+    shape: as a bare `if active:` it can raise "cannot evaluate dynamic
+    'Boolean' as Python bool", and only once enough other kernels have been
+    traced in the same process, so it is not reliably reproducible from a
+    single shape.
+
+    The fallback therefore has to live at the LAUNCH site: an untraceable
+    shape would otherwise raise RuntimeError out of the op rather than
+    degrading to an unguarded launch. GUARD=False is verified bitwise-identical
+    to GUARD=True; it costs throughput, nothing else.
+    """
+    return cached_launch(
+        K,
+        N,
+        E,
+        BLOCK_C,
+        BLOCK_R,
+        GUARD=(K, N, E, BLOCK_C, BLOCK_R) not in _guard_broken,
+    )
+
+
+def launch_guarded(launch, key, compile_args_factory, dispatch_args, param):
+    """Run `launch`, and on a tracer error retry once unguarded, forever.
+
+    Compilation goes through Inductor's FlyDSL cache so the compiled dispatcher
+    is shared with the rest of the Inductor-generated FlyDSL kernels and is
+    keyed the same way (pid, device, constexpr param).
+    """
+    try:
+        return run_cached_flydsl(
+            launch,
+            constexpr_param=param,
+            compiler=flyc.compile,
+            dispatch_args=dispatch_args,
+            compile_args_factory=compile_args_factory,
+        )
+    except Exception as e:
+        # The guard fallback exists for ONE failure mode: the surplus-slot `if`
+        # not tracing on some shapes. An out-of-memory is not that, and treating
+        # it as such both misreports the cause and permanently pins this shape
+        # to the unguarded kernel (up to 1.74x slower). Re-raise it instead.
+        if isinstance(e, torch.OutOfMemoryError) or key in _guard_broken:
+            raise
+        _guard_broken.add(key)
+        _warn_guard_fallback(*key, e)
+        return run_cached_flydsl(
+            cached_launch(*key, GUARD=False),
+            constexpr_param=param.unguarded(),
+            compiler=flyc.compile,
+            dispatch_args=dispatch_args,
+            compile_args_factory=compile_args_factory,
+        )
+
+
+def ceildiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+@dataclasses.dataclass(frozen=True)
+class MXFP8GroupedGemmParam:
+    """The compile key of one MXFP8 grouped GEMM specialisation.
+
+    Deliberately absent: the token count and every group size. Both are
+    runtime values under real MoE routing, and a shape-keyed compile would
+    leak a JIT compile plus a retained GPU module per step per layer.
+
+    This is a plain dataclass rather than an ``fx.struct``: the kernel body
+    closes over these values at trace time (see ``_compile``) instead of
+    reading them from a device-side struct, so FlyDSL never sees the param.
+    It carries ``__cache_signature__`` only so ``run_cached_flydsl`` can key
+    on it exactly as it keys on the dense ``GemmGfx950Param``.
+    """
+
+    k: int
+    n: int
+    group_count: int
+    block_c: int
+    block_r: int
+    guarded: bool = True
+
+    def key(self) -> tuple[int, int, int, int, int]:
+        """The tuple ``cached_launch`` / ``_guard_broken`` are keyed on."""
+        return (self.k, self.n, self.group_count, self.block_c, self.block_r)
+
+    def unguarded(self) -> "MXFP8GroupedGemmParam":
+        return dataclasses.replace(self, guarded=False)
+
+    def __cache_signature__(self) -> tuple[int, int, int, int, int, bool]:
+        return (*self.key(), self.guarded)
+
+
+def make_mxfp8_grouped_gemm_kernel_name(param: MXFP8GroupedGemmParam) -> str:
+    return (
+        f"mxfp8_grouped_gemm_k{param.k}_n{param.n}_e{param.group_count}"
+        f"_t{param.block_r}x{param.block_c}"
+        f"_guard{int(param.guarded)}"
+    )
+
+
+def make_mxfp8_grouped_gemm_param(
+    k: int,
+    n: int,
+    group_count: int,
+    block_r: int = BLOCK_R,
+    block_c: int = BLOCK_C_DEFAULT,
+) -> MXFP8GroupedGemmParam:
+    """Validate one (K, N, E, BLOCK_R, BLOCK_C) against what `_compile` accepts.
+
+    Raises ``ValueError`` rather than tripping the asserts inside ``_compile``,
+    so the Inductor heuristics can prune a config without catching
+    ``AssertionError``.
+    """
+    if k <= 0 or n <= 0 or group_count <= 0:
+        raise ValueError(f"degenerate shape K={k}, N={n}, E={group_count}")
+    if k % BLOCK_M != 0:
+        raise ValueError(f"K ({k}) must be a multiple of {BLOCK_M}")
+    if k // BLOCK_M < 4:
+        raise ValueError(
+            f"K {k} gives {k // BLOCK_M} pipeline steps; need >= 4 "
+            "(2 prologue + 2 tails)"
+        )
+    if block_c not in (128, 256):
+        raise ValueError(f"BLOCK_C {block_c} not supported")
+    if block_r not in (64, 128, 256):
+        raise ValueError(f"BLOCK_R {block_r} not supported")
+    if block_c == 128 and n % 128 != 0:
+        # A 128-wide tile is only ever chosen to remove overhang; taking it on
+        # an N it does not divide adds overhang instead of removing it.
+        raise ValueError(f"BLOCK_C 128 needs N ({n}) to be a multiple of 128")
+    return MXFP8GroupedGemmParam(
+        k=int(k),
+        n=int(n),
+        group_count=int(group_count),
+        block_c=int(block_c),
+        block_r=int(block_r),
+    )
+
+
+def make_mxfp8_grouped_gemm_param_and_validate(
+    k: int, n: int, group_count: int, block_r: int, block_c: int
+) -> MXFP8GroupedGemmParam | None:
+    """`make_mxfp8_grouped_gemm_param`, returning None instead of raising."""
+    try:
+        return make_mxfp8_grouped_gemm_param(k, n, group_count, block_r, block_c)
+    except ValueError:
+        return None
+
+
+def get_mxfp8_grouped_gemm_grid_size(
+    param: MXFP8GroupedGemmParam, rows: int
+) -> tuple[int, int]:
+    """(n_blocks, n_c_tiles) for a launch covering `rows` tokens.
+
+    The row-tile count is over-provisioned to ``ceildiv(rows, BLOCK_R) + E``:
+    a group boundary that falls inside a tile costs the next group a slot, and
+    E boundaries can each do that. Blocks whose slot lands past the last group
+    resolve to ``active == False`` and are predicated off by the surplus-slot
+    guard, so the surplus is a launch-descriptor cost, not work.
+    """
+    n_c_tiles = ceildiv(param.n, param.block_c)
+    n_slots = ceildiv(rows, param.block_r) + param.group_count
+    return n_slots * n_c_tiles, n_c_tiles
+
+
+def launch_mxfp8_grouped_gemm_gfx950(
+    out,
+    mat_a,
+    mat_b,
+    scale_a,
+    scale_b,
+    offs,
+    param: MXFP8GroupedGemmParam,
+    stream,
+    tensor_arg=None,
+    compile_only=False,
+):
+    """MXFP8 forward grouped GEMM over RAGGED token groups, into `out`.
+
+        out[group_g] = mat_a[group_g] @ mat_b[g]^T
+
+    Groups partition the token (output row) dim with device-resident, unequal
+    sizes. Because the ragged axis is NOT the contraction, the whole pipelined
+    K-walk carries over from the even-groups body untouched -- only the
+    block -> (group, tile) mapping and the epilogue mask change.
+
+        out       (M, N)      bf16, contiguous, allocated by the caller
+        mat_a     (M, K)      fp8 e4m3, row-major
+        mat_b     (E, N, K)   fp8 e4m3, row-major (i.e. a [E, K, N] operand
+                              whose K dim is the contiguous one)
+        scale_a   (M, K//32)  e8m0, contiguous
+        scale_b   (E, N, K//32) e8m0, contiguous
+        offs      (E,) int32  cumulative group ends along M, ON DEVICE.
+                              Read by the block itself -- never synced here.
+
+    ROWS PAST ``offs[-1]`` ARE LEFT ALONE. They are covered by no block, which
+    matches what ATen's own 2d-3d grouped GEMMs do with the same tail; the
+    alternative is a full M*N memset, measured at 9.5% of the kernel.
+
+    `tensor_arg` wraps each tensor for the *compile* call; Inductor passes
+    ``flyc.from_torch_tensor(t).mark_layout_dynamic()`` so one compiled
+    dispatcher serves every M.
+
+    `compile_only` warms the disk cache and returns without dispatching. It is
+    what Inductor's precompile entry point uses, where the tensors are fake and
+    the only thing wanted is the compiled artifact. Only the first window is
+    compiled: every window traces the same kernel, and the layout-dynamic
+    compile args make the window's row count a runtime slot.
+    """
+    if tensor_arg is None:
+
+        def tensor_arg(tensor):
+            return tensor
+
+    total_m = int(out.shape[0])
+    if total_m == 0:
+        return out
+
+    a = mat_a.view(torch.int8)
+    a_sc = scale_a.view(torch.uint8)
+    b = mat_b.view(torch.int8).view(-1)
+    b_sc = scale_b.view(torch.uint8).view(-1)
+    offs_i32 = offs.view(torch.int32)
+
+    key = param.key()
+    for row_start, rows, offs_window in _row_windows(
+        total_m, param.k, param.n, offs_i32, param.block_r
+    ):
+        n_blocks, n_c_tiles = get_mxfp8_grouped_gemm_grid_size(param, rows)
+        dispatch_args = (
+            a.narrow(0, row_start, rows).view(-1),
+            b,
+            out.narrow(0, row_start, rows).view(-1),
+            a_sc.narrow(0, row_start, rows).view(-1),
+            b_sc,
+            offs_window,
+            n_blocks,
+            n_c_tiles,
+            rows,
+            param.n,
+            stream,
+        )
+
+        # Deferred: the descriptors are only needed if a compile happens, and
+        # after the first call for a given param it never does. Building them
+        # eagerly cost ~8us of the launcher's ~26us per call, which is dead
+        # weight on shapes whose kernel time is of that order.
+        def compile_args_factory(dispatch_args=dispatch_args):
+            return tuple(
+                tensor_arg(arg) if idx < 6 else arg
+                for idx, arg in enumerate(dispatch_args)
+            )
+
+        if compile_only:
+            flyc.compile(launch_for(*key), *compile_args_factory())
+            return out
+        # A window that fell back re-resolves, so later windows skip the retry.
+        launch_guarded(
+            launch_for(*key), key, compile_args_factory, dispatch_args, param
+        )
+    return out
+
+
+def _row_windows(M, K, N, offs, block_r=BLOCK_R):
+    """Split the token dim into windows no single launch can overflow int32 on.
+
+    FlyDSL's CABI packs a tensor's shape entries as int32
+    (``jit_argument._LayoutPlan``: ``"i" * len(shape)``), and every operand goes
+    over as a 1-D view, so ``shape[0]`` IS the element count. Past 2**31 the pack
+    raises ``struct.error`` from inside the dispatch, which surfaces as a hard
+    failure rather than a fallback. This is reachable in practice: at 65k
+    tokens/rank, M=1,108,768 x K=2048 = 2,270,756,864.
+
+    Splitting is sound HERE, and only here, because the groups partition the
+    OUTPUT ROWS rather than the contraction: each window owns a disjoint row
+    range, so the windows never share a partial sum and need no accumulation.
+
+    Yields ``(row_start, n_rows, window_offsets)``. The offsets are rebased and
+    clamped ON DEVICE -- a group that straddles a boundary ends at ``n_rows`` in
+    one window and starts at 0 in the next, and groups wholly outside collapse to
+    size 0. No host sync, which is the property this whole kernel is built around.
+    """
+    # Bound the widest M-dependent operand: A is (M, K), out is (M, N), and A's
+    # scales are (M, K//32).
+    rows_max = (2**31 - 1) // max(K, N)
+    # Align down to the row-tile size so a window boundary never splits a tile;
+    # the tiling inside each window is then identical to the unsplit case.
+    rows_max = (rows_max // block_r) * block_r
+    if rows_max < block_r:
+        raise NotImplementedError(
+            f"a single row tile of {block_r} rows already exceeds the int32 "
+            f"operand limit at K={K} N={N}"
+        )
+
+    if M <= rows_max:
+        yield 0, M, offs  # unsplit: the single-launch path
+        return
+    for r0 in range(0, M, rows_max):
+        rows = min(rows_max, M - r0)
+        yield r0, rows, (offs - r0).clamp_(0, rows)
+
+
+# Name the lazy-export table in `kernels/__init__.py` binds to.
+pick_mxfp8_grouped_gemm_tile = pick_tile

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -14,7 +14,7 @@
 #      col tile) mapping is resolved ON DEVICE from it, rather than from a
 #      constexpr M_G.
 #   2. `row0 = m_start + r_base` instead of `g * M_G + r_base`.
-#   3. The epilogue store masks on `active & (r_ < m_end)`: a row tile may
+#   3. The epilogue store masks on `r_ < m_end`: a row tile may
 #      overhang its group, and those rows hold this expert's weights applied to
 #      the next group's tokens.
 #   4. The compile key drops M_G and M_TOTAL, keeping only (K, N, E, BLOCK_C).
@@ -22,9 +22,9 @@
 #      count -- invisible under balanced routing, a per-step JIT under real
 #      routing.
 #
-# Host side: the grid is over-provisioned to ceildiv(M, BLOCK_R) + E row tiles
-# and the output is zero-initialised, because a masked store no longer covers
-# every row.
+# Host side: cap a row-tile upper bound at one workgroup per CU. Workgroups
+# traverse actual tiles in N-fast order. When the upper bound fits in the grid,
+# specialize away persistence. Rows beyond OFFS[-1] remain untouched.
 #
 # Two structural consequences of the short contraction (K/128 = 11-16 steps):
 #   * The K-loop is fully unrolled at compile time; the loop-carried a0/b0
@@ -41,7 +41,6 @@
 
 import dataclasses
 import functools
-import logging
 import os
 
 import torch
@@ -144,41 +143,7 @@ def pick_tile(m_total: int, e: int, n: int) -> tuple:
     return br, bc
 
 
-log = logging.getLogger(__name__)
-
 _STARVED_TILES = 256  # one full wave on MI350X's 256 CUs; see pick_tile
-
-_guard_fallback_warned = set()
-
-# (K, N, E, BLOCK_C, BLOCK_R) whose guarded kernel failed to TRACE. FlyDSL
-# traces on first launch, not at compile, so this is discovered at the launch
-# site and remembered here -- see `launch_for` / `launch_guarded`.
-_guard_broken = set()
-
-
-def _warn_guard_fallback(K, N, E, BLOCK_C, BLOCK_R, err) -> None:
-    """Say once, per shape, that the surplus-slot guard did not compile.
-
-    Loud enough to notice (this shape is now paying for its surplus row-tile
-    slots, up to 1.74x) but not per call, and never fatal.
-    """
-    key = (K, N, E, BLOCK_C, BLOCK_R)
-    if key in _guard_fallback_warned:
-        return
-    _guard_fallback_warned.add(key)
-    log.warning(
-        "FlyDSL MXFP8 grouped GEMM: surplus-slot guard failed to compile at "
-        "K=%d N=%d E=%d BLOCK_C=%d BLOCK_R=%d (%s: %s); falling back to the "
-        "unguarded kernel, which is correct but pays for its surplus slots.",
-        K,
-        N,
-        E,
-        BLOCK_C,
-        BLOCK_R,
-        type(err).__name__,
-        str(err).splitlines()[0][:120],
-    )
-
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
@@ -189,6 +154,7 @@ from flydsl.expr.typing import T, Vector as Vec
 
 from . import mxfp8_buffer_ops as buffer_ops
 from .grouped_config import grouped_row_tiles_upper_bound
+from .grouped_scheduling import for_each_grouped_tile_static
 from .mxfp8_gemm_utils import (
     compute_global_swizzle,
     G2SLoader,
@@ -254,7 +220,12 @@ class _VmCounter:
 
 
 def _compile(
-    K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int = BLOCK_R, GUARD: bool = True
+    K: int,
+    N: int,
+    E: int,
+    BLOCK_C: int,
+    BLOCK_R: int = BLOCK_R,
+    PERSISTENT: bool = True,
 ):
     """Compile a RAGGED forward grouped GEMM for one (K, N, E) shape.
 
@@ -370,88 +341,13 @@ def _compile(
     ):
         F8_IR_t = fx.Float8E4M3FN.ir_type
 
-        # ── Block -> (group, row tile, col tile), resolved ON DEVICE ──
-        # Groups partition the OUTPUT ROWS here, not the contraction, so
-        # unlike the wgrad kernel nothing about the K-walk changes: K is
-        # uniform across experts. Only this mapping and the epilogue mask
-        # care that the groups are ragged.
-        bid = fx.block_idx.x
-        slot = ArithValue(bid) // n_c_tiles  # which row tile overall
-        c_base = (ArithValue(bid) % n_c_tiles) * fx.Int32(BLOCK_C)
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
 
-        offs_rsrc = buffer_ops.create_buffer_resource(
-            OFFS, max_size=False, num_records_bytes=E * 4
-        )
-        # Uniform (SGPR) loads: every lane in the block wants the same
-        # boundaries, so this is E scalar loads, not E per-lane loads.
-        ends = [
-            ArithValue(
-                buffer_ops.buffer_load(
-                    offs_rsrc, fx.Int32(i), vec_width=1, dtype=T.i32, is_scalar=True
-                )
-            )
-            for i in range(E)
-        ]
-        starts = [ArithValue(fx.Int32(0))] + ends[:-1]
-
-        # Walk the groups accumulating row tiles until the slot lands in one.
-        # E is constexpr, so this unrolls to E selects on the SALU against a
-        # K-walk of many iterations -- the same O(E) prologue the wgrad
-        # kernel pays. `active` is false for slots past the last group's
-        # tiles, which predicates those blocks off in the epilogue.
-        g = ArithValue(fx.Int32(0))
-        r_base = ArithValue(fx.Int32(0))
-        m_start = ArithValue(fx.Int32(0))
-        m_end = ArithValue(fx.Int32(0))
-        active = fx.Int32(0) > fx.Int32(0)  # false
-        cum = ArithValue(fx.Int32(0))
-        # range_constexpr, not range: the AST rewriter turns a plain `range`
-        # into a device-side scf.for, whose induction variable is an
-        # ArithValue and cannot index the `ends`/`starts` Python lists. This
-        # loop must unroll at trace time.
-        for i in range_constexpr(E):
-            m_i = ends[i] - starts[i]
-            t_i = (m_i + fx.Int32(BLOCK_R - 1)) // fx.Int32(BLOCK_R)
-            hit = (slot >= cum) & (slot < cum + t_i)
-            g = arith.select(hit, fx.Int32(i), g)
-            r_base = arith.select(hit, (slot - cum) * fx.Int32(BLOCK_R), r_base)
-            m_start = arith.select(hit, starts[i], m_start)
-            m_end = arith.select(hit, ends[i], m_end)
-            active = active | hit
-            cum = cum + t_i
-
-        # A is offset by the group's first token row, B by the expert's
-        # weight plane. Both are plain row offsets at the same stride K --
-        # the "dynamic per-group stride" problem the MXFP8-MoE post
-        # describes does not arise on this axis.
-        row0 = m_start + r_base
-        wrow0 = ArithValue(g) * fx.Int32(N) + c_base
-
-        # ── SURPLUS SLOTS EXIT HERE, BEFORE ANY GLOBAL TRAFFIC ──
-        # The host cannot know how many row tiles the groups actually need
-        # -- that is sum_g ceildiv(m_g, BLOCK_R), and the m_g live on the
-        # device -- so it launches the upper bound, ceildiv(M, BLOCK_R) + E.
-        # The slack is real: at g8x512x4096x4096 it is 24 slots launched for
-        # 16 needed, and since n_blocks = n_slots * n_c that is 384 blocks
-        # where 256 would do. On 256 CUs that is the difference between one
-        # wave and two, which is why the surplus cost 1.74x there and
-        # 1.12-1.68x across the shapes -- far more than its 33% share of the
-        # blocks, because it is wave quantization and not just wasted bytes.
-        #
-        # `active` was already computed for the store mask; consulting it
-        # here instead skips the K-walk entirely. It is BLOCK-UNIFORM (it
-        # depends only on block_idx and on scalar loads of OFFS), so every
-        # thread takes the same branch and the barriers inside stay legal.
-        # `GUARD` is a plain Python bool from the compile key, so the tracer
-        # resolves this at TRACE time: True leaves `proceed` dynamic and the
-        # rewriter builds the scf.if; False makes it a Python True and the
-        # body is traced unconditionally, reproducing the pre-guard kernel
-        # byte for byte. One copy of the body, two kernels. The fallback
-        # exists because the guard does not compile everywhere -- see
-        # `cached_launch`.
-        proceed = active if GUARD else True
-        if proceed:
-            lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        def compute_tile(g, bid_m, bid_n, m_g, row_base):
+            row0 = row_base + bid_m * BLOCK_R
+            c_base = bid_n * BLOCK_C
+            m_end = row_base + m_g
+            wrow0 = g * N + c_base
             a_cur0, a_cur1 = lds.A_lds_cur_0, lds.A_lds_cur_1
             a_next0, a_next1 = lds.A_lds_next_0, lds.A_lds_next_1
             b_cur0, b_cur1 = lds.B_lds_cur_0, lds.B_lds_cur_1
@@ -478,26 +374,9 @@ def _compile(
             a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
             b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
 
-            # BOUND THE SCALE DESCRIPTORS. `max_size=True` sets num_records to
-            # 0xFFFFFFFF, so an out-of-range e8m0 read is NOT clamped by the
-            # hardware -- it touches unmapped memory and faults. This kernel
-            # over-provisions row tiles (`n_slots = ceildiv(M, BLOCK_R) + E`) and
-            # relies on `active` to predicate the surplus blocks off in the
-            # epilogue, so a scale read issued before that predicate goes past
-            # the plane whenever the group boundaries leave a slot mapping past
-            # the last group.
-            #
-            # This is observed, not theoretical: group boundaries that leave a
-            # slot mapping past the last group fault with hipErrorIllegalAddress,
-            # reliably when every boundary sits on a row-tile boundary and
-            # intermittently otherwise.
-            #
-            # A bounded descriptor returns 0 for an out-of-range read, and 0 as
-            # an e8m0 is 2**-127, which underflows the product exactly as the
-            # epilogue mask intends.
-            #
-            # A is (M, K/32) with M a runtime value; B is (E, N, K/32), all
-            # constexpr, so its bound folds to a constant.
+            # Bound scale descriptors: a partial row/column tile can read past
+            # the operand allocation. The hardware returns zero for those
+            # reads, and the epilogue masks the corresponding output elements.
             sa_bytes = arith.index_cast(
                 T.i64, arith.index_cast(T.index, out_m * fx.Int32(K // SCALE_BLOCK))
             )
@@ -826,13 +705,12 @@ def _compile(
                             # overhang its group, in which case the overhanging
                             # rows hold this expert's weights applied to the
                             # NEXT group's tokens -- correct arithmetic, wrong
-                            # expert -- so they must not be stored. `active`
-                            # kills whole slots past the last group's tiles.
+                            # expert -- so they must not be stored.
                             # Reading those A rows is harmless: each output
                             # element is one A row dotted with one B column, so
                             # nothing leaks across rows, and any fp8 NaN in the
                             # pad region past m_total lands only in rows we drop.
-                            ok = active & (r_ < m_end) & (r_ < out_m) & col_ok
+                            ok = (r_ < m_end) & (r_ < out_m) & col_ok
                             off = arith.select(ok, r_ * out_n + col, oob)
                             buffer_ops.buffer_store(vec[e].to(fx.BFloat16), o_rsrc, off)
 
@@ -842,6 +720,16 @@ def _compile(
             store_group(
                 c11, base_row + fx.Int32(LDS_BLOCK_R), base_col + fx.Int32(LDS_BLOCK_C)
             )
+
+            if PERSISTENT:
+                # Reset vmcnt as well as synchronizing LDS reuse. Outstanding
+                # epilogue stores must not enter the next tile's hand-counted
+                # load pipeline (loads and stores need not retire in order).
+                wait_barrier(0)
+
+        for_each_grouped_tile_static(
+            OFFS, E, N, BLOCK_R, BLOCK_C, PERSISTENT, compute_tile
+        )
 
     @flyc.jit
     def launch_fwd(
@@ -878,72 +766,10 @@ def _compile(
 
 @functools.lru_cache(maxsize=None)
 def cached_launch(
-    K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int = 256, GUARD: bool = True
+    K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int = 256, PERSISTENT: bool = True
 ):
-    """Build the launcher. GUARD is part of the key -- see `launch_for`.
-
-    NOTE: this does NOT trace. FlyDSL traces lazily, on the first call
-    through `fast_launch`, so a tracer error surfaces at LAUNCH time and
-    cannot be caught here. That is what `launch_for` is for.
-    """
-    return _compile(K, N, E, BLOCK_C, BLOCK_R, GUARD=GUARD)
-
-
-def launch_for(K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int):
-    """The guarded launcher, unless this shape already failed to trace.
-
-    The surplus-slot guard is worth 1.2-1.74x but does not trace on every
-    shape: as a bare `if active:` it can raise "cannot evaluate dynamic
-    'Boolean' as Python bool", and only once enough other kernels have been
-    traced in the same process, so it is not reliably reproducible from a
-    single shape.
-
-    The fallback therefore has to live at the LAUNCH site: an untraceable
-    shape would otherwise raise RuntimeError out of the op rather than
-    degrading to an unguarded launch. GUARD=False is verified bitwise-identical
-    to GUARD=True; it costs throughput, nothing else.
-    """
-    return cached_launch(
-        K,
-        N,
-        E,
-        BLOCK_C,
-        BLOCK_R,
-        GUARD=(K, N, E, BLOCK_C, BLOCK_R) not in _guard_broken,
-    )
-
-
-def launch_guarded(launch, key, compile_args_factory, dispatch_args, param):
-    """Run `launch`, and on a tracer error retry once unguarded, forever.
-
-    Compilation goes through Inductor's FlyDSL cache so the compiled dispatcher
-    is shared with the rest of the Inductor-generated FlyDSL kernels and is
-    keyed the same way (pid, device, constexpr param).
-    """
-    try:
-        return run_cached_flydsl(
-            launch,
-            constexpr_param=param,
-            compiler=flyc.compile,
-            dispatch_args=dispatch_args,
-            compile_args_factory=compile_args_factory,
-        )
-    except Exception as e:
-        # The guard fallback exists for ONE failure mode: the surplus-slot `if`
-        # not tracing on some shapes. An out-of-memory is not that, and treating
-        # it as such both misreports the cause and permanently pins this shape
-        # to the unguarded kernel (up to 1.74x slower). Re-raise it instead.
-        if isinstance(e, torch.OutOfMemoryError) or key in _guard_broken:
-            raise
-        _guard_broken.add(key)
-        _warn_guard_fallback(*key, e)
-        return run_cached_flydsl(
-            cached_launch(*key, GUARD=False),
-            constexpr_param=param.unguarded(),
-            compiler=flyc.compile,
-            dispatch_args=dispatch_args,
-            compile_args_factory=compile_args_factory,
-        )
+    """Build one of two traversal specializations; token counts remain dynamic."""
+    return _compile(K, N, E, BLOCK_C, BLOCK_R, PERSISTENT=PERSISTENT)
 
 
 def ceildiv(a: int, b: int) -> int:
@@ -970,24 +796,28 @@ class MXFP8GroupedGemmParam:
     group_count: int
     block_c: int
     block_r: int
-    guarded: bool = True
+    persistent: bool = True
 
-    def key(self) -> tuple[int, int, int, int, int]:
-        """The tuple ``cached_launch`` / ``_guard_broken`` are keyed on."""
-        return (self.k, self.n, self.group_count, self.block_c, self.block_r)
-
-    def unguarded(self) -> "MXFP8GroupedGemmParam":
-        return dataclasses.replace(self, guarded=False)
+    def key(self) -> tuple[int, int, int, int, int, bool]:
+        """Only traversal mode, not exact token count, specializes the launcher."""
+        return (
+            self.k,
+            self.n,
+            self.group_count,
+            self.block_c,
+            self.block_r,
+            self.persistent,
+        )
 
     def __cache_signature__(self) -> tuple[int, int, int, int, int, bool]:
-        return (*self.key(), self.guarded)
+        return self.key()
 
 
 def make_mxfp8_grouped_gemm_kernel_name(param: MXFP8GroupedGemmParam) -> str:
     return (
         f"mxfp8_grouped_gemm_k{param.k}_n{param.n}_e{param.group_count}"
         f"_t{param.block_r}x{param.block_c}"
-        f"_guard{int(param.guarded)}"
+        f"_persistent{int(param.persistent)}"
     )
 
 
@@ -1046,11 +876,17 @@ def get_mxfp8_grouped_gemm_grid_size(
     """(n_blocks, n_c_tiles) for a launch covering `rows` tokens.
 
     Group sizes are device-resident, so the host uses a row-tile upper bound.
-    Surplus blocks are predicated off by the kernel's active-tile guard.
+    The scheduler visits only actual tiles; surplus workgroups do no GEMM work.
     """
     n_c_tiles = ceildiv(param.n, param.block_c)
     n_slots = grouped_row_tiles_upper_bound(rows, param.group_count, param.block_r)
     return n_slots * n_c_tiles, n_c_tiles
+
+
+def get_mxfp8_grouped_gemm_persistent_grid_size(param, rows, device_properties) -> int:
+    """Cap the grid at one four-wave workgroup per CU, without reading offsets."""
+    tile_bound, _ = get_mxfp8_grouped_gemm_grid_size(param, rows)
+    return max(1, min(tile_bound, device_properties.multi_processor_count))
 
 
 def launch_mxfp8_grouped_gemm_gfx950(
@@ -1094,7 +930,7 @@ def launch_mxfp8_grouped_gemm_gfx950(
     `compile_only` warms the disk cache and returns without dispatching. It is
     what Inductor's precompile entry point uses, where the tensors are fake and
     the only thing wanted is the compiled artifact. Only the first window is
-    compiled: every window traces the same kernel, and the layout-dynamic
+    compiled in both traversal modes, and the layout-dynamic
     compile args make the window's row count a runtime slot.
     """
     if tensor_arg is None:
@@ -1112,11 +948,20 @@ def launch_mxfp8_grouped_gemm_gfx950(
     b_sc = scale_b.view(torch.uint8).view(-1)
     offs_i32 = offs.view(torch.int32)
 
-    key = param.key()
     for row_start, rows, offs_window in _row_windows(
         total_m, param.k, param.n, offs_i32, param.block_r
     ):
-        n_blocks, n_c_tiles = get_mxfp8_grouped_gemm_grid_size(param, rows)
+        tile_bound, n_c_tiles = get_mxfp8_grouped_gemm_grid_size(param, rows)
+        if compile_only:
+            n_blocks = 1
+            launch_param = param
+        else:
+            n_blocks = get_mxfp8_grouped_gemm_persistent_grid_size(
+                param, rows, torch.cuda.get_device_properties(out.device)
+            )
+            # If even the upper bound fits, no CTA can have a second tile.
+            # Specialize out the loop and its live-across-tile scheduler state.
+            launch_param = dataclasses.replace(param, persistent=tile_bound > n_blocks)
         dispatch_args = (
             a.narrow(0, row_start, rows).view(-1),
             b,
@@ -1142,11 +987,20 @@ def launch_mxfp8_grouped_gemm_gfx950(
             )
 
         if compile_only:
-            flyc.compile(launch_for(*key), *compile_args_factory())
+            # Metadata-only compilation cannot query the target's CU count.
+            # Warm both bounded traversal modes; runtime selects using the grid.
+            for persistent in (False, True):
+                compile_param = dataclasses.replace(param, persistent=persistent)
+                flyc.compile(
+                    cached_launch(*compile_param.key()), *compile_args_factory()
+                )
             return out
-        # A window that fell back re-resolves, so later windows skip the retry.
-        launch_guarded(
-            launch_for(*key), key, compile_args_factory, dispatch_args, param
+        run_cached_flydsl(
+            cached_launch(*launch_param.key()),
+            constexpr_param=launch_param,
+            compiler=flyc.compile,
+            dispatch_args=dispatch_args,
+            compile_args_factory=compile_args_factory,
         )
     return out
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -180,8 +180,6 @@ def _warn_guard_fallback(K, N, E, BLOCK_C, BLOCK_R, err) -> None:
     )
 
 
-
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir.dialects import llvm as _llvm
@@ -190,6 +188,7 @@ from flydsl.expr.arith import ArithValue
 from flydsl.expr.typing import T, Vector as Vec
 
 from . import mxfp8_buffer_ops as buffer_ops
+from .grouped_config import grouped_row_tiles_upper_bound
 from .mxfp8_gemm_utils import (
     compute_global_swizzle,
     G2SLoader,
@@ -1046,14 +1045,11 @@ def get_mxfp8_grouped_gemm_grid_size(
 ) -> tuple[int, int]:
     """(n_blocks, n_c_tiles) for a launch covering `rows` tokens.
 
-    The row-tile count is over-provisioned to ``ceildiv(rows, BLOCK_R) + E``:
-    a group boundary that falls inside a tile costs the next group a slot, and
-    E boundaries can each do that. Blocks whose slot lands past the last group
-    resolve to ``active == False`` and are predicated off by the surplus-slot
-    guard, so the surplus is a launch-descriptor cost, not work.
+    Group sizes are device-resident, so the host uses a row-tile upper bound.
+    Surplus blocks are predicated off by the kernel's active-tile guard.
     """
     n_c_tiles = ceildiv(param.n, param.block_c)
-    n_slots = ceildiv(rows, param.block_r) + param.group_count
+    n_slots = grouped_row_tiles_upper_bound(rows, param.group_count, param.block_r)
     return n_slots * n_c_tiles, n_c_tiles
 
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_wgrad_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_wgrad_gfx950.py
@@ -1,0 +1,854 @@
+# SPDX-License-Identifier: MIT
+# Vendored from ROCm/AMD-TorchTitan-Ops amd_titan/_ops/mxwgrad/_kernel_v1.py.
+"""Ragged MXFP8 weight-gradient grouped GEMM for gfx950.
+
+The inputs are row-major ``A[N, M]`` and ``B[K, M]`` views produced by the
+32x1 MXFP8 cast. Device-resident offsets partition the contracting dimension
+``M`` and the kernel writes ``out[G, N, K]``.
+
+Each workgroup owns one output tile and walks the full contraction interval for
+one group. Group sizes and the operand row stride stay runtime values, so routed
+token counts do not become FlyDSL compile keys. The contraction window is
+rounded outward to 256 elements for cooperative scale loads; scale operands are
+masked on both sides outside the group, including empty groups.
+
+The body uses four waves, an eight-buffer LDS pipeline, AGPR accumulators, and
+device-side group scheduling. Large grids use constant-index offset loads and
+XCD-aware rectangular tile rasterization.
+"""
+
+import dataclasses
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith, range_constexpr, rocdl
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T, Vector as Vec
+
+import torch
+from torch._inductor.runtime.flydsl_cache import run_cached_flydsl
+
+from . import mxfp8_buffer_ops as buffer_ops
+from .mxfp8_gemm_utils import (
+    compute_global_swizzle,
+    G2SLoader,
+    make_fp8_buffer_tensor,
+    pack_i32x4_i32x8,
+    S2RLoader,
+    swizzle_128,
+    wait_barrier,
+)
+
+
+BLOCK_R = 256
+BLOCK_C = 256
+BLOCK_M = 128
+SCALE_BLOCK = 32
+WINDOW_ALIGN = 256
+LPT_MAX_E = 32
+ORDER_MODES = ("id", "idsel", "lpt")
+_INTERLEAVE = True
+_IDSEL_MIN_BLOCKS = 1024
+_XCD_COUNT = 8
+_SUPERTILE_TARGET = 4
+
+
+def _divisors(value: int) -> list[int]:
+    return [divisor for divisor in range(1, value + 1) if value % divisor == 0]
+
+
+def _pick_supertile(n_r: int, n_c: int) -> tuple[int, int]:
+    """Pick the largest rectangular tile no bigger than the measured target."""
+    best_score = (0, 0)
+    best_r, best_c = 1, 1
+    for group_r in _divisors(n_r):
+        for group_c in _divisors(n_c):
+            area = group_r * group_c
+            if area > _SUPERTILE_TARGET:
+                continue
+            score = (area, -(group_r + group_c))
+            if score > best_score:
+                best_score = score
+                best_r, best_c = group_r, group_c
+    return best_r, best_c
+
+
+def _swizzle_params(n: int, k: int) -> tuple[int, int, int]:
+    """Return the XCD gather count and rectangular output-tile dimensions."""
+    n_r = ceildiv(n, BLOCK_R)
+    n_c = ceildiv(k, BLOCK_C)
+    group_r, group_c = _pick_supertile(n_r, n_c)
+    xcd_count = _XCD_COUNT if (n_r * n_c) % _XCD_COUNT == 0 else 1
+    return xcd_count, group_r, group_c
+
+
+def _mfma_scale_agpr(a, b, sa, sb, acc):
+    """fp8 16x16x128 scaled MFMA, accumulator pinned in AGPR (=a,...,0) so the
+    f32x4 acc accumulates in place and the compiler does not shuffle it
+    between AGPR slots. a/b are i32x8 (K=128 fp8); sa/sb are broadcast-i32
+    E8M0 scales. cbsz:0 blgp:0, no op_sel (fp8). Identical to v3.3's."""
+    asm = "v_mfma_scale_f32_16x16x128_f8f6f4 $0, $1, $2, $0, $3, $4 cbsz:0 blgp:0"
+    return _llvm.inline_asm(
+        Vec.make_type(4, fx.Float32),
+        [
+            arith._to_raw(a),
+            arith._to_raw(b),
+            arith._to_raw(sa),
+            arith._to_raw(sb),
+            arith._to_raw(acc),
+        ],
+        asm,
+        "=a,v,v,v,v,0",
+        has_side_effects=True,
+    )
+
+
+def _uniform(value):
+    """Place a value known to be wave-uniform in an SGPR."""
+    return fx.Int32(rocdl.readfirstlane(res=T.i32, src=arith._to_raw(value)))
+
+
+def _compile(
+    R: int,
+    C: int,
+    E: int,
+    sc_pair: bool,
+    order: str,
+    xcd_count: int,
+    group_r: int,
+    group_c: int,
+):
+    """Build a kernel keyed by output geometry, group count, and scale loading."""
+    if order not in ORDER_MODES:
+        raise AssertionError(f"unknown order {order!r}")
+    ORDER = order
+    N_R_TILES = ceildiv(R, BLOCK_R)
+    N_C_TILES = ceildiv(C, BLOCK_C)
+    TILES_PER_GROUP = N_R_TILES * N_C_TILES
+    SUPERTILES_PER_ROW = N_C_TILES // group_c
+
+    def tile_coordinates(tile):
+        if xcd_count > 1:
+            tile = (tile % fx.Int32(xcd_count)) * fx.Int32(
+                TILES_PER_GROUP // xcd_count
+            ) + tile // fx.Int32(xcd_count)
+        if group_r * group_c > 1:
+            supertile = tile // fx.Int32(group_r * group_c)
+            within = tile % fx.Int32(group_r * group_c)
+            row = (supertile // fx.Int32(SUPERTILES_PER_ROW)) * fx.Int32(
+                group_r
+            ) + within // fx.Int32(group_c)
+            col = (supertile % fx.Int32(SUPERTILES_PER_ROW)) * fx.Int32(
+                group_c
+            ) + within % fx.Int32(group_c)
+            return row, col
+        return tile // fx.Int32(N_C_TILES), tile % fx.Int32(N_C_TILES)
+
+    N_TILES_A = BLOCK_R // 4 // 16
+    N_TILES_B = BLOCK_C // 4 // 16
+    N_ACCUMS = N_TILES_A * N_TILES_B
+    N_LDS_ROUNDS = max(N_TILES_A, N_TILES_B)
+
+    # Pair loads require M_ROW % 256 == 0. Other 128-aligned rows use two
+    # dword loads; the choice is a compile key because it changes wait counts.
+    SC_PAIR = sc_pair
+    N_SC_OPS = 4 if SC_PAIR else 8  # scale vm ops per unrolled body
+    N_CHUNK = 8  # raw i32 carried per chunk (4 halves x 2 K-steps)
+
+    # These counts track the vector loads trailing each LDS fill. A count that
+    # is too large can expose an incomplete fill before the barrier.
+    W1A = 2 * (N_TILES_A + N_TILES_B)
+    W2A = 2 * (N_TILES_A + N_TILES_B) + N_SC_OPS
+    W1B = 2 * (N_TILES_A + N_TILES_B) + N_SC_OPS
+    W2B = 2 * (N_TILES_A + N_TILES_B)
+
+    LDS_BLOCK_R = BLOCK_R // 2  # 128: each wave-dim half owns 128 rows
+    LDS_BLOCK_C = BLOCK_C // 2
+
+    a_lds_size = LDS_BLOCK_R * BLOCK_M
+    b_lds_size = LDS_BLOCK_C * BLOCK_M
+
+    def slot_to_group(offs_rsrc, slot):
+        """Map a dispatch slot to a group and its device-resident bounds.
+
+        This helper remains outside the traced kernel so the order branch and
+        fixed-length offset loops are resolved and unrolled at compile time.
+        """
+        if ORDER == "id":
+            # Clamp the discarded g=-1 read to the bounded offsets buffer.
+            g = slot
+            g_prev = arith.select(g > fx.Int32(0), g - fx.Int32(1), fx.Int32(0))
+            prev_raw = buffer_ops.buffer_load(
+                offs_rsrc, g_prev, vec_width=1, dtype=T.i32, is_scalar=True
+            )
+            end_raw = buffer_ops.buffer_load(
+                offs_rsrc, g, vec_width=1, dtype=T.i32, is_scalar=True
+            )
+            m_start = arith.select(g > fx.Int32(0), ArithValue(prev_raw), fx.Int32(0))
+            return g, ArithValue(m_start), ArithValue(end_raw)
+
+        # Constant indices let all group boundaries issue together.
+        ends = [
+            ArithValue(
+                buffer_ops.buffer_load(
+                    offs_rsrc, fx.Int32(i), vec_width=1, dtype=T.i32, is_scalar=True
+                )
+            )
+            for i in range(E)
+        ]
+        starts = [ArithValue(fx.Int32(0))] + ends[:-1]
+
+        if ORDER == "idsel":
+            g = slot
+            m_start = ArithValue(fx.Int32(0))
+            m_end = ends[0]
+            for i in range(E):
+                mine = g == fx.Int32(i)
+                m_start = arith.select(mine, starts[i], m_start)
+                m_end = arith.select(mine, ends[i], m_end)
+            return g, ArithValue(m_start), ArithValue(m_end)
+
+        cost = [
+            ends[i] - (starts[i] // fx.Int32(WINDOW_ALIGN)) * fx.Int32(WINDOW_ALIGN)
+            for i in range(E)
+        ]
+
+        g = ArithValue(fx.Int32(0))
+        m_start = ArithValue(fx.Int32(0))
+        m_end = ends[0]
+        for i in range(E):
+            rank = ArithValue(fx.Int32(0))
+            for j in range(E):
+                # Index order breaks ties and makes the ranking a permutation.
+                ahead = (cost[j] >= cost[i]) if j < i else (cost[j] > cost[i])
+                rank = rank + arith.select(ahead, fx.Int32(1), fx.Int32(0))
+            mine = rank == slot
+            g = arith.select(mine, fx.Int32(i), g)
+            m_start = arith.select(mine, starts[i], m_start)
+            m_end = arith.select(mine, ends[i], m_end)
+        return ArithValue(g), ArithValue(m_start), ArithValue(m_end)
+
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_wgrad(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        OUT: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        OFFS: fx.Tensor,
+        out_r: fx.Int32,
+        out_c: fx.Int32,
+        m_row: fx.Int32,
+    ):
+        F8_IR_t = fx.Float8E4M3FN.ir_type
+
+        # Runtime row stride. One e8m0 per 32 contracting elements, 4 packed
+        # per i32, so a row is m_row/128 i32 and m_row/32 bytes.
+        sc_i32_row = ArithValue(m_row) // fx.Int32(BLOCK_M)
+        sc_e8_row = ArithValue(m_row) // fx.Int32(SCALE_BLOCK)
+
+        # -- Block -> (group, output tile). One block per (g, tile). --
+        bid = ArithValue(fx.block_idx.x)
+        slot = bid // fx.Int32(TILES_PER_GROUP)
+        tile = bid % fx.Int32(TILES_PER_GROUP)
+        row_tile, col_tile = tile_coordinates(tile)
+        r_base = row_tile * fx.Int32(BLOCK_R)
+        c_base = col_tile * fx.Int32(BLOCK_C)
+
+        # -- Group bounds, read ON DEVICE (uniform s.buffer.load, no sync) --
+        offs_rsrc = buffer_ops.create_buffer_resource(
+            OFFS, max_size=False, num_records_bytes=E * 4
+        )
+
+        g, m_start, m_end = slot_to_group(offs_rsrc, slot)
+
+        # -- The window: base rounded DOWN to 256, length rounded UP to an
+        # even number of K-steps >= 4. See notes 1-3 in the file header. --
+        lo0 = (m_start // fx.Int32(WINDOW_ALIGN)) * fx.Int32(WINDOW_ALIGN)
+        head = m_start - lo0  # 0..224, multiple of 32
+        span = m_end - lo0  # real elements from the window base
+        k_need = (span + fx.Int32(BLOCK_M - 1)) // fx.Int32(BLOCK_M)
+        k_even = ((k_need + fx.Int32(1)) // fx.Int32(2)) * fx.Int32(2)
+        K_eff = arith.select(k_even < fx.Int32(4), fx.Int32(4), k_even)
+        N_ROLLED = K_eff - fx.Int32(2)  # even, >= 2: no constexpr peel needed
+        m_start_i32 = lo0 // fx.Int32(BLOCK_M)  # even (lo0 is 256-aligned)
+
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        a_cur0, a_cur1 = lds.A_lds_cur_0, lds.A_lds_cur_1
+        a_next0, a_next1 = lds.A_lds_next_0, lds.A_lds_next_1
+        b_cur0, b_cur1 = lds.B_lds_cur_0, lds.B_lds_cur_1
+        b_next0, b_next1 = lds.B_lds_next_0, lds.B_lds_next_1
+
+        lane_id = fx.thread_idx.x % 64
+        wave_id = _uniform(fx.thread_idx.x // 64)
+        wave_i = wave_id // 2
+        wave_j = wave_id % 2
+
+        m_lane = lane_id % fx.Int32(16)
+        k_grp = lane_id // fx.Int32(16)
+        kshift = k_grp * fx.Int32(8)
+        kgrp32 = k_grp * fx.Int32(SCALE_BLOCK)  # this lane's sub-block offset
+        mask_ff = fx.Int32(0xFF)
+        bcast = fx.Int32(0x01010101)
+        zero_i32 = fx.Int32(0)
+
+        # Contraction (K-walk) global offsets; row stride = m_row, base = lo0.
+        A0_gl = r_base * m_row + lo0
+        A1_gl = (r_base + fx.Int32(LDS_BLOCK_R)) * m_row + lo0
+        B0_gl = c_base * m_row + lo0
+        B1_gl = (c_base + fx.Int32(LDS_BLOCK_C)) * m_row + lo0
+
+        gA = make_fp8_buffer_tensor(A, F8_IR_t)
+        gB = make_fp8_buffer_tensor(B, F8_IR_t)
+        a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+        b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+
+        # Scale loads can overhang a row tile and the rounded contraction
+        # window. Bounded descriptors make both cases return zero instead of
+        # reading a neighboring row or an e8m0 NaN.
+        sa_bytes = arith.index_cast(
+            T.i64, arith.index_cast(T.index, fx.Int32(R) * sc_e8_row)
+        )
+        sb_bytes = arith.index_cast(
+            T.i64, arith.index_cast(T.index, fx.Int32(C) * sc_e8_row)
+        )
+        sa_rsrc = buffer_ops.create_buffer_resource(
+            A_scale, max_size=False, num_records_bytes=sa_bytes
+        )
+        sb_rsrc = buffer_ops.create_buffer_resource(
+            B_scale, max_size=False, num_records_bytes=sb_bytes
+        )
+
+        gl_off_a = compute_global_swizzle(
+            lane_id, wave_id, m_row, N_LDS_ROUNDS, preshuffled=False
+        )
+        gl_off_b = compute_global_swizzle(
+            lane_id, wave_id, m_row, N_LDS_ROUNDS, preshuffled=False
+        )
+
+        a_g2s = G2SLoader(a_div, gl_off_a, N_TILES_A, F8_IR_t, wave_id)
+        b_g2s = G2SLoader(b_div, gl_off_b, N_TILES_B, F8_IR_t, wave_id)
+        a_s2r = S2RLoader(wave_i, N_TILES_A)
+        b_s2r = S2RLoader(wave_j, N_TILES_B)
+
+        # Each lane loads one scale row for both K-steps. ds_bpermute then
+        # redistributes the four tile scales within the wave.
+        if N_TILES_A != 4 or N_TILES_B != 4:
+            raise AssertionError("cooperative scale load assumes 4x16=64 rows/half")
+
+        sa0_base = r_base + wave_i * fx.Int32(N_TILES_A * 16)
+        sa1_base = r_base + fx.Int32(LDS_BLOCK_R) + wave_i * fx.Int32(N_TILES_A * 16)
+        sb0_base = c_base + wave_j * fx.Int32(N_TILES_B * 16)
+        sb1_base = c_base + fx.Int32(LDS_BLOCK_C) + wave_j * fx.Int32(N_TILES_B * 16)
+
+        # Half bases and K indices are wave-uniform and use the SGPR soffset.
+        sc_voff = lane_id * sc_i32_row
+        sc_sbase = [
+            (_rs, (_base * sc_i32_row + m_start_i32) * fx.Int32(4))
+            for _rs, _base in (
+                (sa_rsrc, sa0_base),
+                (sa_rsrc, sa1_base),
+                (sb_rsrc, sb0_base),
+                (sb_rsrc, sb1_base),
+            )
+        ]
+        sc_perm = [
+            fx.Int32(t_ * 64) + m_lane * fx.Int32(4)
+            for t_ in range_constexpr(N_TILES_A)
+        ]
+
+        def issue_chunk(k_i32):
+            """Cooperative scale loads for K-steps (k_i32, k_i32+1).
+
+            Returns 2 raw i32 per operand-half, flat: [a0_lo, a0_hi, a1_lo, ...].
+            """
+            out = []
+            for _rs, _sb in sc_sbase:
+                soff = _uniform(_sb + k_i32 * fx.Int32(4))
+                if SC_PAIR:
+                    v = buffer_ops.buffer_load(
+                        _rs, sc_voff, vec_width=2, dtype=T.i32, soffset_bytes=soff
+                    )
+                    out.append(
+                        buffer_ops.vec_extract(
+                            v, static_position=[0], dynamic_position=[]
+                        )
+                    )
+                    out.append(
+                        buffer_ops.vec_extract(
+                            v, static_position=[1], dynamic_position=[]
+                        )
+                    )
+                else:
+                    # Two dwords handle an odd scale-row stride.
+                    out.append(
+                        buffer_ops.buffer_load(
+                            _rs, sc_voff, vec_width=1, dtype=T.i32, soffset_bytes=soff
+                        )
+                    )
+                    out.append(
+                        buffer_ops.buffer_load(
+                            _rs,
+                            sc_voff,
+                            vec_width=1,
+                            dtype=T.i32,
+                            soffset_bytes=soff + fx.Int32(4),
+                        )
+                    )
+            return out
+
+        def window_ok(k_idx):
+            """Return whether this lane's scale block belongs to the group."""
+            e = k_idx * fx.Int32(BLOCK_M) + kgrp32
+            return (e >= head) & (e < span)
+
+        def use_chunk(chunk, p, k_idx):
+            """Redistribute a scale chunk and mask both operands to the group."""
+            ok = window_ok(k_idx)
+            groups = []
+            for h_ in range_constexpr(4):
+                src = chunk[2 * h_ + p]
+                grp = []
+                for t_ in range_constexpr(N_TILES_A):
+                    v = rocdl.ds_bpermute(res=T.i32, index=sc_perm[t_], src=src)
+                    sc = ((ArithValue(v) >> kshift) & mask_ff) * bcast
+                    grp.append(arith.select(ok, sc, zero_i32))
+                groups.append(grp)
+            return groups
+
+        def mma(a, b, c, sa, sb):
+            for i in range_constexpr(N_TILES_A):
+                for j in range_constexpr(N_TILES_B):
+                    idx = i * N_TILES_B + j
+                    c[idx] = _mfma_scale_agpr(a[i], b[j], sa[i], sb[j], c[idx])
+            return c
+
+        zero = Vec.filled(4, 0.0, fx.Float32)
+        c00 = [zero] * N_ACCUMS
+        c01 = [zero] * N_ACCUMS
+        c10 = [zero] * N_ACCUMS
+        c11 = [zero] * N_ACCUMS
+
+        # Pre-fill both sides of the eight-buffer LDS pipeline.
+        chunk = issue_chunk(fx.Int32(0))
+        a_g2s.load(a_cur0, A0_gl + 0 * BLOCK_M)
+        b_g2s.load(b_cur0, B0_gl + 0 * BLOCK_M)
+        b_g2s.load(b_cur1, B1_gl + 0 * BLOCK_M)
+        a_g2s.load(a_cur1, A1_gl + 0 * BLOCK_M)
+
+        a_g2s.load(a_next0, A0_gl + 1 * BLOCK_M)
+        b_g2s.load(b_next0, B0_gl + 1 * BLOCK_M)
+        b_g2s.load(b_next1, B1_gl + 1 * BLOCK_M)
+        a_g2s.load(a_next1, A1_gl + 1 * BLOCK_M)
+
+        wait_barrier((3 * N_TILES_A) + (4 * N_TILES_B))
+        a0 = a_s2r.load(a_cur0)
+        wait_barrier((3 * N_TILES_A) + (3 * N_TILES_B))
+        b0 = b_s2r.load(b_cur0)
+
+        def _lds_swizzle(s2r):
+            out = []
+            for row_off in range_constexpr(s2r.n_tiles):
+                row = (
+                    s2r.wave_idx * fx.Int32(s2r.n_tiles * 16)
+                    + fx.Int32(row_off * 16)
+                    + (lane_id % fx.Int32(16))
+                )
+                swz = []
+                for ii in range_constexpr(2):
+                    col = (lane_id // fx.Int32(16)) * fx.Int32(16) + fx.Int32(ii * 64)
+                    r_, c_ = swizzle_128(row, col)
+                    swz.append(r_ * fx.Int32(BLOCK_M) + c_)
+                out.append(swz)
+            return out
+
+        def _cluster_plain(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+            g2s.load(lds_dst, k_off)
+            rt = s2r.load(lds_src)
+            c = mma(a, b, c, sa, sb)
+            return c, rt
+
+        def _cluster_il(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+            # Interleave the 16 scaled MFMAs (4x4) with the g2s (4 steps) and
+            # s2r (4 tiles x 2 halves) loads of the NEXT fragment, so the loads
+            # co-issue in the MFMA execute shadow.
+            swz = _lds_swizzle(s2r)
+            rt = []
+
+            def M(i, j):
+                c[i * N_TILES_B + j] = _mfma_scale_agpr(
+                    a[i], b[j], sa[i], sb[j], c[i * N_TILES_B + j]
+                )
+
+            M(0, 0)
+            M(0, 1)
+            g2s.load_one(lds_dst, k_off, 0)
+            d0 = s2r.load_one(lds_src, swz[0][0])
+            M(0, 2)
+            d1 = s2r.load_one(lds_src, swz[0][1])
+            rt.append(pack_i32x4_i32x8(d0, d1))
+            M(0, 3)
+            g2s.load_one(lds_dst, k_off, 1)
+            d0 = s2r.load_one(lds_src, swz[1][0])
+            M(1, 0)
+            M(1, 1)
+            d1 = s2r.load_one(lds_src, swz[1][1])
+            rt.append(pack_i32x4_i32x8(d0, d1))
+            M(1, 2)
+            M(1, 3)
+            g2s.load_one(lds_dst, k_off, 2)
+            d0 = s2r.load_one(lds_src, swz[2][0])
+            M(2, 0)
+            M(2, 1)
+            d1 = s2r.load_one(lds_src, swz[2][1])
+            rt.append(pack_i32x4_i32x8(d0, d1))
+            M(2, 2)
+            M(2, 3)
+            g2s.load_one(lds_dst, k_off, 3)
+            d0 = s2r.load_one(lds_src, swz[3][0])
+            M(3, 0)
+            M(3, 1)
+            d1 = s2r.load_one(lds_src, swz[3][1])
+            rt.append(pack_i32x4_i32x8(d0, d1))
+            M(3, 2)
+            M(3, 3)
+            return c, rt
+
+        _cluster = _cluster_il if _INTERLEAVE else _cluster_plain
+
+        # The runtime K-loop advances two steps per body, matching the LDS
+        # ping-pong period and leaving two steps for the drain below.
+        _R = arith._to_raw
+        NA, NB = N_TILES_A, N_TILES_B
+
+        def _one_step(kk_i, a0, b0, accs, bufs, chunk, p, issue_k):
+            """One K-step. `p` is the step's slot in the unrolled body (0 or 1);
+            slot 0 also issues the chunk for K-steps (issue_k, issue_k+1)."""
+            c00, c01, c10, c11 = accs
+            ac0, ac1, an0, an1, bc0, bc1, bn0, bn1 = bufs
+            k2 = (kk_i + fx.Int32(2)) * fx.Int32(BLOCK_M)
+            wait_barrier(W1A if p == 0 else W1B)
+            # Prefetch scales for the body two K-steps ahead.
+            ch_new = issue_chunk(issue_k) if p == 0 else None
+            sa0, sa1, sb0, sb1 = use_chunk(chunk, p, kk_i)
+            c00, b1 = _cluster(
+                ac0, a_g2s, A0_gl + k2, b_s2r, bc1, a0, b0, c00, sa0, sb0
+            )
+            c01, a1 = _cluster(
+                bc0, b_g2s, B0_gl + k2, a_s2r, ac1, a0, b1, c01, sa0, sb1
+            )
+            wait_barrier(W2A if p == 0 else W2B)
+            c10, a0n = _cluster(
+                bc1, b_g2s, B1_gl + k2, a_s2r, an0, a1, b0, c10, sa1, sb0
+            )
+            c11, b0n = _cluster(
+                ac1, a_g2s, A1_gl + k2, b_s2r, bn0, a1, b1, c11, sa1, sb1
+            )
+            new_bufs = (an0, an1, ac0, ac1, bn0, bn1, bc0, bc1)
+            return a0n, b0n, (c00, c01, c10, c11), new_bufs, ch_new
+
+        bufs0 = (a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1)
+
+        def _pack(a0, b0, accs, chunk):
+            c00, c01, c10, c11 = accs
+            return (
+                [_R(x) for x in a0]
+                + [_R(x) for x in b0]
+                + [_R(x) for x in c00]
+                + [_R(x) for x in c01]
+                + [_R(x) for x in c10]
+                + [_R(x) for x in c11]
+                + [_R(x) for x in chunk]
+            )
+
+        def _unpack(state):
+            o = 0
+            a0 = list(state[o : o + NA])
+            o += NA
+            b0 = list(state[o : o + NB])
+            o += NB
+            c00 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            c01 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            c10 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            c11 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            chunk = list(state[o : o + N_CHUNK])
+            o += N_CHUNK
+            return a0, b0, (c00, c01, c10, c11), chunk
+
+        init_state = _pack(a0, b0, (c00, c01, c10, c11), chunk)
+        state = init_state
+        for kk, state in range(0, N_ROLLED, 2, init=init_state):
+            a0, b0, accs, chunk = _unpack(state)
+            kk_i = fx.Int32(kk)
+            a0, b0, accs, bufs, ch_new = _one_step(
+                kk_i, a0, b0, accs, bufs0, chunk, 0, kk_i + fx.Int32(2)
+            )
+            a0, b0, accs, bufs, _ = _one_step(
+                kk_i + fx.Int32(1), a0, b0, accs, bufs, chunk, 1, None
+            )
+            state = yield _pack(a0, b0, accs, ch_new)
+
+        a0, b0, accs, chunk = _unpack(state)
+        c00, c01, c10, c11 = accs
+        a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1 = bufs0
+
+        # Drain the final two prefetched K-steps.
+        t0 = K_eff - fx.Int32(2)
+        t1 = K_eff - fx.Int32(1)
+
+        wait_barrier((2 * N_TILES_A) + (2 * N_TILES_B))
+        sa0, sa1, sb0, sb1 = use_chunk(chunk, 0, t0)
+        b1 = b_s2r.load(b_cur1)
+        c00 = mma(a0, b0, c00, sa0, sb0)
+        a1 = a_s2r.load(a_cur1)
+        c01 = mma(a0, b1, c01, sa0, sb1)
+        wait_barrier((1 * N_TILES_A) + (1 * N_TILES_B))
+        a0 = a_s2r.load(a_next0)
+        c10 = mma(a1, b0, c10, sa1, sb0)
+        b0 = b_s2r.load(b_next0)
+        c11 = mma(a1, b1, c11, sa1, sb1)
+
+        a_cur0, a_next0 = a_next0, a_cur0
+        a_cur1, a_next1 = a_next1, a_cur1
+        b_cur0, b_next0 = b_next0, b_cur0
+        b_cur1, b_next1 = b_next1, b_cur1
+
+        wait_barrier(0)
+        sa0, sa1, sb0, sb1 = use_chunk(chunk, 1, t1)
+        b1 = b_s2r.load(b_cur1)
+        a1 = a_s2r.load(a_cur1)
+        c00 = mma(a0, b0, c00, sa0, sb0)
+        c01 = mma(a0, b1, c01, sa0, sb1)
+        c10 = mma(a1, b0, c10, sa1, sb0)
+        c11 = mma(a1, b1, c11, sa1, sb1)
+
+        # One block owns each output tile. Empty groups are selected to exact
+        # zero because e8m0 0x00 represents 2**-127 rather than mathematical 0.
+        nonempty = m_end > m_start
+        f32_zero = fx.Float32(0.0)
+        out_r_i = arith.index_cast(T.index, out_r)
+        out_c_i = arith.index_cast(T.index, out_c)
+        n_experts = fx.Int32(E)
+        nbytes = arith.index_cast(
+            T.i64,
+            out_r_i * out_c_i * arith.index_cast(T.index, n_experts) * fx.Index(2),
+        )
+        o_rsrc = buffer_ops.create_buffer_resource(
+            OUT, max_size=False, num_records_bytes=nbytes
+        )
+        base_row = r_base + wave_i * fx.Int32(N_TILES_A * 16)
+        base_col = c_base + wave_j * fx.Int32(N_TILES_B * 16)
+        g_off = g * out_r * out_c
+        oob = out_r * out_c * n_experts
+
+        def store_group(frag, br, bc):
+            for ti in range_constexpr(N_TILES_A):
+                row = br + fx.Int32(ti * 16) + k_grp * fx.Int32(4)
+                for tj in range_constexpr(N_TILES_B):
+                    col = bc + fx.Int32(tj * 16) + m_lane
+                    col_ok = col < out_c
+                    vec = frag[ti * N_TILES_B + tj]
+                    for e in range_constexpr(4):
+                        r_ = row + fx.Int32(e)
+                        ok = (r_ < out_r) & col_ok
+                        off = arith.select(ok, g_off + r_ * out_c + col, oob)
+                        val = buffer_ops.vec_extract(
+                            vec, static_position=[e], dynamic_position=[]
+                        )
+                        val = arith.select(nonempty, val, f32_zero)
+                        val = arith.truncf(fx.BFloat16.ir_type, val)
+                        buffer_ops.buffer_store(val, o_rsrc, off)
+
+        store_group(c00, base_row, base_col)
+        store_group(c01, base_row, base_col + fx.Int32(LDS_BLOCK_C))
+        store_group(c10, base_row + fx.Int32(LDS_BLOCK_R), base_col)
+        store_group(
+            c11,
+            base_row + fx.Int32(LDS_BLOCK_R),
+            base_col + fx.Int32(LDS_BLOCK_C),
+        )
+
+    @flyc.jit
+    def launch_wgrad(
+        A,
+        B,
+        OUT,
+        A_scale,
+        B_scale,
+        OFFS,
+        n_blocks: fx.Int32,
+        out_r: fx.Int32,
+        out_c: fx.Int32,
+        m_row: fx.Int32,
+        stream: fx.Stream,
+    ):
+        kernel_wgrad(
+            A,
+            B,
+            OUT,
+            A_scale,
+            B_scale,
+            OFFS,
+            out_r,
+            out_c,
+            m_row,
+            value_attrs={
+                "rocdl.waves_per_eu": 1,
+                "rocdl.flat_work_group_size": "256,256",
+            },
+        ).launch(grid=(n_blocks, 1, 1), block=(256, 1, 1), stream=stream)
+
+    return launch_wgrad
+
+
+@functools.lru_cache(maxsize=None)
+def cached_launch(
+    R: int,
+    C: int,
+    E: int,
+    sc_pair: bool,
+    order: str,
+    xcd_count: int,
+    group_r: int,
+    group_c: int,
+):
+    return _compile(R, C, E, sc_pair, order, xcd_count, group_r, group_c)
+
+
+@dataclasses.dataclass(frozen=True)
+class MXFP8WgradParam:
+    n: int
+    k: int
+    group_count: int
+    sc_pair: bool
+    order: str
+    xcd_count: int
+    group_r: int
+    group_c: int
+
+    def key(self) -> tuple[int, int, int, bool, str, int, int, int]:
+        return (
+            self.n,
+            self.k,
+            self.group_count,
+            self.sc_pair,
+            self.order,
+            self.xcd_count,
+            self.group_r,
+            self.group_c,
+        )
+
+    def __cache_signature__(self) -> tuple[int, int, int, bool, str, int, int, int]:
+        return self.key()
+
+
+def make_mxfp8_wgrad_param(
+    n: int, k: int, group_count: int, *, sc_pair: bool
+) -> MXFP8WgradParam:
+    if n <= 0 or k <= 0 or group_count <= 0:
+        raise NotImplementedError(
+            "MXFP8 wgrad needs positive N, K, and group count; "
+            f"got {n}, {k}, {group_count}"
+        )
+    if n % 16 != 0 or k % 16 != 0:
+        raise NotImplementedError(
+            f"MXFP8 wgrad needs N and K divisible by 16; got N={n}, K={k}"
+        )
+    blocks = group_count * ceildiv(n, BLOCK_R) * ceildiv(k, BLOCK_C)
+    if blocks >= _IDSEL_MIN_BLOCKS:
+        order = "idsel"
+    else:
+        order = "lpt" if group_count <= LPT_MAX_E else "id"
+    xcd_count, group_r, group_c = _swizzle_params(n, k)
+    return MXFP8WgradParam(
+        n, k, group_count, sc_pair, order, xcd_count, group_r, group_c
+    )
+
+
+def launch_mxfp8_wgrad_gfx950(
+    out,
+    mat_a,
+    mat_b,
+    scale_a,
+    scale_b,
+    offs,
+    param: MXFP8WgradParam,
+    stream,
+    tensor_arg=None,
+    compile_only=False,
+):
+    """Run the 2D x 2D MXFP8 grouped GEMM with groups along contraction."""
+    if tensor_arg is None:
+
+        def tensor_arg(tensor):
+            return tensor
+
+    n, m = mat_a.shape
+    k, m_b = mat_b.shape
+    if m != m_b:
+        raise AssertionError(f"contracting dimensions differ: {m} and {m_b}")
+    if m % BLOCK_M != 0:
+        raise NotImplementedError(
+            f"MXFP8 wgrad row stride must be divisible by {BLOCK_M}; got {m}"
+        )
+    if tuple(out.shape) != (param.group_count, n, k):
+        raise AssertionError(
+            f"output shape {tuple(out.shape)} != {(param.group_count, n, k)}"
+        )
+
+    n_r = ceildiv(n, BLOCK_R)
+    n_c = ceildiv(k, BLOCK_C)
+    n_blocks = param.group_count * n_r * n_c
+    dispatch_args = (
+        mat_a.view(torch.int8).view(-1),
+        mat_b.view(torch.int8).view(-1),
+        out.view(-1),
+        scale_a.view(torch.uint8).view(-1),
+        scale_b.view(torch.uint8).view(-1),
+        offs.view(torch.int32),
+        n_blocks,
+        n,
+        k,
+        m,
+        stream,
+    )
+
+    def compile_args_factory():
+        return tuple(
+            tensor_arg(arg) if index < 6 else arg
+            for index, arg in enumerate(dispatch_args)
+        )
+
+    launch = cached_launch(*param.key())
+    if compile_only:
+        flyc.compile(launch, *compile_args_factory())
+        return out
+    run_cached_flydsl(
+        launch,
+        constexpr_param=param,
+        compiler=flyc.compile,
+        dispatch_args=dispatch_args,
+        compile_args_factory=compile_args_factory,
+    )
+    return out
+
+
+def ceildiv(a: int, b: int) -> int:
+    return -(-a // b)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2849,6 +2849,7 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
                 aten.clone.default,
                 aten._scaled_mm.default,
                 aten._scaled_mm_v2.default,
+                aten._scaled_grouped_mm_v2.default,
                 prims.convert_element_type.default,
             )
             or (isinstance(node.target, torch._ops.OpOverload) and is_view(node.target))
@@ -2869,6 +2870,9 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
             aten.clone.default,
             aten._scaled_mm.default,
             aten._scaled_mm_v2.default,
+            # MXFP8 grouped GEMM: the e8m0 scales are consumed by the kernel,
+            # never read arithmetically by generated Triton.
+            aten._scaled_grouped_mm_v2.default,
         ) or is_view(node.target):
             return False
         if node.target == torch.ops.prims.convert_element_type.default:

--- a/torch/_inductor/runtime/flydsl_cache.py
+++ b/torch/_inductor/runtime/flydsl_cache.py
@@ -12,7 +12,7 @@ from torch._inductor.runtime.cache_dir_utils import cache_dir
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping, Sequence
 
 
 # Serialize cold compiles process-wide; warm cache hits bypass this lock.
@@ -112,3 +112,39 @@ def configure_flydsl_cache_dir() -> str:
     resolved = str(_cache_dir())
     os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = resolved
     return resolved
+
+
+def flydsl_tensor_arg(tensor: Any) -> Any:
+    import flydsl.compiler as flyc
+
+    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
+
+
+def precompile_flydsl(
+    kernel: Callable[..., Any],
+    shapes: Mapping[str, Sequence[int]],
+    strides: Mapping[str, Sequence[int]],
+    dtypes: Mapping[str, str],
+    flydsl_gpu_arch: str | None = None,
+) -> None:
+    """Warm the disk cache without allocating tensors or launching a kernel."""
+    import torch
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    updates = {"COMPILE_ONLY": "1"}
+    if flydsl_gpu_arch is not None:
+        updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
+    # Cold launches must not observe FlyDSL's process-global compile-only mode.
+    # Warm launches call the cached dispatcher directly and do not read it.
+    with _compiled_cache_lock, temporary_env(updates), FakeTensorMode():
+        tensors = {
+            name: torch.empty_strided(
+                tuple(shape),
+                tuple(strides[name]),
+                dtype=getattr(torch, dtypes[name]),
+                device="cpu",
+            )
+            for name, shape in shapes.items()
+        }
+        configure_flydsl_cache_dir()
+        kernel(**tensors, stream=0, compile_only=True)

--- a/torch/_inductor/runtime/flydsl_cache.py
+++ b/torch/_inductor/runtime/flydsl_cache.py
@@ -42,8 +42,20 @@ def run_cached_flydsl(
     constexpr_param: Any,
     compiler: Callable[..., Any],
     dispatch_args: tuple[Any, ...],
+    compile_args_factory: Callable[[], tuple[Any, ...]] | None = None,
 ) -> Any:
-    """Cache a layout-dynamic FlyDSL dispatcher by constexpr param."""
+    """Cache a layout-dynamic FlyDSL dispatcher by constexpr param.
+
+    `compile_args` are only read on the compile path -- a cache hit dispatches
+    straight through `dispatch_args`. Building them eagerly therefore wastes
+    work on every call after the first for a given param: the FlyDSL argument
+    descriptors (`from_torch_tensor(...).mark_layout_dynamic()`) are
+    constructed and immediately discarded. Callers that can defer the work
+    should pass `compile_args_factory` instead, a zero-argument callable
+    invoked only when a compile is actually needed.
+    """
+    if compile_args_factory is not None and compile_args:
+        raise TypeError("pass compile_args or compile_args_factory, not both")
     device = getattr(dispatch_args[0], "device", None)
     cache_key = (
         os.getpid(),
@@ -67,7 +79,12 @@ def run_cached_flydsl(
         compiled = compiled_cache.get(cache_key)
         if compiled is None:
             # compile() executes this invocation; dispatching again would double-run.
-            compiled = compiler(jit_func, *compile_args)
+            args = (
+                compile_args_factory()
+                if compile_args_factory is not None
+                else compile_args
+            )
+            compiled = compiler(jit_func, *args)
             compiled_cache[cache_key] = compiled
         else:
             dispatch_after_wait = True

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2566,6 +2566,12 @@ def ensure_nvmatmul_heuristics_available() -> bool:
 
 
 def use_flydsl_gemm_template(layout: Layout) -> bool:
+    """Whether the FlyDSL GEMM templates may be offered for this layout.
+
+    The template compilation infrastructure landed in #192877; the kernels are
+    vendored per feature. Gated strictly on gfx950 because the vendored kernels
+    assume that part's LDS capacity and MFMA shapes.
+    """
     if not _use_autotune_backend("FLYDSL"):
         return False
     if not torch.version.hip:
@@ -2582,9 +2588,6 @@ def use_flydsl_gemm_template(layout: Layout) -> bool:
 
     from .codegen.flydsl.flydsl_scheduling import _get_flydsl_device_arch
 
-    # The vendored FlyDSL GEMM kernel targets the gfx950 (MI350) layout; its LDS
-    # capacity and MFMA assumptions do not hold on other archs, so gate strictly
-    # on gfx950 to avoid emitting kernels that fail to compile or run there.
     device_index = layout.device.index if layout.device.index is not None else 0
     if _get_flydsl_device_arch(device_index) != "gfx950":
         return False


### PR DESCRIPTION
Depends on #194303. Until that PR merges, GitHub includes the parent changes in this draft. The wgrad-only change is commit `846f2eaa9bc`.

> **AI-assisted implementation summary**
>
> Add a FlyDSL template for the 2D x 2D BlockWise1x32 form of `F.scaled_grouped_mm`, where device-resident offsets partition the contracting dimension. Vendor the gfx950 ragged wgrad kernel, write bf16 directly into Inductor's output buffer, and reuse the FlyDSL compilation cache introduced by #194303.
>
> Large grids use constant-index group-boundary loads instead of the quadratic longest-group-first selection, place wave-uniform addresses in SGPRs, and rasterize workgroups into rectangular tiles across XCDs.
>
> **Performance**
>
> MI355X with realistic ragged routing (group-size skew approximately 1.38). Operands are pre-quantized, compilation is excluded, and each result is the median of five interleaved FlyDSL/BF16 passes. The BF16 baseline is `torch._grouped_mm` in the same 2D x 2D form (hipBLASLt grouped GEMM).
>
> Measurement configuration:
> - GPU: AMD Instinct MI355X (gfx950), 256 CUs, 288 GB HBM3E; 2400 MHz max sclk (~2.0 GHz observed under load), 1400 W max package power (~1.0-1.3 kW observed), mclk 1900 MHz
> - ROCm 7.2.3, amdgpu driver 6.16.13, hipBLASLt 1.2.70203
> - PyTorch 2.15.0.dev20260827+rocm7.2 (HIP 7.2.53211), FlyDSL 0.3.2
> - Host: AMD EPYC 9575F, Ubuntu 22.04, Linux 6.8.0-90; one benchmark process per otherwise-idle GPU
> - Contracted M values not divisible by 128 use a row stride padded to the next multiple of 128 with offsets ending at the stated M
>
> | E | N | K | Contracted M | BF16 | FlyDSL MXFP8 | BF16 TF/s | FlyDSL TF/s | Speedup |
> |---:|---:|---:|---:|---:|---:|---:|---:|---:|
> | 8 | 1408 | 2048 | 16,384 | 0.230 ms | **0.078 ms** | 411 | **1,206** | **2.93x** |
> | 8 | 1408 | 2048 | 32,800 | 0.412 ms | **0.138 ms** | 459 | **1,375** | **2.99x** |
> | 8 | 1408 | 2048 | 65,504 | 0.644 ms | **0.232 ms** | 587 | **1,626** | **2.77x** |
> | 8 | 1408 | 2048 | 98,272 | 0.754 ms | **0.357 ms** | 752 | **1,588** | **2.11x** |
> | 8 | 1408 | 2048 | 196,608 | 1.385 ms | **0.689 ms** | 819 | **1,646** | **2.01x** |
> | 8 | 2048 | 1408 | 98,272 | 0.759 ms | **0.342 ms** | 747 | **1,657** | **2.22x** |
> | 8 | 2048 | 1408 | 196,608 | 1.270 ms | **0.668 ms** | 892 | **1,698** | **1.90x** |
> | 32 | 4096 | 7168 | 65,536 | 4.521 ms | **2.382 ms** | 851 | **1,615** | **1.90x** |
> | 32 | 4096 | 7168 | 131,200 | 7.475 ms | **4.327 ms** | 1,031 | **1,780** | **1.73x** |
> | 32 | 4096 | 7168 | 262,016 | 13.917 ms | **7.914 ms** | 1,106 | **1,944** | **1.76x** |
> | 32 | 7168 | 2048 | 131,200 | 3.801 ms | **2.078 ms** | 1,014 | **1,854** | **1.83x** |
> | 32 | 7168 | 2048 | 262,016 | 7.055 ms | **3.870 ms** | 1,090 | **1,988** | **1.82x** |
>
> Across these shapes, FlyDSL reaches 1.21-1.99 PFLOP/s. The geometric-mean speedup is 2.38x for E=8 and 1.81x for E=32. Speedups are unchanged (2.37x / 1.85x) when a 512 MB buffer is written before every launch to evict the caches, and drop modestly (2.24x / 1.71x) with uniform group sizes. Every shape matches an fp32 dequantized per-group reference within bf16 rounding (max relative error 0.39%).
>
> DeepSeek-V3 671B expert shapes (hidden 7168, intermediate 2048; 8 local experts, i.e. EP=32 over 256 routed experts), same ragged protocol:
>
> | E | N | K | Projection | Contracted M | BF16 | FlyDSL MXFP8 | BF16 TF/s | FlyDSL TF/s | Speedup |
> |---:|---:|---:|:--|---:|---:|---:|---:|---:|---:|
> | 8 | 2048 | 7168 | gate / up | 32,768 | 1.012 ms | **0.502 ms** | 951 | **1,918** | **2.02x** |
> | 8 | 2048 | 7168 | gate / up | 65,536 | 1.816 ms | **0.919 ms** | 1,059 | **2,093** | **1.98x** |
> | 8 | 2048 | 7168 | gate / up | 131,072 | 3.277 ms | **1.793 ms** | 1,174 | **2,146** | **1.83x** |
> | 8 | 2048 | 7168 | gate / up | 262,144 | 7.101 ms | **3.392 ms** | 1,084 | **2,269** | **2.09x** |
> | 8 | 4096 | 7168 | fused gate+up | 32,768 | 1.893 ms | **1.017 ms** | 1,016 | **1,893** | **1.86x** |
> | 8 | 4096 | 7168 | fused gate+up | 65,536 | 3.481 ms | **1.821 ms** | 1,106 | **2,113** | **1.91x** |
> | 8 | 4096 | 7168 | fused gate+up | 131,072 | 6.322 ms | **3.479 ms** | 1,217 | **2,212** | **1.82x** |
> | 8 | 4096 | 7168 | fused gate+up | 262,144 | 14.281 ms | **6.791 ms** | 1,078 | **2,267** | **2.10x** |
> | 8 | 7168 | 2048 | down | 32,768 | 0.995 ms | **0.501 ms** | 967 | **1,920** | **1.98x** |
> | 8 | 7168 | 2048 | down | 65,536 | 1.764 ms | **0.917 ms** | 1,091 | **2,098** | **1.92x** |
> | 8 | 7168 | 2048 | down | 131,072 | 3.243 ms | **1.757 ms** | 1,187 | **2,190** | **1.85x** |
> | 8 | 7168 | 2048 | down | 262,144 | 7.058 ms | **3.452 ms** | 1,090 | **2,229** | **2.04x** |
>
> On the DeepSeek-V3 shapes FlyDSL reaches 1.89-2.27 PFLOP/s with a geometric-mean speedup of 1.95x (1.95x with the cache flushed before every launch). Raising the routing skew to 2.0 (largest expert holds twice the mean) slows FlyDSL by only 2-4% per shape and leaves the geometric mean at 1.87x, so the ragged scheduling holds up under heavier load imbalance than the 1.38 used above.
>
> **Test Plan**
>
> `pytest test/inductor/test_flydsl_template.py -q -k 'precompile_fake_tensors or mxfp8_wgrad' -rs`
>
> Authored with assistance from an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @ezyang
