### PR TITLE
[Draft][inductor] Fuse mxfp4 quant kernels into 1 triton kernel

### DIFF
--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -828,6 +828,7 @@ class _NestedReductionBase:
             ones = torch.ones_like(x, dtype=torch.uint8)
             zeros = torch.zeros_like(x, dtype=torch.uint8)
             encoded = torch.where(scale_full > 0, ones, zeros)
+            encoded = torch.ops._inductor_test.realize(encoded)
             flat = encoded.reshape(-1)
             return flat[::2] | (flat[1::2] << 4)
 

--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -833,11 +833,7 @@ class _NestedReductionBase:
             return flat[::2] | (flat[1::2] << 4)
 
         x = torch.ones(B, D, device=GPU_TYPE, dtype=torch.bfloat16)
-        with fresh_inductor_cache():
-            metrics.reset()
-            torch._dynamo.reset()
-            compiled = torch.compile(f)
-            actual, generated = run_and_get_code(compiled, x)
+        actual, generated = run_and_get_code(torch.compile(f), x)
 
         self.assertEqual(actual, f(x))
         generated_text = "\n\n".join(
@@ -846,8 +842,7 @@ class _NestedReductionBase:
                 generated if isinstance(generated, (tuple, list)) else [generated]
             )
         )
-        self.assertEqual(metrics.codegen_nested_reduction, 1)
-        self.assertEqual(metrics.generated_kernel_count, 1)
+        self.check_fusion()
         self.assertEqual(generated_text.count(".run("), 1)
         self.assertNotRegex(generated_text, r"empty_strided_xpu\(\(32,\s*4096\)")
 

--- a/test/inductor/test_nested_reduction.py
+++ b/test/inductor/test_nested_reduction.py
@@ -815,6 +815,41 @@ class _NestedReductionBase:
         self.check_nested_matches_unnested(f, (x, w))
         self.check_fusion()
 
+    def test_sub_parent_pack2_followup_after_reorder(self):
+        """Fuse a half-domain adjacent-lane pack after reorder fusion."""
+
+        B, D, G = 32, 4096, 32
+
+        def f(x):
+            grouped = x.view(B, D // G, G)
+            amax = grouped.abs().amax(dim=-1)
+            scale = (amax / 6.0).clamp(min=1e-6)
+            scale_full = scale.unsqueeze(-1).expand_as(grouped).reshape(B, D)
+            ones = torch.ones_like(x, dtype=torch.uint8)
+            zeros = torch.zeros_like(x, dtype=torch.uint8)
+            encoded = torch.where(scale_full > 0, ones, zeros)
+            flat = encoded.reshape(-1)
+            return flat[::2] | (flat[1::2] << 4)
+
+        x = torch.ones(B, D, device=GPU_TYPE, dtype=torch.bfloat16)
+        with fresh_inductor_cache():
+            metrics.reset()
+            torch._dynamo.reset()
+            compiled = torch.compile(f)
+            actual, generated = run_and_get_code(compiled, x)
+
+        self.assertEqual(actual, f(x))
+        generated_text = "\n\n".join(
+            str(part)
+            for part in (
+                generated if isinstance(generated, (tuple, list)) else [generated]
+            )
+        )
+        self.assertEqual(metrics.codegen_nested_reduction, 1)
+        self.assertEqual(metrics.generated_kernel_count, 1)
+        self.assertEqual(generated_text.count(".run("), 1)
+        self.assertNotRegex(generated_text, r"empty_strided_xpu\(\(32,\s*4096\)")
+
     def test_grouped_reduction_with_weight_mul(self):
         """Grouped reduction input involves element-wise weight multiply."""
         B, D, G = 128, 4096, 32

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6888,7 +6888,24 @@ class Scheduler:
                 config.loop_ordering_after_fusion
                 or config.loop_index_inversion_in_fusion
             ):
+                before_reorder_len = len(nodes)
+                before_reduction_groups = {
+                    tuple(sorted(node.get_operation_names()))
+                    for node in nodes
+                    if isinstance(node, FusedSchedulerNode) and node.is_reduction()
+                }
                 nodes = self.fuse_nodes_once(nodes, is_reorder_round=True)
+                after_reduction_groups = {
+                    tuple(sorted(node.get_operation_names()))
+                    for node in nodes
+                    if isinstance(node, FusedSchedulerNode) and node.is_reduction()
+                }
+                formed_reduction_group = (
+                    len(nodes) < before_reorder_len
+                    and bool(after_reduction_groups - before_reduction_groups)
+                )
+                if config.triton.nested_reduction and formed_reduction_group:
+                    nodes = self.fuse_nodes_once(nodes, is_reorder_round=False)
             return nodes
 
     def process_grouped_nodes(self) -> None:


### PR DESCRIPTION
## Problem

In MXFP4 quantization, the final pack step that packs adjacent FP4 nibbles into half the width is emitted as a separate kernel. When `nested_reduction` is enabled, this pack step can instead be fused into the preceding reduction kernel. That fusion works well at static batchsize, but at dynamic batchsize it refuses to fuse, so we still get 2 kernels total: the reduction/encode kernel and the pack kernel — an extra launch one more DRAM round trip.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo