### PR TITLE
[Bug] Inductor flop counter reports 0 FLOPs on XPU (get_device_tflops…

### DIFF
--- a/test/inductor/test_analysis.py
+++ b/test/inductor/test_analysis.py
@@ -9,7 +9,12 @@ from unittest.mock import patch
 
 import torch
 import torch.nn.functional as F
-from torch._inductor.analysis.device_info import _device_mapping, lookup_device_info
+from torch._inductor.analysis.device_info import (
+    _device_mapping,
+    datasheet_dram_bw_gbs,
+    datasheet_tops,
+    lookup_device_info,
+)
 from torch._inductor.analysis.profile_analysis import (
     _augment_trace_helper,
     _create_extern_mapping,
@@ -281,6 +286,12 @@ class TestUtils(TestCase):
         self.assertIsNotNone(upper)
         self.assertEqual(lookup_device_info("AMD Instinct MI300X"), upper)
         self.assertEqual(lookup_device_info("amd instinct mi300x"), upper)
+
+    def test_datasheet_info_for_intel_data_center_gpu_max_1550(self):
+        device_name = "Intel(R) Data Center GPU Max 1550"
+        self.assertEqual(datasheet_tops(torch.float16, device_name=device_name), 419.43)
+        self.assertEqual(datasheet_tops(torch.float32, device_name=device_name), 26.2)
+        self.assertEqual(datasheet_dram_bw_gbs(device_name=device_name), 3276.8)
 
 
 def has_supported_gpu():

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -267,6 +267,20 @@ _device_mapping: dict[str, DeviceInfo] = {
         dram_bw_gbs=1228.8,
         dram_gb=48,
     ),
+    # Source:
+    # @lint-ignore https://www.intel.com/content/www/us/en/ark/products/series/232874/
+    # intel-data-center-gpu-max-series.html
+    "Intel(R) Data Center GPU Max 1550": DeviceInfo(
+        tops={
+            torch.float32: 26.2,
+            "torch.tf32": 26.2,
+            torch.float16: 419.43,
+            torch.bfloat16: 419.43,
+            torch.int8: 838.86,
+        },
+        dram_bw_gbs=3276.8,
+        dram_gb=128,
+    ),
 }
 _device_mapping["AMD INSTINCT MI350X"] = _device_mapping["AMD MI350X"]
 _device_mapping["AMD INSTINCT MI300X"] = _device_mapping["AMD MI300X"]


### PR DESCRIPTION
… has no non-CUDA fallback)

TestSchedulerXPU.test_flop_counter_op fails on XPU because Inductor's flop
counter reported 0 FLOPs for a compiled mm op instead of the expected
non-zero value. It can be fixed by adding device information according to https://www.intel.com/content/www/us/en/ark/products/series/232874/intel-data-center-gpu-max-series.html

Fix for: [#4853](https://github.com/intel/torch-xpu-ops/issues/4853)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo