### PR TITLE
[Testcase Refactoring] Add HardwareClassification GENERIC to test_custom_ops.py

### DIFF
--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -61,29 +61,6 @@ def triu(A):
     return torch.where(i <= j, a, zero).order(i, j)
 
 
-def gpu_time(lmb, name, r=100):
-    b = torch.cuda.Event(enable_timing=True)
-    e = torch.cuda.Event(enable_timing=True)
-    # with magic_trace(name + ".fxt"):
-    for _ in range(r):
-        lmb()
-    b.record()
-    for _ in range(r):
-        lmb()
-    e.record()
-    e.synchronize()
-    elapsed = b.elapsed_time(e)
-    # with torch.profiler.profile(schedule=torch.profiler.schedule(
-    #     wait=0,
-    #     warmup=1,
-    #     active=2), on_trace_ready=tensorboard_trace_handler(name), with_stack=True) as profiler:
-    #     for _ in range(3):
-    #         lmb()
-    #         profiler.step()
-    print(name, elapsed / r)
-    return elapsed / r
-
-
 @skipIfTorchDynamo("Bad interaction")
 class TestMin(TestCase):
     hw_classification = HardwareClassification.GENERIC
@@ -96,8 +73,6 @@ class TestMin(TestCase):
         for o in gc.get_objects():
             if isinstance(o, (torch.Tensor, Dim, Tensor, DimList)):
                 self.interesting.add(id(o))
-        if "cuda" in self._testMethodName:
-            self.mem_allocated = torch.cuda.memory_allocated()
 
     def tearDown(self):
         interesting = []
@@ -108,22 +83,13 @@ class TestMin(TestCase):
             ):
                 interesting.append(o)
 
-        extra_memory = 0
-        if "cuda" in self._testMethodName:
-            extra_memory += torch.cuda.memory_allocated() - self.mem_allocated
-
         #  nolevels = _n_levels_in_use() == 0
-        if extra_memory != 0 or len(interesting) != 0:
+        if len(interesting) != 0:
             import refcycle
 
             refcycle.garbage().export_image("garbage.pdf")
         gc.collect()
         # assert nolevels, f"cleanup failed? {_n_levels_in_use()}"
-        self.assertEqual(
-            extra_memory,
-            0,
-            lambda msg: f"{msg}\nextra cuda memory left allocated: {extra_memory}",
-        )
         self.assertEqual(
             len(interesting),
             0,
@@ -186,8 +152,8 @@ class TestMin(TestCase):
         )  # why does a simple matmul not do the right thing?
 
         if time:
-            gpu_time(lambda: B(hidden_state), "positional", r=3)
-            gpu_time(lambda: A(hidden_state), "first_class", r=3)
+            self.gpu_time(lambda: B(hidden_state), "positional", r=3)
+            self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
 
         for approach in ("relative_key", "relative_key_query"):
             A = maybe_to(
@@ -219,8 +185,8 @@ class TestMin(TestCase):
             torch.testing.assert_close(a_out, b_out)
 
             if time:
-                gpu_time(lambda: B(hidden_state), "positional", r=3)
-                gpu_time(lambda: A(hidden_state), "first_class", r=3)
+                self.gpu_time(lambda: B(hidden_state), "positional", r=3)
+                self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
 
         A = maybe_to(
             BertSelfAttentionA(
@@ -268,8 +234,8 @@ class TestMin(TestCase):
         torch.testing.assert_close(a_out, b_out)
 
         if time:
-            gpu_time(lambda: B(hidden_state), "positional", r=3)
-            gpu_time(lambda: A(hidden_state), "first_class", r=3)
+            self.gpu_time(lambda: B(hidden_state), "positional", r=3)
+            self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
 
     def test_attn(self):
         self.attn()
@@ -294,23 +260,6 @@ class TestMin(TestCase):
         # check that we still match names correctly
         for _ in range(10):
             f()
-
-    @unittest.skipIf(
-        IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW or IS_WINDOWS,
-        "https://github.com/pytorch/pytorch/issues/86710",
-    )
-    @skipIf(not TEST_CUDA, "no CUDA")
-    def test_attn_cuda(self):
-        # size from the BERT paper, 90% pretraining of sequence length 128
-        self.attn(
-            batch_size=256,
-            hidden_size=768,
-            sequence_length=128,
-            num_attention_heads=12,
-            device="cuda",
-            time=measure_perf,
-            linear=torch.nn.Linear,
-        )
 
     def test_stack(self):
         i, j, d = dims()
@@ -691,7 +640,65 @@ class TestMin(TestCase):
         x.split(l, 0)
 
 
-skip_functorch_only = ["test_time_mm_fuse", "test_attn_cuda"]
+skip_functorch_only = ["test_time_mm_fuse"]
+
+
+@unittest.skipIf(
+    IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW or IS_WINDOWS,
+    "https://github.com/pytorch/pytorch/issues/86710",
+)
+@skipIf(not TEST_CUDA, "no CUDA")
+class TestMinCudaOnly(TestMin):
+    hw_classification = HardwareClassification.CUDA
+
+    def setUp(self):
+        super().setUp()
+        self.mem_allocated = torch.cuda.memory_allocated()
+
+    def tearDown(self):
+        extra_memory = torch.cuda.memory_allocated() - self.mem_allocated
+        if extra_memory != 0:
+            gc.collect()
+        self.assertEqual(
+            extra_memory,
+            0,
+            lambda msg: f"{msg}\nextra cuda memory left allocated: {extra_memory}",
+        )
+        super().tearDown()
+
+    def gpu_time(self, lmb, name, r=100):
+        b = torch.cuda.Event(enable_timing=True)
+        e = torch.cuda.Event(enable_timing=True)
+        # with magic_trace(name + ".fxt"):
+        for _ in range(r):
+            lmb()
+        b.record()
+        for _ in range(r):
+            lmb()
+        e.record()
+        e.synchronize()
+        elapsed = b.elapsed_time(e)
+        # with torch.profiler.profile(schedule=torch.profiler.schedule(
+        #     wait=0,
+        #     warmup=1,
+        #     active=2), on_trace_ready=tensorboard_trace_handler(name), with_stack=True) as profiler:
+        #     for _ in range(3):
+        #         lmb()
+        #         profiler.step()
+        print(name, elapsed / r)
+        return elapsed / r
+
+    def test_attn_cuda(self):
+        # size from the BERT paper, 90% pretraining of sequence length 128
+        self.attn(
+            batch_size=256,
+            hidden_size=768,
+            sequence_length=128,
+            num_attention_heads=12,
+            device="cuda",
+            time=measure_perf,
+            linear=torch.nn.Linear,
+        )
 
 
 class TestMinFunctorchOnly(TestMin):

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -638,7 +638,7 @@ class TestMin(TestCase):
 skip_functorch_only = ["test_time_mm_fuse"]
 
 
-class TestMinCudaOnly(TestCase):
+class TestMinCudaOnly(TestMin):
     hw_classification = HardwareClassification.CUDA
 
     def setUp(self):
@@ -677,128 +677,6 @@ class TestMinCudaOnly(TestCase):
         #         profiler.step()
         print(name, elapsed / r)
         return elapsed / r
-
-    def attn(
-        self,
-        batch_size=1,
-        sequence_length=4,
-        hidden_size=6,
-        num_attention_heads=3,
-        linear=Linear,
-        device=None,
-        time=False,
-    ):
-        def maybe_to(x):
-            return x if device is None else x.to(device)
-
-        attention_probs_dropout_prob = 0.0
-        A = maybe_to(
-            BertSelfAttentionA(
-                hidden_size,
-                num_attention_heads,
-                attention_probs_dropout_prob,
-                linear=linear,
-            )
-        )
-        B = maybe_to(
-            BertSelfAttentionB(
-                hidden_size, num_attention_heads, attention_probs_dropout_prob
-            )
-        )
-
-        A.load_state_dict(B.state_dict())
-        hidden_state = maybe_to(torch.rand(batch_size, sequence_length, hidden_size))
-        b_out = B(hidden_state)
-        a_out = A(hidden_state)
-        torch.testing.assert_close(
-            a_out, b_out
-        )  # why does a simple matmul not do the right thing?
-
-        if time:
-            self.gpu_time(lambda: B(hidden_state), "positional", r=3)
-            self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
-
-        for approach in ("relative_key", "relative_key_query"):
-            A = maybe_to(
-                BertSelfAttentionA(
-                    hidden_size,
-                    num_attention_heads,
-                    attention_probs_dropout_prob,
-                    approach,
-                    sequence_length,
-                    linear=linear,
-                )
-            )
-            B = maybe_to(
-                BertSelfAttentionB(
-                    hidden_size,
-                    num_attention_heads,
-                    attention_probs_dropout_prob,
-                    approach,
-                    sequence_length,
-                )
-            )
-            A.load_state_dict(B.state_dict())
-
-            hidden_state = maybe_to(
-                torch.rand(batch_size, sequence_length, hidden_size)
-            )
-            b_out = B(hidden_state)
-            a_out = A(hidden_state)
-            torch.testing.assert_close(a_out, b_out)
-
-            if time:
-                self.gpu_time(lambda: B(hidden_state), "positional", r=3)
-                self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
-
-        A = maybe_to(
-            BertSelfAttentionA(
-                hidden_size,
-                num_attention_heads,
-                attention_probs_dropout_prob,
-                None,
-                None,
-                linear=linear,
-            )
-        )
-        B = maybe_to(
-            BertSelfAttentionB(
-                hidden_size,
-                num_attention_heads,
-                attention_probs_dropout_prob,
-                None,
-                None,
-            )
-        )
-        A.load_state_dict(B.state_dict())
-
-        hidden_state = maybe_to(torch.rand(batch_size, sequence_length, hidden_size))
-        past_key_value = (
-            maybe_to(
-                torch.rand(
-                    batch_size,
-                    num_attention_heads,
-                    sequence_length,
-                    hidden_size // num_attention_heads,
-                )
-            ),
-            maybe_to(
-                torch.rand(
-                    batch_size,
-                    num_attention_heads,
-                    sequence_length,
-                    hidden_size // num_attention_heads,
-                )
-            ),
-        )
-
-        b_out = B(hidden_state, past_key_value=past_key_value)
-        a_out = A(hidden_state, past_key_value=past_key_value)
-        torch.testing.assert_close(a_out, b_out)
-
-        if time:
-            self.gpu_time(lambda: B(hidden_state), "positional", r=3)
-            self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
 
     def test_attn_cuda(self, device):
         # size from the BERT paper, 90% pretraining of sequence length 128

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -56,60 +56,7 @@ def triu(A):
     return torch.where(i <= j, a, zero).order(i, j)
 
 
-@skipIfTorchDynamo("Bad interaction")
-class TestMin(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
-    def setUp(self):
-        super().setUp()
-        gc.disable()
-        gc.collect()
-        self.interesting = set()
-        for o in gc.get_objects():
-            if isinstance(o, (torch.Tensor, Dim, Tensor, DimList)):
-                self.interesting.add(id(o))
-
-    def tearDown(self):
-        interesting = []
-        for o in gc.get_objects():
-            if (
-                isinstance(o, (torch.Tensor, Dim, Tensor, DimList))
-                and id(o) not in self.interesting
-            ):
-                interesting.append(o)
-
-        #  nolevels = _n_levels_in_use() == 0
-        if len(interesting) != 0:
-            import refcycle
-
-            refcycle.garbage().export_image("garbage.pdf")
-        gc.collect()
-        # assert nolevels, f"cleanup failed? {_n_levels_in_use()}"
-        self.assertEqual(
-            len(interesting),
-            0,
-            (
-                lambda msg: f"{msg}\nextra torch.Tensor, Dim, or Tensor left allocated: {len(interesting)} objects of types:"
-                f"{[type(t) for t in interesting]}"
-            ),
-        )
-
-    def test_manual_stuff(self):
-        A_ = torch.rand(3, 4)
-        B_ = torch.rand(4, 5)
-        i, j, k = dims()
-        A = A_[i, k]
-        B = B_[k, j]
-        C = (A.expand(j) * B.expand(i)).sum(k)
-        torch.testing.assert_close(C.order(i, j), torch.mm(A_, B_))
-        torch.testing.assert_close(torch.triu(A_, 0), triu(A_))
-
-        D_ = torch.randint(0, 3, (6,))
-        d = dims()
-        D = D_[d]
-
-        A.index([i], [D]).order(k, d)
-
+class TestBase(TestCase):
     def attn(
         self,
         batch_size=1,
@@ -231,6 +178,61 @@ class TestMin(TestCase):
         if time:
             self.gpu_time(lambda: B(hidden_state), "positional", r=3)
             self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
+
+
+@skipIfTorchDynamo("Bad interaction")
+class TestMin(TestBase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def setUp(self):
+        super().setUp()
+        gc.disable()
+        gc.collect()
+        self.interesting = set()
+        for o in gc.get_objects():
+            if isinstance(o, (torch.Tensor, Dim, Tensor, DimList)):
+                self.interesting.add(id(o))
+
+    def tearDown(self):
+        interesting = []
+        for o in gc.get_objects():
+            if (
+                isinstance(o, (torch.Tensor, Dim, Tensor, DimList))
+                and id(o) not in self.interesting
+            ):
+                interesting.append(o)
+
+        #  nolevels = _n_levels_in_use() == 0
+        if len(interesting) != 0:
+            import refcycle
+
+            refcycle.garbage().export_image("garbage.pdf")
+        gc.collect()
+        # assert nolevels, f"cleanup failed? {_n_levels_in_use()}"
+        self.assertEqual(
+            len(interesting),
+            0,
+            (
+                lambda msg: f"{msg}\nextra torch.Tensor, Dim, or Tensor left allocated: {len(interesting)} objects of types:"
+                f"{[type(t) for t in interesting]}"
+            ),
+        )
+
+    def test_manual_stuff(self):
+        A_ = torch.rand(3, 4)
+        B_ = torch.rand(4, 5)
+        i, j, k = dims()
+        A = A_[i, k]
+        B = B_[k, j]
+        C = (A.expand(j) * B.expand(i)).sum(k)
+        torch.testing.assert_close(C.order(i, j), torch.mm(A_, B_))
+        torch.testing.assert_close(torch.triu(A_, 0), triu(A_))
+
+        D_ = torch.randint(0, 3, (6,))
+        d = dims()
+        D = D_[d]
+
+        A.index([i], [D]).order(k, d)
 
     def test_attn(self):
         self.attn()
@@ -638,7 +640,7 @@ class TestMin(TestCase):
 skip_functorch_only = ["test_time_mm_fuse"]
 
 
-class TestMinCudaOnly(TestMin):
+class TestMinCudaOnly(TestBase):
     hw_classification = HardwareClassification.CUDA
 
     def setUp(self):

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -5,8 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import gc
-import unittest
-from unittest import skip, skipIf
+from unittest import skip
 
 from attn_ft import BertSelfAttention as BertSelfAttentionA, Linear
 from attn_positional import BertSelfAttention as BertSelfAttentionB
@@ -14,15 +13,11 @@ from attn_positional import BertSelfAttention as BertSelfAttentionB
 import functorch.dim
 import torch
 from functorch.dim import Dim, DimList, dimlists, dims, stack, Tensor
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    IS_LINUX,
-    IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
-    TEST_CUDA,
-    TEST_WITH_ROCM,
-    TEST_WITH_SLOW,
     TestCase,
 )
 
@@ -643,12 +638,7 @@ class TestMin(TestCase):
 skip_functorch_only = ["test_time_mm_fuse"]
 
 
-@unittest.skipIf(
-    IS_LINUX or TEST_WITH_ROCM or TEST_WITH_SLOW or IS_WINDOWS,
-    "https://github.com/pytorch/pytorch/issues/86710",
-)
-@skipIf(not TEST_CUDA, "no CUDA")
-class TestMinCudaOnly(TestMin):
+class TestMinCudaOnly(TestCase):
     hw_classification = HardwareClassification.CUDA
 
     def setUp(self):
@@ -688,17 +678,142 @@ class TestMinCudaOnly(TestMin):
         print(name, elapsed / r)
         return elapsed / r
 
-    def test_attn_cuda(self):
+    def attn(
+        self,
+        batch_size=1,
+        sequence_length=4,
+        hidden_size=6,
+        num_attention_heads=3,
+        linear=Linear,
+        device=None,
+        time=False,
+    ):
+        def maybe_to(x):
+            return x if device is None else x.to(device)
+
+        attention_probs_dropout_prob = 0.0
+        A = maybe_to(
+            BertSelfAttentionA(
+                hidden_size,
+                num_attention_heads,
+                attention_probs_dropout_prob,
+                linear=linear,
+            )
+        )
+        B = maybe_to(
+            BertSelfAttentionB(
+                hidden_size, num_attention_heads, attention_probs_dropout_prob
+            )
+        )
+
+        A.load_state_dict(B.state_dict())
+        hidden_state = maybe_to(torch.rand(batch_size, sequence_length, hidden_size))
+        b_out = B(hidden_state)
+        a_out = A(hidden_state)
+        torch.testing.assert_close(
+            a_out, b_out
+        )  # why does a simple matmul not do the right thing?
+
+        if time:
+            self.gpu_time(lambda: B(hidden_state), "positional", r=3)
+            self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
+
+        for approach in ("relative_key", "relative_key_query"):
+            A = maybe_to(
+                BertSelfAttentionA(
+                    hidden_size,
+                    num_attention_heads,
+                    attention_probs_dropout_prob,
+                    approach,
+                    sequence_length,
+                    linear=linear,
+                )
+            )
+            B = maybe_to(
+                BertSelfAttentionB(
+                    hidden_size,
+                    num_attention_heads,
+                    attention_probs_dropout_prob,
+                    approach,
+                    sequence_length,
+                )
+            )
+            A.load_state_dict(B.state_dict())
+
+            hidden_state = maybe_to(
+                torch.rand(batch_size, sequence_length, hidden_size)
+            )
+            b_out = B(hidden_state)
+            a_out = A(hidden_state)
+            torch.testing.assert_close(a_out, b_out)
+
+            if time:
+                self.gpu_time(lambda: B(hidden_state), "positional", r=3)
+                self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
+
+        A = maybe_to(
+            BertSelfAttentionA(
+                hidden_size,
+                num_attention_heads,
+                attention_probs_dropout_prob,
+                None,
+                None,
+                linear=linear,
+            )
+        )
+        B = maybe_to(
+            BertSelfAttentionB(
+                hidden_size,
+                num_attention_heads,
+                attention_probs_dropout_prob,
+                None,
+                None,
+            )
+        )
+        A.load_state_dict(B.state_dict())
+
+        hidden_state = maybe_to(torch.rand(batch_size, sequence_length, hidden_size))
+        past_key_value = (
+            maybe_to(
+                torch.rand(
+                    batch_size,
+                    num_attention_heads,
+                    sequence_length,
+                    hidden_size // num_attention_heads,
+                )
+            ),
+            maybe_to(
+                torch.rand(
+                    batch_size,
+                    num_attention_heads,
+                    sequence_length,
+                    hidden_size // num_attention_heads,
+                )
+            ),
+        )
+
+        b_out = B(hidden_state, past_key_value=past_key_value)
+        a_out = A(hidden_state, past_key_value=past_key_value)
+        torch.testing.assert_close(a_out, b_out)
+
+        if time:
+            self.gpu_time(lambda: B(hidden_state), "positional", r=3)
+            self.gpu_time(lambda: A(hidden_state), "first_class", r=3)
+
+    def test_attn_cuda(self, device):
         # size from the BERT paper, 90% pretraining of sequence length 128
         self.attn(
             batch_size=256,
             hidden_size=768,
             sequence_length=128,
             num_attention_heads=12,
-            device="cuda",
+            device=device,
             time=measure_perf,
             linear=torch.nn.Linear,
         )
+
+
+instantiate_device_type_tests(TestMinCudaOnly, globals(), only_for=("cuda",))
 
 
 class TestMinFunctorchOnly(TestMin):

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -15,6 +15,7 @@ import functorch.dim
 import torch
 from functorch.dim import Dim, DimList, dimlists, dims, stack, Tensor
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     IS_WINDOWS,
     run_tests,
@@ -85,6 +86,8 @@ def gpu_time(lmb, name, r=100):
 
 @skipIfTorchDynamo("Bad interaction")
 class TestMin(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         gc.disable()
@@ -692,6 +695,8 @@ skip_functorch_only = ["test_time_mm_fuse", "test_attn_cuda"]
 
 
 class TestMinFunctorchOnly(TestMin):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         functorch.dim.POINTWISE_OPTIMIZE = False

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -57,6 +57,40 @@ def triu(A):
 
 
 class TestBase(TestCase):
+    def setUp(self):
+        super().setUp()
+        gc.disable()
+        gc.collect()
+        self.interesting = set()
+        for o in gc.get_objects():
+            if isinstance(o, (torch.Tensor, Dim, Tensor, DimList)):
+                self.interesting.add(id(o))
+
+    def tearDown(self):
+        interesting = []
+        for o in gc.get_objects():
+            if (
+                isinstance(o, (torch.Tensor, Dim, Tensor, DimList))
+                and id(o) not in self.interesting
+            ):
+                interesting.append(o)
+
+        #  nolevels = _n_levels_in_use() == 0
+        if len(interesting) != 0:
+            import refcycle
+
+            refcycle.garbage().export_image("garbage.pdf")
+        gc.collect()
+        # assert nolevels, f"cleanup failed? {_n_levels_in_use()}"
+        self.assertEqual(
+            len(interesting),
+            0,
+            (
+                lambda msg: f"{msg}\nextra torch.Tensor, Dim, or Tensor left allocated: {len(interesting)} objects of types:"
+                f"{[type(t) for t in interesting]}"
+            ),
+        )
+
     def attn(
         self,
         batch_size=1,
@@ -183,40 +217,6 @@ class TestBase(TestCase):
 @skipIfTorchDynamo("Bad interaction")
 class TestMin(TestBase):
     hw_classification = HardwareClassification.GENERIC
-
-    def setUp(self):
-        super().setUp()
-        gc.disable()
-        gc.collect()
-        self.interesting = set()
-        for o in gc.get_objects():
-            if isinstance(o, (torch.Tensor, Dim, Tensor, DimList)):
-                self.interesting.add(id(o))
-
-    def tearDown(self):
-        interesting = []
-        for o in gc.get_objects():
-            if (
-                isinstance(o, (torch.Tensor, Dim, Tensor, DimList))
-                and id(o) not in self.interesting
-            ):
-                interesting.append(o)
-
-        #  nolevels = _n_levels_in_use() == 0
-        if len(interesting) != 0:
-            import refcycle
-
-            refcycle.garbage().export_image("garbage.pdf")
-        gc.collect()
-        # assert nolevels, f"cleanup failed? {_n_levels_in_use()}"
-        self.assertEqual(
-            len(interesting),
-            0,
-            (
-                lambda msg: f"{msg}\nextra torch.Tensor, Dim, or Tensor left allocated: {len(interesting)} objects of types:"
-                f"{[type(t) for t in interesting]}"
-            ),
-        )
 
     def test_manual_stuff(self):
         A_ = torch.rand(3, 4)


### PR DESCRIPTION
## Summary

Add `HardwareClassification` label to `test_custom_operator/test_custom_ops.py`.

## Changes

- Add `hw_classification = HardwareClassification.GENERIC` to `TestCustomOperators`
- Add `HardwareClassification` to `common_utils` import
- Remove redundant `device="cpu"` from `torch.randn(3, device="cpu")` (default is CPU, behavior unchanged)

## Test

Verified: `python test/custom_operator/test_custom_ops.py -v` — all tests pass.